### PR TITLE
fix: mount host .gitconfig into container for git identity

### DIFF
--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 _GHCR = "ghcr.io/wphillipmoore"
 
@@ -89,6 +86,11 @@ def build_docker_args(
     for name in os.environ:
         if name.startswith(("MQ_", "GH_", "GITHUB_")):
             docker_args.extend(["-e", name])
+
+    # Mount host git config so git identity is available in the container.
+    gitconfig = Path.home() / ".gitconfig"
+    if gitconfig.exists():
+        docker_args.extend(["-v", f"{gitconfig}:/root/.gitconfig:ro"])
 
     docker_args.append(image)
     docker_args.extend(command)

--- a/tests/standard_tooling/test_docker.py
+++ b/tests/standard_tooling/test_docker.py
@@ -109,7 +109,12 @@ def test_build_docker_args_extra_volumes(tmp_path: Path) -> None:
 
 
 def test_build_docker_args_empty_extra_volumes(tmp_path: Path) -> None:
-    with patch.dict("os.environ", {"DOCKER_EXTRA_VOLUMES": ";"}, clear=True):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    with (
+        patch.dict("os.environ", {"DOCKER_EXTRA_VOLUMES": ";"}, clear=True),
+        patch("standard_tooling.lib.docker.Path.home", return_value=fake_home),
+    ):
         args = build_docker_args(tmp_path, "img:1", ["cmd"])
     v_indices = [i for i, a in enumerate(args) if a == "-v"]
     assert len(v_indices) == 1
@@ -128,6 +133,30 @@ def test_build_docker_args_no_unrelated_env(tmp_path: Path) -> None:
     with patch.dict("os.environ", {"HOME": "/home/user"}, clear=True):
         args = build_docker_args(tmp_path, "img:1", ["cmd"])
     assert "HOME" not in args
+
+
+def test_build_docker_args_mounts_gitconfig(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    gitconfig = fake_home / ".gitconfig"
+    gitconfig.write_text("[user]\n\tname = Test\n")
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("standard_tooling.lib.docker.Path.home", return_value=fake_home),
+    ):
+        args = build_docker_args(tmp_path, "img:1", ["cmd"])
+    assert f"{gitconfig}:/root/.gitconfig:ro" in args
+
+
+def test_build_docker_args_no_gitconfig(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("standard_tooling.lib.docker.Path.home", return_value=fake_home),
+    ):
+        args = build_docker_args(tmp_path, "img:1", ["cmd"])
+    assert all("/root/.gitconfig" not in a for a in args)
 
 
 # -- assert_docker_available --------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Mount host .gitconfig read-only into container so git identity works

## Issue Linkage

- Fixes #244

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -