### PR TITLE
feat(ci): add category prefixes to CI job names

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 ## Testing
 
 - markdownlint
-- shellcheck
+- ci: shellcheck
 
 ## Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   docs-only:
-    name: docs-only
+    name: "ci: docs-only"
     runs-on: ubuntu-latest
     outputs:
       docs-only: ${{ steps.detect.outputs.docs-only }}
@@ -28,7 +28,7 @@ jobs:
         uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
 
   standards-compliance:
-    name: standards-compliance
+    name: "ci: standards-compliance"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
           skip-sync-check: "true"
 
   shellcheck:
-    name: shellcheck
+    name: "ci: shellcheck"
     runs-on: ubuntu-latest
     needs: docs-only
     steps:


### PR DESCRIPTION
# Pull Request

## Summary

- Add ci: category prefix to CI job display names

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#198

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -
