### PR TITLE
feat: make standard-tooling a first-class repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Pull Request
+
+## Summary
+
+-
+
+## Issue Linkage
+
+- Fixes # (default; use when no acceptance criteria exist)
+- Ref # (use when acceptance criteria exist)
+- Work is not complete until the issue is closed.
+- If no issue exists, open one before any work begins.
+
+## Testing
+
+- markdownlint
+- shellcheck
+
+## Notes
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI - Test and Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-only:
+    name: docs-only
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect docs-only changes
+        id: detect
+        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+
+  standards-compliance:
+    name: standards-compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate standards
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+        with:
+          skip-sync-check: "true"
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    needs: docs-only
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping shellcheck."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: |
+          files=$(find scripts -type f \( -name '*.sh' -o -path '*/git-hooks/*' \) | sort)
+          if [ -n "$files" ]; then
+            echo "$files" | xargs shellcheck
+          else
+            echo "No shell scripts found."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+.env
+.env.*
+*.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working in this repository.
+
+## Documentation Strategy
+
+This repository uses two complementary approaches for AI agent guidance:
+
+- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
+- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
+
+<!-- include: docs/repository-standards.md -->
+
+## Project Overview
+
+This is the canonical source for shared scripts used across all managed repositories: lint scripts, git hooks, and development automation. Changes here propagate to consuming repositories via `sync-tooling.sh`.
+
+**Project name**: standard-tooling
+
+**Status**: Stable (v1.x)
+
+**Canonical Standards**: This repository follows standards at <https://github.com/wphillipmoore/standards-and-conventions> (local path: `../standards-and-conventions` if available)
+
+## Development Commands
+
+### Environment Setup
+
+- **Git hooks**: `git config core.hooksPath scripts/git-hooks` (required before committing)
+- **markdownlint**: `npm install --global markdownlint-cli`
+- **shellcheck**: `brew install shellcheck`
+
+### Validation
+
+```bash
+scripts/lint/markdown-standards.sh   # Canonical validation (markdownlint + structural checks)
+shellcheck scripts/lint/*.sh scripts/dev/*.sh scripts/git-hooks/*  # Shell script lint
+```
+
+## Architecture
+
+### Script Categories
+
+- **`scripts/git-hooks/`** — Pre-commit (branch naming) and commit-msg (conventional commits, co-author validation) hooks
+- **`scripts/lint/`** — Validation scripts for markdown, commit messages, co-author trailers, PR issue linkage, and repository profiles
+- **`scripts/dev/`** — Development automation: `sync-tooling.sh` (sync mechanism), `prepare_release.py` (release prep), `finalize_repo.sh` (post-merge cleanup)
+
+### Sync Mechanism
+
+`sync-tooling.sh` keeps consuming repositories synchronized with this canonical source:
+
+- **`--check`** (default): Reports whether local copies are stale
+- **`--fix`**: Updates local copies from this repository
+- **`--ref TAG`**: Pin to a specific standard-tooling version
+- **`--actions-compat`**: Also sync lint scripts to `actions/standards-compliance/scripts/` (for standard-actions)
+
+### Managed Files
+
+All git hooks, all lint scripts, `prepare_release.py`, `finalize_repo.sh`, and `sync-tooling.sh` itself are managed. Consuming repos must not modify these files directly.
+
+### Key Constraints
+
+- **Portability**: Scripts must work on both macOS and Linux
+- **shellcheck clean**: All scripts must pass shellcheck
+- **No repo-specific logic**: Scripts must work in any consuming repository
+- **`skip-sync-check`**: This repo uses `skip-sync-check: "true"` in CI because it IS the canonical tooling source — staleness detection would be circular
+
+## Branching and PR Workflow
+
+- **Protected branches**: `main`, `develop` — no direct commits (enforced by pre-commit hook)
+- **Branch naming**: `feature/*`, `bugfix/*`, or `hotfix/*` only
+- **Feature/bugfix PRs** target `develop` with squash merge: `gh pr merge --auto --squash --delete-branch`
+- **Release PRs** target `main` with regular merge: `gh pr merge --auto --merge --delete-branch`
+- **Pre-flight**: Always check branch with `git status -sb` before modifying files. If on `develop`, create a `feature/*` branch first.
+
+## Key References
+
+**Canonical Standards**: <https://github.com/wphillipmoore/standards-and-conventions>
+
+- Local path (preferred): `../standards-and-conventions`
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+
+**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -36,7 +36,7 @@
 
 Hard gates (required status checks on `develop`):
 
-- Standards compliance (`.github/workflows/standards-gates.yml`):
+- Standards compliance (`.github/workflows/ci.yml`):
   - Repository profile validation (`scripts/lint/repo-profile.sh`)
   - Markdownlint (`scripts/lint/markdown-standards.sh`)
   - Commit message lint (`scripts/lint/commit-messages.sh`)


### PR DESCRIPTION
## Summary

- Add CI workflow with docs-only, standards-compliance (skip-sync-check: true), and shellcheck jobs
- Create CLAUDE.md with project overview, development commands, architecture, and workflow documentation
- Create PR template with validation commands
- Create .gitignore for OS/editor noise
- Fix workflow filename reference in docs/repository-standards.md (standards-gates.yml -> ci.yml)

## Issue Linkage

- Fixes #5

## Testing

- markdownlint
- shellcheck

## Notes

- Uses `skip-sync-check: "true"` in CI because this repo IS the canonical tooling source
- shellcheck finds both `.sh` files and extensionless git hooks via `find scripts -type f \( -name '*.sh' -o -path '*/git-hooks/*' \)`
