### PR TITLE
docs: add canonical source comment to repo-profile.sh

### DIFF
--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # Variables are read via indirect expansion (${!key}).
+# Canonical source: standard-tooling
 set -euo pipefail
 
 profile_file="docs/repository-standards.md"


### PR DESCRIPTION
## Summary

- Add canonical source comment to repo-profile.sh
- Test change for end-to-end propagation validation of sync-tooling mechanism

## Test plan

- [ ] Merge, tag v1.0.1
- [ ] Verify consuming repos detect staleness
- [ ] Verify --fix propagates the change

Ref #1
