### PR TITLE
feat(hooks): allow dots in branch name validation

### DIFF
--- a/scripts/lib/git-hooks/pre-commit
+++ b/scripts/lib/git-hooks/pre-commit
@@ -70,7 +70,7 @@ fi
 # Format: {type}/{issue}-{description}
 # Exempt: release/* (automated by the publish workflow, no issue association).
 issue_required_regex='^(feature|bugfix|hotfix|chore)/'
-issue_format_regex='^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9-]*$'
+issue_format_regex='^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9.-]*$'
 
 if [[ "$current_branch" =~ $issue_required_regex ]]; then
   if [[ ! "$current_branch" =~ $issue_format_regex ]]; then


### PR DESCRIPTION
# Pull Request

## Summary

- Add dot (.) to the allowed character class in the issue-format regex of the pre-commit hook, enabling branch names like feature/42-mq.rest.client

## Issue Linkage

- Fixes #92

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -