### PR TITLE
feat(labels): add canonical label registry and sync modes to st-ensure-label

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -6,6 +6,26 @@ body:
     attributes:
       value: |
         Use this form to capture the required issue details.
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      description: Select the type that best describes this issue.
+      options:
+        - feature
+        - bug
+        - documentation
+        - style
+        - refactor
+        - test
+        - chore
+        - ci
+        - build
+        - research
+        - rtfm
+        - observability
+    validations:
+      required: true
   - type: textarea
     id: summary
     attributes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dev = ["ruff", "mypy", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]
 [tool.setuptools]
 package-dir = {"" = "src"}
 
+[tool.setuptools.package-data]
+standard_tooling = ["data/*.json"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/standard_tooling/bin/ensure_label.py
+++ b/src/standard_tooling/bin/ensure_label.py
@@ -1,6 +1,10 @@
-"""Ensure a label exists in a GitHub repository. Creates it if missing.
+"""Ensure labels exist in GitHub repositories.
 
-Idempotent: exits 0 whether the label already existed or was created.
+Supports three modes:
+
+1. **Single-label** — create/update one label in one repo.
+2. **Sync** — provision every label from the canonical registry into a repo.
+3. **Project** — discover repos via a GitHub Project and sync each one.
 """
 
 from __future__ import annotations
@@ -9,35 +13,93 @@ import argparse
 import sys
 
 from standard_tooling.lib import github
+from standard_tooling.lib.labels import load_labels
+from standard_tooling.lib.observatory import list_project_repos
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description="Ensure a GitHub label exists.")
-    parser.add_argument("--repo", required=True, help="Repository (OWNER/REPO)")
-    parser.add_argument("--label", required=True, help="Label name")
-    return parser.parse_args(argv)
+    parser = argparse.ArgumentParser(description="Ensure GitHub labels exist.")
+
+    # Single-label mode
+    parser.add_argument("--repo", help="Repository (OWNER/REPO)")
+    parser.add_argument("--label", help="Label name (single-label mode)")
+    parser.add_argument("--color", help="Label color hex (no #)")
+    parser.add_argument("--description", help="Label description")
+
+    # Sync mode
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="Provision all labels from the canonical registry",
+    )
+
+    # Project mode
+    parser.add_argument("--owner", help="GitHub owner (project mode)")
+    parser.add_argument("--project", help="GitHub Project number (project mode)")
+
+    args = parser.parse_args(argv)
+
+    # Validation
+    if args.owner or args.project:
+        if not (args.owner and args.project and args.sync):
+            parser.error("--owner and --project require each other and --sync")
+    elif args.sync:
+        if not args.repo:
+            parser.error("--sync requires --repo (or --owner/--project)")
+    else:
+        if not (args.repo and args.label):
+            parser.error("--repo and --label are required in single-label mode")
+
+    return args
+
+
+def _ensure_single(repo: str, name: str, color: str | None, description: str | None) -> None:
+    """Create or update a single label."""
+    cmd: list[str] = ["label", "create", name, "--repo", repo, "--force"]
+    if color:
+        cmd.extend(["--color", color])
+    if description:
+        cmd.extend(["--description", description])
+    github.run(*cmd)
+    print(f"  {name}")
+
+
+def _delete_label(repo: str, name: str) -> None:
+    """Delete a label, ignoring errors if it doesn't exist."""
+    try:
+        github.run("label", "delete", name, "--repo", repo, "--yes")
+        print(f"  deleted {name}")
+    except Exception:  # noqa: BLE001, S110
+        pass  # label didn't exist — nothing to do
+
+
+def sync_repo(repo: str) -> None:
+    """Provision all canonical labels and delete deprecated ones."""
+    registry = load_labels()
+    print(f"Syncing labels for {repo}:")
+    for label in registry["labels"]:
+        _ensure_single(repo, label["name"], label["color"], label["description"])
+    for name in registry.get("delete", []):
+        _delete_label(repo, name)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    existing = github.read_output(
-        "label",
-        "list",
-        "--repo",
-        args.repo,
-        "--search",
-        args.label,
-        "--json",
-        "name",
-        "--jq",
-        ".[].name",
-    )
-    if args.label in existing.splitlines():
-        print(f"Label '{args.label}' already exists in {args.repo}")
+
+    if args.owner and args.project:
+        # Project mode: discover repos, sync each
+        repos = list_project_repos(args.owner, args.project)
+        print(f"Found {len(repos)} repos in project {args.project}")
+        for repo in repos:
+            sync_repo(repo)
+    elif args.sync:
+        # Sync mode: single repo
+        sync_repo(args.repo)
     else:
-        github.run("label", "create", args.label, "--repo", args.repo)
-        print(f"Label '{args.label}' created in {args.repo}")
+        # Single-label mode
+        _ensure_single(args.repo, args.label, args.color, args.description)
+
     return 0
 
 

--- a/src/standard_tooling/data/labels.json
+++ b/src/standard_tooling/data/labels.json
@@ -1,0 +1,15 @@
+{
+  "labels": [
+    {"name": "feature", "color": "0e8a16", "description": "New feature or capability"},
+    {"name": "style", "color": "bfdadc", "description": "Formatting, whitespace, no code change"},
+    {"name": "refactor", "color": "d4c5f9", "description": "Code restructuring, no behavior change"},
+    {"name": "test", "color": "fbca04", "description": "Adding or updating tests"},
+    {"name": "chore", "color": "c5def5", "description": "Maintenance, tooling, configuration"},
+    {"name": "ci", "color": "e6e6e6", "description": "CI/CD pipeline changes"},
+    {"name": "build", "color": "bfd4f2", "description": "Build system or dependencies"},
+    {"name": "research", "color": "d876e3", "description": "Investigation or spike"},
+    {"name": "rtfm", "color": "f9d0c4", "description": "Resolved by reading existing docs"},
+    {"name": "observability", "color": "1d76db", "description": "Monitoring, reporting, health checks"}
+  ],
+  "delete": ["enhancement"]
+}

--- a/src/standard_tooling/lib/labels.py
+++ b/src/standard_tooling/lib/labels.py
@@ -1,0 +1,21 @@
+"""Label registry: load the canonical label set from ``data/labels.json``."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any
+
+
+def load_labels() -> dict[str, Any]:
+    """Return the parsed label registry.
+
+    The returned dict has two keys:
+
+    * ``labels`` — list of dicts with *name*, *color*, and *description*.
+    * ``delete`` — list of label names to remove.
+    """
+    ref = resources.files("standard_tooling.data").joinpath("labels.json")
+    text = ref.read_text(encoding="utf-8")
+    data: dict[str, Any] = json.loads(text)
+    return data

--- a/tests/standard_tooling/test_ensure_label.py
+++ b/tests/standard_tooling/test_ensure_label.py
@@ -4,26 +4,172 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from standard_tooling.bin.ensure_label import main, parse_args
 
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
 
-def test_parse_args() -> None:
+
+def test_parse_args_single_label() -> None:
     args = parse_args(["--repo", "owner/repo", "--label", "bug"])
     assert args.repo == "owner/repo"
     assert args.label == "bug"
+    assert args.sync is False
 
 
-def test_main_label_exists() -> None:
-    with patch("standard_tooling.bin.ensure_label.github.read_output", return_value="bug"):
-        result = main(["--repo", "owner/repo", "--label", "bug"])
+def test_parse_args_single_with_color_description() -> None:
+    args = parse_args(
+        [
+            "--repo",
+            "owner/repo",
+            "--label",
+            "feature",
+            "--color",
+            "0e8a16",
+            "--description",
+            "New feature",
+        ]
+    )
+    assert args.color == "0e8a16"
+    assert args.description == "New feature"
+
+
+def test_parse_args_sync_mode() -> None:
+    args = parse_args(["--repo", "owner/repo", "--sync"])
+    assert args.sync is True
+    assert args.repo == "owner/repo"
+
+
+def test_parse_args_project_mode() -> None:
+    args = parse_args(["--owner", "myorg", "--project", "3", "--sync"])
+    assert args.owner == "myorg"
+    assert args.project == "3"
+    assert args.sync is True
+
+
+def test_parse_args_project_without_sync_fails() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--owner", "myorg", "--project", "3"])
+
+
+def test_parse_args_sync_without_repo_fails() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--sync"])
+
+
+def test_parse_args_no_args_fails() -> None:
+    with pytest.raises(SystemExit):
+        parse_args([])
+
+
+# ---------------------------------------------------------------------------
+# Single-label mode
+# ---------------------------------------------------------------------------
+
+
+def test_main_single_label() -> None:
+    with patch("standard_tooling.bin.ensure_label.github.run") as mock_run:
+        result = main(["--repo", "o/r", "--label", "bug"])
+    assert result == 0
+    mock_run.assert_called_once_with(
+        "label",
+        "create",
+        "bug",
+        "--repo",
+        "o/r",
+        "--force",
+    )
+
+
+def test_main_single_label_with_color_description() -> None:
+    with patch("standard_tooling.bin.ensure_label.github.run") as mock_run:
+        result = main(
+            [
+                "--repo",
+                "o/r",
+                "--label",
+                "feature",
+                "--color",
+                "0e8a16",
+                "--description",
+                "New feature",
+            ]
+        )
+    assert result == 0
+    mock_run.assert_called_once_with(
+        "label",
+        "create",
+        "feature",
+        "--repo",
+        "o/r",
+        "--force",
+        "--color",
+        "0e8a16",
+        "--description",
+        "New feature",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sync mode
+# ---------------------------------------------------------------------------
+
+
+def test_main_sync_provisions_all_labels() -> None:
+    with patch("standard_tooling.bin.ensure_label.github.run") as mock_run:
+        result = main(["--repo", "o/r", "--sync"])
+    assert result == 0
+    # Should have called once per label + once for the delete
+    label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
+    assert len(label_calls) == 10  # 10 labels in the registry
+
+
+def test_main_sync_uses_force_with_color_description() -> None:
+    with patch("standard_tooling.bin.ensure_label.github.run") as mock_run:
+        main(["--repo", "o/r", "--sync"])
+    # Check one representative call has --force, --color, --description
+    first_create = next(c for c in mock_run.call_args_list if c.args[1] == "create")
+    assert "--force" in first_create.args
+    assert "--color" in first_create.args
+    assert "--description" in first_create.args
+
+
+def test_main_sync_deletes_deprecated_labels() -> None:
+    with patch("standard_tooling.bin.ensure_label.github.run") as mock_run:
+        main(["--repo", "o/r", "--sync"])
+    delete_calls = [c for c in mock_run.call_args_list if c.args[1] == "delete"]
+    assert len(delete_calls) == 1
+    assert "enhancement" in delete_calls[0].args
+
+
+def test_main_sync_delete_ignores_missing_label() -> None:
+    """Deleting a non-existent label should not raise."""
+
+    def side_effect(*args: str) -> None:
+        if args[1] == "delete":
+            raise RuntimeError("label not found")
+
+    with patch("standard_tooling.bin.ensure_label.github.run", side_effect=side_effect):
+        result = main(["--repo", "o/r", "--sync"])
     assert result == 0
 
 
-def test_main_label_not_found() -> None:
+# ---------------------------------------------------------------------------
+# Project mode
+# ---------------------------------------------------------------------------
+
+
+def test_main_project_mode_discovers_and_syncs() -> None:
     with (
-        patch("standard_tooling.bin.ensure_label.github.read_output", return_value=""),
-        patch("standard_tooling.bin.ensure_label.github.run") as mock_run,
+        patch(
+            "standard_tooling.bin.ensure_label.list_project_repos",
+            return_value=["owner/a", "owner/b"],
+        ) as mock_discover,
+        patch("standard_tooling.bin.ensure_label.github.run"),
     ):
-        result = main(["--repo", "owner/repo", "--label", "bug"])
+        result = main(["--owner", "myorg", "--project", "3", "--sync"])
     assert result == 0
-    mock_run.assert_called_once_with("label", "create", "bug", "--repo", "owner/repo")
+    mock_discover.assert_called_once_with("myorg", "3")

--- a/tests/standard_tooling/test_labels.py
+++ b/tests/standard_tooling/test_labels.py
@@ -1,0 +1,61 @@
+"""Tests for standard_tooling.lib.labels."""
+
+from __future__ import annotations
+
+from standard_tooling.lib.labels import load_labels
+
+# GitHub default labels that must not collide with the registry.
+_GITHUB_DEFAULTS = frozenset(
+    {
+        "bug",
+        "documentation",
+        "duplicate",
+        "good first issue",
+        "help wanted",
+        "invalid",
+        "question",
+        "wontfix",
+    }
+)
+
+
+def test_load_labels_returns_dict() -> None:
+    registry = load_labels()
+    assert isinstance(registry, dict)
+    assert "labels" in registry
+    assert "delete" in registry
+
+
+def test_labels_have_required_fields() -> None:
+    registry = load_labels()
+    for label in registry["labels"]:
+        assert "name" in label, f"Label missing 'name': {label}"
+        assert "color" in label, f"Label {label['name']} missing 'color'"
+        assert "description" in label, f"Label {label['name']} missing 'description'"
+
+
+def test_label_colors_are_valid_hex() -> None:
+    registry = load_labels()
+    for label in registry["labels"]:
+        color = label["color"]
+        assert len(color) == 6, f"Color '{color}' for {label['name']} is not 6 chars"
+        int(color, 16)  # raises ValueError if not valid hex
+
+
+def test_no_collision_with_github_defaults() -> None:
+    registry = load_labels()
+    names = {label["name"] for label in registry["labels"]}
+    collisions = names & _GITHUB_DEFAULTS
+    assert not collisions, f"Labels collide with GitHub defaults: {collisions}"
+
+
+def test_no_duplicate_label_names() -> None:
+    registry = load_labels()
+    names = [label["name"] for label in registry["labels"]]
+    assert len(names) == len(set(names)), f"Duplicate label names: {names}"
+
+
+def test_delete_list_is_strings() -> None:
+    registry = load_labels()
+    for name in registry["delete"]:
+        assert isinstance(name, str)


### PR DESCRIPTION
# Pull Request

## Summary

- Add canonical label registry, sync/project modes to st-ensure-label, and issue type dropdown

## Issue Linkage

- Fixes #138

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -