### PR TITLE
chore(ci): remove push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI - Test and Validate
 
 on:
   pull_request:
-  push:
-    branches:
-      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
# Pull Request

## Summary

- Remove push trigger from CI workflow

## Issue Linkage

- Fixes #40

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -
