### PR TITLE
fix: strip ^{} suffix from dereferenced tags in sync-tooling.sh

### DIFF
--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -110,7 +110,7 @@ if [[ -n "$ref" ]]; then
 else
   # Discover the latest tag without a full clone.
   clone_ref="$(git ls-remote --tags --sort=-v:refname "$TOOLING_REPO" 'v*' \
-    | head -n 1 | sed 's|.*refs/tags/||')"
+    | head -n 1 | sed 's|.*refs/tags/||; s|\^{}$||')"
   if [[ -z "$clone_ref" ]]; then
     echo "ERROR: no tags found in $TOOLING_REPO" >&2
     exit 1


### PR DESCRIPTION
# Pull Request

## Summary

- Strip ^{} suffix from dereferenced tags in sync-tooling.sh

## Issue Linkage

- Fixes #50

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -
