### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Thumbs.db
 .env
 .env.*
 *.log
+
+# Python
+__pycache__/


### PR DESCRIPTION
# Pull Request

## Summary

- Add __pycache__ to .gitignore for shared Python dev tooling

## Issue Linkage

- Fixes #29

## Testing

- markdownlint
- shellcheck

## Notes

- -
