### PR TITLE
fix: update docker-test references to st-docker-test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,14 +137,14 @@ Grandfathered validators consumed via PATH (no `.sh` extensions):
 - `validate-local-python` — Python-specific validation
 - `validate-local-go` — Go-specific validation
 - `validate-local-java` — Java-specific validation
-- `docker-test` — run repo test suite inside a dev container
+- `st-docker-test` — run repo test suite inside a dev container
 
 ### Docker Dev Images
 
 Dev container images (Dockerfiles, build script, publish workflow) are
 maintained in [standard-tooling-docker](https://github.com/wphillipmoore/standard-tooling-docker).
 
-The `docker-test` script (`scripts/bin/docker-test`) auto-detects the project
+The `st-docker-test` entry point auto-detects the project
 language (Gemfile, pyproject.toml, go.mod, pom.xml/mvnw) and runs the test
 suite inside the appropriate container. Consuming repos call it directly or wrap
 it in a thin `scripts/dev/test.sh`. Environment overrides:

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=standard_tooling --cov-branch --cov-fail-under=100}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/src/standard_tooling/bin/validate_local.py
+++ b/src/standard_tooling/bin/validate_local.py
@@ -47,7 +47,7 @@ def _run_validator(name: str, scripts_bin: Path) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    required = {"docker": ("docker",), "docker-test": ("st-docker-test",)}
+    required = {"docker": ("docker",), "st-docker-test": ("st-docker-test",)}
     for tool, candidates in required.items():
         if not any(shutil.which(c) for c in candidates):
             print(f"ERROR: {tool} is required for local validation", file=sys.stderr)

--- a/tests/standard_tooling/test_validate_local.py
+++ b/tests/standard_tooling/test_validate_local.py
@@ -127,7 +127,7 @@ def test_main_docker_test_missing() -> None:
 
 
 def test_main_st_docker_test_found() -> None:
-    """st-docker-test entry point satisfies the docker-test requirement."""
+    """st-docker-test entry point satisfies the st-docker-test requirement."""
 
     def which_side_effect(tool: str) -> str | None:
         if tool in ("docker", "st-docker-test"):


### PR DESCRIPTION
# Pull Request

## Summary

- Update all stale docker-test references to st-docker-test entry point after legacy bash wrappers were removed in #227

## Issue Linkage

- Fixes #233

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -