### PR TITLE
docs: move Releases nav to right of Home for consistency

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -55,6 +55,10 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Releases:
+      - Changelog: changelog.md
+      - Release Notes:
+          - releases/index.md
   - Getting Started: getting-started.md
   - Script Reference:
       - Overview: reference/index.md
@@ -72,10 +76,6 @@ nav:
           - st-prepare-release: reference/dev/prepare-release.md
           - st-finalize-repo: reference/dev/finalize-repo.md
           - st-validate-local: reference/dev/validate-local.md
-  - Releases:
-      - Changelog: changelog.md
-      - Release Notes:
-          - releases/index.md
   - Guides:
       - Consuming Repo Setup: guides/consuming-repo-setup.md
       - Three-Tier CI: guides/three-tier-ci.md


### PR DESCRIPTION
# Pull Request

## Summary

- Move Releases nav tab to right of Home, consistent with standard-actions

## Issue Linkage

- Fixes #135

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -