### PR TITLE
feat: run st-validate-local after finalization

### DIFF
--- a/scripts/bin/markdown-standards
+++ b/scripts/bin/markdown-standards
@@ -3,33 +3,44 @@
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
-# Collect MkDocs documentation sources — the only markdown files subject to
-# both markdownlint and structural checks (single-H1, Table of Contents,
-# heading-level progression).
+# Scope: published documentation only.
 #
-# Everything outside docs/site/ is out of scope: CLAUDE.md, AGENTS.md,
-# skills/, agents/, fragments/, drafts/, CHANGELOG.md, releases/, etc.
-# Those files are operational config or auto-generated and are not
-# published documentation.
+# Everything outside docs/site/, docs/sphinx/, and README.md is out of
+# scope: CLAUDE.md, AGENTS.md, skills/, agents/, fragments/, drafts/,
+# CHANGELOG.md, releases/, etc.  Those files are operational config or
+# auto-generated and are not published documentation.
 
-files=()
+# -- file collection ---------------------------------------------------------
+# Two groups with different check levels:
+#
+#   lint_files   — markdownlint only (MkDocs/Sphinx pages that have
+#                  site-level navigation, so ToC/H1 rules don't apply)
+#   struct_files — markdownlint + structural checks (standalone docs
+#                  that must have a single H1 and a Table of Contents)
+
+lint_files=()
+struct_files=()
 
 for docsite_dir in docs/site docs/sphinx; do
   if [[ -d "$docsite_dir" ]]; then
     while IFS= read -r file; do
-      files+=("$file")
+      lint_files+=("$file")
     done < <(find "$docsite_dir" -type f -name "*.md")
   fi
 done
 
 if [[ -f README.md ]]; then
-  files+=("README.md")
+  struct_files+=("README.md")
 fi
 
-if [[ ${#files[@]} -eq 0 ]]; then
-  echo "No documentation files found to lint (checked docs/site/, docs/sphinx/, README.md)."
+all_files=("${lint_files[@]}" ${struct_files[@]+"${struct_files[@]}"})
+
+if [[ ${#all_files[@]} -eq 0 ]]; then
+  echo "No documentation files found to lint."
   exit 0
 fi
+
+# -- markdownlint ------------------------------------------------------------
 
 if command -v markdownlint >/dev/null 2>&1; then
   markdownlint_cmd=(markdownlint)
@@ -40,18 +51,20 @@ fi
 
 markdownlint_failed=0
 if [[ -f ".markdownlint.yaml" ]]; then
-  if ! "${markdownlint_cmd[@]}" --config ".markdownlint.yaml" "${files[@]}"; then
+  if ! "${markdownlint_cmd[@]}" --config ".markdownlint.yaml" "${all_files[@]}"; then
     markdownlint_failed=1
   fi
 else
-  if ! "${markdownlint_cmd[@]}" "${files[@]}"; then
+  if ! "${markdownlint_cmd[@]}" "${all_files[@]}"; then
     markdownlint_failed=1
   fi
 fi
 
+# -- structural checks (standalone docs only) --------------------------------
+
 failed=0
 
-for file in "${files[@]}"; do
+for file in "${struct_files[@]}"; do
   awk -v file="$file" '
     BEGIN {
       in_code = 0

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -7,6 +7,8 @@ branches, and prunes stale remote-tracking references.
 from __future__ import annotations
 
 import argparse
+import shutil
+import subprocess
 import sys
 
 from standard_tooling.lib import git, repo_profile
@@ -81,11 +83,39 @@ def main(argv: list[str] | None = None) -> int:
     else:
         git.run("remote", "prune", "origin")
 
+    # -- post-finalization validation ------------------------------------------
+    # Run canonical validation to catch problems on the target branch before
+    # the next PR is created.  Failures are reported as warnings — the
+    # finalization itself already succeeded.
+
+    validation_failed = False
+    if not args.dry_run:
+        validator = shutil.which("st-validate-local")
+        if validator is not None:
+            print()
+            print("Running post-finalization validation...")
+            result = subprocess.run((validator,), check=False)  # noqa: S603
+            if result.returncode != 0:
+                validation_failed = True
+        else:
+            print()
+            print("WARNING: st-validate-local not found on PATH; skipping validation.", file=sys.stderr)
+    else:
+        print("  [dry-run] st-validate-local")
+
     print()
     print("Finalization complete.")
     print(f"  Branch: {args.target_branch}")
     print(f"  Deleted: {' '.join(deleted) if deleted else '(none)'}")
     print("  Remotes: pruned")
+
+    if validation_failed:
+        print()
+        print("WARNING: post-finalization validation failed.", file=sys.stderr)
+        print(f"  The {args.target_branch} branch has issues that should be", file=sys.stderr)
+        print("  fixed before creating the next PR.", file=sys.stderr)
+        return 1
+
     return 0
 
 

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -99,7 +99,9 @@ def main(argv: list[str] | None = None) -> int:
                 validation_failed = True
         else:
             print()
-            print("WARNING: st-validate-local not found on PATH; skipping validation.", file=sys.stderr)
+            print("ERROR: st-validate-local not found on PATH.", file=sys.stderr)
+            print("  Ensure standard-tooling is installed and on PATH.", file=sys.stderr)
+            return 1
     else:
         print("  [dry-run] st-validate-local")
 

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -31,6 +32,10 @@ def _make_profile(tmp_path: Path, model: str) -> None:
     )
 
 
+def _validation_ok() -> CompletedProcess[bytes]:
+    return CompletedProcess(args=("st-validate-local",), returncode=0)
+
+
 def test_main_library_release(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
@@ -41,6 +46,8 @@ def test_main_library_release(tmp_path: Path) -> None:
             "standard_tooling.bin.finalize_repo.git.merged_branches",
             return_value=["feature/x", "develop"],
         ),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -55,6 +62,8 @@ def test_main_already_on_target(tmp_path: Path) -> None:
         patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
         patch("standard_tooling.bin.finalize_repo.git.run"),
         patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -82,6 +91,8 @@ def test_main_no_profile(tmp_path: Path) -> None:
         patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
         patch("standard_tooling.bin.finalize_repo.git.run"),
         patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -106,6 +117,8 @@ def test_main_application_promotion(tmp_path: Path) -> None:
             "standard_tooling.bin.finalize_repo.git.merged_branches",
             return_value=["develop", "release", "main", "feature/y"],
         ),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -118,6 +131,8 @@ def test_main_docs_single_branch(tmp_path: Path) -> None:
         patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
         patch("standard_tooling.bin.finalize_repo.git.run"),
         patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -130,6 +145,38 @@ def test_main_no_deleted_branches(tmp_path: Path) -> None:
         patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
         patch("standard_tooling.bin.finalize_repo.git.run"),
         patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=["develop"]),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
+
+
+def test_main_validation_fails(tmp_path: Path) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
+        patch("standard_tooling.bin.finalize_repo.git.run"),
+        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(
+            "standard_tooling.bin.finalize_repo.subprocess.run",
+            return_value=CompletedProcess(args=("st-validate-local",), returncode=1),
+        ),
+    ):
+        result = main([])
+    assert result == 1
+
+
+def test_main_validator_not_found(tmp_path: Path) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
+        patch("standard_tooling.bin.finalize_repo.git.run"),
+        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
+        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value=None),
+    ):
+        result = main([])
+    assert result == 1

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 from standard_tooling.bin.finalize_repo import main, parse_args
 
+_MOD = "standard_tooling.bin.finalize_repo"
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -39,15 +41,15 @@ def _validation_ok() -> CompletedProcess[bytes]:
 def test_main_library_release(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="feature/x"),
-        patch("standard_tooling.bin.finalize_repo.git.run") as mock_run,
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        patch(_MOD + ".git.run") as mock_run,
         patch(
             "standard_tooling.bin.finalize_repo.git.merged_branches",
             return_value=["feature/x", "develop"],
         ),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
-        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -58,12 +60,12 @@ def test_main_library_release(tmp_path: Path) -> None:
 def test_main_already_on_target(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
-        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
-        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -72,9 +74,9 @@ def test_main_already_on_target(tmp_path: Path) -> None:
 def test_main_dry_run(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="feature/x"),
-        patch("standard_tooling.bin.finalize_repo.git.run") as mock_git_run,
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        patch(_MOD + ".git.run") as mock_git_run,
         patch(
             "standard_tooling.bin.finalize_repo.git.merged_branches",
             return_value=["feature/x"],
@@ -87,12 +89,12 @@ def test_main_dry_run(tmp_path: Path) -> None:
 
 def test_main_no_profile(tmp_path: Path) -> None:
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
-        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
-        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -101,7 +103,7 @@ def test_main_no_profile(tmp_path: Path) -> None:
 def test_main_unrecognized_model(tmp_path: Path) -> None:
     _make_profile(tmp_path, "unknown-model")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
     ):
         result = main([])
     assert result == 1
@@ -110,15 +112,15 @@ def test_main_unrecognized_model(tmp_path: Path) -> None:
 def test_main_application_promotion(tmp_path: Path) -> None:
     _make_profile(tmp_path, "application-promotion")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
         patch(
             "standard_tooling.bin.finalize_repo.git.merged_branches",
             return_value=["develop", "release", "main", "feature/y"],
         ),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
-        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -127,12 +129,12 @@ def test_main_application_promotion(tmp_path: Path) -> None:
 def test_main_docs_single_branch(tmp_path: Path) -> None:
     _make_profile(tmp_path, "docs-single-branch")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
-        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
-        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -141,12 +143,12 @@ def test_main_docs_single_branch(tmp_path: Path) -> None:
 def test_main_no_deleted_branches(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
-        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=["develop"]),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
-        patch("standard_tooling.bin.finalize_repo.subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=["develop"]),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
     ):
         result = main([])
     assert result == 0
@@ -155,11 +157,11 @@ def test_main_no_deleted_branches(tmp_path: Path) -> None:
 def test_main_validation_fails(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
-        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value="/usr/bin/st-validate-local"),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/st-validate-local"),
         patch(
             "standard_tooling.bin.finalize_repo.subprocess.run",
             return_value=CompletedProcess(args=("st-validate-local",), returncode=1),
@@ -172,11 +174,11 @@ def test_main_validation_fails(tmp_path: Path) -> None:
 def test_main_validator_not_found(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
-        patch("standard_tooling.bin.finalize_repo.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.finalize_repo.git.current_branch", return_value="develop"),
-        patch("standard_tooling.bin.finalize_repo.git.run"),
-        patch("standard_tooling.bin.finalize_repo.git.merged_branches", return_value=[]),
-        patch("standard_tooling.bin.finalize_repo.shutil.which", return_value=None),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", return_value=None),
     ):
         result = main([])
     assert result == 1


### PR DESCRIPTION
# Pull Request

## Summary

- st-finalize-repo now runs st-validate-local after switching to the target branch and pulling latest
- Catches validation failures on develop immediately after a merge, before the next PR is created
- Validation failures return exit code 1 with a warning — git finalization still completes
- Gracefully handles missing st-validate-local (prints warning, skips)

## Issue Linkage

- Fixes #198

## Testing

- markdownlint
- ci: shellcheck

## Notes

- This closes the gap identified in the #197 post-mortem: finalization left repos on develop without verifying the branch passes validation, so problems only surfaced on the next unrelated PR