### PR TITLE
feat: mount ~/.ssh in container for git SSH remote operations

### DIFF
--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -92,6 +92,11 @@ def build_docker_args(
     if gitconfig.exists():
         docker_args.extend(["-v", f"{gitconfig}:/root/.gitconfig:ro"])
 
+    # Mount host SSH directory so git can authenticate for remote operations.
+    ssh_dir = Path.home() / ".ssh"
+    if ssh_dir.is_dir():
+        docker_args.extend(["-v", f"{ssh_dir}:/root/.ssh:ro"])
+
     docker_args.append(image)
     docker_args.extend(command)
 

--- a/tests/standard_tooling/test_docker.py
+++ b/tests/standard_tooling/test_docker.py
@@ -148,6 +148,31 @@ def test_build_docker_args_mounts_gitconfig(tmp_path: Path) -> None:
     assert f"{gitconfig}:/root/.gitconfig:ro" in args
 
 
+def test_build_docker_args_mounts_ssh_dir(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    ssh_dir = fake_home / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_rsa").write_text("key\n")
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("standard_tooling.lib.docker.Path.home", return_value=fake_home),
+    ):
+        args = build_docker_args(tmp_path, "img:1", ["cmd"])
+    assert f"{ssh_dir}:/root/.ssh:ro" in args
+
+
+def test_build_docker_args_no_ssh_dir(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("standard_tooling.lib.docker.Path.home", return_value=fake_home),
+    ):
+        args = build_docker_args(tmp_path, "img:1", ["cmd"])
+    assert all("/root/.ssh" not in a for a in args)
+
+
 def test_build_docker_args_no_gitconfig(tmp_path: Path) -> None:
     fake_home = tmp_path / "home"
     fake_home.mkdir()


### PR DESCRIPTION
# Pull Request

## Summary

- Mount ~/.ssh read-only in container and add openssh-client to images for git SSH operations

## Issue Linkage

- Closes #247

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -