### PR TITLE
chore(ci): pass run-standards and run-security flags to ci-security workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,11 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    name: "security-and-standards"
-    if: ${{ inputs.run-security != 'false' }}
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
     with:
       language: python
+      run-standards: ${{ inputs.run-release-gates || 'true' }}
+      run-security: ${{ inputs.run-security || 'true' }}
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
# Pull Request

## Summary

- Pass run-standards and run-security flags independently to ci-security workflow, aligning with mq-rest-admin-python pattern (wphillipmoore/standard-actions#137)

## Issue Linkage

- Ref #137

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -