### PR TITLE
chore: add .coverage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 src/standard_tooling.egg-info/
 dist/
 build/
+.coverage
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/


### PR DESCRIPTION
# Pull Request

## Summary

- Add .coverage to .gitignore to prevent pytest-cov output showing as untracked.

## Issue Linkage

- Fixes #224

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -