### PR TITLE
feat: add Rust development tooling

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -25,5 +25,7 @@ build java   java   JDK_VERSION    17
 build java   java   JDK_VERSION    21
 build go     go     GO_VERSION     1.25
 build go     go     GO_VERSION     1.26
+build rust   rust   RUST_VERSION   1.92
+build rust   rust   RUST_VERSION   1.93
 
 echo "All images built successfully."

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -1,0 +1,35 @@
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
+ARG RUST_VERSION=1.93
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
+FROM rust:${RUST_VERSION}-slim
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      pkg-config \
+      xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
+
+RUN rustup component add clippy rustfmt llvm-tools
+
+RUN cargo install cargo-deny@0.18.2 && \
+    cargo install cargo-llvm-cov@0.6.16 && \
+    rm -rf /usr/local/cargo/registry
+
+WORKDIR /workspace

--- a/scripts/bin/docker-test
+++ b/scripts/bin/docker-test
@@ -15,6 +15,8 @@ detect_language() {
     echo "python"
   elif [[ -f "${repo_root}/go.mod" ]]; then
     echo "go"
+  elif [[ -f "${repo_root}/Cargo.toml" ]]; then
+    echo "rust"
   elif [[ -f "${repo_root}/pom.xml" ]] || [[ -f "${repo_root}/mvnw" ]]; then
     echo "java"
   else
@@ -27,6 +29,7 @@ default_image() {
     ruby)   echo "dev-ruby:3.4"   ;;
     python) echo "dev-python:3.14" ;;
     go)     echo "dev-go:1.26"     ;;
+    rust)   echo "dev-rust:1.93"   ;;
     java)   echo "dev-java:21"     ;;
     *)      echo ""                ;;
   esac
@@ -37,6 +40,7 @@ default_test_cmd() {
     ruby)   echo "bundle install --jobs 4 && bundle exec rake" ;;
     python) echo "uv sync && uv run pytest tests/ -v"          ;;
     go)     echo "go test ./..."                                ;;
+    rust)   echo "cargo test"                                   ;;
     java)   echo "./mvnw verify"                                ;;
     *)      echo ""                                             ;;
   esac

--- a/scripts/bin/validate-local-rust
+++ b/scripts/bin/validate-local-rust
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
+# validate-local-rust — Rust-specific local validation checks.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- required tools ----------------------------------------------------------
+
+missing=()
+command -v cargo >/dev/null 2>&1 || missing+=("cargo")
+command -v cargo-clippy >/dev/null 2>&1 || missing+=("clippy")
+command -v rustfmt >/dev/null 2>&1 || missing+=("rustfmt")
+command -v cargo-deny >/dev/null 2>&1 || missing+=("cargo-deny")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: required tools not found: ${missing[*]}" >&2
+  exit 1
+fi
+
+# -- auto-discover workspace from Cargo.toml --------------------------------
+
+manifest_dir=""
+if [[ -f "$repo_root/Cargo.toml" ]]; then
+  manifest_dir="$repo_root"
+else
+  # Search one level down for Cargo.toml.
+  while IFS= read -r f; do
+    manifest_dir="$(dirname "$f")"
+    break
+  done < <(find "$repo_root" -maxdepth 2 -name Cargo.toml -not -path '*/target/*' 2>/dev/null)
+fi
+
+if [[ -z "$manifest_dir" ]]; then
+  echo "ERROR: could not find Cargo.toml" >&2
+  exit 1
+fi
+
+echo "Cargo manifest directory: $manifest_dir"
+cd "$manifest_dir"
+
+# -- format ------------------------------------------------------------------
+
+run cargo fmt --all -- --check
+
+# -- lint --------------------------------------------------------------------
+
+run cargo clippy -- -D warnings
+
+# -- unit tests --------------------------------------------------------------
+
+run cargo test
+
+# -- coverage ----------------------------------------------------------------
+
+if command -v cargo-llvm-cov >/dev/null 2>&1; then
+  run cargo llvm-cov --fail-under-lines 0
+fi
+
+# -- dependency audit and license compliance ---------------------------------
+
+run cargo deny check

--- a/src/standard_tooling/lib/registry.py
+++ b/src/standard_tooling/lib/registry.py
@@ -45,7 +45,9 @@ def crates_latest(crate: str) -> RegistryVersion | None:
     url = f"https://crates.io/api/v1/crates/{crate}"
     req = urllib.request.Request(  # noqa: S310
         url,
-        headers={"User-Agent": "standard-tooling (https://github.com/wphillipmoore/standard-tooling)"},
+        headers={
+            "User-Agent": "standard-tooling (https://github.com/wphillipmoore/standard-tooling)"
+        },
     )
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310

--- a/src/standard_tooling/lib/registry.py
+++ b/src/standard_tooling/lib/registry.py
@@ -43,7 +43,7 @@ def go_proxy_latest(module: str) -> RegistryVersion | None:
 def crates_latest(crate: str) -> RegistryVersion | None:
     """Return the latest crates.io version for *crate*, or ``None`` on failure."""
     url = f"https://crates.io/api/v1/crates/{crate}"
-    req = urllib.request.Request(
+    req = urllib.request.Request(  # noqa: S310
         url,
         headers={"User-Agent": "standard-tooling (https://github.com/wphillipmoore/standard-tooling)"},
     )


### PR DESCRIPTION
# Pull Request

## Summary

- Add Rust development tooling (Docker, validation, registry)

## Issue Linkage

- Fixes #138

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Part of mq-rest-admin-common#10 (Rust port prerequisites). Adds: docker/rust/Dockerfile (rust:VERSION-slim with clippy, rustfmt, cargo-deny, cargo-llvm-cov), validate-local-rust script, Cargo.toml detection in docker-test, crates.io registry lookup with tests, build.sh entries for Rust 1.92/1.93. Decision: no custom Rust setup action needed — use actions-rust-lang/setup-rust-toolchain directly in downstream repos.