### PR TITLE
feat(generate): add st-generate-commands CLI for multi-language MQSC method generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ st-ensure-label = "standard_tooling.bin.ensure_label:main"
 st-list-project-repos = "standard_tooling.bin.list_project_repos:main"
 st-set-project-field = "standard_tooling.bin.set_project_field:main"
 st-observatory = "standard_tooling.bin.observatory:main"
+st-generate-commands = "standard_tooling.bin.generate_commands:main"
 
 [dependency-groups]
 dev = ["ruff", "mypy", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]

--- a/src/standard_tooling/bin/generate_commands.py
+++ b/src/standard_tooling/bin/generate_commands.py
@@ -1,0 +1,802 @@
+"""Generate MQSC command methods for all language ports.
+
+Reads mapping-data.json and generates complete command method blocks for
+Python, Ruby, Java, Go, and Rust.  Output is written between
+BEGIN/END GENERATED MQSC METHODS markers in the target file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Metadata defaults
+# ---------------------------------------------------------------------------
+# Commands whose MQSC qualifier matches one of these target the queue manager
+# itself — no ``name`` parameter in any language.
+NO_NAME_QUALIFIERS = frozenset({"QMGR", "CMDSERV", "QMSTATUS"})
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Describes one MQSC command for code generation."""
+
+    verb: str
+    mqsc_qualifier: str
+    qualifier: str
+    pattern: str  # "singleton" | "list" | "required_name" | "optional_name" | "no_name"
+    name_default: str | None  # e.g. "*" for DISPLAY QUEUE
+
+
+def classify_command(
+    verb: str,
+    mqsc_qualifier: str,
+    entry: dict[str, object],
+) -> CommandSpec:
+    """Derive a CommandSpec from a mapping-data.json command entry."""
+    qualifier = entry.get("qualifier", mqsc_qualifier.lower())
+    if not isinstance(qualifier, str):
+        qualifier = mqsc_qualifier.lower()
+
+    explicit_pattern = entry.get("pattern")
+    name_required = entry.get("name_required", False)
+    name_default = entry.get("name_default")
+
+    if explicit_pattern == "singleton":
+        pattern = "singleton"
+    elif verb == "DISPLAY" and mqsc_qualifier not in NO_NAME_QUALIFIERS:
+        # All non-singleton DISPLAY commands return a list.
+        pattern = "list"
+    elif name_required:
+        pattern = "required_name"
+    elif mqsc_qualifier in NO_NAME_QUALIFIERS:
+        pattern = "no_name"
+    else:
+        pattern = "optional_name"
+
+    return CommandSpec(
+        verb=verb,
+        mqsc_qualifier=mqsc_qualifier,
+        qualifier=qualifier,
+        pattern=pattern,
+        name_default=str(name_default) if name_default is not None else None,
+    )
+
+
+def load_commands(mapping_data_path: Path) -> list[CommandSpec]:
+    """Load and classify all commands from mapping-data.json."""
+    data = json.loads(mapping_data_path.read_text(encoding="utf-8"))
+    commands_raw = data.get("commands", {})
+    if not isinstance(commands_raw, dict):
+        return []
+
+    specs: list[CommandSpec] = []
+    for command_key in sorted(commands_raw.keys()):
+        parts = command_key.split(" ", 1)
+        if len(parts) != 2:  # noqa: PLR2004
+            continue
+        verb, mqsc_qualifier = parts
+        entry = commands_raw[command_key]
+        if not isinstance(entry, dict):
+            continue
+        specs.append(classify_command(verb, mqsc_qualifier, entry))
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Python generation
+# ---------------------------------------------------------------------------
+
+MQSC_REF_URL = "https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands"
+PYTHON_DOCS_BASE_URL = "https://wphillipmoore.github.io/mq-rest-admin-python"
+
+
+def _python_docstring(cmd: CommandSpec, mapping_pages: frozenset[str]) -> str:
+    """Build a Python docstring for a command method."""
+    command_label = f"{cmd.verb} {cmd.mqsc_qualifier}"
+    lines = [f'        """Execute the MQSC ``{command_label}`` command.']
+    lines.append("")
+    lines.append(f"        See `MQSC reference <{MQSC_REF_URL}>`__")
+    lines.append("        for command details.")
+    if cmd.qualifier in mapping_pages:
+        lines.append(
+            f"        See `{cmd.qualifier} attribute mappings"
+            f" <{PYTHON_DOCS_BASE_URL}/mappings/{cmd.qualifier}.html>`__."
+        )
+    lines.append("")
+
+    # Args section
+    lines.append("        Args:")
+    if cmd.pattern in ("list", "optional_name", "required_name"):
+        name_desc = "Object name or generic pattern." if cmd.pattern == "list" else "Object name."
+        lines.append(f"            name: {name_desc}")
+    lines.append("            request_parameters: Request attributes as a dict. Mapped")
+    lines.append("                from ``snake_case`` when mapping is enabled.")
+    lines.append("            response_parameters: Response attributes to return.")
+    lines.append('                Defaults to ``["all"]``.')
+    if cmd.pattern == "list":
+        lines.append('            where: Filter expression (e.g. ``"current_depth GT 100"``).')
+        lines.append("                The keyword is mapped from ``snake_case`` when mapping")
+        lines.append("                is enabled.")
+    lines.append("")
+
+    # Returns/Raises section
+    if cmd.pattern == "singleton":
+        lines.append("        Returns:")
+        lines.append("            Parameter dict, or ``None``.")
+    elif cmd.pattern == "list":
+        lines.append("        Returns:")
+        lines.append("            List of parameter dicts, one per matching object. Empty")
+        lines.append("            list if no objects match.")
+    else:
+        lines.append("        Raises:")
+        lines.append("            MQRESTCommandError: If the command fails.")
+    lines.append("")
+    lines.append('        """')
+    return "\n".join(lines)
+
+
+def _python_method(cmd: CommandSpec, mapping_pages: frozenset[str]) -> str:
+    """Generate one Python method."""
+    method_name = f"{cmd.verb.lower()}_{cmd.mqsc_qualifier.lower()}"
+
+    # Signature
+    sig_lines = [f"    def {method_name}(", "        self,"]
+    if cmd.pattern == "required_name":
+        sig_lines.append("        name: str,")
+    elif cmd.pattern in ("list", "optional_name"):
+        sig_lines.append("        name: str | None = None,")
+    sig_lines.append("        request_parameters: Mapping[str, object] | None = None,")
+    sig_lines.append("        response_parameters: Sequence[str] | None = None,")
+    if cmd.pattern == "list":
+        sig_lines.append("        where: str | None = None,")
+
+    if cmd.pattern == "singleton":
+        sig_lines.append("    ) -> dict[str, object] | None:")
+    elif cmd.pattern == "list":
+        sig_lines.append("    ) -> list[dict[str, object]]:")
+    else:
+        sig_lines.append("    ) -> None:")
+
+    # Docstring
+    docstring = _python_docstring(cmd, mapping_pages)
+
+    # Body
+    body_lines: list[str] = []
+    if cmd.pattern == "list":
+        body_lines.append("        return self._mqsc_command(")
+    elif cmd.pattern == "singleton":
+        body_lines.append("        objects = self._mqsc_command(")
+    else:
+        body_lines.append("        self._mqsc_command(")
+
+    body_lines.append(f'            command="{cmd.verb}",')
+    body_lines.append(f'            mqsc_qualifier="{cmd.mqsc_qualifier}",')
+
+    if cmd.pattern == "list" and cmd.name_default:
+        body_lines.append(f'            name=name or "{cmd.name_default}",')
+    elif cmd.pattern in ("required_name", "optional_name", "list"):
+        body_lines.append("            name=name,")
+    else:
+        body_lines.append("            name=None,")
+
+    body_lines.append("            request_parameters=request_parameters,")
+    body_lines.append("            response_parameters=response_parameters,")
+    if cmd.pattern == "list":
+        body_lines.append("            where=where,")
+    body_lines.append("        )")
+
+    if cmd.pattern == "singleton":
+        body_lines.append("        if objects:")
+        body_lines.append("            return objects[0]")
+        body_lines.append("        return None")
+
+    return "\n".join(sig_lines + [docstring] + body_lines)
+
+
+def generate_python(specs: list[CommandSpec], mapping_pages: frozenset[str]) -> str:
+    """Generate all Python methods."""
+    methods = [_python_method(cmd, mapping_pages) for cmd in specs]
+    return "\n\n".join(methods)
+
+
+# ---------------------------------------------------------------------------
+# Ruby generation
+# ---------------------------------------------------------------------------
+
+
+def _ruby_method(cmd: CommandSpec) -> str:
+    """Generate one Ruby method."""
+    method_name = f"{cmd.verb.lower()}_{cmd.mqsc_qualifier.lower()}"
+    command_label = f"{cmd.verb} {cmd.mqsc_qualifier}"
+
+    lines: list[str] = []
+
+    # YARD doc
+    lines.append(f"        # Execute the MQSC +{command_label}+ command.")
+    lines.append("        #")
+
+    if cmd.pattern == "required_name":
+        lines.append("        # @param name [String] the object name")
+    elif cmd.pattern in ("list", "optional_name"):
+        if cmd.pattern == "list" and cmd.name_default:
+            lines.append(
+                f"        # @param name [String, nil] object name or pattern,"
+                f' defaults to +"{cmd.name_default}"+'
+            )
+        else:
+            lines.append("        # @param name [String, nil] object name")
+
+    lines.append(
+        "        # @param request_parameters [Hash{String => Object}, nil] request attributes"
+    )
+    lines.append(
+        "        # @param response_parameters [Array<String>, nil] response attributes to return"
+    )
+    if cmd.pattern == "list":
+        lines.append("        # @param where [String, nil] filter expression")
+
+    if cmd.pattern == "singleton":
+        lines.append(
+            "        # @return [Hash{String => Object}, nil] parameter hash, or nil if empty"
+        )
+    elif cmd.pattern == "list":
+        lines.append("        # @return [Array<Hash{String => Object}>] parameter hashes")
+    else:
+        lines.append("        # @return [nil]")
+
+    lines.append("        # @raise [CommandError] if the MQSC command fails")
+    lines.append("        # @raise [MappingError] if attribute mapping fails in strict mode")
+
+    # Signature
+    if cmd.pattern == "required_name":
+        lines.append(
+            f"        def {method_name}(name, request_parameters: nil, response_parameters: nil)"
+        )
+    elif cmd.pattern in ("no_name", "singleton"):
+        lines.append(
+            f"        def {method_name}(request_parameters: nil, response_parameters: nil)"
+        )
+    elif cmd.pattern == "list":
+        lines.append(
+            f"        def {method_name}(name: nil, request_parameters: nil,"
+            f" response_parameters: nil, where: nil)"
+        )
+    else:  # optional_name
+        lines.append(
+            f"        def {method_name}(name: nil, request_parameters: nil,"
+            f" response_parameters: nil)"
+        )
+
+    # Body
+    if cmd.pattern == "list" and cmd.name_default:
+        name_expr = f"name || '{cmd.name_default}'"
+    elif cmd.pattern in ("required_name", "optional_name", "list"):
+        name_expr = "name"
+    else:
+        name_expr = "nil"
+
+    if cmd.pattern == "list":
+        lines.append("          mqsc_command(")
+        lines.append(f"            command: '{cmd.verb}', mqsc_qualifier: '{cmd.mqsc_qualifier}',")
+        lines.append(f"            name: {name_expr}, request_parameters: request_parameters,")
+        lines.append("            response_parameters: response_parameters, where: where")
+        lines.append("          )")
+    elif cmd.pattern == "singleton":
+        lines.append("          objects = mqsc_command(")
+        lines.append(f"            command: '{cmd.verb}', mqsc_qualifier: '{cmd.mqsc_qualifier}',")
+        lines.append(f"            name: {name_expr}, request_parameters: request_parameters,")
+        lines.append("            response_parameters: response_parameters")
+        lines.append("          )")
+        lines.append("          objects.empty? ? nil : objects[0]")
+    else:
+        lines.append("          mqsc_command(")
+        lines.append(f"            command: '{cmd.verb}', mqsc_qualifier: '{cmd.mqsc_qualifier}',")
+        lines.append(f"            name: {name_expr}, request_parameters: request_parameters,")
+        lines.append("            response_parameters: response_parameters")
+        lines.append("          )")
+        lines.append("          nil")
+
+    lines.append("        end")
+    return "\n".join(lines)
+
+
+def generate_ruby(specs: list[CommandSpec]) -> str:
+    """Generate all Ruby methods."""
+    methods = [_ruby_method(cmd) for cmd in specs]
+    return "\n\n".join(methods)
+
+
+# ---------------------------------------------------------------------------
+# Java generation
+# ---------------------------------------------------------------------------
+
+
+def _java_method_name(cmd: CommandSpec) -> str:
+    """Convert verb_qualifier to camelCase."""
+    parts = f"{cmd.verb.lower()}_{cmd.mqsc_qualifier.lower()}".split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def _java_method(cmd: CommandSpec) -> str:
+    """Generate one Java method."""
+    method_name = _java_method_name(cmd)
+    command_label = f"{cmd.verb} {cmd.mqsc_qualifier}"
+
+    lines: list[str] = []
+    article = "an" if cmd.verb[0] in "AEIOU" else "a"
+    lines.append(f"  /** Executes {article} {command_label} MQSC command. */")
+
+    if cmd.pattern == "singleton":
+        lines.append(f"  public @Nullable Map<String, Object> {method_name}(")
+        lines.append(
+            "      @Nullable Map<String, Object> requestParameters,"
+            " @Nullable List<String> responseParameters) {"
+        )
+        lines.append("    List<Map<String, Object>> objects =")
+        lines.append(
+            f'        mqscCommand("{cmd.verb}", "{cmd.mqsc_qualifier}",'
+            f" null, requestParameters, responseParameters, null);"
+        )
+        lines.append("    return objects.isEmpty() ? null : objects.get(0);")
+    elif cmd.pattern == "list":
+        lines.append(f"  public List<Map<String, Object>> {method_name}(")
+        lines.append("      @Nullable String name,")
+        lines.append("      @Nullable Map<String, Object> requestParameters,")
+        lines.append("      @Nullable List<String> responseParameters,")
+        lines.append("      @Nullable String where) {")
+        if cmd.name_default:
+            lines.append(
+                f'    return mqscCommand("{cmd.verb}", "{cmd.mqsc_qualifier}",'
+                f' name != null ? name : "{cmd.name_default}",'
+                f" requestParameters, responseParameters, where);"
+            )
+        else:
+            lines.append(
+                f'    return mqscCommand("{cmd.verb}", "{cmd.mqsc_qualifier}",'
+                f" name, requestParameters, responseParameters, where);"
+            )
+    elif cmd.pattern == "required_name":
+        lines.append(f"  public void {method_name}(")
+        lines.append("      @Nullable String name,")
+        lines.append("      @Nullable Map<String, Object> requestParameters,")
+        lines.append("      @Nullable List<String> responseParameters) {")
+        lines.append('    Objects.requireNonNull(name, "name");')
+        lines.append(
+            f'    mqscCommand("{cmd.verb}", "{cmd.mqsc_qualifier}",'
+            f" name, requestParameters, responseParameters, null);"
+        )
+    elif cmd.pattern == "no_name":
+        lines.append(f"  public void {method_name}(")
+        lines.append(
+            "      @Nullable Map<String, Object> requestParameters,"
+            " @Nullable List<String> responseParameters) {"
+        )
+        lines.append(
+            f'    mqscCommand("{cmd.verb}", "{cmd.mqsc_qualifier}",'
+            f" null, requestParameters, responseParameters, null);"
+        )
+    else:  # optional_name
+        lines.append(f"  public void {method_name}(")
+        lines.append("      @Nullable String name,")
+        lines.append("      @Nullable Map<String, Object> requestParameters,")
+        lines.append("      @Nullable List<String> responseParameters) {")
+        lines.append(
+            f'    mqscCommand("{cmd.verb}", "{cmd.mqsc_qualifier}",'
+            f" name, requestParameters, responseParameters, null);"
+        )
+
+    lines.append("  }")
+    return "\n".join(lines)
+
+
+def generate_java(specs: list[CommandSpec]) -> str:
+    """Generate all Java methods."""
+    methods = [_java_method(cmd) for cmd in specs]
+    return "\n\n".join(methods)
+
+
+# ---------------------------------------------------------------------------
+# Go generation
+# ---------------------------------------------------------------------------
+
+
+def _go_method_name(cmd: CommandSpec) -> str:
+    """Convert verb_qualifier to PascalCase."""
+    parts = f"{cmd.verb.lower()}_{cmd.mqsc_qualifier.lower()}".split("_")
+    return "".join(p.capitalize() for p in parts)
+
+
+def _go_method(cmd: CommandSpec) -> str:
+    """Generate one Go method."""
+    method_name = _go_method_name(cmd)
+    command_label = f"{cmd.verb} {cmd.mqsc_qualifier}"
+
+    lines: list[str] = []
+
+    if cmd.pattern == "singleton":
+        lines.append(f"// {method_name} executes the {command_label} command.")
+        lines.append(
+            f"func (session *Session) {method_name}(ctx context.Context,"
+            f" opts ...CommandOption) (map[string]any, error) {{"
+        )
+        lines.append("	config := buildCommandConfig(opts)")
+        lines.append(
+            f'	objects, err := session.mqscCommand(ctx, "{cmd.verb}",'
+            f' "{cmd.mqsc_qualifier}", nil,'
+            f" config.requestParameters, config.responseParameters, nil, true)"
+        )
+        lines.append("	if err != nil {")
+        lines.append("		return nil, err")
+        lines.append("	}")
+        lines.append("	if len(objects) == 0 {")
+        lines.append("		return nil, nil")
+        lines.append("	}")
+        lines.append("	return objects[0], nil")
+        lines.append("}")
+    elif cmd.pattern == "list" and cmd.name_default:
+        lines.append(
+            f"// {method_name} executes the {command_label} command."
+            f' Name defaults to "{cmd.name_default}" if empty.'
+        )
+        lines.append(
+            f"func (session *Session) {method_name}(ctx context.Context,"
+            f" name string, opts ...CommandOption) ([]map[string]any, error) {{"
+        )
+        lines.append("	config := buildCommandConfig(opts)")
+        lines.append("	displayName := name")
+        lines.append('	if displayName == "" {')
+        lines.append(f'		displayName = "{cmd.name_default}"')
+        lines.append("	}")
+        lines.append(
+            f'	return session.mqscCommand(ctx, "{cmd.verb}",'
+            f' "{cmd.mqsc_qualifier}", &displayName,'
+            f" config.requestParameters, config.responseParameters,"
+            f" config.where, true)"
+        )
+        lines.append("}")
+    elif cmd.pattern == "list":
+        lines.append(f"// {method_name} executes the {command_label} command.")
+        lines.append(
+            f"func (session *Session) {method_name}(ctx context.Context,"
+            f" name string, opts ...CommandOption) ([]map[string]any, error) {{"
+        )
+        lines.append(f'	return session.displayList(ctx, "{cmd.mqsc_qualifier}", name, opts)')
+        lines.append("}")
+    elif cmd.pattern == "required_name":
+        lines.append(f"// {method_name} executes the {command_label} command. Name is required.")
+        lines.append(
+            f"func (session *Session) {method_name}(ctx context.Context,"
+            f" name string, opts ...CommandOption) error {{"
+        )
+        lines.append(
+            f'	return session.voidCommand(ctx, "{cmd.verb}",'
+            f' "{cmd.mqsc_qualifier}", &name, opts)'
+        )
+        lines.append("}")
+    elif cmd.pattern == "no_name":
+        lines.append(f"// {method_name} executes the {command_label} command.")
+        lines.append(
+            f"func (session *Session) {method_name}(ctx context.Context,"
+            f" opts ...CommandOption) error {{"
+        )
+        lines.append(
+            f'	return session.voidCommand(ctx, "{cmd.verb}", "{cmd.mqsc_qualifier}", nil, opts)'
+        )
+        lines.append("}")
+    else:  # optional_name
+        lines.append(f"// {method_name} executes the {command_label} command.")
+        lines.append(
+            f"func (session *Session) {method_name}(ctx context.Context,"
+            f" name string, opts ...CommandOption) error {{"
+        )
+        lines.append(
+            f'	return session.voidCommandOptionalName(ctx, "{cmd.verb}",'
+            f' "{cmd.mqsc_qualifier}", name, opts)'
+        )
+        lines.append("}")
+
+    return "\n".join(lines)
+
+
+def generate_go(specs: list[CommandSpec]) -> str:
+    """Generate all Go methods."""
+    methods = [_go_method(cmd) for cmd in specs]
+    return "\n\n".join(methods)
+
+
+# ---------------------------------------------------------------------------
+# Rust generation
+# ---------------------------------------------------------------------------
+
+
+def _rust_method(cmd: CommandSpec) -> str:
+    """Generate one Rust method."""
+    method_name = f"{cmd.verb.lower()}_{cmd.mqsc_qualifier.lower()}"
+    command_label = f"{cmd.verb} {cmd.mqsc_qualifier}"
+
+    lines: list[str] = []
+    lines.append(f"    /// Execute the MQSC `{command_label}` command.")
+
+    if cmd.pattern == "singleton":
+        lines.append("    pub fn " + method_name + "(")
+        lines.append("        &mut self,")
+        lines.append("        request_parameters: Option<&HashMap<String, Value>>,")
+        lines.append("        response_parameters: Option<&[&str]>,")
+        lines.append("    ) -> Result<Option<HashMap<String, Value>>> {")
+        lines.append("        let objects = self.mqsc_command(")
+        lines.append(f'            "{cmd.verb}",')
+        lines.append(f'            "{cmd.mqsc_qualifier}",')
+        lines.append("            None,")
+        lines.append("            request_parameters,")
+        lines.append("            response_parameters,")
+        lines.append("            None,")
+        lines.append("        )?;")
+        lines.append("        Ok(objects.into_iter().next())")
+        lines.append("    }")
+    elif cmd.pattern == "list":
+        lines.append("    pub fn " + method_name + "(")
+        lines.append("        &mut self,")
+        lines.append("        name: Option<&str>,")
+        lines.append("        request_parameters: Option<&HashMap<String, Value>>,")
+        lines.append("        response_parameters: Option<&[&str]>,")
+        lines.append("        where_clause: Option<&str>,")
+        lines.append("    ) -> Result<Vec<HashMap<String, Value>>> {")
+        if cmd.name_default:
+            lines.append("        self.mqsc_command(")
+            lines.append(f'            "{cmd.verb}",')
+            lines.append(f'            "{cmd.mqsc_qualifier}",')
+            lines.append(f'            Some(name.unwrap_or("{cmd.name_default}")),')
+            lines.append("            request_parameters,")
+            lines.append("            response_parameters,")
+            lines.append("            where_clause,")
+            lines.append("        )")
+        else:
+            lines.append("        self.mqsc_command(")
+            lines.append(f'            "{cmd.verb}",')
+            lines.append(f'            "{cmd.mqsc_qualifier}",')
+            lines.append("            name,")
+            lines.append("            request_parameters,")
+            lines.append("            response_parameters,")
+            lines.append("            where_clause,")
+            lines.append("        )")
+        lines.append("    }")
+    elif cmd.pattern == "required_name":
+        lines.append("    pub fn " + method_name + "(")
+        lines.append("        &mut self,")
+        lines.append("        name: &str,")
+        lines.append("        request_parameters: Option<&HashMap<String, Value>>,")
+        lines.append("        response_parameters: Option<&[&str]>,")
+        lines.append("    ) -> Result<()> {")
+        lines.append("        self.mqsc_command(")
+        lines.append(f'            "{cmd.verb}",')
+        lines.append(f'            "{cmd.mqsc_qualifier}",')
+        lines.append("            Some(name),")
+        lines.append("            request_parameters,")
+        lines.append("            response_parameters,")
+        lines.append("            None,")
+        lines.append("        )?;")
+        lines.append("        Ok(())")
+        lines.append("    }")
+    elif cmd.pattern == "no_name":
+        lines.append("    pub fn " + method_name + "(")
+        lines.append("        &mut self,")
+        lines.append("        request_parameters: Option<&HashMap<String, Value>>,")
+        lines.append("        response_parameters: Option<&[&str]>,")
+        lines.append("    ) -> Result<()> {")
+        lines.append("        self.mqsc_command(")
+        lines.append(f'            "{cmd.verb}",')
+        lines.append(f'            "{cmd.mqsc_qualifier}",')
+        lines.append("            None,")
+        lines.append("            request_parameters,")
+        lines.append("            response_parameters,")
+        lines.append("            None,")
+        lines.append("        )?;")
+        lines.append("        Ok(())")
+        lines.append("    }")
+    else:  # optional_name
+        lines.append("    pub fn " + method_name + "(")
+        lines.append("        &mut self,")
+        lines.append("        name: Option<&str>,")
+        lines.append("        request_parameters: Option<&HashMap<String, Value>>,")
+        lines.append("        response_parameters: Option<&[&str]>,")
+        lines.append("    ) -> Result<()> {")
+        lines.append("        self.mqsc_command(")
+        lines.append(f'            "{cmd.verb}",')
+        lines.append(f'            "{cmd.mqsc_qualifier}",')
+        lines.append("            name,")
+        lines.append("            request_parameters,")
+        lines.append("            response_parameters,")
+        lines.append("            None,")
+        lines.append("        )?;")
+        lines.append("        Ok(())")
+        lines.append("    }")
+
+    return "\n".join(lines)
+
+
+def generate_rust(specs: list[CommandSpec]) -> str:
+    """Generate all Rust methods."""
+    methods = [_rust_method(cmd) for cmd in specs]
+    return "\n\n".join(methods)
+
+
+# ---------------------------------------------------------------------------
+# Language dispatch
+# ---------------------------------------------------------------------------
+
+LANGUAGES = ("python", "ruby", "java", "go", "rust")
+
+GENERATORS: dict[str, object] = {
+    "python": generate_python,
+    "ruby": generate_ruby,
+    "java": generate_java,
+    "go": generate_go,
+    "rust": generate_rust,
+}
+
+
+def generate(
+    language: str,
+    specs: list[CommandSpec],
+    *,
+    mapping_pages: frozenset[str] | None = None,
+) -> str:
+    """Generate command methods for the given language."""
+    if language == "python":
+        return generate_python(specs, mapping_pages or frozenset())
+    if language == "ruby":
+        return generate_ruby(specs)
+    if language == "java":
+        return generate_java(specs)
+    if language == "go":
+        return generate_go(specs)
+    if language == "rust":
+        return generate_rust(specs)
+    msg = f"Unsupported language: {language}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Marker-based file update
+# ---------------------------------------------------------------------------
+
+MARKERS: dict[str, tuple[str, str]] = {
+    "python": ("    # BEGIN GENERATED MQSC METHODS", "    # END GENERATED MQSC METHODS"),
+    "ruby": ("        # BEGIN GENERATED MQSC METHODS", "        # END GENERATED MQSC METHODS"),
+    "java": ("  // BEGIN GENERATED MQSC METHODS", "  // END GENERATED MQSC METHODS"),
+    "go": ("// BEGIN GENERATED MQSC METHODS", "// END GENERATED MQSC METHODS"),
+    "rust": ("    // BEGIN GENERATED MQSC METHODS", "    // END GENERATED MQSC METHODS"),
+}
+
+
+def update_file(target_path: Path, language: str, generated: str) -> bool:
+    """Replace content between markers in target file. Returns True if changed."""
+    begin_marker, end_marker = MARKERS[language]
+    source = target_path.read_text(encoding="utf-8")
+
+    begin_idx = source.index(begin_marker)
+    end_idx = source.index(end_marker)
+
+    new_source = (
+        source[:begin_idx]
+        + begin_marker
+        + "\n"
+        + generated
+        + "\n\n"
+        + end_marker
+        + source[end_idx + len(end_marker) :]
+    )
+
+    changed = new_source != source
+    if changed:
+        target_path.write_text(new_source, encoding="utf-8")
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate MQSC command methods from mapping-data.json."
+    )
+    parser.add_argument(
+        "--language",
+        required=True,
+        choices=LANGUAGES,
+        help="Target language for code generation.",
+    )
+    parser.add_argument(
+        "--mapping-data",
+        required=True,
+        type=Path,
+        help="Path to mapping-data.json.",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        help="Target source file to update (between markers). If omitted, prints to stdout.",
+    )
+    parser.add_argument(
+        "--mapping-pages-dir",
+        type=Path,
+        default=None,
+        help="Directory containing Sphinx mapping .md files (Python only).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check that generated output matches the target file (exit 1 if different).",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_mapping_pages(mapping_pages_dir: Path | None) -> frozenset[str]:
+    """Discover available mapping pages from a directory."""
+    if mapping_pages_dir is None or not mapping_pages_dir.is_dir():
+        return frozenset()
+    return frozenset(
+        p.stem for p in mapping_pages_dir.iterdir() if p.suffix == ".md" and p.stem != "index"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.mapping_data.is_file():
+        print(f"Error: mapping-data.json not found: {args.mapping_data}", file=sys.stderr)
+        return 1
+
+    specs = load_commands(args.mapping_data)
+    mapping_pages = _resolve_mapping_pages(args.mapping_pages_dir)
+    generated = generate(args.language, specs, mapping_pages=mapping_pages)
+
+    if args.target is not None:
+        if args.check:
+            return _check_target(args.target, args.language, generated)
+        changed = update_file(args.target, args.language, generated)
+        status = "updated" if changed else "unchanged"
+        print(f"{args.target}: {status} ({len(specs)} methods)")
+    else:
+        print(generated)
+
+    return 0
+
+
+def _check_target(target: Path, language: str, generated: str) -> int:
+    """Verify that the target file matches the generated output."""
+    begin_marker, end_marker = MARKERS[language]
+    source = target.read_text(encoding="utf-8")
+
+    begin_idx = source.index(begin_marker)
+    end_idx = source.index(end_marker)
+
+    expected = (
+        source[:begin_idx]
+        + begin_marker
+        + "\n"
+        + generated
+        + "\n\n"
+        + end_marker
+        + source[end_idx + len(end_marker) :]
+    )
+
+    if source == expected:
+        print(f"{target}: up to date")
+        return 0
+
+    print(f"{target}: out of date (run st-generate-commands to update)", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/standard_tooling/test_generate_commands.py
+++ b/tests/standard_tooling/test_generate_commands.py
@@ -1,0 +1,675 @@
+"""Tests for standard_tooling.bin.generate_commands."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from standard_tooling.bin.generate_commands import (
+    classify_command,
+    generate,
+    load_commands,
+    main,
+    parse_args,
+    update_file,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal mapping-data.json for testing
+# ---------------------------------------------------------------------------
+
+MINIMAL_MAPPING_DATA = {
+    "commands": {
+        "ALTER AUTHINFO": {"qualifier": "authinfo"},
+        "ALTER QMGR": {"qualifier": "qmgr"},
+        "DEFINE CHANNEL": {"qualifier": "channel", "name_required": True},
+        "DEFINE QLOCAL": {"qualifier": "queue", "name_required": True},
+        "DELETE QUEUE": {"qualifier": "queue", "name_required": True},
+        "DISPLAY CHANNEL": {"qualifier": "channel", "pattern": "list", "name_default": "*"},
+        "DISPLAY CMDSERV": {"qualifier": "cmdserv", "pattern": "singleton"},
+        "DISPLAY QMGR": {"qualifier": "qmgr", "pattern": "singleton"},
+        "DISPLAY QUEUE": {"qualifier": "queue", "pattern": "list", "name_default": "*"},
+        "START CHANNEL": {"qualifier": "channel"},
+        "START QMGR": {"qualifier": "qmgr"},
+        "STOP CMDSERV": {"qualifier": "cmdserv"},
+    },
+    "qualifiers": {},
+}
+
+
+@pytest.fixture()
+def mapping_data_file(tmp_path: Path) -> Path:
+    path = tmp_path / "mapping-data.json"
+    path.write_text(json.dumps(MINIMAL_MAPPING_DATA), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# parse_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_minimal(tmp_path: Path) -> None:
+    p = tmp_path / "m.json"
+    args = parse_args(["--language", "python", "--mapping-data", str(p)])
+    assert args.language == "python"
+    assert args.mapping_data == p
+    assert args.target is None
+    assert args.check is False
+
+
+def test_parse_args_all_options(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    t = tmp_path / "out.go"
+    pages = tmp_path / "pages"
+    args = parse_args(
+        [
+            "--language",
+            "go",
+            "--mapping-data",
+            str(m),
+            "--target",
+            str(t),
+            "--mapping-pages-dir",
+            str(pages),
+            "--check",
+        ]
+    )
+    assert args.language == "go"
+    assert args.target == t
+    assert args.mapping_pages_dir == pages
+    assert args.check is True
+
+
+def test_parse_args_invalid_language(tmp_path: Path) -> None:
+    p = tmp_path / "m.json"
+    with pytest.raises(SystemExit):
+        parse_args(["--language", "fortran", "--mapping-data", str(p)])
+
+
+# ---------------------------------------------------------------------------
+# classify_command
+# ---------------------------------------------------------------------------
+
+
+def test_classify_singleton() -> None:
+    spec = classify_command("DISPLAY", "QMGR", {"qualifier": "qmgr", "pattern": "singleton"})
+    assert spec.pattern == "singleton"
+    assert spec.qualifier == "qmgr"
+
+
+def test_classify_list_with_default() -> None:
+    spec = classify_command(
+        "DISPLAY", "QUEUE", {"qualifier": "queue", "pattern": "list", "name_default": "*"}
+    )
+    assert spec.pattern == "list"
+    assert spec.name_default == "*"
+
+
+def test_classify_display_list_without_explicit_pattern() -> None:
+    """All non-singleton DISPLAY commands are list pattern."""
+    spec = classify_command("DISPLAY", "AUTHINFO", {"qualifier": "authinfo"})
+    assert spec.pattern == "list"
+    assert spec.name_default is None
+
+
+def test_classify_required_name() -> None:
+    spec = classify_command("DEFINE", "QLOCAL", {"qualifier": "queue", "name_required": True})
+    assert spec.pattern == "required_name"
+
+
+def test_classify_no_name() -> None:
+    spec = classify_command("ALTER", "QMGR", {"qualifier": "qmgr"})
+    assert spec.pattern == "no_name"
+
+
+def test_classify_no_name_cmdserv() -> None:
+    spec = classify_command("STOP", "CMDSERV", {"qualifier": "cmdserv"})
+    assert spec.pattern == "no_name"
+
+
+def test_classify_optional_name_default() -> None:
+    spec = classify_command("ALTER", "AUTHINFO", {"qualifier": "authinfo"})
+    assert spec.pattern == "optional_name"
+
+
+def test_classify_fallback_qualifier() -> None:
+    """Falls back to mqsc_qualifier.lower() if qualifier is missing or invalid."""
+    spec = classify_command("ALTER", "AUTHINFO", {})
+    assert spec.qualifier == "authinfo"
+
+    spec2 = classify_command("ALTER", "AUTHINFO", {"qualifier": 42})
+    assert spec2.qualifier == "authinfo"
+
+
+# ---------------------------------------------------------------------------
+# load_commands
+# ---------------------------------------------------------------------------
+
+
+def test_load_commands(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    assert len(specs) == len(MINIMAL_MAPPING_DATA["commands"])
+    names = [f"{s.verb} {s.mqsc_qualifier}" for s in specs]
+    assert names == sorted(names)  # alphabetical order
+
+
+def test_load_commands_empty(tmp_path: Path) -> None:
+    path = tmp_path / "empty.json"
+    path.write_text('{"commands": {}}', encoding="utf-8")
+    assert load_commands(path) == []
+
+
+def test_load_commands_no_commands_key(tmp_path: Path) -> None:
+    path = tmp_path / "no.json"
+    path.write_text("{}", encoding="utf-8")
+    assert load_commands(path) == []
+
+
+def test_load_commands_non_dict(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"commands": "invalid"}', encoding="utf-8")
+    assert load_commands(path) == []
+
+
+def test_load_commands_skips_invalid_entries(tmp_path: Path) -> None:
+    path = tmp_path / "partial.json"
+    data = {
+        "commands": {
+            "ALTER AUTHINFO": {"qualifier": "authinfo"},
+            "BADENTRY": {"qualifier": "bad"},  # no space, skipped
+            "ALTER CHANNEL": "not_a_dict",  # skipped
+        }
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    specs = load_commands(path)
+    assert len(specs) == 1
+    assert specs[0].verb == "ALTER"
+
+
+# ---------------------------------------------------------------------------
+# Python generation
+# ---------------------------------------------------------------------------
+
+
+def test_python_singleton(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("python", specs)
+    assert "def display_qmgr(" in output
+    assert "-> dict[str, object] | None:" in output
+    assert "objects = self._mqsc_command(" in output
+    assert "return objects[0]" in output
+    assert "name=None," in output
+
+
+def test_python_list_with_default(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("python", specs)
+    assert "def display_queue(" in output
+    assert "-> list[dict[str, object]]:" in output
+    assert 'name=name or "*",' in output
+    assert "where: str | None = None," in output
+
+
+def test_python_list_without_default(mapping_data_file: Path) -> None:
+    """DISPLAY commands without name_default still pass name directly."""
+    data = {"commands": {"DISPLAY AUTHINFO": {"qualifier": "authinfo"}}}
+    path = mapping_data_file.parent / "auth.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    specs = load_commands(path)
+    output = generate("python", specs)
+    assert "def display_authinfo(" in output
+    assert "name=name," in output
+    assert "where=where," in output
+
+
+def test_python_required_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("python", specs)
+    assert "def define_qlocal(" in output
+    assert "name: str," in output
+    assert "-> None:" in output
+
+
+def test_python_optional_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("python", specs)
+    assert "def alter_authinfo(" in output
+    assert "name: str | None = None," in output
+    assert "-> None:" in output
+
+
+def test_python_no_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("python", specs)
+    assert "def alter_qmgr(" in output
+    # Should not have name parameter
+    assert "alter_qmgr(\n        self,\n        request_parameters:" in output
+
+
+def test_python_mapping_pages(mapping_data_file: Path, tmp_path: Path) -> None:
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "queue.md").write_text("# Queue")
+    (pages_dir / "index.md").write_text("# Index")
+    mapping_pages = frozenset(
+        p.stem for p in pages_dir.iterdir() if p.suffix == ".md" and p.stem != "index"
+    )
+    specs = load_commands(mapping_data_file)
+    output = generate("python", specs, mapping_pages=mapping_pages)
+    assert "queue attribute mappings" in output
+    # Index should not appear
+    assert "index attribute mappings" not in output
+
+
+# ---------------------------------------------------------------------------
+# Ruby generation
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_singleton(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("ruby", specs)
+    assert "def display_qmgr(request_parameters: nil, response_parameters: nil)" in output
+    assert "objects.empty? ? nil : objects[0]" in output
+
+
+def test_ruby_list_with_default(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("ruby", specs)
+    assert "def display_queue(name: nil," in output
+    assert "name: name || '*'" in output
+    assert "where: where" in output
+
+
+def test_ruby_required_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("ruby", specs)
+    assert "def define_qlocal(name, request_parameters:" in output
+    assert "nil\n        end" in output
+
+
+def test_ruby_optional_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("ruby", specs)
+    assert "def alter_authinfo(name: nil," in output
+
+
+def test_ruby_no_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("ruby", specs)
+    assert "def alter_qmgr(request_parameters: nil, response_parameters: nil)" in output
+    assert "name: nil, request_parameters:" in output
+
+
+# ---------------------------------------------------------------------------
+# Java generation
+# ---------------------------------------------------------------------------
+
+
+def test_java_singleton(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("java", specs)
+    assert "public @Nullable Map<String, Object> displayQmgr(" in output
+    assert "objects.isEmpty() ? null : objects.get(0);" in output
+
+
+def test_java_list_with_default(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("java", specs)
+    assert "public List<Map<String, Object>> displayQueue(" in output
+    assert 'name != null ? name : "*"' in output
+
+
+def test_java_required_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("java", specs)
+    assert "public void defineQlocal(" in output
+    assert 'Objects.requireNonNull(name, "name")' in output
+
+
+def test_java_optional_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("java", specs)
+    assert "public void alterAuthinfo(" in output
+    # No requireNonNull for optional
+    lines_between = output[output.index("alterAuthinfo(") : output.index("alterQmgr(")]
+    assert "requireNonNull" not in lines_between
+
+
+def test_java_no_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("java", specs)
+    assert "public void alterQmgr(" in output
+    assert "null, requestParameters, responseParameters, null);" in output
+
+
+# ---------------------------------------------------------------------------
+# Go generation
+# ---------------------------------------------------------------------------
+
+
+def test_go_singleton(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("go", specs)
+    assert "func (session *Session) DisplayQmgr(ctx context.Context," in output
+    assert "(map[string]any, error)" in output
+    assert "return objects[0], nil" in output
+
+
+def test_go_list_with_default(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("go", specs)
+    assert "func (session *Session) DisplayQueue(ctx context.Context, name string," in output
+    assert "([]map[string]any, error)" in output
+    assert 'displayName = "*"' in output
+
+
+def test_java_list_without_default(mapping_data_file: Path) -> None:
+    """DISPLAY commands without name_default pass name directly in Java."""
+    data = {"commands": {"DISPLAY AUTHINFO": {"qualifier": "authinfo"}}}
+    path = mapping_data_file.parent / "auth.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    specs = load_commands(path)
+    output = generate("java", specs)
+    assert "displayAuthinfo(" in output
+    assert "name, requestParameters, responseParameters, where" in output
+
+
+def test_rust_list_without_default(mapping_data_file: Path) -> None:
+    """DISPLAY commands without name_default pass name directly in Rust."""
+    data = {"commands": {"DISPLAY AUTHINFO": {"qualifier": "authinfo"}}}
+    path = mapping_data_file.parent / "auth.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    specs = load_commands(path)
+    output = generate("rust", specs)
+    assert "pub fn display_authinfo(" in output
+    assert "            name," in output
+
+
+def test_go_list_without_default(mapping_data_file: Path) -> None:
+    """DISPLAY commands without name_default use displayList helper."""
+    data = {"commands": {"DISPLAY AUTHINFO": {"qualifier": "authinfo"}}}
+    path = mapping_data_file.parent / "auth.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    specs = load_commands(path)
+    output = generate("go", specs)
+    assert "displayList(ctx," in output
+
+
+def test_go_required_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("go", specs)
+    assert "func (session *Session) DefineQlocal(ctx context.Context, name string," in output
+    assert "error {" in output
+    assert "voidCommand(ctx," in output
+
+
+def test_go_optional_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("go", specs)
+    assert "func (session *Session) AlterAuthinfo(ctx context.Context, name string," in output
+    assert "voidCommandOptionalName(ctx," in output
+
+
+def test_go_no_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("go", specs)
+    assert "func (session *Session) AlterQmgr(ctx context.Context, opts ...CommandOption)" in output
+    assert "voidCommand(ctx," in output
+
+
+# ---------------------------------------------------------------------------
+# Rust generation
+# ---------------------------------------------------------------------------
+
+
+def test_rust_singleton(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("rust", specs)
+    assert "pub fn display_qmgr(" in output
+    assert "Result<Option<HashMap<String, Value>>>" in output
+    assert "Ok(objects.into_iter().next())" in output
+
+
+def test_rust_list_with_default(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("rust", specs)
+    assert "pub fn display_queue(" in output
+    assert "Result<Vec<HashMap<String, Value>>>" in output
+    assert 'Some(name.unwrap_or("*"))' in output
+
+
+def test_rust_required_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("rust", specs)
+    assert "pub fn define_qlocal(" in output
+    assert "name: &str," in output
+    assert "Result<()>" in output
+    assert "Some(name)," in output
+
+
+def test_rust_optional_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("rust", specs)
+    assert "pub fn alter_authinfo(" in output
+    assert "name: Option<&str>," in output
+
+
+def test_rust_no_name(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("rust", specs)
+    assert "pub fn alter_qmgr(" in output
+    # Should not have name parameter
+    section = output[output.index("pub fn alter_qmgr(") : output.index("pub fn define_channel(")]
+    assert "name:" not in section
+    assert "None," in section  # passes None for name
+
+
+# ---------------------------------------------------------------------------
+# generate() dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_generate_invalid_language(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    with pytest.raises(ValueError, match="Unsupported language"):
+        generate("fortran", specs)
+
+
+# ---------------------------------------------------------------------------
+# update_file
+# ---------------------------------------------------------------------------
+
+
+def test_update_file_python(tmp_path: Path, mapping_data_file: Path) -> None:
+    target = tmp_path / "commands.py"
+    target.write_text(
+        textwrap.dedent("""\
+            class Mixin:
+                # BEGIN GENERATED MQSC METHODS
+                # old content
+                # END GENERATED MQSC METHODS
+                pass
+        """).replace("            ", "    "),
+        encoding="utf-8",
+    )
+    specs = load_commands(mapping_data_file)
+    generated = generate("python", specs)
+    changed = update_file(target, "python", generated)
+    assert changed is True
+    content = target.read_text()
+    assert "# BEGIN GENERATED MQSC METHODS" in content
+    assert "# END GENERATED MQSC METHODS" in content
+    assert "def display_qmgr(" in content
+    assert "# old content" not in content
+
+
+def test_update_file_idempotent(tmp_path: Path, mapping_data_file: Path) -> None:
+    target = tmp_path / "commands.py"
+    target.write_text(
+        "    # BEGIN GENERATED MQSC METHODS\n    # old\n    # END GENERATED MQSC METHODS\n",
+        encoding="utf-8",
+    )
+    specs = load_commands(mapping_data_file)
+    generated = generate("python", specs)
+    update_file(target, "python", generated)
+    changed = update_file(target, "python", generated)
+    assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def test_main_stdout(mapping_data_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    result = main(["--language", "python", "--mapping-data", str(mapping_data_file)])
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "def display_qmgr(" in captured.out
+
+
+def test_main_target_update(
+    mapping_data_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out.py"
+    target.write_text(
+        "    # BEGIN GENERATED MQSC METHODS\n    # END GENERATED MQSC METHODS\n",
+        encoding="utf-8",
+    )
+    result = main(
+        [
+            "--language",
+            "python",
+            "--mapping-data",
+            str(mapping_data_file),
+            "--target",
+            str(target),
+        ]
+    )
+    assert result == 0
+    assert "def display_qmgr(" in target.read_text()
+    captured = capsys.readouterr()
+    assert "updated" in captured.out
+
+
+def test_main_check_pass(
+    mapping_data_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out.py"
+    target.write_text(
+        "    # BEGIN GENERATED MQSC METHODS\n    # END GENERATED MQSC METHODS\n",
+        encoding="utf-8",
+    )
+    # First write
+    main(
+        [
+            "--language",
+            "python",
+            "--mapping-data",
+            str(mapping_data_file),
+            "--target",
+            str(target),
+        ]
+    )
+    # Then check
+    result = main(
+        [
+            "--language",
+            "python",
+            "--mapping-data",
+            str(mapping_data_file),
+            "--target",
+            str(target),
+            "--check",
+        ]
+    )
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "up to date" in captured.out
+
+
+def test_main_check_fail(
+    mapping_data_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out.py"
+    target.write_text(
+        "    # BEGIN GENERATED MQSC METHODS\n    # stale\n    # END GENERATED MQSC METHODS\n",
+        encoding="utf-8",
+    )
+    result = main(
+        [
+            "--language",
+            "python",
+            "--mapping-data",
+            str(mapping_data_file),
+            "--target",
+            str(target),
+            "--check",
+        ]
+    )
+    assert result == 1
+
+
+def test_main_missing_mapping_data(capsys: pytest.CaptureFixture[str]) -> None:
+    result = main(["--language", "python", "--mapping-data", "/nonexistent/mapping.json"])
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "not found" in captured.err
+
+
+def test_main_all_languages(mapping_data_file: Path) -> None:
+    for lang in ("python", "ruby", "java", "go", "rust"):
+        result = main(["--language", lang, "--mapping-data", str(mapping_data_file)])
+        assert result == 0, f"Failed for {lang}"
+
+
+def test_main_mapping_pages(mapping_data_file: Path, tmp_path: Path) -> None:
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "queue.md").write_text("# Queue")
+    result = main(
+        [
+            "--language",
+            "python",
+            "--mapping-data",
+            str(mapping_data_file),
+            "--mapping-pages-dir",
+            str(pages_dir),
+        ]
+    )
+    assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Method count consistency
+# ---------------------------------------------------------------------------
+
+
+def test_all_languages_same_method_count(mapping_data_file: Path) -> None:
+    """All languages should generate the same number of methods."""
+    specs = load_commands(mapping_data_file)
+    expected = len(specs)
+    for lang in ("python", "ruby", "java", "go", "rust"):
+        output = generate(lang, specs)
+        # Count methods by language-specific markers
+        if lang == "python":
+            count = output.count("    def ")
+        elif lang == "ruby":
+            count = output.count("        def ")
+        elif lang == "java":
+            count = output.count("  public ")
+        elif lang == "go":
+            count = output.count("func (session *Session) ")
+        elif lang == "rust":
+            count = output.count("    pub fn ")
+        else:
+            continue
+        assert count == expected, f"{lang}: expected {expected} methods, got {count}"


### PR DESCRIPTION
# Pull Request

## Summary

- Add st-generate-commands CLI tool that reads mapping-data.json and generates MQSC command methods for Python, Ruby, Java, Go, and Rust with marker-based file updates and CI check mode

## Issue Linkage

- Fixes #153

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -