### PR TITLE
ci: add concurrency group to ci-push workflow

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -8,6 +8,10 @@ on:
       - 'hotfix/**'
       - 'chore/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write


### PR DESCRIPTION
# Pull Request

## Summary

- Add concurrency group to ci-push.yml so new pushes cancel in-flight runs

## Issue Linkage

- Ref #148

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ci.yml already has concurrency groups. The 5 language repos also need ci-push.yml updated — those are separate PRs in each repo.