### PR TITLE
ci: migrate CI to three-tier model

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,20 @@
+name: CI (push)
+
+on:
+  push:
+    branches:
+      - 'feature/**'
+      - 'bugfix/**'
+      - 'hotfix/**'
+      - 'chore/**'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    with:
+      run-security: 'false'
+      run-release-gates: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,6 @@ jobs:
       - name: Check lockfile integrity
         run: uv lock --check
 
-      - name: Check dependency sync
-        run: uv sync --check --frozen
-
   # ---------------------------------------------------------------------------
   # Security and standards (shared reusable workflow)
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
-name: CI - Test and Validate
+name: CI
 
 on:
   pull_request:
+  workflow_call:
+    inputs:
+      run-security:
+        type: string
+        default: 'true'
+      run-release-gates:
+        type: string
+        default: 'true'
 
 permissions:
   contents: read
@@ -11,46 +19,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs-only:
-    name: "ci: docs-only"
+
+  # ---------------------------------------------------------------------------
+  # Quality: lint, type-check, tests, shellcheck, dependency audit
+  # ---------------------------------------------------------------------------
+
+  python:
+    name: "ci: python"
     runs-on: ubuntu-latest
-    outputs:
-      docs-only: ${{ steps.detect.outputs.docs-only }}
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:3.12
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Detect docs-only changes
-        id: detect
-        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-  standards-compliance:
-    name: "ci: standards-compliance"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Fetch base branch for version checks
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }} --depth=1
 
-      - name: Validate standards
-        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+      - name: Install dependencies
+        run: uv sync --group dev --frozen
+
+      - name: Lint
+        run: uv run ruff check src/ tests/
+
+      - name: Format check
+        run: uv run ruff format --check .
+
+      - name: Type check
+        run: uv run mypy src/
+
+      - name: Tests
+        run: uv run pytest tests/ --cov=standard_tooling --cov-branch --cov-fail-under=100
 
   shellcheck:
     name: "ci: shellcheck"
     runs-on: ubuntu-latest
-    needs: docs-only
     steps:
-      - name: Docs-only short-circuit
-        if: needs.docs-only.outputs.docs-only == 'true'
-        run: echo "Docs-only changes detected; skipping shellcheck."
-
       - name: Checkout code
-        if: needs.docs-only.outputs.docs-only != 'true'
         uses: actions/checkout@v6
 
       - name: Run shellcheck
-        if: needs.docs-only.outputs.docs-only != 'true'
         run: |
           files=$(find scripts -type f \( -path '*/bin/*' -o -path '*/git-hooks/*' \) | sort)
           if [ -n "$files" ]; then
@@ -59,45 +71,63 @@ jobs:
             echo "No shell scripts found."
           fi
 
-  python:
-    name: "ci: python"
+  dependency-audit:
+    name: "ci: dependency-audit"
     runs-on: ubuntu-latest
-    needs: docs-only
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:3.12
     steps:
-      - name: Docs-only short-circuit
-        if: needs.docs-only.outputs.docs-only == 'true'
-        run: echo "Docs-only changes detected; skipping Python checks."
-
       - name: Checkout code
-        if: needs.docs-only.outputs.docs-only != 'true'
         uses: actions/checkout@v6
 
-      - name: Set up uv
-        if: needs.docs-only.outputs.docs-only != 'true'
-        uses: astral-sh/setup-uv@v6
+      - name: Check lockfile integrity
+        run: uv lock --check
 
-      - name: Set up Python
-        if: needs.docs-only.outputs.docs-only != 'true'
-        uses: actions/setup-python@v5
+      - name: Check dependency sync
+        run: uv sync --check --frozen
+
+  # ---------------------------------------------------------------------------
+  # Security and standards (shared reusable workflow)
+  # ---------------------------------------------------------------------------
+
+  security-and-standards:
+    name: "security-and-standards"
+    if: ${{ inputs.run-security != 'false' }}
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    with:
+      language: python
+    permissions:
+      contents: read
+      security-events: write
+
+  # ---------------------------------------------------------------------------
+  # Release gates (PR only)
+  # ---------------------------------------------------------------------------
+
+  release-gates:
+    name: "release: gates"
+    if: ${{ inputs.run-release-gates != 'false' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:3.12
+    steps:
+      - name: Skip on non-PR events
+        if: github.event_name != 'pull_request'
+        run: echo "Not a pull request; skipping release gates."
+
+      - name: Checkout code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
         with:
-          python-version: "3.12"
+          fetch-depth: 0
 
-      - name: Install dependencies
-        if: needs.docs-only.outputs.docs-only != 'true'
-        run: uv sync --group dev --frozen
+      - name: Mark workspace safe for git
+        if: github.event_name == 'pull_request'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Lint
-        if: needs.docs-only.outputs.docs-only != 'true'
-        run: uv run ruff check src/ tests/
-
-      - name: Format check
-        if: needs.docs-only.outputs.docs-only != 'true'
-        run: uv run ruff format --check .
-
-      - name: Type check
-        if: needs.docs-only.outputs.docs-only != 'true'
-        run: uv run mypy src/
-
-      - name: Tests
-        if: needs.docs-only.outputs.docs-only != 'true'
-        run: uv run pytest tests/ --cov=standard_tooling --cov-branch --cov-fail-under=100
+      - name: Version divergence gate (PRs targeting develop)
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        with:
+          head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
+          main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv lock --check}"
+
+if command -v docker-test >/dev/null 2>&1; then
+  exec docker-test
+fi
+
+# Fallback: run docker directly if docker-test is not on PATH.
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "Image:   ${DOCKER_DEV_IMAGE}"
+echo "Command: ${DOCKER_TEST_CMD}"
+echo "---"
+
+exec docker run --rm \
+  -v "${repo_root}:/workspace" \
+  -w /workspace \
+  "${DOCKER_DEV_IMAGE}" \
+  bash -c "${DOCKER_TEST_CMD}"

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
+
+if command -v docker-test >/dev/null 2>&1; then
+  exec docker-test
+fi
+
+# Fallback: run docker directly if docker-test is not on PATH.
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "Image:   ${DOCKER_DEV_IMAGE}"
+echo "Command: ${DOCKER_TEST_CMD}"
+echo "---"
+
+exec docker run --rm \
+  -v "${repo_root}:/workspace" \
+  -w /workspace \
+  "${DOCKER_DEV_IMAGE}" \
+  bash -c "${DOCKER_TEST_CMD}"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=standard_tooling --cov-branch --cov-fail-under=100}"
+
+if command -v docker-test >/dev/null 2>&1; then
+  exec docker-test
+fi
+
+# Fallback: run docker directly if docker-test is not on PATH.
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "Image:   ${DOCKER_DEV_IMAGE}"
+echo "Command: ${DOCKER_TEST_CMD}"
+echo "---"
+
+exec docker run --rm \
+  -v "${repo_root}:/workspace" \
+  -w /workspace \
+  "${DOCKER_DEV_IMAGE}" \
+  bash -c "${DOCKER_TEST_CMD}"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate CI to three-tier model with reusable workflow, push CI, dev scripts, security scanning, and release gates

## Issue Linkage

- Fixes #111

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -