### PR TITLE
feat(release): add Rust/Cargo ecosystem support to st-prepare-release

### DIFF
--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -8,6 +8,7 @@ Supported ecosystems:
   - Maven:  reads version from pom.xml
   - Go:     reads version from **/version.go
   - Ruby:   reads version from **/version.rb
+  - Cargo:  reads version from Cargo.toml
   - VERSION file: reads version from VERSION (fallback)
 """
 
@@ -66,6 +67,15 @@ def _detect_ruby() -> str | None:
     return None
 
 
+def _detect_cargo() -> str | None:
+    path = Path("Cargo.toml")
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
 def _detect_version_file() -> str | None:
     path = Path("VERSION")
     if not path.is_file():
@@ -87,6 +97,7 @@ _DETECTORS: list[tuple[str, _Detector]] = [
     ("maven", _detect_maven),
     ("go", _detect_go),
     ("ruby", _detect_ruby),
+    ("cargo", _detect_cargo),
     ("version-file", _detect_version_file),
 ]
 
@@ -103,6 +114,7 @@ def detect_ecosystem() -> tuple[str, str]:
         "  - pom.xml with version (Maven)\n"
         "  - go.mod + **/version.go (Go)\n"
         "  - Gemfile + **/version.rb (Ruby)\n"
+        "  - Cargo.toml with version (Cargo/Rust)\n"
         "  - VERSION file with MAJOR.MINOR.PATCH"
     )
     raise SystemExit(msg)

--- a/tests/standard_tooling/test_prepare_release.py
+++ b/tests/standard_tooling/test_prepare_release.py
@@ -149,9 +149,7 @@ def test_detect_cargo_no_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 def test_detect_ecosystem_cargo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "Cargo.toml").write_text(
-        '[package]\nname = "my-crate"\nversion = "1.2.0"\n'
-    )
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "my-crate"\nversion = "1.2.0"\n')
     name, version = detect_ecosystem()
     assert name == "cargo"
     assert version == "1.2.0"

--- a/tests/standard_tooling/test_prepare_release.py
+++ b/tests/standard_tooling/test_prepare_release.py
@@ -11,6 +11,7 @@ import pytest
 from standard_tooling.bin.prepare_release import (
     RELEASE_NOTES_CONFIG,
     RELEASE_NOTES_DIR,
+    _detect_cargo,
     _detect_go,
     _detect_maven,
     _detect_python,
@@ -125,6 +126,35 @@ def test_detect_ruby_no_version_in_file(tmp_path: Path, monkeypatch: pytest.Monk
     lib.mkdir()
     (lib / "version.rb").write_text("module Foo\nend\n")
     assert _detect_ruby() is None
+
+
+def test_detect_cargo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "my-crate"\nversion = "1.2.0"\nedition = "2024"\n'
+    )
+    assert _detect_cargo() == "1.2.0"
+
+
+def test_detect_cargo_no_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert _detect_cargo() is None
+
+
+def test_detect_cargo_no_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "my-crate"\n')
+    assert _detect_cargo() is None
+
+
+def test_detect_ecosystem_cargo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "my-crate"\nversion = "1.2.0"\n'
+    )
+    name, version = detect_ecosystem()
+    assert name == "cargo"
+    assert version == "1.2.0"
 
 
 def test_detect_version_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add Cargo.toml detection so st-prepare-release works for Rust repos

## Issue Linkage

- Fixes #175

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -