### PR TITLE
feat: add st-observatory CLI for cross-repo health reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ st-validate-local = "standard_tooling.bin.validate_local:main"
 st-ensure-label = "standard_tooling.bin.ensure_label:main"
 st-list-project-repos = "standard_tooling.bin.list_project_repos:main"
 st-set-project-field = "standard_tooling.bin.set_project_field:main"
+st-observatory = "standard_tooling.bin.observatory:main"
 
 [dependency-groups]
 dev = ["ruff", "mypy", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]

--- a/src/standard_tooling/bin/observatory.py
+++ b/src/standard_tooling/bin/observatory.py
@@ -1,0 +1,69 @@
+"""Generate Markdown health reports for repositories in a GitHub Project."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from standard_tooling.lib.observatory import (
+    collect_repo_health,
+    list_project_repos,
+    project_title,
+    render_report,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate a health report for repos in a GitHub Project.",
+    )
+    parser.add_argument("--owner", required=True, help="GitHub owner")
+    parser.add_argument("--project", required=True, help="Project number")
+    parser.add_argument(
+        "--output-dir",
+        help="Directory to write the report file (default: stdout)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    title = project_title(args.owner, args.project)
+    if not title:
+        title = f"Project {args.project}"
+    title = f"Observatory: {title}"
+
+    repos = list_project_repos(args.owner, args.project)
+    if not repos:
+        print(f"No repositories found for project {args.project}.", file=sys.stderr)
+        return 1
+
+    print(f"Collecting health data for {len(repos)} repositories...", file=sys.stderr)
+
+    health_data = []
+    for repo in repos:
+        print(f"  {repo}...", file=sys.stderr)
+        health_data.append(collect_repo_health(repo))
+
+    now = datetime.now(tz=UTC)
+    report = render_report(health_data, title, timestamp=now)
+
+    if args.output_dir:
+        out_dir = Path(args.output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"observatory-{now.strftime('%Y-%m-%dT%H-%M-%S')}.md"
+        out_path = out_dir / filename
+        out_path.write_text(report)
+        print(f"Report written to {out_path}", file=sys.stderr)
+    else:
+        print(report)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/standard_tooling/lib/observatory.py
+++ b/src/standard_tooling/lib/observatory.py
@@ -1,0 +1,353 @@
+"""Observatory: repo health collection and Markdown report rendering."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from standard_tooling.lib import github, registry
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CIStatus:
+    """CI run result for a single branch."""
+
+    branch: str
+    conclusion: str  # "success", "failure", "cancelled", etc.
+    status: str  # "completed", "in_progress", etc.
+
+
+@dataclass
+class RepoHealth:
+    """Health snapshot for a single repository."""
+
+    name: str
+    open_issues: int = 0
+    open_prs: int = 0
+    latest_release: str = ""
+    release_date: str = ""
+    primary_language: str = ""
+    wip_branches: list[str] = field(default_factory=list)
+    ci_statuses: list[CIStatus] = field(default_factory=list)
+    registry_version: registry.RegistryVersion | None = None
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Repo discovery (mirrors list_project_repos.py pattern)
+# ---------------------------------------------------------------------------
+
+_ETERNAL_BRANCHES = frozenset({"main", "master", "develop", "gh-pages"})
+
+
+def list_project_repos(owner: str, project: str) -> list[str]:
+    """Return sorted, unique repos linked to a GitHub Project."""
+    jq_filter = (
+        f".[] | select(.projectsV2.Nodes | length > 0) "
+        f"| select(.projectsV2.Nodes[].number == {project}) "
+        f"| .nameWithOwner"
+    )
+    output = github.read_output(
+        "repo",
+        "list",
+        owner,
+        "--json",
+        "nameWithOwner,projectsV2",
+        "--limit",
+        "100",
+        "--jq",
+        jq_filter,
+    )
+    return sorted({r for r in output.splitlines() if r})
+
+
+def project_title(owner: str, project: str) -> str:
+    """Return the human-readable title of a GitHub Project."""
+    return github.read_output(
+        "project",
+        "view",
+        project,
+        "--owner",
+        owner,
+        "--format",
+        "json",
+        "--jq",
+        ".title",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-repo data collection
+# ---------------------------------------------------------------------------
+
+
+def _run_gh(*args: str) -> str:
+    """Run a ``gh`` command, returning stripped stdout or empty on failure."""
+    try:
+        result = subprocess.run(  # noqa: S603, S607
+            ("gh", *args),
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def _collect_branches(repo: str) -> list[str]:
+    raw = _run_gh(
+        "api",
+        f"repos/{repo}/branches",
+        "--paginate",
+        "--jq",
+        ".[].name",
+    )
+    return [b for b in raw.splitlines() if b and b not in _ETERNAL_BRANCHES]
+
+
+def _collect_ci(repo: str) -> list[CIStatus]:
+    statuses: list[CIStatus] = []
+    eternal = ["main", "develop"]
+    for branch in eternal:
+        raw = _run_gh(
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--branch",
+            branch,
+            "--limit",
+            "1",
+            "--json",
+            "conclusion,status",
+        )
+        if not raw:
+            continue
+        runs = json.loads(raw)
+        if runs:
+            statuses.append(
+                CIStatus(
+                    branch=branch,
+                    conclusion=runs[0].get("conclusion", ""),
+                    status=runs[0].get("status", ""),
+                )
+            )
+    return statuses
+
+
+def _collect_open_issues(repo: str) -> int:
+    raw = _run_gh(
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number",
+        "--jq",
+        "length",
+    )
+    return int(raw) if raw else 0
+
+
+def _collect_open_prs(repo: str) -> int:
+    raw = _run_gh(
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number",
+        "--jq",
+        "length",
+    )
+    return int(raw) if raw else 0
+
+
+def _collect_release(repo: str) -> tuple[str, str]:
+    raw = _run_gh(
+        "release",
+        "list",
+        "--repo",
+        repo,
+        "--limit",
+        "1",
+        "--json",
+        "tagName,publishedAt",
+    )
+    if not raw:
+        return "", ""
+    releases = json.loads(raw)
+    if not releases:
+        return "", ""
+    return releases[0].get("tagName", ""), releases[0].get("publishedAt", "")
+
+
+def _collect_language(repo: str) -> str:
+    return _run_gh(
+        "repo",
+        "view",
+        repo,
+        "--json",
+        "primaryLanguage",
+        "--jq",
+        ".primaryLanguage.name",
+    )
+
+
+def collect_repo_health(repo: str) -> RepoHealth:
+    """Collect all health data for a single repo. Never raises."""
+    health = RepoHealth(name=repo)
+    try:
+        health.primary_language = _collect_language(repo)
+        health.wip_branches = _collect_branches(repo)
+        health.ci_statuses = _collect_ci(repo)
+        health.open_issues = _collect_open_issues(repo)
+        health.open_prs = _collect_open_prs(repo)
+        health.latest_release, health.release_date = _collect_release(repo)
+
+        if health.primary_language:
+            owner, name = repo.split("/", 1)
+            health.registry_version = registry.lookup(health.primary_language, owner, name)
+    except Exception as exc:  # noqa: BLE001
+        health.error = str(exc)
+        print(f"Warning: error collecting data for {repo}: {exc}", file=sys.stderr)
+    return health
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _format_date(iso_date: str) -> str:
+    if not iso_date:
+        return ""
+    try:
+        dt = datetime.fromisoformat(iso_date.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return iso_date
+
+
+def render_report(
+    repos: list[RepoHealth],
+    title: str,
+    timestamp: datetime | None = None,
+) -> str:
+    """Render a Markdown health report."""
+    if timestamp is None:
+        timestamp = datetime.now(tz=UTC)
+
+    lines: list[str] = []
+    ts_str = timestamp.strftime("%Y-%m-%d %H:%M UTC")
+
+    # Title
+    lines.append(f"# {title}")
+    lines.append("")
+    lines.append(f"Generated: {ts_str}")
+    lines.append("")
+
+    # Summary
+    ci_failures = sum(1 for r in repos for s in r.ci_statuses if s.conclusion == "failure")
+    stale_count = sum(len(r.wip_branches) for r in repos)
+    drift_count = sum(
+        1
+        for r in repos
+        if r.registry_version
+        and r.latest_release
+        and r.registry_version.version != r.latest_release.lstrip("v")
+    )
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Repositories | {len(repos)} |")
+    lines.append(f"| CI failures | {ci_failures} |")
+    lines.append(f"| WIP branches | {stale_count} |")
+    lines.append(f"| Version drift | {drift_count} |")
+    lines.append("")
+
+    # Alerts
+    alerts: list[str] = []
+    for r in repos:
+        for s in r.ci_statuses:
+            if s.conclusion == "failure":
+                alerts.append(f"- **CI failure**: {r.name} on `{s.branch}`")
+        if r.registry_version and r.latest_release:
+            reg_ver = r.registry_version.version
+            rel_ver = r.latest_release.lstrip("v")
+            if reg_ver != rel_ver:
+                alerts.append(
+                    f"- **Version drift**: {r.name} — "
+                    f"release `{r.latest_release}`, "
+                    f"{r.registry_version.registry} `{r.registry_version.version}`"
+                )
+        if r.wip_branches:
+            alerts.append(
+                f"- **WIP branches**: {r.name} — " + ", ".join(f"`{b}`" for b in r.wip_branches)
+            )
+
+    if alerts:
+        lines.append("## Alerts")
+        lines.append("")
+        lines.extend(alerts)
+        lines.append("")
+
+    # Per-repo details
+    for r in repos:
+        lines.append(f"## {r.name}")
+        lines.append("")
+
+        if r.error:
+            lines.append(f"**Data collection error**: {r.error}")
+            lines.append("")
+            continue
+
+        # Issues / PRs / Release
+        lines.append("| Stat | Value |")
+        lines.append("| --- | --- |")
+        lines.append(f"| Language | {r.primary_language or 'unknown'} |")
+        lines.append(f"| Open issues | {r.open_issues} |")
+        lines.append(f"| Open PRs | {r.open_prs} |")
+        release_str = r.latest_release or "none"
+        if r.release_date:
+            release_str += f" ({_format_date(r.release_date)})"
+        lines.append(f"| Latest release | {release_str} |")
+        if r.registry_version:
+            lines.append(
+                f"| {r.registry_version.registry} version | {r.registry_version.version} |"
+            )
+        lines.append("")
+
+        # CI status
+        if r.ci_statuses:
+            lines.append("### CI Status")
+            lines.append("")
+            lines.append("| Branch | Status | Conclusion |")
+            lines.append("| --- | --- | --- |")
+            for s in r.ci_statuses:
+                lines.append(f"| {s.branch} | {s.status} | {s.conclusion} |")
+            lines.append("")
+
+        # WIP branches
+        if r.wip_branches:
+            lines.append("### WIP Branches")
+            lines.append("")
+            for b in r.wip_branches:
+                lines.append(f"- `{b}`")
+            lines.append("")
+
+    return "\n".join(lines)

--- a/src/standard_tooling/lib/registry.py
+++ b/src/standard_tooling/lib/registry.py
@@ -1,0 +1,57 @@
+"""Package registry HTTP lookups (PyPI, Go proxy)."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass
+class RegistryVersion:
+    """Latest version information from a package registry."""
+
+    name: str
+    version: str
+    registry: str
+
+
+def pypi_latest(package: str) -> RegistryVersion | None:
+    """Return the latest PyPI version for *package*, or ``None`` on failure."""
+    url = f"https://pypi.org/pypi/{package}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+        version: str = data["info"]["version"]
+        return RegistryVersion(name=package, version=version, registry="PyPI")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def go_proxy_latest(module: str) -> RegistryVersion | None:
+    """Return the latest Go module version from the Go proxy, or ``None``."""
+    url = f"https://proxy.golang.org/{module}/@latest"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+        version: str = data["Version"]
+        return RegistryVersion(name=module, version=version, registry="Go proxy")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def maven_latest(_artifact: str) -> RegistryVersion | None:
+    """Maven Central lookup — deferred (needs group:artifact, can't infer)."""
+    return None
+
+
+def lookup(language: str, owner: str, repo: str) -> RegistryVersion | None:
+    """Infer the registry from *language* and look up the latest version."""
+    lang = language.lower() if language else ""
+    if lang == "python":
+        return pypi_latest(repo)
+    if lang == "go":
+        return go_proxy_latest(f"github.com/{owner}/{repo}")
+    if lang == "java":
+        return maven_latest(repo)
+    return None

--- a/tests/standard_tooling/test_observatory.py
+++ b/tests/standard_tooling/test_observatory.py
@@ -1,0 +1,103 @@
+"""Tests for standard_tooling.bin.observatory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from standard_tooling.bin.observatory import main, parse_args
+from standard_tooling.lib.observatory import RepoHealth
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_parse_args_required() -> None:
+    args = parse_args(["--owner", "acme", "--project", "5"])
+    assert args.owner == "acme"
+    assert args.project == "5"
+    assert args.output_dir is None
+
+
+def test_parse_args_output_dir() -> None:
+    args = parse_args(["--owner", "acme", "--project", "5", "--output-dir", "./out"])
+    assert args.output_dir == "./out"
+
+
+def test_main_no_repos() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.observatory.project_title",
+            return_value="Test Project",
+        ),
+        patch(
+            "standard_tooling.bin.observatory.list_project_repos",
+            return_value=[],
+        ),
+    ):
+        result = main(["--owner", "acme", "--project", "5"])
+    assert result == 1
+
+
+def test_main_stdout(capsys: object) -> None:
+    health = RepoHealth(name="acme/repo", open_issues=1, primary_language="Python")
+    with (
+        patch(
+            "standard_tooling.bin.observatory.project_title",
+            return_value="My Project",
+        ),
+        patch(
+            "standard_tooling.bin.observatory.list_project_repos",
+            return_value=["acme/repo"],
+        ),
+        patch(
+            "standard_tooling.bin.observatory.collect_repo_health",
+            return_value=health,
+        ),
+    ):
+        result = main(["--owner", "acme", "--project", "5"])
+    assert result == 0
+
+
+def test_main_output_dir(tmp_path: Path) -> None:
+    health = RepoHealth(name="acme/repo", open_issues=0)
+    with (
+        patch(
+            "standard_tooling.bin.observatory.project_title",
+            return_value="My Project",
+        ),
+        patch(
+            "standard_tooling.bin.observatory.list_project_repos",
+            return_value=["acme/repo"],
+        ),
+        patch(
+            "standard_tooling.bin.observatory.collect_repo_health",
+            return_value=health,
+        ),
+    ):
+        result = main(["--owner", "acme", "--project", "5", "--output-dir", str(tmp_path)])
+    assert result == 0
+    files = list(tmp_path.glob("observatory-*.md"))
+    assert len(files) == 1
+    content = files[0].read_text()
+    assert "Observatory: My Project" in content
+
+
+def test_main_fallback_title() -> None:
+    health = RepoHealth(name="acme/repo")
+    with (
+        patch(
+            "standard_tooling.bin.observatory.project_title",
+            return_value="",
+        ),
+        patch(
+            "standard_tooling.bin.observatory.list_project_repos",
+            return_value=["acme/repo"],
+        ),
+        patch(
+            "standard_tooling.bin.observatory.collect_repo_health",
+            return_value=health,
+        ),
+    ):
+        result = main(["--owner", "acme", "--project", "5"])
+    assert result == 0

--- a/tests/standard_tooling/test_observatory_lib.py
+++ b/tests/standard_tooling/test_observatory_lib.py
@@ -1,0 +1,347 @@
+"""Tests for standard_tooling.lib.observatory."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from standard_tooling.lib.observatory import (
+    CIStatus,
+    RepoHealth,
+    _collect_branches,
+    _collect_ci,
+    _collect_language,
+    _collect_open_issues,
+    _collect_open_prs,
+    _collect_release,
+    _format_date,
+    _run_gh,
+    collect_repo_health,
+    list_project_repos,
+    project_title,
+    render_report,
+)
+from standard_tooling.lib.registry import RegistryVersion
+
+# ---------------------------------------------------------------------------
+# list_project_repos
+# ---------------------------------------------------------------------------
+
+
+def test_list_project_repos() -> None:
+    with patch(
+        "standard_tooling.lib.observatory.github.read_output",
+        return_value="acme/repo-b\nacme/repo-a\nacme/repo-a\n",
+    ):
+        repos = list_project_repos("acme", "5")
+    assert repos == ["acme/repo-a", "acme/repo-b"]
+
+
+def test_list_project_repos_empty() -> None:
+    with patch(
+        "standard_tooling.lib.observatory.github.read_output",
+        return_value="",
+    ):
+        assert list_project_repos("acme", "5") == []
+
+
+# ---------------------------------------------------------------------------
+# project_title
+# ---------------------------------------------------------------------------
+
+
+def test_project_title() -> None:
+    with patch(
+        "standard_tooling.lib.observatory.github.read_output",
+        return_value="My Project",
+    ):
+        assert project_title("acme", "5") == "My Project"
+
+
+# ---------------------------------------------------------------------------
+# collect_repo_health
+# ---------------------------------------------------------------------------
+
+
+def _gh_side_effect(*args: str) -> str:
+    """Simulate gh CLI responses based on arguments."""
+    joined = " ".join(args)
+    if "primaryLanguage" in joined:
+        return "Python"
+    if "/branches" in joined:
+        return "main\ndevelop\nfeature/wip\n"
+    if "run list" in joined:
+        return json.dumps([{"conclusion": "success", "status": "completed"}])
+    if "issue list" in joined:
+        return "3"
+    if "pr list" in joined:
+        return "1"
+    if "release list" in joined:
+        return json.dumps([{"tagName": "v1.0.0", "publishedAt": "2025-01-15T10:00:00Z"}])
+    return ""
+
+
+def test_collect_repo_health() -> None:
+    with (
+        patch("standard_tooling.lib.observatory.registry.lookup", return_value=None),
+        patch("standard_tooling.lib.observatory._run_gh", side_effect=_gh_side_effect),
+        patch("standard_tooling.lib.observatory._collect_language", return_value="Python"),
+    ):
+        health = collect_repo_health("acme/repo")
+
+    assert health.name == "acme/repo"
+    assert health.error == ""
+
+
+def _completed(returncode: int = 0, stdout: str = "") -> object:
+    """Build a fake CompletedProcess."""
+    import subprocess
+
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
+
+
+def test_collect_repo_health_with_error() -> None:
+    with patch(
+        "standard_tooling.lib.observatory._collect_language",
+        side_effect=RuntimeError("boom"),
+    ):
+        health = collect_repo_health("acme/broken")
+    assert health.name == "acme/broken"
+    assert "boom" in health.error
+
+
+# ---------------------------------------------------------------------------
+# render_report
+# ---------------------------------------------------------------------------
+
+_FIXED_TS = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def test_render_report_basic() -> None:
+    repos = [
+        RepoHealth(
+            name="acme/repo-a",
+            open_issues=2,
+            open_prs=1,
+            latest_release="v1.0.0",
+            release_date="2025-01-15T10:00:00Z",
+            primary_language="Python",
+            ci_statuses=[CIStatus(branch="main", conclusion="success", status="completed")],
+        ),
+    ]
+    report = render_report(repos, "Test Report", timestamp=_FIXED_TS)
+
+    assert "# Test Report" in report
+    assert "2025-06-15 12:00 UTC" in report
+    assert "| Repositories | 1 |" in report
+    assert "| CI failures | 0 |" in report
+    assert "acme/repo-a" in report
+    assert "v1.0.0" in report
+
+
+def test_render_report_with_alerts() -> None:
+    repos = [
+        RepoHealth(
+            name="acme/failing",
+            ci_statuses=[CIStatus(branch="main", conclusion="failure", status="completed")],
+            wip_branches=["feature/old"],
+            latest_release="v1.0.0",
+            registry_version=RegistryVersion(name="failing", version="0.9.0", registry="PyPI"),
+        ),
+    ]
+    report = render_report(repos, "Alert Report", timestamp=_FIXED_TS)
+
+    assert "## Alerts" in report
+    assert "**CI failure**" in report
+    assert "**Version drift**" in report
+    assert "**WIP branches**" in report
+
+
+def test_render_report_error_repo() -> None:
+    repos = [
+        RepoHealth(name="acme/broken", error="data unavailable"),
+    ]
+    report = render_report(repos, "Error Report", timestamp=_FIXED_TS)
+    assert "**Data collection error**" in report
+    assert "data unavailable" in report
+
+
+def test_render_report_no_alerts() -> None:
+    repos = [
+        RepoHealth(
+            name="acme/clean",
+            ci_statuses=[CIStatus(branch="main", conclusion="success", status="completed")],
+        ),
+    ]
+    report = render_report(repos, "Clean Report", timestamp=_FIXED_TS)
+    assert "## Alerts" not in report
+
+
+def test_render_report_registry_version() -> None:
+    repos = [
+        RepoHealth(
+            name="acme/lib",
+            primary_language="Python",
+            latest_release="v2.0.0",
+            registry_version=RegistryVersion(name="lib", version="2.0.0", registry="PyPI"),
+        ),
+    ]
+    report = render_report(repos, "Registry Report", timestamp=_FIXED_TS)
+    assert "PyPI version" in report
+    assert "2.0.0" in report
+    # No drift alert since versions match
+    assert "## Alerts" not in report
+
+
+# ---------------------------------------------------------------------------
+# _run_gh
+# ---------------------------------------------------------------------------
+
+
+def test_run_gh_success() -> None:
+    with patch("standard_tooling.lib.observatory.subprocess.run") as mock_run:
+        mock_run.return_value = _completed(stdout="hello\n")
+        assert _run_gh("repo", "view") == "hello"
+
+
+def test_run_gh_failure() -> None:
+    import subprocess as sp
+
+    with patch(
+        "standard_tooling.lib.observatory.subprocess.run",
+        side_effect=sp.CalledProcessError(1, "gh"),
+    ):
+        assert _run_gh("bad", "cmd") == ""
+
+
+# ---------------------------------------------------------------------------
+# _collect_* helpers
+# ---------------------------------------------------------------------------
+
+
+def test_collect_branches() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value="main\ndevelop\nfeat/x\n"):
+        result = _collect_branches("acme/repo")
+    assert result == ["feat/x"]
+
+
+def test_collect_ci_with_runs() -> None:
+    runs_json = json.dumps([{"conclusion": "success", "status": "completed"}])
+    with patch("standard_tooling.lib.observatory._run_gh", return_value=runs_json):
+        statuses = _collect_ci("acme/repo")
+    # Both main and develop get the same mock response
+    assert len(statuses) == 2
+    assert statuses[0].branch == "main"
+    assert statuses[0].conclusion == "success"
+
+
+def test_collect_ci_no_runs() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value=""):
+        statuses = _collect_ci("acme/repo")
+    assert statuses == []
+
+
+def test_collect_ci_empty_json_list() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value="[]"):
+        statuses = _collect_ci("acme/repo")
+    assert statuses == []
+
+
+def test_collect_open_issues() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value="5"):
+        assert _collect_open_issues("acme/repo") == 5
+
+
+def test_collect_open_issues_empty() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value=""):
+        assert _collect_open_issues("acme/repo") == 0
+
+
+def test_collect_open_prs() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value="2"):
+        assert _collect_open_prs("acme/repo") == 2
+
+
+def test_collect_release_with_data() -> None:
+    data = json.dumps([{"tagName": "v1.0.0", "publishedAt": "2025-06-01T00:00:00Z"}])
+    with patch("standard_tooling.lib.observatory._run_gh", return_value=data):
+        tag, date = _collect_release("acme/repo")
+    assert tag == "v1.0.0"
+    assert date == "2025-06-01T00:00:00Z"
+
+
+def test_collect_release_empty() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value=""):
+        tag, date = _collect_release("acme/repo")
+    assert tag == ""
+    assert date == ""
+
+
+def test_collect_release_empty_list() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value="[]"):
+        tag, date = _collect_release("acme/repo")
+    assert tag == ""
+    assert date == ""
+
+
+def test_collect_language() -> None:
+    with patch("standard_tooling.lib.observatory._run_gh", return_value="Python"):
+        assert _collect_language("acme/repo") == "Python"
+
+
+# ---------------------------------------------------------------------------
+# _format_date
+# ---------------------------------------------------------------------------
+
+
+def test_format_date_iso() -> None:
+    assert _format_date("2025-01-15T10:00:00Z") == "2025-01-15"
+
+
+def test_format_date_empty() -> None:
+    assert _format_date("") == ""
+
+
+def test_format_date_invalid() -> None:
+    assert _format_date("not-a-date") == "not-a-date"
+
+
+# ---------------------------------------------------------------------------
+# render_report default timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_render_report_default_timestamp() -> None:
+    repos = [RepoHealth(name="acme/repo")]
+    report = render_report(repos, "Default TS Report")
+    assert "# Default TS Report" in report
+    assert "Generated:" in report
+
+
+# ---------------------------------------------------------------------------
+# collect_repo_health with registry lookup
+# ---------------------------------------------------------------------------
+
+
+def test_collect_repo_health_with_registry() -> None:
+    rv = RegistryVersion(name="repo", version="1.0.0", registry="PyPI")
+    with (
+        patch("standard_tooling.lib.observatory._run_gh", side_effect=_gh_side_effect),
+        patch("standard_tooling.lib.observatory._collect_language", return_value="Python"),
+        patch("standard_tooling.lib.observatory.registry.lookup", return_value=rv),
+    ):
+        health = collect_repo_health("acme/repo")
+    assert health.registry_version == rv
+    assert health.primary_language == "Python"
+
+
+def test_collect_repo_health_no_language() -> None:
+    with (
+        patch("standard_tooling.lib.observatory._run_gh", return_value=""),
+        patch("standard_tooling.lib.observatory._collect_language", return_value=""),
+        patch("standard_tooling.lib.observatory.registry.lookup") as mock_lookup,
+    ):
+        health = collect_repo_health("acme/repo")
+    mock_lookup.assert_not_called()
+    assert health.registry_version is None

--- a/tests/standard_tooling/test_registry.py
+++ b/tests/standard_tooling/test_registry.py
@@ -1,0 +1,97 @@
+"""Tests for standard_tooling.lib.registry."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from standard_tooling.lib.registry import (
+    RegistryVersion,
+    go_proxy_latest,
+    lookup,
+    maven_latest,
+    pypi_latest,
+)
+
+_URLOPEN = "standard_tooling.lib.registry.urllib.request.urlopen"
+
+
+class _FakeResponse:
+    """Minimal file-like object for urllib responses."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+def test_pypi_latest_success() -> None:
+    body = json.dumps({"info": {"version": "2.1.0"}}).encode()
+    with patch(_URLOPEN, return_value=_FakeResponse(body)):
+        result = pypi_latest("my-package")
+    assert result == RegistryVersion(
+        name="my-package",
+        version="2.1.0",
+        registry="PyPI",
+    )
+
+
+def test_pypi_latest_network_error() -> None:
+    with patch(_URLOPEN, side_effect=OSError("timeout")):
+        assert pypi_latest("bad-package") is None
+
+
+def test_go_proxy_latest_success() -> None:
+    body = json.dumps({"Version": "v1.5.3"}).encode()
+    with patch(_URLOPEN, return_value=_FakeResponse(body)):
+        result = go_proxy_latest("github.com/acme/tool")
+    assert result == RegistryVersion(
+        name="github.com/acme/tool",
+        version="v1.5.3",
+        registry="Go proxy",
+    )
+
+
+def test_go_proxy_latest_network_error() -> None:
+    with patch(_URLOPEN, side_effect=OSError("404")):
+        assert go_proxy_latest("github.com/acme/missing") is None
+
+
+def test_maven_latest_returns_none() -> None:
+    assert maven_latest("some-artifact") is None
+
+
+def test_lookup_python() -> None:
+    body = json.dumps({"info": {"version": "3.0.0"}}).encode()
+    with patch(_URLOPEN, return_value=_FakeResponse(body)):
+        result = lookup("Python", "acme", "my-lib")
+    assert result is not None
+    assert result.registry == "PyPI"
+    assert result.version == "3.0.0"
+
+
+def test_lookup_go() -> None:
+    body = json.dumps({"Version": "v0.2.1"}).encode()
+    with patch(_URLOPEN, return_value=_FakeResponse(body)):
+        result = lookup("Go", "acme", "my-tool")
+    assert result is not None
+    assert result.registry == "Go proxy"
+
+
+def test_lookup_java_deferred() -> None:
+    assert lookup("Java", "acme", "my-app") is None
+
+
+def test_lookup_unknown_language() -> None:
+    assert lookup("Rust", "acme", "my-crate") is None
+
+
+def test_lookup_empty_language() -> None:
+    assert lookup("", "acme", "repo") is None


### PR DESCRIPTION
# Pull Request

## Summary

- Add st-observatory CLI tool for cross-repo health reports scoped by GitHub Projects

## Issue Linkage

- Fixes #49

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -