### PR TITLE
fix(docker): bump Go dev images from 1.23 to 1.25 and 1.26

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,7 +50,10 @@ jobs:
             version: "21"
             build-arg: JDK_VERSION
           - language: go
-            version: "1.23"
+            version: "1.25"
+            build-arg: GO_VERSION
+          - language: go
+            version: "1.26"
             build-arg: GO_VERSION
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Version matrix:
 | Ruby     | 3.2, 3.3, 3.4 |
 | Python   | 3.13, 3.14 |
 | Java     | 21 |
-| Go       | 1.23 |
+| Go       | 1.25, 1.26 |
 
 To trigger a rebuild manually: Actions → "Publish dev container images" →
 Run workflow.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -23,6 +23,7 @@ build python python PYTHON_VERSION 3.13
 build python python PYTHON_VERSION 3.14
 build java   java   JDK_VERSION    17
 build java   java   JDK_VERSION    21
-build go     go     GO_VERSION     1.23
+build go     go     GO_VERSION     1.25
+build go     go     GO_VERSION     1.26
 
 echo "All images built successfully."

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,6 +1,6 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}
 
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \

--- a/scripts/bin/docker-test
+++ b/scripts/bin/docker-test
@@ -26,7 +26,7 @@ default_image() {
   case "$1" in
     ruby)   echo "dev-ruby:3.4"   ;;
     python) echo "dev-python:3.14" ;;
-    go)     echo "dev-go:1.23"     ;;
+    go)     echo "dev-go:1.26"     ;;
     java)   echo "dev-java:21"     ;;
     *)      echo ""                ;;
   esac


### PR DESCRIPTION
# Pull Request

## Summary

- Bump Go dev images from 1.23 to 1.25 and 1.26 to fix golangci-lint compatibility

## Issue Linkage

- Fixes #101

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -