### PR TITLE
fix: allow merge commits through commit-msg hook

### DIFF
--- a/scripts/lint/commit-message.sh
+++ b/scripts/lint/commit-message.sh
@@ -10,6 +10,12 @@ fi
 
 subject_line="$(head -n 1 "$commit_message_file")"
 
+# Allow merge commits through without conventional commit validation.
+merge_regex='^Merge '
+if [[ "$subject_line" =~ $merge_regex ]]; then
+  exit 0
+fi
+
 conventional_regex='^(feat|fix|docs|style|refactor|test|chore|ci|build)(\([^\)]+\))?: .+'
 
 if [[ ! "$subject_line" =~ $conventional_regex ]]; then


### PR DESCRIPTION
# Pull Request

## Summary

- Allow merge commits through commit-msg hook

## Issue Linkage

- Fixes #56

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -
