### PR TITLE
fix(lint): accept cross-repo issue references in PR linkage check

### DIFF
--- a/scripts/lint/pr-issue-linkage.sh
+++ b/scripts/lint/pr-issue-linkage.sh
@@ -18,7 +18,7 @@ if [[ -z "$pr_body" ]]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+#[0-9]+'; then
-  echo "ERROR: pull request body must include primary issue linkage (Fixes #123, Closes #123, Resolves #123, or Ref #123)." >&2
+if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+'; then
+  echo "ERROR: pull request body must include primary issue linkage (Fixes #123, Closes #123, Resolves #123, or Ref #123). Cross-repo references (owner/repo#123) are also accepted." >&2
   exit 1
 fi


### PR DESCRIPTION
# Pull Request

## Summary

- Accept cross-repo issue references in PR linkage check

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#280

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -
