### PR TITLE
docs: add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Documentation
+
+on:
+  push:
+    branches: [develop, main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: "deploy: docs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Deploy docs
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        with:
+          version-command: cat VERSION | cut -d. -f1,2

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -1,0 +1,77 @@
+# Getting Started
+
+This guide covers setting up a consuming repository to use standard-tooling
+scripts.
+
+## Prerequisites
+
+- Git
+- Bash (macOS or Linux)
+- [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):
+  `npm install --global markdownlint-cli`
+- [shellcheck](https://www.shellcheck.net/): `brew install shellcheck`
+
+## Initial Setup
+
+### 1. Clone standard-tooling
+
+```bash
+git clone https://github.com/wphillipmoore/standard-tooling.git
+```
+
+### 2. Sync scripts into your repository
+
+From your consuming repository root:
+
+```bash
+path/to/standard-tooling/scripts/dev/sync-tooling.sh --fix --ref v1.1.5
+```
+
+This copies all managed files into your repository at the expected paths.
+
+### 3. Configure git hooks
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+This tells git to use the standard-tooling hooks for branch naming and commit
+message validation.
+
+### 4. Create a repository profile
+
+Create `docs/repository-standards.md` with the required attributes:
+
+```markdown
+# Repository Standards
+
+## Table of Contents
+
+- [Repository profile](#repository-profile)
+
+## Repository profile
+
+- repository_type: <application|library|tooling|documentation>
+- versioning_scheme: <semver|calver|none>
+- branching_model: <library-release|application-promotion|docs-single-branch>
+- release_model: <tagged-release|continuous-deploy|none>
+- supported_release_lines: <number>
+- primary_language: <python|go|java|shell|none>
+```
+
+### 5. Verify
+
+Run the markdown linter to confirm everything is wired up:
+
+```bash
+scripts/lint/markdown-standards.sh
+```
+
+## Next Steps
+
+- Read the [Consuming Repo Setup](guides/consuming-repo-setup.md) guide for
+  detailed onboarding instructions
+- See the [Script Reference](reference/index.md) for documentation on each
+  managed script
+- Review the [Validation Matrix](guides/validation-matrix.md) to understand
+  which checks run where

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -1,0 +1,139 @@
+# Consuming Repo Setup
+
+This guide walks through end-to-end onboarding of a new repository to
+use standard-tooling managed scripts.
+
+## Prerequisites
+
+Install the required tools:
+
+**macOS:**
+
+```bash
+brew install shellcheck
+npm install --global markdownlint-cli
+```
+
+**Linux:**
+
+```bash
+sudo apt-get install shellcheck
+npm install --global markdownlint-cli
+```
+
+## Step 1: Clone Standard-Tooling
+
+Clone the canonical source alongside your repository:
+
+```bash
+git clone \
+  https://github.com/wphillipmoore/standard-tooling.git
+```
+
+## Step 2: Create the Repository Profile
+
+Create `docs/repository-standards.md` in your repository. This file
+is read by multiple scripts for configuration.
+
+Required sections:
+
+```markdown
+# Repository Standards
+
+## Table of Contents
+
+- [AI co-authors](#ai-co-authors)
+- [Repository profile](#repository-profile)
+
+## AI co-authors
+
+- Co-Authored-By: your-codex <email>
+- Co-Authored-By: your-claude <email>
+
+## Repository profile
+
+- repository_type: library
+- versioning_scheme: semver
+- branching_model: library-release
+- release_model: tagged-release
+- supported_release_lines: 1
+- primary_language: python
+```
+
+## Step 3: Sync Managed Files
+
+Run the sync script to copy all managed files:
+
+```bash
+path/to/standard-tooling/scripts/dev/sync-tooling.sh \
+  --fix --ref v1.1.5
+```
+
+This creates:
+
+- `scripts/git-hooks/pre-commit` and `commit-msg`
+- `scripts/lint/*.sh` (6 lint scripts)
+- `scripts/dev/*.sh` and `*.py` (10 dev scripts)
+
+## Step 4: Configure Git Hooks
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+!!! tip
+    Add this to your project's setup documentation so all
+    contributors configure hooks.
+
+## Step 5: Add CI Workflow
+
+Create `.github/workflows/ci.yml` with the standard checks:
+
+- `scripts/lint/repo-profile.sh`
+- `scripts/lint/markdown-standards.sh`
+- `scripts/lint/commit-messages.sh` with base and head refs
+- `scripts/lint/pr-issue-linkage.sh`
+- `sync-tooling.sh --check`
+
+See `standard-actions` for reusable workflow actions.
+
+## Step 6: Create Markdownlint Config
+
+Create `.markdownlint.yaml` at the repository root:
+
+```yaml
+default: true
+no-duplicate-heading:
+  siblings_only: true
+```
+
+## Step 7: Verify
+
+```bash
+# Verify repo profile
+scripts/lint/repo-profile.sh
+
+# Verify markdown
+scripts/lint/markdown-standards.sh
+
+# Verify hooks work
+git checkout -b feature/1-test-setup
+echo "test" >> test.txt
+git add test.txt
+scripts/dev/commit.sh \
+  --type chore --message "test setup" --agent claude
+```
+
+## Keeping Up to Date
+
+When standard-tooling releases a new version:
+
+```bash
+# See what changed
+scripts/dev/sync-tooling.sh --check
+
+# Update to new version
+scripts/dev/sync-tooling.sh --fix --ref v1.2.0
+```
+
+See the [Releasing](releasing.md) guide for the full workflow.

--- a/docs/site/docs/guides/releasing.md
+++ b/docs/site/docs/guides/releasing.md
@@ -1,0 +1,104 @@
+# Releasing
+
+This guide covers the release workflow for standard-tooling and the
+required ordering for syncing consuming repositories.
+
+## Release Workflow
+
+### 1. Develop Changes
+
+All changes start as feature PRs targeting `develop`:
+
+```bash
+git checkout -b feature/42-add-new-check
+# ... make changes ...
+scripts/dev/commit.sh \
+  --type feat --message "add new check" --agent claude
+scripts/dev/submit-pr.sh \
+  --issue 42 --summary "Add new check"
+```
+
+### 2. Prepare the Release
+
+Once `develop` has all changes for the release, run:
+
+```bash
+scripts/dev/prepare_release.py --issue 50
+```
+
+This script:
+
+- Creates a `release/{version}` branch from develop
+- Merges main to incorporate prior release history
+- Generates the changelog via git-cliff
+- Creates a PR to main with auto-merge enabled
+
+### 3. Tag the Release
+
+After the release PR merges to main, create and push the tag:
+
+```bash
+git checkout main
+git pull
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+### 4. Finalize
+
+Clean up local state:
+
+```bash
+scripts/dev/finalize_repo.sh
+```
+
+## Sync Ordering
+
+!!! warning "Critical: tag before syncing"
+    Consuming repos' CI runs `sync-tooling.sh --check` against the
+    **latest tagged release**. If you sync consuming repos before
+    tagging, their CI will fail because the tag still points to the
+    old managed-files list.
+
+**Required ordering:**
+
+1. Merge changes to `develop` (feature PR)
+2. Create a release PR to `main`, merge it, and **tag the new
+   version**
+3. **Only then** sync consuming repos
+
+### Syncing Consuming Repos
+
+After tagging:
+
+```bash
+cd path/to/consuming-repo
+scripts/dev/sync-tooling.sh --fix
+```
+
+For repos that use `standard-actions`:
+
+```bash
+scripts/dev/sync-tooling.sh --fix --actions-compat
+```
+
+## Version Detection
+
+`prepare_release.py` auto-detects the version from the project
+ecosystem:
+
+| Ecosystem | Source |
+| --------- | ------ |
+| Python | `pyproject.toml` |
+| Maven | `pom.xml` |
+| Go | `**/version.go` |
+| Fallback | `VERSION` file |
+
+Standard-tooling uses the `VERSION` file at the repository root.
+
+## Documentation Deployment
+
+The documentation site deploys automatically on pushes to `develop`
+and `main` via `.github/workflows/docs.yml`. The version displayed
+in the site is derived from `VERSION` using `cut -d. -f1,2`
+(major.minor).

--- a/docs/site/docs/guides/validation-matrix.md
+++ b/docs/site/docs/guides/validation-matrix.md
@@ -1,0 +1,90 @@
+# Validation Matrix
+
+This page maps every validation check to where it runs, its trigger,
+and its exit codes.
+
+## Check Summary
+
+| Check | Hook | CI | Script |
+| ----- | ---- | -- | ------ |
+| Branch naming | Yes | -- | `pre-commit` |
+| Conventional Commits (single) | Yes | -- | `commit-message.sh` |
+| Co-author trailers | Yes | -- | `co-author.sh` |
+| Conventional Commits (range) | -- | Yes | `commit-messages.sh` |
+| Repository profile | -- | Yes | `repo-profile.sh` |
+| Markdown standards | -- | Yes | `markdown-standards.sh` |
+| PR issue linkage | -- | Yes | `pr-issue-linkage.sh` |
+| Shellcheck | -- | Yes | CI workflow step |
+| Sync-tooling staleness | -- | Yes | `sync-tooling.sh --check` |
+
+## Local Hooks
+
+### pre-commit
+
+**Trigger:** Every `git commit`
+
+| Check | Error Message | Fix |
+| ----- | ------------- | --- |
+| Detached HEAD | `detached HEAD is not allowed` | Create a branch |
+| Protected branch | `direct commits...forbidden` | Create a feature branch |
+| Bad prefix | `branch name must use...` | Rename branch |
+| Missing issue | `must include a repo issue` | Rename to `type/123-desc` |
+
+### commit-msg
+
+**Trigger:** Every `git commit` (after pre-commit)
+
+| Check | Error Message | Fix |
+| ----- | ------------- | --- |
+| Bad format | `does not follow Conventional Commits` | Use `commit.sh` |
+| Bad co-author | `unapproved co-author trailer` | Add to repo profile |
+
+## CI Checks
+
+### commit-messages.sh
+
+**Trigger:** PR opened or updated
+
+Validates all non-merge commits in the PR range. Supports
+`COMMIT_CUTOFF_SHA` for legacy repositories.
+
+### repo-profile.sh
+
+**Trigger:** PR opened or updated
+
+Validates `docs/repository-standards.md` has all six required
+attributes.
+
+### markdown-standards.sh
+
+**Trigger:** PR opened or updated
+
+Runs markdownlint on all markdown files. Structural checks (single
+H1, TOC, heading hierarchy) apply to standard docs only -- not
+doc-site pages or CHANGELOG.md.
+
+### pr-issue-linkage.sh
+
+**Trigger:** PR opened or updated
+
+Validates the PR body contains `Fixes #N`, `Closes #N`,
+`Resolves #N`, or `Ref #N`.
+
+### sync-tooling.sh --check
+
+**Trigger:** PR opened or updated
+
+Compares all 18 managed files against the latest tagged release.
+Fails if any file is stale or missing.
+
+!!! note
+    Standard-tooling itself uses `skip-sync-check: "true"` because
+    it is the canonical source.
+
+## Exit Code Reference
+
+| Code | Meaning | Scripts |
+| ---- | ------- | ------- |
+| 0 | Success | All scripts |
+| 1 | Validation failure | All scripts |
+| 2 | Usage error | Most lint scripts (missing args or file) |

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,0 +1,42 @@
+# Standard Tooling
+
+Standard-tooling is the canonical source for shared scripts used across all
+managed repositories. It provides git hooks, lint scripts, and development
+automation that enforce consistent standards.
+
+## Script Categories
+
+| Category | Path | Purpose |
+| -------- | ---- | ------- |
+| **Git Hooks** | `scripts/git-hooks/` | Branch naming, commit-msg checks |
+| **Lint Scripts** | `scripts/lint/` | Markdown, commit, co-author, PR |
+| **Dev Scripts** | `scripts/dev/` | Commit, PR, sync, release, finalization |
+
+## Design Principles
+
+- **Portability** -- scripts run on both macOS and Linux
+- **shellcheck clean** -- all shell scripts pass shellcheck
+- **No repo-specific logic** -- every script works in any consuming
+  repository
+- **Single source of truth** -- consuming repos sync from this
+  repository via `sync-tooling.sh` and must not modify managed files
+  directly
+
+## How It Works
+
+1. This repository defines the canonical version of each managed
+   script.
+2. Consuming repos run `sync-tooling.sh --check` in CI to detect
+   drift.
+3. When scripts change, a new version is tagged and consumers run
+   `sync-tooling.sh --fix` to update.
+
+## Managed Files
+
+Standard-tooling currently manages 18 files:
+
+- 2 git hooks (`pre-commit`, `commit-msg`)
+- 6 lint scripts
+- 10 dev scripts (including language-specific validation variants)
+
+See the [Script Reference](reference/index.md) for the full list.

--- a/docs/site/docs/reference/dev/commit.md
+++ b/docs/site/docs/reference/dev/commit.md
@@ -1,0 +1,68 @@
+# commit.sh
+
+**Path:** `scripts/dev/commit.sh`
+
+Wrapper script that constructs standards-compliant commit messages
+with correct Conventional Commits format and Co-Authored-By trailers.
+
+!!! warning "Required for AI agents"
+    AI agents **must** use this script instead of raw `git commit`.
+    The script resolves the correct co-author identity automatically.
+
+## Usage
+
+```bash
+scripts/dev/commit.sh \
+  --type TYPE --message MESSAGE --agent AGENT [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+| `--type` | Yes | Conventional commit type |
+| `--message` | Yes | Commit description |
+| `--agent` | Yes | AI tool identity: `claude` or `codex` |
+| `--scope` | No | Conventional commit scope |
+| `--body` | No | Detailed commit body |
+
+### Allowed Types
+
+`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`,
+`build`
+
+## Examples
+
+```bash
+# Feature with scope
+scripts/dev/commit.sh \
+  --type feat --scope lint \
+  --message "add new check" --agent claude
+
+# Bug fix
+scripts/dev/commit.sh \
+  --type fix \
+  --message "correct regex pattern" --agent claude
+
+# Documentation with body
+scripts/dev/commit.sh \
+  --type docs --message "update README" \
+  --body "Expanded usage section" --agent claude
+```
+
+## Behavior
+
+1. Validates all required arguments.
+2. Reads `docs/repository-standards.md` to find the approved
+   co-author identity matching the `--agent` value.
+3. Verifies staged changes exist.
+4. Constructs the commit message in a temporary file.
+5. Runs `git commit --file` (which triggers the `commit-msg` hook
+   for validation).
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Commit created successfully |
+| 1 | Validation failure or missing identity |

--- a/docs/site/docs/reference/dev/finalize-repo.md
+++ b/docs/site/docs/reference/dev/finalize-repo.md
@@ -1,0 +1,54 @@
+# finalize_repo.sh
+
+**Path:** `scripts/dev/finalize_repo.sh`
+
+Cleans up a repository after a PR merge: switches to the target
+branch, fast-forward pulls, deletes merged local branches, and
+prunes remote tracking references.
+
+## Usage
+
+```bash
+scripts/dev/finalize_repo.sh [--target-branch BRANCH] [--dry-run]
+```
+
+## Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `--target-branch` | Branch to switch to (default: `develop`) |
+| `--dry-run` | Show what would be done without making changes |
+
+## Behavior
+
+### 1. Switch to Target Branch
+
+Checks out the target branch (default: `develop`).
+
+### 2. Fast-Forward Pull
+
+Fetches and fast-forward merges `origin/{target}`.
+
+### 3. Delete Merged Branches
+
+Deletes local branches that have been merged into the target branch.
+Eternal branches are protected from deletion based on the
+`branching_model`:
+
+| Branching Model | Protected Branches |
+| --------------- | ------------------ |
+| `docs-single-branch` | `develop`, `gh-pages` |
+| `library-release` | `develop`, `main`, `gh-pages` |
+| `application-promotion` | `develop`, `release`, `main`, `gh-pages` |
+
+### 4. Prune Remote References
+
+Runs `git remote prune origin` to clean up stale remote-tracking
+branches.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Finalization complete |
+| 1 | Unrecognized branching model |

--- a/docs/site/docs/reference/dev/prepare-release.md
+++ b/docs/site/docs/reference/dev/prepare-release.md
@@ -1,0 +1,60 @@
+# prepare_release.py
+
+**Path:** `scripts/dev/prepare_release.py`
+
+Automates release preparation for library repositories: creates a
+release branch, generates the changelog, creates a PR to main, and
+enables auto-merge.
+
+## Usage
+
+```bash
+scripts/dev/prepare_release.py --issue 42
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+| `--issue` | Yes | GitHub issue number for release tracking |
+
+## Prerequisites
+
+- Must be on the `develop` branch
+- Working tree must be clean
+- Local `develop` must match `origin/develop`
+- Required tools: `gh`, `git-cliff`, `markdownlint`
+
+## Ecosystem Detection
+
+The script auto-detects the project ecosystem to find the version:
+
+| Ecosystem | Version Source |
+| --------- | -------------- |
+| Python | `pyproject.toml` |
+| Maven | `pom.xml` |
+| Go | `**/version.go` |
+| VERSION file | `VERSION` (fallback) |
+
+## Release Steps
+
+1. **Precondition checks** -- verifies branch, clean tree, and
+   tool availability.
+2. **Create release branch** -- `release/{version}` from current
+   develop HEAD.
+3. **Merge main** -- incorporates prior release history to prevent
+   changelog conflicts. Uses `-X ours` for auto-resolution.
+4. **Generate changelog** -- runs `git-cliff` with a boundary tag,
+   validates with markdownlint.
+5. **Push branch** -- pushes `release/{version}` to origin.
+6. **Create PR** -- creates a PR targeting `main` with
+   `Ref #{issue}` linkage.
+7. **Enable auto-merge** -- configures merge (not squash) strategy.
+8. **Return to develop** -- checks out develop after completion.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Release preparation complete |
+| Non-zero | Precondition failure or tool error |

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -1,0 +1,73 @@
+# submit-pr.sh
+
+**Path:** `scripts/dev/submit-pr.sh`
+
+Wrapper script that creates standards-compliant pull requests with
+proper issue linkage, testing sections, and auto-merge configuration.
+
+!!! warning "Required for AI agents"
+    AI agents **must** use this script instead of raw
+    `gh pr create`. The script populates the PR template and
+    configures auto-merge automatically.
+
+## Usage
+
+```bash
+scripts/dev/submit-pr.sh \
+  --issue NUMBER --summary TEXT [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+| `--issue` | Yes | Issue number or cross-repo ref |
+| `--summary` | Yes | One-line PR summary |
+| `--linkage` | No | Linkage keyword (default: `Fixes`) |
+| `--title` | No | PR title (default: last commit subject) |
+| `--notes` | No | Additional notes for the PR |
+| `--docs-only` | No | Apply docs-only testing exception |
+| `--dry-run` | No | Print PR body without executing |
+
+### Linkage Keywords
+
+`Fixes`, `Closes`, `Resolves`, `Ref`
+
+## Examples
+
+```bash
+# Standard PR
+scripts/dev/submit-pr.sh \
+  --issue 42 --summary "Add new lint check for X"
+
+# Docs-only PR with Ref linkage
+scripts/dev/submit-pr.sh \
+  --issue 42 --linkage Ref \
+  --summary "Update docs" --docs-only
+
+# Dry run to preview
+scripts/dev/submit-pr.sh \
+  --issue 42 --summary "Fix regex bug" --dry-run
+```
+
+## Behavior
+
+1. Validates arguments and issue reference format.
+2. Detects target branch and merge strategy from the current
+   branch:
+    - `release/*` branches target `main` with merge strategy
+    - All other branches target `develop` with squash strategy
+3. Reads the testing section from
+   `.github/pull_request_template.md`.
+4. For `--docs-only`, replaces the testing section with changed
+   file list.
+5. Pushes the branch to origin.
+6. Creates the PR via `gh pr create`.
+7. Enables auto-merge with the detected strategy.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | PR created and auto-merge enabled |
+| 1 | Validation failure |

--- a/docs/site/docs/reference/dev/sync-tooling.md
+++ b/docs/site/docs/reference/dev/sync-tooling.md
@@ -1,0 +1,63 @@
+# sync-tooling.sh
+
+**Path:** `scripts/dev/sync-tooling.sh`
+
+Keeps consuming repositories synchronized with the canonical versions
+of all managed scripts in standard-tooling.
+
+## Usage
+
+```bash
+scripts/dev/sync-tooling.sh \
+  [--check | --fix] [--ref TAG] [--actions-compat]
+```
+
+## Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `--check` | Compare local copies (default) |
+| `--fix` | Overwrite local copies with canonical versions |
+| `--ref TAG` | Tag to sync against (default: latest tag) |
+| `--actions-compat` | Also sync lint scripts to actions path |
+
+## Behavior
+
+### Check Mode (default)
+
+1. Clones the canonical standard-tooling at the specified tag (or
+   latest).
+2. Compares each managed file against the canonical version.
+3. Reports `STALE` for modified files and `MISSING` for absent
+   files.
+4. Exits with code 1 if any files are out of sync.
+
+### Fix Mode
+
+1. Clones the canonical source (same as check mode).
+2. Overwrites local copies with canonical versions.
+3. Adds missing files and creates directories as needed.
+4. Preserves file permissions from the canonical source.
+
+### Self-Update
+
+If `sync-tooling.sh` itself is stale, fix mode updates the script
+and re-executes with the same arguments.
+
+### Actions Compatibility
+
+With `--actions-compat`, lint scripts are also synced to
+`actions/standards-compliance/scripts/` for use by
+`standard-actions`.
+
+## Managed Files
+
+See the [Script Reference overview](../index.md) for the complete
+list of 18 managed files.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All files up to date (check) or sync complete (fix) |
+| 1 | Stale files detected (check mode only) |

--- a/docs/site/docs/reference/dev/validate-local.md
+++ b/docs/site/docs/reference/dev/validate-local.md
@@ -1,0 +1,64 @@
+# validate_local.sh
+
+**Path:** `scripts/dev/validate_local.sh`
+
+Shared driver for pre-PR local validation. Orchestrates common checks
+and language-specific validation based on the repository profile.
+
+## Usage
+
+```bash
+scripts/dev/validate_local.sh
+```
+
+Run from the repository root. No arguments required.
+
+## Behavior
+
+The script reads `primary_language` from
+`docs/repository-standards.md` and runs up to three validation
+stages:
+
+### 1. Common Checks (always)
+
+Runs `scripts/dev/validate_local_common.sh` if present. This script
+contains checks shared across all repositories (markdown linting,
+shellcheck, etc.).
+
+### 2. Language-Specific Checks
+
+If `primary_language` is set and not `none`, runs the corresponding
+script:
+
+| Language | Script |
+| -------- | ------ |
+| `python` | `validate_local_python.sh` |
+| `go` | `validate_local_go.sh` |
+| `java` | `validate_local_java.sh` |
+
+### 3. Custom Checks
+
+Runs `scripts/dev/validate_local_custom.sh` if present. This is a
+repo-specific escape hatch for validation that does not fit the
+common or language-specific scripts.
+
+!!! note
+    `validate_local_custom.sh` is **not** a managed file. Consuming
+    repos can create and maintain it freely.
+
+## Language Validation Scripts
+
+The language-specific scripts are managed files synced by
+`sync-tooling.sh`:
+
+- `validate_local_common.sh`
+- `validate_local_python.sh`
+- `validate_local_go.sh`
+- `validate_local_java.sh`
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All validation stages passed |
+| Non-zero | One or more stages failed |

--- a/docs/site/docs/reference/hooks/commit-msg.md
+++ b/docs/site/docs/reference/hooks/commit-msg.md
@@ -1,0 +1,33 @@
+# commit-msg
+
+**Path:** `scripts/git-hooks/commit-msg`
+
+Dispatches commit message validation to the lint scripts. This hook
+runs automatically on every commit when git hooks are configured.
+
+## Behavior
+
+The hook calls two scripts in sequence, passing the commit message
+file path:
+
+1. **`scripts/lint/commit-message.sh`** -- validates Conventional
+   Commits format
+2. **`scripts/lint/co-author.sh`** -- validates Co-Authored-By
+   trailers
+
+If either script fails, the commit is rejected.
+
+## Setup
+
+Configure git to use the standard hooks directory:
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Commit message is valid |
+| 1 | Validation failure (from either lint script) |

--- a/docs/site/docs/reference/hooks/pre-commit.md
+++ b/docs/site/docs/reference/hooks/pre-commit.md
@@ -1,0 +1,60 @@
+# pre-commit
+
+**Path:** `scripts/git-hooks/pre-commit`
+
+Enforces branch naming conventions before allowing a commit. Reads the
+`branching_model` attribute from `docs/repository-standards.md` to
+determine allowed branch prefixes.
+
+## Checks
+
+The hook runs five checks in order:
+
+### 1. Detached HEAD
+
+Commits on a detached HEAD are blocked unconditionally.
+
+### 2. Protected Branch
+
+Direct commits to `develop`, `release`, and `main` are forbidden.
+
+### 3. Branching Model Detection
+
+Reads `branching_model` from `docs/repository-standards.md`. If not
+found, falls back to `feature/*` and `bugfix/*` with a warning.
+
+### 4. Branch Prefix Validation
+
+Allowed prefixes depend on the branching model:
+
+| Branching Model | Allowed Prefixes |
+| --------------- | ---------------- |
+| `docs-single-branch` | `feature/*`, `bugfix/*`, `chore/*` |
+| `application-promotion` | `feature`, `bugfix`, `hotfix`, `chore`, `promo` |
+| `library-release` | `feature`, `bugfix`, `hotfix`, `chore`, `release` |
+
+### 5. Issue Number Naming
+
+Work branches (`feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`) must
+include a repository issue number:
+
+```text
+{type}/{issue}-{description}
+```
+
+**Example:** `feature/42-add-caching`
+
+`release/*` and `promotion/*` branches are exempt from this check
+because they are created by automated workflows.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All checks passed |
+| 1 | Validation failure |
+
+## Configuration
+
+The hook reads `branching_model` from
+`docs/repository-standards.md`. No other configuration is required.

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -1,0 +1,59 @@
+# Script Reference
+
+Standard-tooling manages 18 files across three categories. All files
+carry the header
+`Managed by standard-tooling -- DO NOT EDIT in downstream repos`.
+
+## Git Hooks
+
+| Script | Purpose |
+| ------ | ------- |
+| [pre-commit](hooks/pre-commit.md) | Branch naming enforcement |
+| [commit-msg](hooks/commit-msg.md) | Commit message validation dispatcher |
+
+## Lint Scripts
+
+| Script | Purpose |
+| ------ | ------- |
+| [commit-message.sh](lint/commit-message.md) | Single commit Conventional Commits validation |
+| [co-author.sh](lint/co-author.md) | Co-author trailer validation |
+| [commit-messages.sh](lint/commit-messages.md) | CI range-based commit validation |
+| [repo-profile.sh](lint/repo-profile.md) | Repository profile attribute validation |
+| [markdown-standards.sh](lint/markdown-standards.md) | Markdown linting and structural checks |
+| [pr-issue-linkage.sh](lint/pr-issue-linkage.md) | PR body issue linkage validation |
+
+## Dev Scripts
+
+| Script | Purpose |
+| ------ | ------- |
+| [commit.sh](dev/commit.md) | Standards-compliant commit wrapper |
+| [submit-pr.sh](dev/submit-pr.md) | Standards-compliant PR submission wrapper |
+| [sync-tooling.sh](dev/sync-tooling.md) | Sync managed files from canonical source |
+| [prepare_release.py](dev/prepare-release.md) | Automated release preparation |
+| [finalize_repo.sh](dev/finalize-repo.md) | Post-merge repository cleanup |
+| [validate_local.sh](dev/validate-local.md) | Local validation driver |
+
+## Managed File List
+
+The complete list of files synced by `sync-tooling.sh`:
+
+```text
+scripts/git-hooks/commit-msg
+scripts/git-hooks/pre-commit
+scripts/lint/co-author.sh
+scripts/lint/commit-message.sh
+scripts/lint/commit-messages.sh
+scripts/lint/markdown-standards.sh
+scripts/lint/pr-issue-linkage.sh
+scripts/lint/repo-profile.sh
+scripts/dev/commit.sh
+scripts/dev/submit-pr.sh
+scripts/dev/prepare_release.py
+scripts/dev/finalize_repo.sh
+scripts/dev/sync-tooling.sh
+scripts/dev/validate_local.sh
+scripts/dev/validate_local_common.sh
+scripts/dev/validate_local_python.sh
+scripts/dev/validate_local_go.sh
+scripts/dev/validate_local_java.sh
+```

--- a/docs/site/docs/reference/lint/co-author.md
+++ b/docs/site/docs/reference/lint/co-author.md
@@ -1,0 +1,44 @@
+# co-author.sh
+
+**Path:** `scripts/lint/co-author.sh`
+
+Validates `Co-Authored-By` trailers in commit messages against the
+approved identities listed in `docs/repository-standards.md`.
+
+## Usage
+
+```bash
+scripts/lint/co-author.sh <commit-message-file>
+```
+
+This script is typically called by the `commit-msg` git hook, not
+invoked directly.
+
+## Validation Rules
+
+1. **No trailers** -- human-only commits (no `Co-Authored-By` lines)
+   are always valid.
+2. **Approved identities** -- each `Co-Authored-By` trailer must
+   match an entry in the `AI co-authors` section of
+   `docs/repository-standards.md`.
+3. **Whitespace normalization** -- comparison normalizes whitespace
+   so minor formatting differences do not cause false failures.
+
+## Repository Profile Format
+
+The approved identities are listed as bullet items:
+
+```markdown
+## AI co-authors
+
+- Co-Authored-By: name <email>
+- Co-Authored-By: name <email>
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All trailers approved (or no trailers present) |
+| 1 | One or more unapproved trailers found |
+| 2 | Missing or invalid commit message file path |

--- a/docs/site/docs/reference/lint/commit-message.md
+++ b/docs/site/docs/reference/lint/commit-message.md
@@ -1,0 +1,42 @@
+# commit-message.sh
+
+**Path:** `scripts/lint/commit-message.sh`
+
+Validates that a single commit message follows the
+[Conventional Commits](https://www.conventionalcommits.org/)
+specification.
+
+## Usage
+
+```bash
+scripts/lint/commit-message.sh <commit-message-file>
+```
+
+This script is typically called by the `commit-msg` git hook, not
+invoked directly.
+
+## Validation Rules
+
+The subject line must match:
+
+```text
+<type>(optional-scope): <description>
+```
+
+### Allowed Types
+
+`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`,
+`build`
+
+### Merge Commits
+
+Merge commits (subject starting with "Merge ") are allowed through
+without Conventional Commits validation.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Valid commit message |
+| 1 | Does not match Conventional Commits |
+| 2 | Missing or invalid commit message file path |

--- a/docs/site/docs/reference/lint/commit-messages.md
+++ b/docs/site/docs/reference/lint/commit-messages.md
@@ -1,0 +1,49 @@
+# commit-messages.sh
+
+**Path:** `scripts/lint/commit-messages.sh`
+
+Validates all commits in a range against the Conventional Commits
+specification. This is the CI variant of `commit-message.sh` -- it
+checks every commit between a base ref and head ref rather than a
+single commit message file.
+
+## Usage
+
+```bash
+scripts/lint/commit-messages.sh <base-ref> <head-ref>
+```
+
+**Example:**
+
+```bash
+scripts/lint/commit-messages.sh develop HEAD
+```
+
+## Behavior
+
+1. Resolves bare branch names to `origin/` when the local branch
+   does not exist.
+2. Iterates over non-merge commits in the range
+   `base-ref..head-ref`.
+3. Validates each commit subject against the Conventional Commits
+   pattern.
+4. Stops at the first failing commit and reports the error.
+
+## Cutoff SHA
+
+Repositories that adopted Conventional Commits after initial
+development can set the `COMMIT_CUTOFF_SHA` environment variable.
+Commits at or before the cutoff are excluded from validation.
+
+```bash
+COMMIT_CUTOFF_SHA=abc123 \
+  scripts/lint/commit-messages.sh main HEAD
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All commits in range are valid |
+| 1 | One or more commits failed validation |
+| 2 | Missing base or head ref arguments |

--- a/docs/site/docs/reference/lint/markdown-standards.md
+++ b/docs/site/docs/reference/lint/markdown-standards.md
@@ -1,0 +1,60 @@
+# markdown-standards.sh
+
+**Path:** `scripts/lint/markdown-standards.sh`
+
+Validates markdown files using markdownlint and structural checks.
+Applies different levels of validation depending on file location.
+
+## Usage
+
+```bash
+scripts/lint/markdown-standards.sh
+```
+
+Run from the repository root. No arguments required.
+
+## File Discovery
+
+The script collects files from three sources:
+
+### Standard Docs (markdownlint + structural checks)
+
+Files found in `docs/` (excluding `docs/sphinx/`, `docs/site/`, and
+`docs/announcements/`), plus `README.md` if it exists.
+
+### Doc-Site Files (markdownlint only)
+
+Files under `docs/sphinx/` and `docs/site/`. These are exempt from
+structural checks because documentation site generators (MkDocs,
+Sphinx) handle structure.
+
+### CHANGELOG.md (markdownlint only)
+
+`CHANGELOG.md` gets markdownlint but no structural checks because
+changelog files have different heading conventions.
+
+## Structural Checks
+
+Applied only to standard docs, these checks enforce:
+
+| Check | Rule |
+| ----- | ---- |
+| **Single H1** | Exactly one `#` heading per file |
+| **Table of Contents** | A `## Table of Contents` section must exist |
+| **Heading Hierarchy** | No skipped heading levels |
+
+Code blocks (fenced with `` ``` `` or `~~~`) are excluded from
+structural analysis.
+
+## Configuration
+
+Markdownlint uses `.markdownlint.yaml` at the repository root if
+present. Otherwise it runs with default rules.
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All files pass |
+| 1 | One or more validation failures |
+| 2 | No markdown files found, or markdownlint not installed |

--- a/docs/site/docs/reference/lint/pr-issue-linkage.md
+++ b/docs/site/docs/reference/lint/pr-issue-linkage.md
@@ -1,0 +1,45 @@
+# pr-issue-linkage.sh
+
+**Path:** `scripts/lint/pr-issue-linkage.sh`
+
+Validates that a pull request body contains issue linkage. Runs in
+CI using the GitHub event payload.
+
+## Usage
+
+This script is called by CI workflows, not invoked directly. It
+reads the PR body from `$GITHUB_EVENT_PATH`.
+
+## Validation Rules
+
+The PR body must contain at least one line matching:
+
+```text
+Fixes #123
+Closes #123
+Resolves #123
+Ref #123
+```
+
+Cross-repository references are also accepted:
+
+```text
+Fixes owner/repo#123
+```
+
+The pattern allows optional leading whitespace, list markers
+(`-` or `*`), and an optional colon after the keyword.
+
+## Environment
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `GITHUB_EVENT_PATH` | Yes | Path to the GitHub event JSON payload |
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Valid issue linkage found |
+| 1 | No issue linkage or empty PR body |
+| 2 | `GITHUB_EVENT_PATH` not set or file not found |

--- a/docs/site/docs/reference/lint/repo-profile.md
+++ b/docs/site/docs/reference/lint/repo-profile.md
@@ -1,0 +1,51 @@
+# repo-profile.sh
+
+**Path:** `scripts/lint/repo-profile.sh`
+
+Validates that `docs/repository-standards.md` contains all required
+repository profile attributes with non-placeholder values.
+
+## Usage
+
+```bash
+scripts/lint/repo-profile.sh
+```
+
+Run from the repository root. The script reads
+`docs/repository-standards.md` relative to the current directory.
+
+## Required Attributes
+
+The following attributes must be present and non-empty:
+
+| Attribute | Example Values |
+| --------- | -------------- |
+| `repository_type` | `application`, `library`, `tooling` |
+| `versioning_scheme` | `semver`, `calver`, `none` |
+| `branching_model` | `library-release`, `application-promotion` |
+| `release_model` | `tagged-release`, `continuous-deploy` |
+| `supported_release_lines` | `1`, `2` |
+| `primary_language` | `python`, `go`, `java`, `shell` |
+
+## Validation Rules
+
+1. **Presence** -- each attribute must exist in the file.
+2. **No placeholders** -- values containing `<`, `>`, or `|` are
+   rejected as unfilled template placeholders.
+
+## Format
+
+Attributes are expected as YAML-like key-value pairs in markdown:
+
+```markdown
+- repository_type: library
+- versioning_scheme: semver
+```
+
+## Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | All required attributes present and valid |
+| 1 | One or more attributes missing or placeholder |
+| 2 | Profile file not found |

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,0 +1,80 @@
+site_name: Standard Tooling
+site_description: Shared scripts for git hooks, linting, and development automation
+repo_url: https://github.com/wphillipmoore/standard-tooling
+repo_name: wphillipmoore/standard-tooling
+
+docs_dir: docs
+strict: true
+edit_uri: ""
+
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - search
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.highlight
+    - search.suggest
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Script Reference:
+      - Overview: reference/index.md
+      - Git Hooks:
+          - pre-commit: reference/hooks/pre-commit.md
+          - commit-msg: reference/hooks/commit-msg.md
+      - Lint Scripts:
+          - commit-message.sh: reference/lint/commit-message.md
+          - co-author.sh: reference/lint/co-author.md
+          - commit-messages.sh: reference/lint/commit-messages.md
+          - repo-profile.sh: reference/lint/repo-profile.md
+          - markdown-standards.sh: reference/lint/markdown-standards.md
+          - pr-issue-linkage.sh: reference/lint/pr-issue-linkage.md
+      - Dev Scripts:
+          - commit.sh: reference/dev/commit.md
+          - submit-pr.sh: reference/dev/submit-pr.md
+          - sync-tooling.sh: reference/dev/sync-tooling.md
+          - prepare_release.py: reference/dev/prepare-release.md
+          - finalize_repo.sh: reference/dev/finalize-repo.md
+          - validate_local.sh: reference/dev/validate-local.md
+  - Guides:
+      - Consuming Repo Setup: guides/consuming-repo-setup.md
+      - Validation Matrix: guides/validation-matrix.md
+      - Releasing: guides/releasing.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add MkDocs/mike documentation site with Material theme, deployment workflow, script reference pages, and guides

## Issue Linkage

- Fixes #69

## Testing

Docs-only: tests skipped

Changed files:
- .github/workflows/docs.yml
- docs/site/docs/getting-started.md
- docs/site/docs/guides/consuming-repo-setup.md
- docs/site/docs/guides/releasing.md
- docs/site/docs/guides/validation-matrix.md
- docs/site/docs/index.md
- docs/site/docs/reference/dev/commit.md
- docs/site/docs/reference/dev/finalize-repo.md
- docs/site/docs/reference/dev/prepare-release.md
- docs/site/docs/reference/dev/submit-pr.md
- docs/site/docs/reference/dev/sync-tooling.md
- docs/site/docs/reference/dev/validate-local.md
- docs/site/docs/reference/hooks/commit-msg.md
- docs/site/docs/reference/hooks/pre-commit.md
- docs/site/docs/reference/index.md
- docs/site/docs/reference/lint/co-author.md
- docs/site/docs/reference/lint/commit-message.md
- docs/site/docs/reference/lint/commit-messages.md
- docs/site/docs/reference/lint/markdown-standards.md
- docs/site/docs/reference/lint/pr-issue-linkage.md
- docs/site/docs/reference/lint/repo-profile.md
- docs/site/mkdocs.yml

## Notes

- -
