### PR TITLE
feat(release): generate per-release verbose release notes files

### DIFF
--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -163,25 +163,20 @@ def _merge_main(version: str) -> None:
     )
 
 
+RELEASE_NOTES_CONFIG = "cliff-release-notes.toml"
+RELEASE_NOTES_DIR = "releases"
+
+
 def _generate_changelog(version: str) -> None:
     for tool in ("git-cliff", "markdownlint"):
         _ensure_tool(tool)
     tag = f"develop-v{version}"
     print(f"Generating changelog with boundary tag: {tag}")
     subprocess.run(("git-cliff", "--tag", tag, "-o", "CHANGELOG.md"), check=True)  # noqa: S603, S607
-    changelog = Path("CHANGELOG.md")
-    changelog.write_text(changelog.read_text(encoding="utf-8").rstrip() + "\n", encoding="utf-8")
-    result = subprocess.run(  # noqa: S603, S607
-        ("markdownlint", "CHANGELOG.md"), capture_output=True, text=True
-    )
-    if result.returncode != 0:
-        print(result.stdout)
-        print(result.stderr)
-        raise SystemExit(
-            "CHANGELOG.md failed markdownlint validation. "
-            "Fix cliff.toml template or CHANGELOG content before releasing."
-        )
+    _normalize_trailing_newline(Path("CHANGELOG.md"))
+    _validate_markdownlint(Path("CHANGELOG.md"))
     git.run("add", "CHANGELOG.md")
+    _generate_release_notes(version, tag)
     status = git.read_output("status", "--porcelain")
     if not status:
         raise SystemExit(
@@ -190,6 +185,37 @@ def _generate_changelog(version: str) -> None:
             f"Aborting release preparation."
         )
     git.run("commit", "-m", f"chore: prepare release {version}")
+
+
+def _generate_release_notes(version: str, tag: str) -> None:
+    config = Path(RELEASE_NOTES_CONFIG)
+    if not config.is_file():
+        return
+    releases_dir = Path(RELEASE_NOTES_DIR)
+    releases_dir.mkdir(exist_ok=True)
+    output_file = releases_dir / f"v{version}.md"
+    print(f"Generating release notes: {output_file}")
+    subprocess.run(  # noqa: S603, S607
+        ("git-cliff", "--config", str(config), "--tag", tag, "--latest", "-o", str(output_file)),
+        check=True,
+    )
+    _normalize_trailing_newline(output_file)
+    _validate_markdownlint(output_file)
+    git.run("add", str(releases_dir))
+
+
+def _normalize_trailing_newline(path: Path) -> None:
+    path.write_text(path.read_text(encoding="utf-8").rstrip() + "\n", encoding="utf-8")
+
+
+def _validate_markdownlint(path: Path) -> None:
+    result = subprocess.run(  # noqa: S603, S607
+        ("markdownlint", str(path)), capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr)
+        raise SystemExit(f"{path} failed markdownlint validation.")
 
 
 def _create_pr(version: str, issue: int) -> str:


### PR DESCRIPTION
# Pull Request

## Summary

- Generate per-release verbose release notes when cliff-release-notes.toml exists

## Issue Linkage

- Fixes #113

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Also references wphillipmoore/standard-actions#89. Refactors changelog generation to extract _normalize_trailing_newline and _validate_markdownlint helpers. Follow-up PRs needed to add cliff-release-notes.toml to consuming repos and sync the vendored copy in standards-and-conventions.