### PR TITLE
fix: prevent --actions-compat from leaking during self-update re-exec

### DIFF
--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -42,7 +42,7 @@ ACTIONS_SCRIPTS_DIR="actions/standards-compliance/scripts"
 
 mode="check"
 ref=""
-actions_compat=false
+actions_compat=""
 
 usage() {
   cat <<EOF


### PR DESCRIPTION
## Summary

- Fix `actions_compat` initialization from `false` to `""` so that `${actions_compat:+--actions-compat}` correctly expands to nothing during self-update re-exec

## Test plan

- [x] Manual test: modify `sync-tooling.sh` locally, run `--fix` without `--actions-compat`, verify re-exec does not include the flag
- [ ] Sync to consuming repos

Fixes #3
