### PR TITLE
feat(docker): add CI quality gates for dev container images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,14 +12,30 @@ on:
 permissions:
   packages: write
   contents: read
+  security-events: write
+  attestations: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  publish:
+  hadolint:
+    name: Lint Dockerfiles
+    runs-on: ubuntu-latest
+    container:
+      image: hadolint/hadolint:v2.12.0-alpine
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Hadolint
+        run: hadolint docker/*/Dockerfile
+
+  build-scan-push:
     name: "publish: dev-${{ matrix.language }}:${{ matrix.version }}"
+    needs: [hadolint]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -56,6 +72,9 @@ jobs:
             version: "1.26"
             build-arg: GO_VERSION
 
+    env:
+      IMAGE: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -71,9 +90,29 @@ jobs:
         run: |
           docker build \
             --build-arg "${{ matrix.build-arg }}=${{ matrix.version }}" \
-            -t "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}" \
+            -t "$IMAGE" \
             "docker/${{ matrix.language }}"
+
+      - name: Trivy image scan
+        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+        with:
+          scan-type: image
+          scan-ref: ${{ env.IMAGE }}
+          exit-code: "1"
+          sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}"
 
       - name: Push image
         run: |
-          docker push "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}"
+          docker push "$IMAGE"
+
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}"
+          subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+ignored:
+  - DL3008  # pin versions in apt-get install — impractical for dev images
+  - DL3059  # multiple consecutive RUN instructions — intentional for clarity


### PR DESCRIPTION
# Pull Request

## Summary

- Add hadolint, Trivy scanning, and build provenance attestation to docker-publish workflow

## Issue Linkage

- Fixes #108

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Depends on standard-actions#115 for the sarif-category input (already submitted). Start with exit-code 1 (blocking); if base image CVEs cause failures, add .trivyignore.