### PR TITLE
feat: add ci and build to allowed conventional commit types

### DIFF
--- a/scripts/lint/commit-message.sh
+++ b/scripts/lint/commit-message.sh
@@ -10,12 +10,12 @@ fi
 
 subject_line="$(head -n 1 "$commit_message_file")"
 
-conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore|ci|build)(\([^\)]+\))?: .+'
 
 if [[ ! "$subject_line" =~ $conventional_regex ]]; then
   echo "ERROR: commit message does not follow Conventional Commits." >&2
   echo "Expected: <type>(optional-scope): <description>" >&2
-  echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+  echo "Allowed types: feat, fix, docs, style, refactor, test, chore, ci, build" >&2
   echo "Got: $subject_line" >&2
   exit 1
 fi

--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -17,7 +17,7 @@ if ! git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
   fi
 fi
 
-conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore|ci|build)(\([^\)]+\))?: .+'
 
 # Commits at or before the cutoff SHA predate the conventional commits
 # convention and are excluded from validation.  Consuming repos pass their
@@ -35,7 +35,7 @@ while IFS= read -r commit_sha; do
   if [[ ! "$subject_line" =~ $conventional_regex ]]; then
     echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2
     echo "Expected: <type>(optional-scope): <description>" >&2
-    echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+    echo "Allowed types: feat, fix, docs, style, refactor, test, chore, ci, build" >&2
     echo "Got: $subject_line" >&2
     failed=1
   fi


### PR DESCRIPTION
# Pull Request

## Summary

- Add `ci` and `build` to the allowed conventional commit type regex in both `commit-message.sh` (local git hook) and `commit-messages.sh` (CI range check)
- Update error messages to list the new types
- Aligns with the broader Conventional Commits specification

## Issue Linkage

- Ref wphillipmoore/standard-actions#31

## Testing

- `shellcheck` passes on both files

## Notes

- This is the canonical source of truth. After merging, sync outward:
  1. `standard-actions`: run `sync-tooling.sh --fix --actions-compat`
  2. Consumer repos (mq-rest-admin-go, -python, -java): run `sync-tooling.sh --fix`