### PR TITLE
fix: Ruby list DISPLAY methods without name_default use required positional name param

### DIFF
--- a/src/standard_tooling/bin/generate_commands.py
+++ b/src/standard_tooling/bin/generate_commands.py
@@ -220,10 +220,10 @@ def _ruby_method(cmd: CommandSpec) -> str:
     lines.append(f"        # Execute the MQSC +{command_label}+ command.")
     lines.append("        #")
 
-    if cmd.pattern == "required_name":
+    if cmd.pattern == "required_name" or (cmd.pattern == "list" and not cmd.name_default):
         lines.append("        # @param name [String] the object name")
     elif cmd.pattern in ("list", "optional_name"):
-        if cmd.pattern == "list" and cmd.name_default:
+        if cmd.name_default:
             lines.append(
                 f"        # @param name [String, nil] object name or pattern,"
                 f' defaults to +"{cmd.name_default}"+'
@@ -261,9 +261,14 @@ def _ruby_method(cmd: CommandSpec) -> str:
         lines.append(
             f"        def {method_name}(request_parameters: nil, response_parameters: nil)"
         )
-    elif cmd.pattern == "list":
+    elif cmd.pattern == "list" and cmd.name_default:
         lines.append(
             f"        def {method_name}(name: nil, request_parameters: nil,"
+            f" response_parameters: nil, where: nil)"
+        )
+    elif cmd.pattern == "list":
+        lines.append(
+            f"        def {method_name}(name, request_parameters: nil,"
             f" response_parameters: nil, where: nil)"
         )
     else:  # optional_name

--- a/tests/standard_tooling/test_generate_commands.py
+++ b/tests/standard_tooling/test_generate_commands.py
@@ -29,6 +29,7 @@ MINIMAL_MAPPING_DATA = {
         "ALTER AUTHINFO": {"qualifier": "authinfo"},
         "ALTER QMGR": {"qualifier": "qmgr"},
         "DEFINE CHANNEL": {"qualifier": "channel", "name_required": True},
+        "DISPLAY AUTHINFO": {"qualifier": "authinfo"},
         "DEFINE QLOCAL": {"qualifier": "queue", "name_required": True},
         "DELETE QUEUE": {"qualifier": "queue", "name_required": True},
         "DISPLAY CHANNEL": {"qualifier": "channel", "pattern": "list", "name_default": "*"},
@@ -285,6 +286,13 @@ def test_ruby_list_with_default(mapping_data_file: Path) -> None:
     output = generate("ruby", specs)
     assert "def display_queue(name: nil," in output
     assert "name: name || '*'" in output
+    assert "where: where" in output
+
+
+def test_ruby_list_without_default(mapping_data_file: Path) -> None:
+    specs = load_commands(mapping_data_file)
+    output = generate("ruby", specs)
+    assert "def display_authinfo(name, request_parameters:" in output
     assert "where: where" in output
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fix Ruby generator to use required positional name param for list DISPLAY methods without name_default

## Issue Linkage

- Fixes #157

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -