### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,18 +16,14 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.1
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
           version-command: python3 -c "import tomllib; from pathlib import Path; v=tomllib.loads(Path('pyproject.toml').read_text())['project']['version']; print('.'.join(v.split('.')[:2]))"


### PR DESCRIPTION
# Pull Request

## Summary

- Run docs workflow inside ghcr.io/wphillipmoore/dev-docs:latest
- Remove manual Python setup step
- Update docs-deploy action ref from v1.1 to @develop

## Issue Linkage

- Fixes #211

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Merge after standard-tooling-docker#27 and standard-actions#174
