### PR TITLE
fix: resolve commit-msg hook fallback relative to hook directory, not consuming repo

### DIFF
--- a/scripts/lib/git-hooks/commit-msg
+++ b/scripts/lib/git-hooks/commit-msg
@@ -7,6 +7,6 @@ set -euo pipefail
 if command -v commit-message >/dev/null 2>&1; then
   commit-message "$1"
 else
-  repo_root="$(git rev-parse --show-toplevel)"
-  "$repo_root/scripts/bin/commit-message" "$1"
+  hook_dir="$(cd "$(dirname "$0")" && pwd)"
+  "$hook_dir/../../bin/commit-message" "$1"
 fi


### PR DESCRIPTION
# Pull Request

## Summary

- Fix commit-msg hook fallback to resolve relative to hook directory instead of consuming repo root

## Issue Linkage

- Fixes #89

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -