### PR TITLE
feat(validate): add validate_local.sh dispatch architecture

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -21,6 +21,7 @@
 - branching_model: library-release
 - release_model: tagged-release
 - supported_release_lines: 1
+- primary_language: shell
 
 ## Validation policy
 

--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -29,6 +29,11 @@ MANAGED_FILES=(
   scripts/dev/prepare_release.py
   scripts/dev/finalize_repo.sh
   scripts/dev/sync-tooling.sh
+  scripts/dev/validate_local.sh
+  scripts/dev/validate_local_common.sh
+  scripts/dev/validate_local_python.sh
+  scripts/dev/validate_local_go.sh
+  scripts/dev/validate_local_java.sh
 )
 
 # Lint scripts that also get copied to the actions path.

--- a/scripts/dev/validate_local.sh
+++ b/scripts/dev/validate_local.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Canonical source: standard-tooling
+# validate_local.sh — shared driver for pre-PR local validation.
+#
+# Reads primary_language from docs/repository-standards.md, then runs:
+#   1. validate_local_common.sh   (always)
+#   2. validate_local_<lang>.sh   (if primary_language is set and script exists)
+#   3. validate_local_custom.sh   (if exists — repo-specific escape hatch)
+set -euo pipefail
+
+scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$scripts_dir/../.." && pwd)"
+profile_file="$repo_root/docs/repository-standards.md"
+
+# -- helpers -----------------------------------------------------------------
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- read primary_language from repo profile ---------------------------------
+
+primary_language=""
+if [[ -f "$profile_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]-]*primary_language:[[:space:]]*(.+)$ ]]; then
+      primary_language="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < "$profile_file"
+fi
+
+echo "========================================"
+echo "validate_local.sh"
+echo "primary_language: ${primary_language:-<not set>}"
+echo "========================================"
+echo ""
+
+# -- common checks (always) -------------------------------------------------
+
+common_script="$scripts_dir/validate_local_common.sh"
+if [[ -f "$common_script" ]]; then
+  run "$common_script"
+else
+  echo "WARNING: $common_script not found; skipping common checks" >&2
+fi
+
+# -- language-specific checks ------------------------------------------------
+
+if [[ -n "$primary_language" && "$primary_language" != "none" ]]; then
+  lang_script="$scripts_dir/validate_local_${primary_language}.sh"
+  if [[ -f "$lang_script" ]]; then
+    echo ""
+    run "$lang_script"
+  fi
+fi
+
+# -- repo-specific custom checks --------------------------------------------
+
+custom_script="$scripts_dir/validate_local_custom.sh"
+if [[ -f "$custom_script" ]]; then
+  echo ""
+  run "$custom_script"
+fi
+
+echo ""
+echo "========================================"
+echo "validate_local.sh: all checks passed"
+echo "========================================"

--- a/scripts/dev/validate_local_common.sh
+++ b/scripts/dev/validate_local_common.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Canonical source: standard-tooling
+# validate_local_common.sh — shared checks run for ALL repos.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- required tools ----------------------------------------------------------
+
+missing=()
+command -v shellcheck >/dev/null 2>&1 || missing+=("shellcheck")
+command -v markdownlint >/dev/null 2>&1 || missing+=("markdownlint")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: required tools not found: ${missing[*]}" >&2
+  exit 1
+fi
+
+# -- repo profile validation -------------------------------------------------
+
+if [[ -f "$repo_root/scripts/lint/repo-profile.sh" ]]; then
+  run "$repo_root/scripts/lint/repo-profile.sh"
+fi
+
+# -- markdown lint -----------------------------------------------------------
+
+if [[ -f "$repo_root/scripts/lint/markdown-standards.sh" ]]; then
+  run "$repo_root/scripts/lint/markdown-standards.sh"
+fi
+
+# -- shellcheck on all shell scripts -----------------------------------------
+
+shell_files=()
+while IFS= read -r f; do
+  shell_files+=("$f")
+done < <(
+  find "$repo_root/scripts" -type f -name '*.sh' 2>/dev/null
+  find "$repo_root/scripts/git-hooks" -type f 2>/dev/null
+)
+
+if [[ ${#shell_files[@]} -gt 0 ]]; then
+  run shellcheck "${shell_files[@]}"
+fi

--- a/scripts/dev/validate_local_go.sh
+++ b/scripts/dev/validate_local_go.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Canonical source: standard-tooling
+# validate_local_go.sh — Go-specific local validation checks.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- required tools ----------------------------------------------------------
+
+missing=()
+command -v go >/dev/null 2>&1 || missing+=("go")
+command -v golangci-lint >/dev/null 2>&1 || missing+=("golangci-lint")
+command -v gocyclo >/dev/null 2>&1 || missing+=("gocyclo")
+command -v govulncheck >/dev/null 2>&1 || missing+=("govulncheck")
+command -v go-licenses >/dev/null 2>&1 || missing+=("go-licenses")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: required tools not found: ${missing[*]}" >&2
+  exit 1
+fi
+
+# -- auto-discover module directory from go.mod ------------------------------
+
+module_dir=""
+if [[ -f "$repo_root/go.mod" ]]; then
+  module_dir="$repo_root"
+else
+  # Search one level down for go.mod.
+  while IFS= read -r f; do
+    module_dir="$(dirname "$f")"
+    break
+  done < <(find "$repo_root" -maxdepth 2 -name go.mod -not -path '*/vendor/*' 2>/dev/null)
+fi
+
+if [[ -z "$module_dir" ]]; then
+  echo "ERROR: could not find go.mod" >&2
+  exit 1
+fi
+
+echo "Go module directory: $module_dir"
+cd "$module_dir"
+
+# -- vet ---------------------------------------------------------------------
+
+run go vet ./...
+
+# -- lint --------------------------------------------------------------------
+
+run golangci-lint run ./...
+
+# -- cyclomatic complexity ---------------------------------------------------
+
+run gocyclo -over 15 .
+
+# -- unit tests --------------------------------------------------------------
+
+run go test -race -count=1 ./...
+
+# -- coverage ----------------------------------------------------------------
+
+if [[ -f "$module_dir/.testcoverage.yml" ]]; then
+  if command -v go-test-coverage >/dev/null 2>&1; then
+    run go-test-coverage --config .testcoverage.yml
+  fi
+fi
+
+# -- vulnerability scan ------------------------------------------------------
+
+run govulncheck ./...
+
+# -- license compliance ------------------------------------------------------
+
+allowlist_file="$module_dir/.go-licenses-allowlist"
+if [[ -f "$allowlist_file" ]]; then
+  allow_list=""
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+    if [[ -n "$allow_list" ]]; then
+      allow_list="$allow_list,$line"
+    else
+      allow_list="$line"
+    fi
+  done < "$allowlist_file"
+
+  if [[ -n "$allow_list" ]]; then
+    run go-licenses check ./... --allowed_licenses="$allow_list"
+  fi
+fi

--- a/scripts/dev/validate_local_java.sh
+++ b/scripts/dev/validate_local_java.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Canonical source: standard-tooling
+# validate_local_java.sh — Java-specific local validation checks.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- required tools ----------------------------------------------------------
+
+if ! command -v java >/dev/null 2>&1; then
+  echo "ERROR: required tool not found: java" >&2
+  exit 1
+fi
+
+if [[ ! -x "$repo_root/mvnw" ]]; then
+  echo "ERROR: Maven wrapper (mvnw) not found or not executable at $repo_root/mvnw" >&2
+  exit 1
+fi
+
+# -- build + test ------------------------------------------------------------
+
+run "$repo_root/mvnw" verify -B
+
+# -- license compliance ------------------------------------------------------
+
+allowlist_file="$repo_root/.mvn-licenses-allowlist"
+if [[ -f "$allowlist_file" ]]; then
+  allow_list=""
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+    if [[ -n "$allow_list" ]]; then
+      allow_list="$allow_list,$line"
+    else
+      allow_list="$line"
+    fi
+  done < "$allowlist_file"
+
+  if [[ -n "$allow_list" ]]; then
+    run "$repo_root/mvnw" license:add-third-party \
+      -Dlicense.excludedScopes=test \
+      -Dlicense.failIfWarning=true \
+      "-Dlicense.includedLicenses=$allow_list" \
+      -B
+  fi
+fi

--- a/scripts/dev/validate_local_python.sh
+++ b/scripts/dev/validate_local_python.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Canonical source: standard-tooling
+# validate_local_python.sh — Python-specific local validation checks.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- required tools ----------------------------------------------------------
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: required tool not found: uv" >&2
+  exit 1
+fi
+
+# -- auto-discover package name from pyproject.toml --------------------------
+
+pkg_name=""
+if [[ -f "$repo_root/pyproject.toml" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+      pkg_name="${BASH_REMATCH[1]}"
+      # Convert hyphens to underscores for Python import name.
+      pkg_name="${pkg_name//-/_}"
+      break
+    fi
+  done < "$repo_root/pyproject.toml"
+fi
+
+if [[ -z "$pkg_name" ]]; then
+  echo "ERROR: could not discover package name from pyproject.toml" >&2
+  exit 1
+fi
+
+echo "Python package: $pkg_name"
+
+# -- lock integrity ----------------------------------------------------------
+
+run uv lock --check
+
+# -- sync check --------------------------------------------------------------
+
+run uv sync --check --frozen --group dev
+
+# -- vulnerability scan ------------------------------------------------------
+
+req_files=()
+for f in requirements.txt requirements-dev.txt; do
+  if [[ -f "$repo_root/$f" ]]; then
+    req_files+=(-r "$f")
+  fi
+done
+
+if [[ ${#req_files[@]} -gt 0 ]]; then
+  run uv run pip-audit "${req_files[@]}"
+fi
+
+# -- license compliance ------------------------------------------------------
+
+allowlist_file="$repo_root/.pip-licenses-allowlist"
+if [[ -f "$allowlist_file" ]]; then
+  allow_list=""
+  while IFS= read -r line; do
+    # Skip blank lines and comments.
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+    if [[ -n "$allow_list" ]]; then
+      allow_list="$allow_list;$line"
+    else
+      allow_list="$line"
+    fi
+  done < "$allowlist_file"
+
+  if [[ -n "$allow_list" ]]; then
+    run uv run pip-licenses --allow-only="$allow_list"
+  fi
+fi
+
+# -- linting -----------------------------------------------------------------
+
+run uv run ruff check
+
+# -- formatting --------------------------------------------------------------
+
+run uv run ruff format --check .
+
+# -- type checking (mypy) ----------------------------------------------------
+
+if [[ -d "$repo_root/src" ]]; then
+  run uv run mypy src/
+fi
+
+# -- type checking (ty) ------------------------------------------------------
+
+if uv run ty --version >/dev/null 2>&1; then
+  if [[ -d "$repo_root/src" ]]; then
+    run uv run ty check src
+  fi
+fi
+
+# -- unit tests + coverage ---------------------------------------------------
+
+run uv run pytest --cov="$pkg_name" --cov-branch --cov-fail-under=100

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -16,6 +16,7 @@ versioning_scheme=""
 branching_model=""
 release_model=""
 supported_release_lines=""
+primary_language=""
 
 while IFS= read -r line; do
   if [[ "$line" =~ ^[[:space:]-]*repository_type:[[:space:]]*(.+)$ ]]; then
@@ -28,12 +29,14 @@ while IFS= read -r line; do
     release_model="${BASH_REMATCH[1]}"
   elif [[ "$line" =~ ^[[:space:]-]*supported_release_lines:[[:space:]]*(.+)$ ]]; then
     supported_release_lines="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*primary_language:[[:space:]]*(.+)$ ]]; then
+    primary_language="${BASH_REMATCH[1]}"
   fi
 done < "$profile_file"
 
 failed=0
 
-for key in repository_type versioning_scheme branching_model release_model supported_release_lines; do
+for key in repository_type versioning_scheme branching_model release_model supported_release_lines primary_language; do
   value="${!key}"
   if [[ -z "$value" ]]; then
     echo "ERROR: repository profile missing required attribute '$key' in $profile_file" >&2


### PR DESCRIPTION
# Pull Request

## Summary

- Add validate_local.sh dispatch architecture with language-specific scripts

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#280

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Phase 1 of validate_local standardization. Creates shared driver that reads primary_language from repo profile and dispatches to common + language-specific + custom validation scripts.
