### PR TITLE
fix(docker): use v2 module path for go-licenses

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:${GO_VERSION}
 
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
-    go install github.com/google/go-licenses@v2.0.1 && \
+    go install github.com/google/go-licenses/v2@v2.0.1 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Fix go-licenses v2 module path for Go 1.26 compatibility

## Issue Linkage

- Fixes #101

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -