### PR TITLE
fix(docker): suppress DL3028 hadolint warning for gem version pinning

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,4 @@
 ignored:
   - DL3008  # pin versions in apt-get install — impractical for dev images
+  - DL3028  # pin versions in gem install — impractical for dev images
   - DL3059  # multiple consecutive RUN instructions — intentional for clarity


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress DL3028 hadolint warning for unpinned gem install in dev images

## Issue Linkage

- Ref #108

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -