### PR TITLE
fix: use GHCR image URLs as default dev container references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ cd ../standard-tooling-docker && docker/build.sh
 
 Environment overrides:
 
-- `DOCKER_DEV_IMAGE` — override the container image (default: `dev-python:3.12`)
+- `DOCKER_DEV_IMAGE` — override the container image
+  (default: `ghcr.io/wphillipmoore/dev-python:3.12`)
 - `DOCKER_TEST_CMD` — override the test command
 
 ## Architecture

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check}"
 
 if ! command -v docker-test >/dev/null 2>&1; then

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
 
 if ! command -v docker-test >/dev/null 2>&1; then

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=standard_tooling --cov-branch --cov-fail-under=100}"
 
 if ! command -v docker-test >/dev/null 2>&1; then

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.12}"
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/}"
 
 if ! command -v docker-test >/dev/null 2>&1; then

--- a/src/standard_tooling/bin/docker_docs.py
+++ b/src/standard_tooling/bin/docker_docs.py
@@ -21,7 +21,7 @@ def _usage(port: str) -> None:
     print("  build   Build the static documentation site")
     print()
     print("Environment variables:")
-    print("  DOCKER_DOCS_IMAGE  Docker image (default: dev-docs:latest)")
+    print("  DOCKER_DOCS_IMAGE  Docker image (default: ghcr.io/wphillipmoore/dev-docs:latest)")
     print("  MKDOCS_CONFIG      Path to mkdocs.yml (default: docs/site/mkdocs.yml)")
     print("  DOCS_PORT          Host port for serve (default: 8000)")
 
@@ -29,7 +29,7 @@ def _usage(port: str) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
 
-    image = os.environ.get("DOCKER_DOCS_IMAGE", "dev-docs:latest")
+    image = os.environ.get("DOCKER_DOCS_IMAGE", "ghcr.io/wphillipmoore/dev-docs:latest")
     config = os.environ.get("MKDOCS_CONFIG", "docs/site/mkdocs.yml")
     port = os.environ.get("DOCS_PORT", "8000")
 

--- a/src/standard_tooling/bin/docker_test.py
+++ b/src/standard_tooling/bin/docker_test.py
@@ -8,6 +8,7 @@ via environment variables.
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from typing import TYPE_CHECKING
 
@@ -16,12 +17,14 @@ from standard_tooling.lib import git
 if TYPE_CHECKING:
     from pathlib import Path
 
+_GHCR = "ghcr.io/wphillipmoore"
+
 _DEFAULT_IMAGES: dict[str, str] = {
-    "ruby": "dev-ruby:3.4",
-    "python": "dev-python:3.14",
-    "go": "dev-go:1.26",
-    "rust": "dev-rust:1.93",
-    "java": "dev-java:21",
+    "ruby": f"{_GHCR}/dev-ruby:3.4",
+    "python": f"{_GHCR}/dev-python:3.14",
+    "go": f"{_GHCR}/dev-go:1.26",
+    "rust": f"{_GHCR}/dev-rust:1.93",
+    "java": f"{_GHCR}/dev-java:21",
 }
 
 _DEFAULT_COMMANDS: dict[str, str] = {
@@ -99,6 +102,20 @@ def build_docker_args(repo_root: Path, lang: str) -> list[str]:
     return docker_args
 
 
+def _docker_is_available() -> bool:
+    """Check whether the Docker daemon is reachable."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],  # noqa: S603, S607
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     repo_root = git.repo_root()
     lang = _detect_language(repo_root)
@@ -112,6 +129,14 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         return 1
 
     docker_args = build_docker_args(repo_root, lang)
+
+    if not _docker_is_available():
+        print(
+            "ERROR: Docker is not available. Ensure the Docker daemon is running.",
+            file=sys.stderr,
+        )
+        return 1
+
     os.execvp("docker", docker_args)  # noqa: S606, S607
     return 0  # pragma: no cover
 

--- a/src/standard_tooling/bin/validate_local_common.py
+++ b/src/standard_tooling/bin/validate_local_common.py
@@ -14,7 +14,7 @@ from standard_tooling.bin import docker_test
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     if not os.environ.get("DOCKER_DEV_IMAGE"):
-        os.environ["DOCKER_DEV_IMAGE"] = "dev-python:3.14"
+        os.environ["DOCKER_DEV_IMAGE"] = "ghcr.io/wphillipmoore/dev-python:3.14"
     os.environ["DOCKER_TEST_CMD"] = "st-validate-local-common-container"
 
     return docker_test.main()

--- a/tests/standard_tooling/test_docker_test.py
+++ b/tests/standard_tooling/test_docker_test.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from standard_tooling.bin.docker_test import (
     _detect_language,
+    _docker_is_available,
     build_docker_args,
     main,
 )
@@ -69,7 +71,7 @@ def test_detect_ruby_priority(tmp_path: Path) -> None:
 def test_build_docker_args_python(tmp_path: Path) -> None:
     with patch.dict("os.environ", {}, clear=True):
         args = build_docker_args(tmp_path, "python")
-    assert "dev-python:3.14" in args
+    assert "ghcr.io/wphillipmoore/dev-python:3.14" in args
     assert "uv sync && uv run pytest tests/ -v" in args
     assert "-v" in args
 
@@ -135,10 +137,24 @@ def test_main_no_language_no_env(tmp_path: Path) -> None:
         assert main() == 1
 
 
+def test_main_docker_not_available(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    with (
+        patch("standard_tooling.bin.docker_test.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_test._docker_is_available", return_value=False),
+        patch("standard_tooling.bin.docker_test.os.execvp") as mock_exec,
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        result = main()
+    assert result == 1
+    mock_exec.assert_not_called()
+
+
 def test_main_calls_execvp(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text("[project]\n")
     with (
         patch("standard_tooling.bin.docker_test.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_test._docker_is_available", return_value=True),
         patch("standard_tooling.bin.docker_test.os.execvp") as mock_exec,
         patch.dict("os.environ", {}, clear=True),
     ):
@@ -146,4 +162,32 @@ def test_main_calls_execvp(tmp_path: Path) -> None:
     mock_exec.assert_called_once()
     call_args = mock_exec.call_args
     assert call_args[0][0] == "docker"
-    assert "dev-python:3.14" in call_args[0][1]
+    assert "ghcr.io/wphillipmoore/dev-python:3.14" in call_args[0][1]
+
+
+# -- _docker_is_available ----------------------------------------------------
+
+
+def test_docker_is_available_true() -> None:
+    mock_result = MagicMock(returncode=0)
+    with patch("standard_tooling.bin.docker_test.subprocess.run", return_value=mock_result):
+        assert _docker_is_available() is True
+
+
+def test_docker_is_available_false() -> None:
+    mock_result = MagicMock(returncode=1)
+    with patch("standard_tooling.bin.docker_test.subprocess.run", return_value=mock_result):
+        assert _docker_is_available() is False
+
+
+def test_docker_is_available_not_installed() -> None:
+    with patch("standard_tooling.bin.docker_test.subprocess.run", side_effect=FileNotFoundError):
+        assert _docker_is_available() is False
+
+
+def test_docker_is_available_timeout() -> None:
+    with patch(
+        "standard_tooling.bin.docker_test.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="docker info", timeout=10),
+    ):
+        assert _docker_is_available() is False

--- a/tests/standard_tooling/test_validate_local_common.py
+++ b/tests/standard_tooling/test_validate_local_common.py
@@ -54,7 +54,7 @@ def test_main_sets_default_image() -> None:
         patch.dict("os.environ", {}, clear=True),
     ):
         main()
-    assert captured["DOCKER_DEV_IMAGE"] == "dev-python:3.14"
+    assert captured["DOCKER_DEV_IMAGE"] == "ghcr.io/wphillipmoore/dev-python:3.14"
 
 
 def test_main_sets_cmd() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Use ghcr.io/wphillipmoore/ GHCR URLs as default image references so Docker pulls published images instead of resolving stale local tags

## Issue Linkage

- Fixes #231

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -