### PR TITLE
feat(docker): harden dev images with patched base packages, Node 22 LTS, shellcheck 0.11.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,6 +104,7 @@ jobs:
           scan-ref: ${{ env.IMAGE }}
           exit-code: "1"
           sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}"
+          trivyignores: .trivyignore
 
       - name: Push image
         run: |

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,34 @@
+# Trivy ignore file for dev container images.
+#
+# Linux kernel CVEs — containers use the host kernel, not the kernel
+# headers/modules baked into the base image. These are false positives
+# for container image scanning.
+
+CVE-2013-7445
+CVE-2019-19449
+CVE-2019-19814
+CVE-2021-3847
+CVE-2021-3864
+CVE-2024-21803
+CVE-2024-58015
+CVE-2024-58093
+CVE-2025-22104
+CVE-2025-38137
+CVE-2025-38187
+CVE-2025-38204
+CVE-2025-38206
+CVE-2025-38421
+CVE-2025-38584
+CVE-2025-38627
+CVE-2025-38636
+CVE-2025-39859
+CVE-2025-39862
+CVE-2025-39958
+CVE-2025-40064
+CVE-2025-40135
+CVE-2025-40158
+CVE-2025-40168
+CVE-2026-23066
+CVE-2026-23152
+CVE-2026-23171
+CVE-2026-23210

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,12 +1,24 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 ARG GO_VERSION=1.25
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
 FROM golang:${GO_VERSION}
 
+COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      shellcheck nodejs npm && \
+      xz-utils && \
     rm -rf /var/lib/apt/lists/*
+
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
 
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
@@ -14,6 +26,6 @@ RUN npm install -g markdownlint-cli@0.47.0 && \
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \
-    go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+    go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -1,12 +1,24 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 ARG JDK_VERSION=21
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
 FROM eclipse-temurin:${JDK_VERSION}-jdk
 
+COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl shellcheck nodejs npm && \
+      git curl xz-utils && \
     rm -rf /var/lib/apt/lists/*
+
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
 
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,12 +1,24 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 ARG PYTHON_VERSION=3.14
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
 FROM python:${PYTHON_VERSION}-slim
 
+COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl shellcheck nodejs npm && \
+      git curl xz-utils && \
     rm -rf /var/lib/apt/lists/*
+
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
 
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,12 +1,24 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 ARG RUBY_VERSION=3.4
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
 FROM ruby:${RUBY_VERSION}-slim
 
+COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      build-essential git curl shellcheck nodejs npm && \
+      build-essential git curl xz-utils && \
     rm -rf /var/lib/apt/lists/*
+
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
 
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force


### PR DESCRIPTION
# Pull Request

## Summary

- Harden dev images: apt-get upgrade, Node 22 LTS, shellcheck 0.11.0, kernel CVE trivyignore

## Issue Linkage

- Ref #108

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -