### PR TITLE
ci: restore standards-compliance after wrapper fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,7 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.1
     with:
       language: python
-      # TODO: restore after wrapper fallback lands on develop (#217)
-      run-standards: 'false'
+      run-standards: ${{ inputs.run-release-gates || 'true' }}
       run-security: ${{ inputs.run-security || 'true' }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Restores `run-standards` to its original expression after the wrapper fallback fix landed on develop via #218

## Test plan

- [ ] CI standards-compliance job runs and passes (validates the wrapper fallback works from develop)

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)