### PR TITLE
feat(docker): add shellcheck and markdownlint to all dev images

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -3,6 +3,14 @@
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      shellcheck nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
+
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -5,8 +5,11 @@ FROM eclipse-temurin:${JDK_VERSION}-jdk
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git curl && \
+      git curl shellcheck nodejs npm && \
     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
 
 # Maven wrapper self-bootstraps from consuming repos.
 

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -5,8 +5,11 @@ FROM python:${PYTHON_VERSION}-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git curl && \
+      git curl shellcheck nodejs npm && \
     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -5,8 +5,11 @@ FROM ruby:${RUBY_VERSION}-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      build-essential git curl && \
+      build-essential git curl shellcheck nodejs npm && \
     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
 
 RUN gem install bundler
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add shellcheck, Node.js, npm, and markdownlint-cli@0.47.0 to all four dev container images, closing the host-tool gap

## Issue Linkage

- Fixes #106

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -