### PR TITLE
chore(docker): add Python 3.12 and Java 17 to image matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,11 +35,17 @@ jobs:
             version: "3.4"
             build-arg: RUBY_VERSION
           - language: python
+            version: "3.12"
+            build-arg: PYTHON_VERSION
+          - language: python
             version: "3.13"
             build-arg: PYTHON_VERSION
           - language: python
             version: "3.14"
             build-arg: PYTHON_VERSION
+          - language: java
+            version: "17"
+            build-arg: JDK_VERSION
           - language: java
             version: "21"
             build-arg: JDK_VERSION

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -18,8 +18,10 @@ build() {
 build ruby   ruby   RUBY_VERSION   3.2
 build ruby   ruby   RUBY_VERSION   3.3
 build ruby   ruby   RUBY_VERSION   3.4
+build python python PYTHON_VERSION 3.12
 build python python PYTHON_VERSION 3.13
 build python python PYTHON_VERSION 3.14
+build java   java   JDK_VERSION    17
 build java   java   JDK_VERSION    21
 build go     go     GO_VERSION     1.23
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add Python 3.12 and Java 17 to docker-publish matrix and build.sh

## Issue Linkage

- Fixes #103

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -