### PR TITLE
docs: add Python 3.12 to dev-python version matrix in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Version matrix:
 | Language | Versions |
 |----------|----------|
 | Ruby     | 3.2, 3.3, 3.4 |
-| Python   | 3.13, 3.14 |
+| Python   | 3.12, 3.13, 3.14 |
 | Java     | 21 |
 | Go       | 1.25, 1.26 |
 


### PR DESCRIPTION
# Pull Request

## Summary

- Align CLAUDE.md version matrix with actual docker/build.sh and docker-publish.yml which already include Python 3.12

## Issue Linkage

- Fixes #165

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -