### PR TITLE
chore: remove legacy bash wrapper scripts and use st-* entry points directly

### DIFF
--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -35,12 +35,11 @@ This installs the `st-*` CLI tools into `.venv/bin/`.
 From your consuming repository:
 
 ```bash
-export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH"
+export PATH="../standard-tooling/.venv/bin:$PATH"
 ```
 
-This makes both the Python CLI tools (`st-commit`, `st-submit-pr`, etc.)
-and bash validators (`repo-profile`, `markdown-standards`, etc.) available
-by bare name.
+This makes the `st-*` CLI tools (`st-commit`, `st-submit-pr`, etc.)
+available by name.
 
 ### 4. Configure git hooks
 
@@ -89,7 +88,7 @@ Create `docs/repository-standards.md` with the required attributes:
 Run a validator to confirm everything is wired up:
 
 ```bash
-repo-profile
+st-repo-profile
 ```
 
 ## Next Steps

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -40,7 +40,7 @@ cd ../your-repo
 Add standard-tooling to PATH and configure git hooks:
 
 ```bash
-export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH"
+export PATH="../standard-tooling/.venv/bin:$PATH"
 git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks
 ```
 
@@ -89,9 +89,9 @@ Use the `standard-actions` composite action in your CI workflow:
 
 The action checks out standard-tooling, adds it to PATH, and runs:
 
-- `repo-profile` -- validates the repository profile
-- `markdown-standards` -- validates markdown formatting
-- `pr-issue-linkage` -- validates PR issue linkage (on PRs only)
+- `st-repo-profile` -- validates the repository profile
+- `st-markdown-standards` -- validates markdown formatting
+- `st-pr-issue-linkage` -- validates PR issue linkage (on PRs only)
 
 See `standard-actions` for reusable workflow actions.
 
@@ -109,10 +109,10 @@ no-duplicate-heading:
 
 ```bash
 # Verify repo profile
-repo-profile
+st-repo-profile
 
 # Verify markdown
-markdown-standards
+st-markdown-standards
 
 # Verify hooks work
 git checkout -b feature/1-test-setup

--- a/docs/site/docs/guides/three-tier-ci.md
+++ b/docs/site/docs/guides/three-tier-ci.md
@@ -49,7 +49,7 @@ Each script follows the same pattern:
 
 1. Set `DOCKER_DEV_IMAGE` (default: `dev-<language>:<latest-version>`)
 2. Set `DOCKER_TEST_CMD` (language-specific command)
-3. Delegate to `docker-test` if available, otherwise run `docker run`
+3. Delegate to `st-docker-test` if available, otherwise run `docker run`
    directly
 
 Environment overrides:

--- a/docs/site/docs/guides/validation-matrix.md
+++ b/docs/site/docs/guides/validation-matrix.md
@@ -8,9 +8,9 @@ and its exit codes.
 | Check | Hook | CI | Script |
 | ----- | ---- | -- | ------ |
 | Branch naming | Yes | -- | `pre-commit` |
-| Repository profile | -- | Yes | `repo-profile` |
-| Markdown standards | -- | Yes | `markdown-standards` |
-| PR issue linkage | -- | Yes | `pr-issue-linkage` |
+| Repository profile | -- | Yes | `st-repo-profile` |
+| Markdown standards | -- | Yes | `st-markdown-standards` |
+| PR issue linkage | -- | Yes | `st-pr-issue-linkage` |
 | Shellcheck | -- | Yes | CI workflow step |
 
 ## Local Hooks
@@ -28,14 +28,14 @@ and its exit codes.
 
 ## CI Checks
 
-### repo-profile
+### st-repo-profile
 
 **Trigger:** PR opened or updated
 
 Validates `docs/repository-standards.md` has all six required
 attributes.
 
-### markdown-standards
+### st-markdown-standards
 
 **Trigger:** PR opened or updated
 
@@ -43,7 +43,7 @@ Runs markdownlint on all markdown files. Structural checks (single
 H1, TOC, heading hierarchy) apply to standard docs only -- not
 doc-site pages or CHANGELOG.md.
 
-### pr-issue-linkage
+### st-pr-issue-linkage
 
 **Trigger:** PR opened or updated
 

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -11,9 +11,9 @@ commits, PRs, releases, and validation alongside bash validators and git hooks
 `st-commit`, `st-submit-pr`, `st-prepare-release`,
 `st-finalize-repo`, `st-validate-local`
 
-**Bash validators** (`scripts/bin/`):
-`commit-message`, `repo-profile`, `markdown-standards`,
-`pr-issue-linkage`, validation drivers
+**Lint tools** (installed as `st-*`):
+`st-repo-profile`, `st-markdown-standards`,
+`st-pr-issue-linkage`, validation drivers
 
 **Git hooks** (`scripts/lib/git-hooks/`):
 Branch naming enforcement, commit message validation
@@ -33,7 +33,7 @@ Branch naming enforcement, commit message validation
    or checked out in CI (GitHub Actions).
 2. The Python package is installed via `uv sync`, making `st-*` CLI
    tools available in `.venv/bin/`.
-3. Both `.venv/bin/` and `scripts/bin/` are added to PATH.
+3. `.venv/bin/` is added to PATH.
 4. Git hooks are configured to point at `scripts/lib/git-hooks/`.
 5. Consuming repos call tools by bare name -- no file copying or syncing.
 

--- a/docs/site/docs/reference/dev/validate-local.md
+++ b/docs/site/docs/reference/dev/validate-local.md
@@ -23,9 +23,9 @@ stages:
 
 ### 1. Common Checks (always)
 
-Runs `validate-local-common` (resolved via PATH). This script
+Runs `st-validate-local-common` (resolved via PATH). This script
 contains checks shared across all repositories (markdown linting,
-shellcheck, repo-profile validation).
+shellcheck, st-repo-profile validation).
 
 ### 2. Language-Specific Checks
 
@@ -34,9 +34,9 @@ validation script (resolved via PATH):
 
 | Language | Script |
 | -------- | ------ |
-| `python` | `validate-local-python` |
-| `go` | `validate-local-go` |
-| `java` | `validate-local-java` |
+| `python` | `st-validate-local-python` |
+| `go` | `st-validate-local-go` |
+| `java` | `st-validate-local-java` |
 
 ### 3. Custom Checks
 

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -1,8 +1,7 @@
 # Script Reference
 
-Standard-tooling provides two categories of tools: Python CLI tools
-installed as `st-*` console scripts, and bash validators consumed via
-PATH.
+Standard-tooling provides Python CLI tools installed as `st-*` console
+scripts, plus git hooks -- all consumed via PATH.
 
 ## Python CLI Tools
 
@@ -13,14 +12,9 @@ PATH.
 | [st-prepare-release](dev/prepare-release.md) | Automated release preparation |
 | [st-finalize-repo](dev/finalize-repo.md) | Post-merge repository cleanup |
 | [st-validate-local](dev/validate-local.md) | Local validation driver |
-
-## Bash Validators
-
-| Script | Purpose |
-| ------ | ------- |
-| [repo-profile](lint/repo-profile.md) | Repository profile attribute validation |
-| [markdown-standards](lint/markdown-standards.md) | Markdown linting and structural checks |
-| [pr-issue-linkage](lint/pr-issue-linkage.md) | PR body issue linkage validation |
+| [st-repo-profile](lint/repo-profile.md) | Repository profile attribute validation |
+| [st-markdown-standards](lint/markdown-standards.md) | Markdown linting and structural checks |
+| [st-pr-issue-linkage](lint/pr-issue-linkage.md) | PR body issue linkage validation |
 
 ## Git Hooks
 
@@ -30,15 +24,14 @@ PATH.
 
 ## Validation Drivers
 
-The following bash scripts orchestrate language-specific local validation
-and are consumed via PATH:
+The following `st-*` tools orchestrate language-specific local validation:
 
-| Script | Purpose |
-| ------ | ------- |
-| `validate-local-common` | Shared checks (shellcheck, markdownlint) |
-| `validate-local-python` | Python-specific validation |
-| `validate-local-go` | Go-specific validation |
-| `validate-local-java` | Java-specific validation |
+| Tool | Purpose |
+| ---- | ------- |
+| `st-validate-local-common` | Shared checks (shellcheck, markdownlint) |
+| `st-validate-local-python` | Python-specific validation |
+| `st-validate-local-go` | Go-specific validation |
+| `st-validate-local-java` | Java-specific validation |
 
 These are called by `st-validate-local` based on the `primary_language`
 in the repository profile.

--- a/docs/site/docs/reference/lint/markdown-standards.md
+++ b/docs/site/docs/reference/lint/markdown-standards.md
@@ -1,6 +1,6 @@
-# markdown-standards
+# st-markdown-standards
 
-**Path:** `scripts/bin/markdown-standards`
+**Installed as:** `st-markdown-standards` (Python console script)
 
 Validates markdown files using markdownlint and structural checks.
 Applies different levels of validation depending on file location.
@@ -8,7 +8,7 @@ Applies different levels of validation depending on file location.
 ## Usage
 
 ```bash
-markdown-standards
+st-markdown-standards
 ```
 
 Run from the repository root. No arguments required.

--- a/docs/site/docs/reference/lint/pr-issue-linkage.md
+++ b/docs/site/docs/reference/lint/pr-issue-linkage.md
@@ -1,6 +1,6 @@
-# pr-issue-linkage
+# st-pr-issue-linkage
 
-**Path:** `scripts/bin/pr-issue-linkage`
+**Installed as:** `st-pr-issue-linkage` (Python console script)
 
 Validates that a pull request body contains issue linkage. Runs in
 CI using the GitHub event payload.

--- a/docs/site/docs/reference/lint/repo-profile.md
+++ b/docs/site/docs/reference/lint/repo-profile.md
@@ -1,6 +1,6 @@
-# repo-profile
+# st-repo-profile
 
-**Path:** `scripts/bin/repo-profile`
+**Installed as:** `st-repo-profile` (Python console script)
 
 Validates that `docs/repository-standards.md` contains all required
 repository profile attributes with non-placeholder values.
@@ -8,7 +8,7 @@ repository profile attributes with non-placeholder values.
 ## Usage
 
 ```bash
-repo-profile
+st-repo-profile
 ```
 
 Run from the repository root. The script reads

--- a/scripts/bin/docker-docs
+++ b/scripts/bin/docker-docs
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-docker-docs >/dev/null 2>&1; then
-    exec st-docker-docs "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.docker_docs import main; sys.exit(main())" "$@"

--- a/scripts/bin/docker-test
+++ b/scripts/bin/docker-test
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-docker-test >/dev/null 2>&1; then
-    exec st-docker-test "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.docker_test import main; sys.exit(main())" "$@"

--- a/scripts/bin/markdown-standards
+++ b/scripts/bin/markdown-standards
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-markdown-standards >/dev/null 2>&1; then
-    exec st-markdown-standards "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.markdown_standards import main; sys.exit(main())" "$@"

--- a/scripts/bin/pr-issue-linkage
+++ b/scripts/bin/pr-issue-linkage
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-pr-issue-linkage >/dev/null 2>&1; then
-    exec st-pr-issue-linkage "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.pr_issue_linkage import main; sys.exit(main())" "$@"

--- a/scripts/bin/repo-profile
+++ b/scripts/bin/repo-profile
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-repo-profile >/dev/null 2>&1; then
-    exec st-repo-profile "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.repo_profile_cli import main; sys.exit(main())" "$@"

--- a/scripts/bin/validate-local-common
+++ b/scripts/bin/validate-local-common
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-validate-local-common >/dev/null 2>&1; then
-    exec st-validate-local-common "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.validate_local_common import main; sys.exit(main())" "$@"

--- a/scripts/bin/validate-local-common-container
+++ b/scripts/bin/validate-local-common-container
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-validate-local-common-container >/dev/null 2>&1; then
-    exec st-validate-local-common-container "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.validate_local_common_container import main; sys.exit(main())" "$@"

--- a/scripts/bin/validate-local-go
+++ b/scripts/bin/validate-local-go
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-validate-local-go >/dev/null 2>&1; then
-    exec st-validate-local-go "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.validate_local_lang import main; sys.exit(main())" --language go "$@"

--- a/scripts/bin/validate-local-java
+++ b/scripts/bin/validate-local-java
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-validate-local-java >/dev/null 2>&1; then
-    exec st-validate-local-java "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.validate_local_lang import main; sys.exit(main())" --language java "$@"

--- a/scripts/bin/validate-local-python
+++ b/scripts/bin/validate-local-python
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-validate-local-python >/dev/null 2>&1; then
-    exec st-validate-local-python "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.validate_local_lang import main; sys.exit(main())" --language python "$@"

--- a/scripts/bin/validate-local-rust
+++ b/scripts/bin/validate-local-rust
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Managed by standard-tooling — DO NOT EDIT in downstream repos.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling
-if command -v st-validate-local-rust >/dev/null 2>&1; then
-    exec st-validate-local-rust "$@"
-fi
-_st_root="$(cd "$(dirname "$0")/../.." && pwd)"
-PYTHONPATH="${_st_root}/src${PYTHONPATH:+:$PYTHONPATH}" \
-    exec python3 -c "import sys; from standard_tooling.bin.validate_local_lang import main; sys.exit(main())" --language rust "$@"

--- a/src/standard_tooling/bin/validate_local.py
+++ b/src/standard_tooling/bin/validate_local.py
@@ -25,15 +25,11 @@ def _find_validator(name: str, scripts_bin: Path) -> str | None:
 
     Search order:
       1. ``st-{name}`` on PATH (installed entry point)
-      2. *name* on PATH (legacy bash wrapper)
-      3. The repository's own ``scripts/bin/`` directory
+      2. The repository's own ``scripts/bin/`` directory
     """
     entry_point = shutil.which(f"st-{name}")
     if entry_point is not None:
         return entry_point
-    on_path = shutil.which(name)
-    if on_path is not None:
-        return on_path
     local = scripts_bin / name
     if local.is_file() and os.access(local, os.X_OK):
         return str(local)
@@ -51,7 +47,7 @@ def _run_validator(name: str, scripts_bin: Path) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    required = {"docker": ("docker",), "docker-test": ("st-docker-test", "docker-test")}
+    required = {"docker": ("docker",), "docker-test": ("st-docker-test",)}
     for tool, candidates in required.items():
         if not any(shutil.which(c) for c in candidates):
             print(f"ERROR: {tool} is required for local validation", file=sys.stderr)

--- a/src/standard_tooling/bin/validate_local_common.py
+++ b/src/standard_tooling/bin/validate_local_common.py
@@ -1,25 +1,21 @@
 """Shared checks run for all repos — containerised via docker-test.
 
-Sets ``DOCKER_DEV_IMAGE``, ``DOCKER_EXTRA_VOLUMES``, and
-``DOCKER_TEST_CMD`` then delegates to ``docker_test.main()``.
+Sets ``DOCKER_DEV_IMAGE`` and ``DOCKER_TEST_CMD`` then delegates to
+``docker_test.main()``.
 """
 
 from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 
 from standard_tooling.bin import docker_test
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    st_bin = str(Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "bin")
-
     if not os.environ.get("DOCKER_DEV_IMAGE"):
         os.environ["DOCKER_DEV_IMAGE"] = "dev-python:3.14"
-    os.environ["DOCKER_EXTRA_VOLUMES"] = f"{st_bin}:/st-bin:ro"
-    os.environ["DOCKER_TEST_CMD"] = "export PATH=/st-bin:$PATH && validate-local-common-container"
+    os.environ["DOCKER_TEST_CMD"] = "st-validate-local-common-container"
 
     return docker_test.main()
 

--- a/tests/standard_tooling/test_validate_local.py
+++ b/tests/standard_tooling/test_validate_local.py
@@ -20,17 +20,6 @@ def test_find_validator_entry_point() -> None:
     assert result == "/usr/bin/st-v"
 
 
-def test_find_validator_on_path() -> None:
-    def which_side_effect(name: str) -> str | None:
-        if name == "v":
-            return "/usr/bin/v"
-        return None
-
-    with patch("standard_tooling.bin.validate_local.shutil.which", side_effect=which_side_effect):
-        result = _find_validator("v", Path("/scripts/bin"))
-    assert result == "/usr/bin/v"
-
-
 def test_find_validator_local_fallback(tmp_path: Path) -> None:
     scripts_bin = tmp_path / "scripts" / "bin"
     scripts_bin.mkdir(parents=True)
@@ -42,14 +31,12 @@ def test_find_validator_local_fallback(tmp_path: Path) -> None:
     assert result == str(validator)
 
 
-def test_find_validator_entry_point_preferred_over_bare(tmp_path: Path) -> None:
-    """st- entry point is preferred over bare name on PATH."""
+def test_find_validator_entry_point_found(tmp_path: Path) -> None:
+    """st- entry point is found on PATH."""
 
     def which_side_effect(name: str) -> str | None:
         if name == "st-validate-local-common":
             return "/usr/bin/st-validate-local-common"
-        if name == "validate-local-common":
-            return "/usr/bin/validate-local-common"
         return None
 
     with patch("standard_tooling.bin.validate_local.shutil.which", side_effect=which_side_effect):

--- a/tests/standard_tooling/test_validate_local_common.py
+++ b/tests/standard_tooling/test_validate_local_common.py
@@ -57,7 +57,7 @@ def test_main_sets_default_image() -> None:
     assert captured["DOCKER_DEV_IMAGE"] == "dev-python:3.14"
 
 
-def test_main_sets_volumes_and_cmd() -> None:
+def test_main_sets_cmd() -> None:
     import os
 
     captured: dict[str, str] = {}
@@ -74,8 +74,8 @@ def test_main_sets_volumes_and_cmd() -> None:
         patch.dict("os.environ", {}, clear=True),
     ):
         main()
-    assert "/st-bin:ro" in captured["DOCKER_EXTRA_VOLUMES"]
-    assert "validate-local-common-container" in captured["DOCKER_TEST_CMD"]
+    assert "DOCKER_EXTRA_VOLUMES" not in captured
+    assert captured["DOCKER_TEST_CMD"] == "st-validate-local-common-container"
 
 
 def test_main_propagates_failure() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Remove all 11 legacy bash wrapper scripts from scripts/bin/ and update all code, tests, and docs to use st-* entry points exclusively. Fixes the ModuleNotFoundError bug in st-finalize-repo → st-validate-local → subprocess wrapper → Docker chain.

## Issue Linkage

- Fixes #226

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -