### PR TITLE
refactor: remove --docs-only flag from st-submit-pr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ st-commit --type docs --message "update README" --body "Expanded usage section" 
 
 ```bash
 st-submit-pr --issue 42 --summary "Add new lint check for X"
-st-submit-pr --issue 42 --linkage Ref --summary "Update docs" --docs-only
+st-submit-pr --issue 42 --linkage Ref --summary "Update docs"
 st-submit-pr --issue 42 --summary "Fix regex bug" --notes "Tested on macOS and Linux"
 ```
 
@@ -280,7 +280,6 @@ st-submit-pr --issue 42 --summary "Fix regex bug" --notes "Tested on macOS and L
 - `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
 - `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
-- `--docs-only` (optional): applies docs-only testing exception
 - `--dry-run` (optional): print generated PR without executing
 
 ## Key References

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -81,7 +81,7 @@ The script resolves the correct `Co-Authored-By` identity from the
 st-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
-  [--notes TEXT] [--docs-only] [--dry-run]
+  [--notes TEXT] [--dry-run]
 ```
 
 - `--issue` (required): GitHub issue number (just the number)
@@ -89,7 +89,6 @@ st-submit-pr \
 - `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
 - `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
-- `--docs-only` (optional): applies docs-only testing exception
 - `--dry-run` (optional): print generated PR without executing
 
 The script detects the target branch and merge strategy automatically.

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -28,7 +28,6 @@ st-submit-pr \
 | `--linkage` | No | Linkage keyword (default: `Fixes`) |
 | `--title` | No | PR title (default: last commit subject) |
 | `--notes` | No | Additional notes for the PR |
-| `--docs-only` | No | Apply docs-only testing exception |
 | `--dry-run` | No | Print PR body without executing |
 
 ### Linkage Keywords
@@ -42,10 +41,10 @@ st-submit-pr \
 st-submit-pr \
   --issue 42 --summary "Add new lint check for X"
 
-# Docs-only PR with Ref linkage
+# PR with Ref linkage
 st-submit-pr \
   --issue 42 --linkage Ref \
-  --summary "Update docs" --docs-only
+  --summary "Update docs"
 
 # Dry run to preview
 st-submit-pr \
@@ -61,9 +60,7 @@ st-submit-pr \
     - All other branches target `develop` with squash strategy
 3. Reads the testing section from
    `.github/pull_request_template.md`.
-4. For `--docs-only`, replaces the testing section with changed
-   file list.
-5. Pushes the branch to origin.
+4. Pushes the branch to origin.
 6. Creates the PR via `gh pr create`.
 7. Enables auto-merge with the detected strategy.
 

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -61,8 +61,8 @@ st-submit-pr \
 3. Reads the testing section from
    `.github/pull_request_template.md`.
 4. Pushes the branch to origin.
-6. Creates the PR via `gh pr create`.
-7. Enables auto-merge with the detected strategy.
+5. Creates the PR via `gh pr create`.
+6. Enables auto-merge with the detected strategy.
 
 ## Exit Codes
 

--- a/src/standard_tooling/bin/submit_pr.py
+++ b/src/standard_tooling/bin/submit_pr.py
@@ -30,7 +30,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--notes", default="", help="Additional notes")
     parser.add_argument("--title", default="", help="PR title (default: latest commit subject)")
-    parser.add_argument("--docs-only", action="store_true", help="Docs-only testing exception")
     parser.add_argument("--dry-run", action="store_true", help="Print without executing")
     return parser.parse_args(argv)
 
@@ -79,14 +78,6 @@ def main(argv: list[str] | None = None) -> int:
     title = args.title or git.read_output("log", "-1", "--pretty=%s")
 
     testing_section = _extract_testing_section(root)
-
-    if args.docs_only:
-        try:
-            changed = git.read_output("diff", "--name-only", f"{target_branch}...HEAD")
-        except Exception:  # noqa: BLE001
-            changed = git.read_output("diff", "--name-only", "HEAD~1")
-        file_lines = "\n".join(f"- {f}" for f in changed.splitlines() if f)
-        testing_section = f"Docs-only: tests skipped\n\nChanged files:\n{file_lines}"
 
     notes_section = args.notes or "-"
 


### PR DESCRIPTION
# Pull Request

## Summary

- Remove --docs-only flag from st-submit-pr and all related documentation

## Issue Linkage

- Ref wphillipmoore/standard-actions#108

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -