### PR TITLE
chore: add per-release notes and generate retroactive release notes

### DIFF
--- a/cliff-release-notes.toml
+++ b/cliff-release-notes.toml
@@ -1,0 +1,39 @@
+[changelog]
+header = ""
+body = """{% if version -%}
+    # Release {{ version | trim_start_matches(pat="develop-v") }} ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else -%}
+    # Unreleased
+{% endif %}{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - **{{ commit.message | split(pat="\n") | first | trim }}**\
+          {% if commit.body %}
+          {{ commit.body | trim }}
+          {% endif -%}
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "develop-v[0-9].*"
+skip_tags = ""
+sort_commits = "oldest"

--- a/releases/.markdownlint.json
+++ b/releases/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "MD004": false,
+  "MD012": false,
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD032": false,
+  "MD033": false,
+  "MD037": false,
+  "MD041": false,
+  "MD050": false
+}

--- a/releases/v1.1.2.md
+++ b/releases/v1.1.2.md
@@ -1,0 +1,83 @@
+
+# Release 1.1.2 (2026-02-21)
+
+## Bug fixes
+
+- **handle empty docsite_files array with set -u**
+The docsite_files array expansion fails with set -u (nounset) when no
+docs/sphinx or docs/site directories exist. Use the ${arr[@]+...} pattern
+to safely expand potentially empty arrays.
+
+- **prevent --actions-compat from leaking during self-update re-exec**
+The actions_compat variable was initialized to "false" (non-empty string).
+During self-update re-exec, ${actions_compat:+--actions-compat} expands
+to --actions-compat for any non-empty value, causing the re-exec to
+incorrectly include the flag even when the user did not pass it.
+
+Change the default to an empty string so the expansion correctly omits
+the flag when --actions-compat was not specified.
+
+- **accept cross-repo issue references in PR linkage check (#36)**
+The regex in pr-issue-linkage.sh only matched local references (#123) but submit-pr.sh supports cross-repo references (owner/repo#123). Update the regex to accept both formats.
+
+
+## Documentation
+
+- **add canonical source comment to repo-profile.sh**
+Test change for end-to-end propagation validation.
+
+- **document release-before-sync requirement (#20)**
+Consuming repos' CI checks tooling against the latest tagged release. Syncing from an unreleased ref causes CI failures. Added mandatory ordering to CLAUDE.md and AGENTS.md.
+
+- **ban MEMORY.md usage in CLAUDE.md (#32)**
+Add auto-memory policy requiring agents to discuss behavioral rules with the human rather than storing them in unmanaged MEMORY.md files.
+
+- **ban heredocs in shell commands (#33)**
+Replace soft 'prefer temp files' guidance with explicit ban on heredocs. Heredocs routinely fail due to shell escaping and waste time debugging.
+
+
+## Features
+
+- **add CI workflow, CLAUDE.md, and repository infrastructure (#6)**
+Add CI with docs-only, standards-compliance (skip-sync-check), and
+shellcheck jobs.  Create CLAUDE.md, PR template, and .gitignore.
+Fix workflow filename reference in docs/repository-standards.md.
+
+- **add add-to-project workflow for standards project**
+Adds a GitHub Actions workflow that automatically adds new issues
+to the standards GitHub Project (#4).
+
+- **add GitHub Project helper scripts for skill automation (#12)**
+* feat: add GitHub Project helper scripts for skill automation
+
+Add standalone shell scripts in scripts/gh/ that wrap gh CLI commands
+for common GitHub Project operations. These eliminate ad-hoc code in
+skills that need to query project metadata.
+
+- list-project-repos.sh: list unique repos linked to a project
+- ensure-label.sh: idempotent label check/create
+- set-project-field.sh: resolve field/option names to IDs and set value
+
+- **add ci and build to allowed conventional commit types (#13)**
+Update both commit-message.sh (local hook) and commit-messages.sh (CI
+range check) to accept ci: and build: prefixes, aligning with the
+broader Conventional Commits specification.
+
+- **add commit and PR submission wrapper scripts (#17)**
+Wrapper scripts that construct standards-compliant commit messages and PR bodies programmatically, eliminating agent compliance failures for Co-Authored-By trailers and issue linkage.
+
+- **support cross-repo issue references (#23)**
+- **add VERSION file detector to prepare_release.py (#27)**
+Adds detect_version_file() as a fallback detector. Validates semver format (MAJOR.MINOR.PATCH). Also adds VERSION file for this repo.
+
+- **add category prefixes to CI job names (#31)**
+Standardize job display names with ci: category prefix so checks cluster naturally in the GitHub status list.
+
+- **add validate_local.sh dispatch architecture (#34)**
+Shared driver reads primary_language from repo profile and dispatches to common, language-specific, and custom validation scripts. Adds validate_local.sh, validate_local_common.sh, validate_local_python.sh, validate_local_go.sh, validate_local_java.sh. Updates repo-profile.sh to validate primary_language field. Updates sync-tooling.sh MANAGED_FILES.
+
+- **validate issue-linked branch names in pre-commit hook (#44)**
+Feature, bugfix, and hotfix branches must follow {type}/{issue}-{description} format. Release branches are exempt (automated by publish workflow).
+
+- **add publish workflow for automated tagging and version bumps (#46)**
+* chore: bump version to 1.1.2

--- a/releases/v1.1.3.md
+++ b/releases/v1.1.3.md
@@ -1,0 +1,6 @@
+
+# Release 1.1.3 (2026-02-21)
+
+## Bug fixes
+
+- **strip ^{} suffix from dereferenced tags in sync-tooling.sh (#51)**

--- a/releases/v1.1.4.md
+++ b/releases/v1.1.4.md
@@ -1,0 +1,19 @@
+
+# Release 1.1.4 (2026-02-21)
+
+## Bug fixes
+
+- **fix CHANGELOG.md formatting for markdownlint compliance**
+Add H1 heading, fix blank lines around sections, remove emoji prefixes from heading names. Enable siblings_only for MD024 to allow repeated subsection names across changelog versions.
+
+- **fix CHANGELOG.md formatting for markdownlint compliance**
+- **fix CHANGELOG.md formatting for markdownlint compliance**
+- **fix CHANGELOG.md formatting for markdownlint compliance**
+- **validate CHANGELOG.md with markdownlint before committing (#55)**
+* fix: add cliff.toml for markdownlint-compliant changelog generation
+
+- **allow merge commits through commit-msg hook (#57)**
+
+## Features
+
+- **annotate synced scripts with provenance comments (#58)**

--- a/releases/v1.2.0.md
+++ b/releases/v1.2.0.md
@@ -1,0 +1,40 @@
+
+# Release 1.2.0 (2026-02-23)
+
+## Bug fixes
+
+- **update add-to-project action to v1.0.2 (#64)**
+- **read version from pyproject.toml in publish and docs workflows (#82)**
+The v1.2.0 release merged to main but both post-merge workflows failed because they read from a VERSION file that no longer exists. Update publish.yml and docs.yml to use tomllib-based version extraction from pyproject.toml, matching the pattern used by mq-rest-admin-python. Also add setup-uv step for post-bump uv lock.
+
+
+## Documentation
+
+- **document git hooks and validation rules (#71)**
+- **add MkDocs documentation site (#72)**
+Add MkDocs/mike documentation site matching sibling repos pattern. Includes mkdocs.yml with Material theme, docs deployment workflow, 19 content pages covering all managed scripts, guides for consuming repos, validation matrix, and release workflow.
+
+- **update documentation site for PATH-based architecture (#79)**
+Rewrite all documentation pages to reflect the restructuring from a sync-tooling model to PATH-based consumption. Delete obsolete pages (co-author, commit-messages range validator, sync-tooling). Update all script paths, tool names, and consumption instructions.
+
+
+## Features
+
+- **add chore/ as allowed branch prefix in pre-commit hook (#66)**
+- **restructure as Python package with PATH-based consumption (#73)**
+Replace copy-and-sync model with checkout-and-PATH consumption. CLI tools become st-* Python entry points, bash validators move to scripts/bin/ (no .sh extensions), git hooks move to scripts/lib/git-hooks/. Drop co-author.sh, commit-messages.sh, sync-tooling.sh.
+
+- **add commit-messages range validator for CI (#76)**
+Port the commit-messages validator (range-based, for CI PR validation) from standard-actions back to scripts/bin/. This was dropped in the restructuring (#73) but is still needed by the standards-compliance action. Unlike the existing commit-message (singular) which validates a single file for the git hook, this script validates all non-merge commits in a base..head range.
+
+
+## Refactoring
+
+- **remove commit-messages range validator (#77)**
+The CI commit message validation is being removed from the standards-compliance action. The git commit-msg hook provides sufficient enforcement at commit time. This removes the range-based validator added in the previous commit.
+
+
+## Testing
+
+- **achieve 100% line and branch coverage for all Python modules (#74)**
+Add comprehensive tests for all lib and bin modules. Configure coverage exclusions for __main__ guards and TYPE_CHECKING blocks. Reformat source with ruff format for CI consistency.


### PR DESCRIPTION
# Pull Request

## Summary

- Add per-release verbose release notes and retroactively generate notes for all existing releases

## Issue Linkage

- Fixes #115

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -