### PR TITLE
fix(docker): disable fail-fast in docker-publish matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ jobs:
     name: "publish: dev-${{ matrix.language }}:${{ matrix.version }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - language: ruby


### PR DESCRIPTION
# Pull Request

## Summary

- Disable fail-fast in docker-publish matrix so healthy builds are not cancelled

## Issue Linkage

- Fixes #99

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -