### PR TITLE
fix(docker): use hadolint binary instead of container to avoid musl/node24 incompatibility

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,11 +24,15 @@ jobs:
   hadolint:
     name: Lint Dockerfiles
     runs-on: ubuntu-latest
-    container:
-      image: hadolint/hadolint:v2.12.0-alpine
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Download Hadolint
+        run: |
+          curl -sL "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64" \
+            -o /usr/local/bin/hadolint
+          chmod +x /usr/local/bin/hadolint
 
       - name: Run Hadolint
         run: hadolint docker/*/Dockerfile


### PR DESCRIPTION
# Pull Request

## Summary

- Fix hadolint container incompatibility with actions/checkout@v6 Node 24

## Issue Linkage

- Ref #108

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -