### PR TITLE
Container-first validation infrastructure

### DIFF
--- a/scripts/bin/docker-test
+++ b/scripts/bin/docker-test
@@ -48,7 +48,7 @@ default_test_cmd() {
 
 lang="$(detect_language)"
 
-if [[ -z "$lang" ]]; then
+if [[ -z "$lang" ]] && [[ -z "${DOCKER_DEV_IMAGE:-}" ]]; then
   echo "ERROR: could not detect project language from repo contents." >&2
   echo "Set DOCKER_DEV_IMAGE and DOCKER_TEST_CMD explicitly." >&2
   exit 1
@@ -80,6 +80,14 @@ if [[ -n "$network" ]]; then
   docker_args+=(--network "$network")
 fi
 
+# Extra bind mounts (semicolon-separated, e.g. "/host/path:/container/path:ro").
+if [[ -n "${DOCKER_EXTRA_VOLUMES:-}" ]]; then
+  IFS=';' read -ra vols <<< "$DOCKER_EXTRA_VOLUMES"
+  for vol in "${vols[@]}"; do
+    [[ -n "$vol" ]] && docker_args+=(-v "$vol")
+  done
+fi
+
 # Pass through MQ_* environment variables for integration tests.
 while IFS='=' read -r name _; do
   docker_args+=(-e "$name")
@@ -90,7 +98,7 @@ docker_args+=(bash -c "$test_cmd")
 
 # -- run ----------------------------------------------------------------------
 
-echo "Language: ${lang}"
+echo "Language: ${lang:-<none>}"
 echo "Image:    ${image}"
 echo "Command:  ${test_cmd}"
 [[ -n "$network" ]] && echo "Network:  ${network}"

--- a/scripts/bin/validate-local-common
+++ b/scripts/bin/validate-local-common
@@ -1,53 +1,14 @@
 #!/usr/bin/env bash
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
-# validate-local-common — shared checks run for ALL repos.
+# validate-local-common — shared checks run for ALL repos (containerised).
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+st_bin="$(cd "$(dirname "$0")" && pwd)"
 
-run() {
-  echo "Running: $*"
-  "$@"
-}
-
-# -- required tools ----------------------------------------------------------
-
-missing=()
-command -v shellcheck >/dev/null 2>&1 || missing+=("shellcheck")
-command -v markdownlint >/dev/null 2>&1 || missing+=("markdownlint")
-
-if [[ ${#missing[@]} -gt 0 ]]; then
-  echo "ERROR: required tools not found: ${missing[*]}" >&2
-  exit 1
-fi
-
-# -- repo profile validation -------------------------------------------------
-# Prefer PATH-based command, fall back to known locations.
-
-if command -v repo-profile >/dev/null 2>&1; then
-  run repo-profile
-elif [[ -f "$repo_root/scripts/bin/repo-profile" ]]; then
-  run "$repo_root/scripts/bin/repo-profile"
-fi
-
-# -- markdown lint -----------------------------------------------------------
-
-if command -v markdown-standards >/dev/null 2>&1; then
-  run markdown-standards
-elif [[ -f "$repo_root/scripts/bin/markdown-standards" ]]; then
-  run "$repo_root/scripts/bin/markdown-standards"
-fi
-
-# -- shellcheck on all shell scripts -----------------------------------------
-
-shell_files=()
-while IFS= read -r f; do
-  shell_files+=("$f")
-done < <(
-  find "$repo_root/scripts" -type f \( -name '*.sh' -o -path '*/git-hooks/*' -o -path '*/bin/*' \) 2>/dev/null
-)
-
-if [[ ${#shell_files[@]} -gt 0 ]]; then
-  run shellcheck "${shell_files[@]}"
-fi
+# All dev images include shellcheck, markdownlint, shfmt, yamllint, actionlint.
+# Default to dev-python:3.14 for repos with no language marker.
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
+export DOCKER_EXTRA_VOLUMES="${st_bin}:/st-bin:ro"
+export DOCKER_TEST_CMD="export PATH=/st-bin:\$PATH && validate-local-common-container"
+exec docker-test

--- a/scripts/bin/validate-local-common-container
+++ b/scripts/bin/validate-local-common-container
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
+# validate-local-common-container — runs INSIDE a dev container.
+# Called by validate-local-common via docker-test.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# -- repo profile validation -------------------------------------------------
+
+if command -v repo-profile >/dev/null 2>&1; then
+  run repo-profile
+elif [[ -f "$repo_root/scripts/bin/repo-profile" ]]; then
+  run "$repo_root/scripts/bin/repo-profile"
+fi
+
+# -- markdown lint -----------------------------------------------------------
+
+if command -v markdown-standards >/dev/null 2>&1; then
+  run markdown-standards
+elif [[ -f "$repo_root/scripts/bin/markdown-standards" ]]; then
+  run "$repo_root/scripts/bin/markdown-standards"
+fi
+
+# -- shellcheck on all shell scripts -----------------------------------------
+
+shell_files=()
+while IFS= read -r f; do
+  shell_files+=("$f")
+done < <(
+  find "$repo_root/scripts" -type f \( -name '*.sh' -o -path '*/git-hooks/*' -o -path '*/bin/*' \) 2>/dev/null
+)
+
+if [[ ${#shell_files[@]} -gt 0 ]]; then
+  run shellcheck "${shell_files[@]}"
+fi

--- a/scripts/bin/validate-local-go
+++ b/scripts/bin/validate-local-go
@@ -2,93 +2,18 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate-local-go — Go-specific local validation checks.
+# Delegates to the repo's scripts/dev/ scripts which run inside containers.
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+failed=0
 
-run() {
-  echo "Running: $*"
-  "$@"
-}
-
-# -- required tools ----------------------------------------------------------
-
-missing=()
-command -v go >/dev/null 2>&1 || missing+=("go")
-command -v golangci-lint >/dev/null 2>&1 || missing+=("golangci-lint")
-command -v gocyclo >/dev/null 2>&1 || missing+=("gocyclo")
-command -v govulncheck >/dev/null 2>&1 || missing+=("govulncheck")
-command -v go-licenses >/dev/null 2>&1 || missing+=("go-licenses")
-
-if [[ ${#missing[@]} -gt 0 ]]; then
-  echo "ERROR: required tools not found: ${missing[*]}" >&2
-  exit 1
-fi
-
-# -- auto-discover module directory from go.mod ------------------------------
-
-module_dir=""
-if [[ -f "$repo_root/go.mod" ]]; then
-  module_dir="$repo_root"
-else
-  # Search one level down for go.mod.
-  while IFS= read -r f; do
-    module_dir="$(dirname "$f")"
-    break
-  done < <(find "$repo_root" -maxdepth 2 -name go.mod -not -path '*/vendor/*' 2>/dev/null)
-fi
-
-if [[ -z "$module_dir" ]]; then
-  echo "ERROR: could not find go.mod" >&2
-  exit 1
-fi
-
-echo "Go module directory: $module_dir"
-cd "$module_dir"
-
-# -- vet ---------------------------------------------------------------------
-
-run go vet ./...
-
-# -- lint --------------------------------------------------------------------
-
-run golangci-lint run ./...
-
-# -- cyclomatic complexity ---------------------------------------------------
-
-run gocyclo -over 15 .
-
-# -- unit tests --------------------------------------------------------------
-
-run go test -race -count=1 ./...
-
-# -- coverage ----------------------------------------------------------------
-
-if [[ -f "$module_dir/.testcoverage.yml" ]]; then
-  if command -v go-test-coverage >/dev/null 2>&1; then
-    run go-test-coverage --config .testcoverage.yml
+for script in lint.sh typecheck.sh test.sh audit.sh; do
+  target="$repo_root/scripts/dev/$script"
+  if [[ -x "$target" ]]; then
+    echo "Running: scripts/dev/$script"
+    "$target" || failed=1
   fi
-fi
+done
 
-# -- vulnerability scan ------------------------------------------------------
-
-run govulncheck ./...
-
-# -- license compliance ------------------------------------------------------
-
-allowlist_file="$module_dir/.go-licenses-allowlist"
-if [[ -f "$allowlist_file" ]]; then
-  allow_list=""
-  while IFS= read -r line; do
-    [[ -z "$line" || "$line" =~ ^# ]] && continue
-    if [[ -n "$allow_list" ]]; then
-      allow_list="$allow_list,$line"
-    else
-      allow_list="$line"
-    fi
-  done < "$allowlist_file"
-
-  if [[ -n "$allow_list" ]]; then
-    run go-licenses check ./... --allowed_licenses="$allow_list"
-  fi
-fi
+exit $failed

--- a/scripts/bin/validate-local-java
+++ b/scripts/bin/validate-local-java
@@ -2,50 +2,18 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate-local-java — Java-specific local validation checks.
+# Delegates to the repo's scripts/dev/ scripts which run inside containers.
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+failed=0
 
-run() {
-  echo "Running: $*"
-  "$@"
-}
-
-# -- required tools ----------------------------------------------------------
-
-if ! command -v java >/dev/null 2>&1; then
-  echo "ERROR: required tool not found: java" >&2
-  exit 1
-fi
-
-if [[ ! -x "$repo_root/mvnw" ]]; then
-  echo "ERROR: Maven wrapper (mvnw) not found or not executable at $repo_root/mvnw" >&2
-  exit 1
-fi
-
-# -- build + test ------------------------------------------------------------
-
-run "$repo_root/mvnw" verify -B
-
-# -- license compliance ------------------------------------------------------
-
-allowlist_file="$repo_root/.mvn-licenses-allowlist"
-if [[ -f "$allowlist_file" ]]; then
-  allow_list=""
-  while IFS= read -r line; do
-    [[ -z "$line" || "$line" =~ ^# ]] && continue
-    if [[ -n "$allow_list" ]]; then
-      allow_list="$allow_list,$line"
-    else
-      allow_list="$line"
-    fi
-  done < "$allowlist_file"
-
-  if [[ -n "$allow_list" ]]; then
-    run "$repo_root/mvnw" license:add-third-party \
-      -Dlicense.excludedScopes=test \
-      -Dlicense.failIfWarning=true \
-      "-Dlicense.includedLicenses=$allow_list" \
-      -B
+for script in lint.sh typecheck.sh test.sh audit.sh; do
+  target="$repo_root/scripts/dev/$script"
+  if [[ -x "$target" ]]; then
+    echo "Running: scripts/dev/$script"
+    "$target" || failed=1
   fi
-fi
+done
+
+exit $failed

--- a/scripts/bin/validate-local-python
+++ b/scripts/bin/validate-local-python
@@ -2,106 +2,18 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate-local-python — Python-specific local validation checks.
+# Delegates to the repo's scripts/dev/ scripts which run inside containers.
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+failed=0
 
-run() {
-  echo "Running: $*"
-  "$@"
-}
-
-# -- required tools ----------------------------------------------------------
-
-if ! command -v uv >/dev/null 2>&1; then
-  echo "ERROR: required tool not found: uv" >&2
-  exit 1
-fi
-
-# -- auto-discover package name from pyproject.toml --------------------------
-
-pkg_name=""
-if [[ -f "$repo_root/pyproject.toml" ]]; then
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
-      pkg_name="${BASH_REMATCH[1]}"
-      # Convert hyphens to underscores for Python import name.
-      pkg_name="${pkg_name//-/_}"
-      break
-    fi
-  done < "$repo_root/pyproject.toml"
-fi
-
-if [[ -z "$pkg_name" ]]; then
-  echo "ERROR: could not discover package name from pyproject.toml" >&2
-  exit 1
-fi
-
-echo "Python package: $pkg_name"
-
-# -- lock integrity ----------------------------------------------------------
-
-run uv lock --check
-
-# -- sync check --------------------------------------------------------------
-
-run uv sync --check --frozen --group dev
-
-# -- vulnerability scan ------------------------------------------------------
-
-req_files=()
-for f in requirements.txt requirements-dev.txt; do
-  if [[ -f "$repo_root/$f" ]]; then
-    req_files+=(-r "$f")
+for script in lint.sh typecheck.sh test.sh audit.sh; do
+  target="$repo_root/scripts/dev/$script"
+  if [[ -x "$target" ]]; then
+    echo "Running: scripts/dev/$script"
+    "$target" || failed=1
   fi
 done
 
-if [[ ${#req_files[@]} -gt 0 ]]; then
-  run uv run pip-audit "${req_files[@]}"
-fi
-
-# -- license compliance ------------------------------------------------------
-
-allowlist_file="$repo_root/.pip-licenses-allowlist"
-if [[ -f "$allowlist_file" ]]; then
-  allow_list=""
-  while IFS= read -r line; do
-    # Skip blank lines and comments.
-    [[ -z "$line" || "$line" =~ ^# ]] && continue
-    if [[ -n "$allow_list" ]]; then
-      allow_list="$allow_list;$line"
-    else
-      allow_list="$line"
-    fi
-  done < "$allowlist_file"
-
-  if [[ -n "$allow_list" ]]; then
-    run uv run pip-licenses --allow-only="$allow_list"
-  fi
-fi
-
-# -- linting -----------------------------------------------------------------
-
-run uv run ruff check
-
-# -- formatting --------------------------------------------------------------
-
-run uv run ruff format --check .
-
-# -- type checking (mypy) ----------------------------------------------------
-
-if [[ -d "$repo_root/src" ]]; then
-  run uv run mypy src/
-fi
-
-# -- type checking (ty) ------------------------------------------------------
-
-if uv run ty --version >/dev/null 2>&1; then
-  if [[ -d "$repo_root/src" ]]; then
-    run uv run ty check src
-  fi
-fi
-
-# -- unit tests + coverage ---------------------------------------------------
-
-run uv run pytest --cov="$pkg_name" --cov-branch --cov-fail-under=100
+exit $failed

--- a/scripts/bin/validate-local-rust
+++ b/scripts/bin/validate-local-rust
@@ -2,67 +2,18 @@
 # Managed by standard-tooling — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate-local-rust — Rust-specific local validation checks.
+# Delegates to the repo's scripts/dev/ scripts which run inside containers.
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+failed=0
 
-run() {
-  echo "Running: $*"
-  "$@"
-}
+for script in lint.sh typecheck.sh test.sh audit.sh; do
+  target="$repo_root/scripts/dev/$script"
+  if [[ -x "$target" ]]; then
+    echo "Running: scripts/dev/$script"
+    "$target" || failed=1
+  fi
+done
 
-# -- required tools ----------------------------------------------------------
-
-missing=()
-command -v cargo >/dev/null 2>&1 || missing+=("cargo")
-command -v cargo-clippy >/dev/null 2>&1 || missing+=("clippy")
-command -v rustfmt >/dev/null 2>&1 || missing+=("rustfmt")
-command -v cargo-deny >/dev/null 2>&1 || missing+=("cargo-deny")
-
-if [[ ${#missing[@]} -gt 0 ]]; then
-  echo "ERROR: required tools not found: ${missing[*]}" >&2
-  exit 1
-fi
-
-# -- auto-discover workspace from Cargo.toml --------------------------------
-
-manifest_dir=""
-if [[ -f "$repo_root/Cargo.toml" ]]; then
-  manifest_dir="$repo_root"
-else
-  # Search one level down for Cargo.toml.
-  while IFS= read -r f; do
-    manifest_dir="$(dirname "$f")"
-    break
-  done < <(find "$repo_root" -maxdepth 2 -name Cargo.toml -not -path '*/target/*' 2>/dev/null)
-fi
-
-if [[ -z "$manifest_dir" ]]; then
-  echo "ERROR: could not find Cargo.toml" >&2
-  exit 1
-fi
-
-echo "Cargo manifest directory: $manifest_dir"
-cd "$manifest_dir"
-
-# -- format ------------------------------------------------------------------
-
-run cargo fmt --all -- --check
-
-# -- lint --------------------------------------------------------------------
-
-run cargo clippy -- -D warnings
-
-# -- unit tests --------------------------------------------------------------
-
-run cargo test
-
-# -- coverage ----------------------------------------------------------------
-
-if command -v cargo-llvm-cov >/dev/null 2>&1; then
-  run cargo llvm-cov --fail-under-lines 0
-fi
-
-# -- dependency audit and license compliance ---------------------------------
-
-run cargo deny check
+exit $failed

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -2,21 +2,11 @@
 set -euo pipefail
 
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv lock --check}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=standard_tooling --cov-branch --cov-fail-under=100}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/src/standard_tooling/bin/validate_local.py
+++ b/src/standard_tooling/bin/validate_local.py
@@ -47,6 +47,11 @@ def _run_validator(name: str, scripts_bin: Path) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
+    for tool in ("docker", "docker-test"):
+        if shutil.which(tool) is None:
+            print(f"ERROR: {tool} is required for local validation", file=sys.stderr)
+            return 1
+
     root = git.repo_root()
     scripts_bin = root / "scripts" / "bin"
 

--- a/tests/standard_tooling/test_validate_local.py
+++ b/tests/standard_tooling/test_validate_local.py
@@ -76,6 +76,13 @@ def test_run_validator_not_found(tmp_path: Path) -> None:
         assert _run_validator("missing", tmp_path) is True
 
 
+def _which_allows_docker(tool: str) -> str | None:
+    """Mock shutil.which: allow docker and docker-test, block everything else."""
+    if tool in ("docker", "docker-test"):
+        return f"/usr/bin/{tool}"
+    return None
+
+
 def _make_profile(tmp_path: Path, language: str) -> None:
     docs = tmp_path / "docs"
     docs.mkdir(exist_ok=True)
@@ -84,11 +91,30 @@ def _make_profile(tmp_path: Path, language: str) -> None:
     )
 
 
+def test_main_docker_missing() -> None:
+    with patch("standard_tooling.bin.validate_local.shutil.which", return_value=None):
+        result = main([])
+    assert result == 1
+
+
+def test_main_docker_test_missing() -> None:
+    def which_only_docker(tool: str) -> str | None:
+        return "/usr/bin/docker" if tool == "docker" else None
+
+    with patch("standard_tooling.bin.validate_local.shutil.which", side_effect=which_only_docker):
+        result = main([])
+    assert result == 1
+
+
 def test_main_all_pass(tmp_path: Path) -> None:
     _make_profile(tmp_path, "python")
     scripts_bin = tmp_path / "scripts" / "bin"
     scripts_bin.mkdir(parents=True)
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
     ):
@@ -106,6 +132,10 @@ def test_main_common_fails(tmp_path: Path) -> None:
         return name != "validate-local-common"
 
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",
@@ -123,6 +153,10 @@ def test_main_language_validator_fails(tmp_path: Path) -> None:
         return name != "validate-local-python"
 
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",
@@ -135,6 +169,10 @@ def test_main_language_validator_fails(tmp_path: Path) -> None:
 
 def test_main_no_profile(tmp_path: Path) -> None:
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
     ):
@@ -145,6 +183,10 @@ def test_main_no_profile(tmp_path: Path) -> None:
 def test_main_language_none(tmp_path: Path) -> None:
     _make_profile(tmp_path, "none")
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.validate_local._run_validator", return_value=True),
         patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
@@ -168,6 +210,10 @@ def test_main_custom_validator_exists(tmp_path: Path) -> None:
         return True
 
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",
@@ -194,6 +240,10 @@ def test_main_custom_validator_fails(tmp_path: Path) -> None:
 
     _make_profile(tmp_path, "python")
     with (
+        patch(
+            "standard_tooling.bin.validate_local.shutil.which",
+            side_effect=_which_allows_docker,
+        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",


### PR DESCRIPTION
## Summary
- Rewrite `validate-local-{common,python,go,java,rust}` to delegate to repo `scripts/dev/*.sh` (which run inside containers via `docker-test`)
- Add `DOCKER_EXTRA_VOLUMES` and language detection fallback to `docker-test`
- Create `validate-local-common-container` for containerised common checks
- Add Docker pre-flight check to `validate_local.py`
- Remove fallback `docker run` blocks from dev scripts; add `uv sync --check` to `audit.sh`
- Net -218 lines: simpler, consistent, container-only validation

## Test plan
- [ ] Run `st-validate-local` in standard-tooling — all checks pass
- [ ] Verify `docker` and `docker-test` missing gives clear error
- [ ] Run `st-validate-local` in a language-less repo with `DOCKER_DEV_IMAGE` set
- [ ] Run full test suite — 249 tests pass at 100% coverage

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)