### PR TITLE
feat: adopt git worktree convention for parallel AI agent development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,72 @@ belong in managed, version-controlled documentation (CLAUDE.md, AGENTS.md,
 skills, or docs/). If you want to persist something, tell the human what you
 would save and let them decide where it belongs.
 
+## Parallel AI agent development
+
+This repository supports running multiple Claude Code agents in parallel via
+git worktrees. The convention keeps parallel agents' working trees isolated
+while preserving shared project memory (which Claude Code derives from the
+session's starting CWD).
+
+**Canonical spec:**
+[`docs/specs/worktree-convention.md`](docs/specs/worktree-convention.md) —
+full rationale, trust model, failure modes, and memory-path implications.
+
+### Structure
+
+```text
+~/dev/github/standard-tooling/           ← sessions ALWAYS start here
+  .git/
+  CLAUDE.md, src/, docs/, …              ← main worktree (usually `develop`)
+  .worktrees/                            ← container for parallel worktrees
+    issue-258-worktree-convention/       ← worktree on feature/258-worktree-convention
+    …
+```
+
+### Rules
+
+1. **Sessions always start at the project root.**
+   `cd ~/dev/github/standard-tooling && claude` — never from inside
+   `.worktrees/<name>/`. This keeps the memory-path slug stable and shared.
+2. **Each parallel agent is assigned exactly one worktree.** The session
+   prompt names the worktree (see Agent prompt contract below).
+   - For Read / Edit / Write tools: use the worktree's absolute path.
+   - For Bash commands that touch files: `cd` into the worktree first,
+     or use absolute paths.
+3. **The main worktree is read-only.** All edits flow through a worktree
+   on a feature branch — the logical endpoint of the standing
+   "no direct commits to develop" policy.
+4. **One worktree per issue.** Don't stack in-flight issues. When a
+   branch lands, remove the worktree before starting the next.
+5. **Naming: `issue-<N>-<short-slug>`.** `<N>` is the GitHub issue
+   number; `<short-slug>` is 2–4 kebab-case tokens.
+
+### Agent prompt contract
+
+When launching a parallel-agent session, use this template (fill in the
+placeholders):
+
+```text
+You are working on issue #<N>: <issue title>.
+
+Your worktree is: /Users/pmoore/dev/github/standard-tooling/.worktrees/issue-<N>-<slug>/
+Your branch is:   feature/<N>-<slug>
+
+Rules for this session:
+- Do all git operations from inside your worktree:
+    cd <absolute-worktree-path> && git <command>
+- For Read / Edit / Write tools, use the absolute worktree path.
+- For Bash commands that touch files, cd into the worktree first
+  or use absolute paths.
+- Do not edit files at the project root. The main worktree is
+  read-only — all changes flow through your worktree on your
+  feature branch.
+- When you need to run validation, run it from inside your worktree
+  (st-docker-run mounts the current directory).
+```
+
+All fields are required.
+
 ## Project Overview
 
 This is a Python package providing shared development tooling for all managed

--- a/docs/plans/worktree-convention-plan.md
+++ b/docs/plans/worktree-convention-plan.md
@@ -1,0 +1,307 @@
+# Implementation Plan: Git Worktree Convention
+
+**Status:** Draft — awaiting `paad:alignment` against the spec
+**Spec:** [`docs/specs/worktree-convention.md`](../specs/worktree-convention.md)
+**Issue:** [#258](https://github.com/wphillipmoore/standard-tooling/issues/258)
+**Last updated:** 2026-04-22
+
+## Scope
+
+This plan covers implementation of the worktree convention as defined
+in the spec. Rollout is sequenced in five phases that map directly to
+the spec's **Rollout plan** section:
+
+1. Land the convention in `standard-tooling` (this repo).
+2. Pilot the convention in one active-parallel repo.
+3. Cascade to the remaining consuming repos.
+4. Canonicalize in `standards-and-conventions`.
+5. Retrospective and feedback-memory capture.
+
+Each phase has observable completion criteria and a defined blocker
+or handoff to the next phase.
+
+## Out of scope for this plan
+
+Tracked separately, per the spec's **Enforcement and follow-up work**
+and **Adjacent work surfaced during pushback** sections. Each gets
+its own issue (opened in Phase 1, Task 1.6):
+
+- Git hook that refuses commits from the project root (enforcement
+  backstop for rules 1–3).
+- `st-finalize-repo` extension: worktree removal for the finalized
+  branch (implements the Cleanup section's canonical flow).
+- `st-worktree-prompt` helper: emits the canonical prompt template
+  given `<issue-number>` and `<slug>`.
+- `st-worktree-prune` (optional, needs-driven, for abandoned
+  branches).
+- MEMORY.md ban removal in this repo's CLAUDE.md (and fleet-wide
+  where applicable). **Blocks Phase 5 feedback-memory capture.**
+- Deprecation of the "include this doc and remember it" pattern
+  fleet-wide.
+
+## Phase 1: Land the convention in `standard-tooling`
+
+**Goal:** The canonical convention text lives in this repo's
+CLAUDE.md and `.worktrees/` is gitignored, so that when someone
+starts using worktrees here, the convention governs their behavior.
+
+### Task 1.1: Add `.worktrees/` to `.gitignore`
+
+- **Action:** Append `.worktrees/` to `/.gitignore`.
+- **Verification:** `git check-ignore -v .worktrees/any-path` returns
+  exit 0 and points at the new rule.
+
+### Task 1.2: Add a Parallel AI agent development section to `CLAUDE.md`
+
+- **Action:** Add a new section (after existing "Auto-memory policy"
+  or similar top-of-file location) that covers:
+  - The structure (`~/dev/github/standard-tooling/.worktrees/...`)
+  - The five rules (verbatim from the spec)
+  - A pointer to the canonical spec
+    (`docs/specs/worktree-convention.md`)
+  - The Agent prompt contract (canonical template, copy-pasteable)
+- **Length guideline:** Short enough to be read every session —
+  roughly 40–80 lines. Push the full design (Problem statement, Trust
+  model, Memory-path implications, Failure modes) to the linked
+  spec, not CLAUDE.md.
+- **Verification:**
+  - `grep -q "Parallel AI agent development" CLAUDE.md`
+  - `grep -q "Your worktree is:" CLAUDE.md` (prompt template marker)
+  - Spec link resolves (`docs/specs/worktree-convention.md` exists)
+
+### Task 1.3: Verify the rules actually work in this repo
+
+- **Action:** Dry-run the onboarding procedure against a throwaway
+  issue number:
+  - `git worktree add .worktrees/test-worktree-convention -b
+    test/worktree-convention origin/develop`
+  - Confirm `.worktrees/` stays gitignored (main tree status clean).
+  - Confirm `cd .worktrees/test-worktree-convention && git status`
+    reports the feature branch.
+  - Confirm `st-docker-run` from inside the worktree mounts that
+    directory (not the main tree).
+  - Clean up: `git worktree remove .worktrees/test-worktree-convention
+    && git branch -D test/worktree-convention`.
+- **Verification:** Shell session transcript (or a note in the PR
+  description) confirming each step.
+
+### Task 1.4: Open the PR, get it merged, `st-finalize-repo`
+
+- **Action:** Follow the standard PR workflow. PR body references
+  #258 and summarizes the convention in one paragraph.
+- **Verification:** PR merged to `develop`; `st-finalize-repo` run;
+  issue #258 remains open (Phase 5 wraps it up).
+
+### Task 1.5: Update issue #258 acceptance criteria
+
+- **Action:** Tick off "This repo: `.gitignore` + CLAUDE.md updated"
+  in #258's acceptance criteria. Post a short comment linking to the
+  PR.
+- **Verification:** #258 shows the item checked.
+
+### Task 1.6: Open follow-up issues for the deferred items
+
+- **Action:** Open one issue per deferred item from the
+  "Out of scope for this plan" list above. Each issue references
+  #258 and the spec's **Enforcement and follow-up work** section.
+  At minimum:
+  - Git hook: refuse commits from project root / outside
+    `.worktrees/*`.
+  - `st-finalize-repo`: worktree-aware cleanup.
+  - MEMORY.md ban removal (this repo).
+  - Include-pattern deprecation (cross-repo; may be filed in
+    `standards-and-conventions` instead).
+  - (Optional, defer if unsure) `st-worktree-prompt` helper.
+- **Verification:** All issues created and linked from #258's
+  "Related" section.
+
+**Phase 1 exit criteria:** PR merged. `.gitignore` and CLAUDE.md
+updated. Dry-run successful. Follow-up issues filed. No pilot work
+starts before this phase lands.
+
+## Phase 2: Pilot in an active-parallel repo
+
+**Goal:** Use the convention end-to-end in a repo where parallel
+agent work actually happens, surface gaps that only appear in live
+use, and feed those gaps back into the spec before fleet cascade.
+
+### Task 2.1: Choose the pilot repo
+
+- **Action:** Pick whichever of `the-infrastructure-mindset` or
+  `ai-research-methodology` has imminent parallel-agent work. Default
+  to `the-infrastructure-mindset` if both are equally active, since
+  the 2026-04-22 collision originated there and makes a natural
+  before/after comparison.
+- **Verification:** Decision recorded in #258 as a comment, with the
+  next parallel-agent work item that will test the convention.
+
+### Task 2.2: Apply the convention to the pilot repo
+
+- **Action:** In the pilot repo:
+  - Add `.worktrees/` to `.gitignore`.
+  - Add the Parallel AI agent development section to its CLAUDE.md
+    (same body as Phase 1 Task 1.2, with repo-specific paths).
+- **Verification:** Pilot repo's CLAUDE.md and `.gitignore` updated
+  via PR; merged.
+
+### Task 2.3: Run two parallel agents using the convention
+
+- **Action:** Start two Claude Code sessions at the pilot repo's
+  root. Before launching each session, run `pwd` and confirm the
+  output is the pilot repo's root path — **not** a worktree path.
+  Then use the canonical prompt template to assign each session a
+  worktree on a different feature branch. Let them work to
+  completion (or at least through a first round of file edits +
+  commits).
+- **Verification:**
+  - **Collision prevention (git-level):** Both agents complete their
+    work without filesystem collisions and without committing to
+    the wrong branch. Git log for each feature branch shows only
+    that worktree's commits.
+  - **Memory-path sharing (load-bearing claim):** After both
+    sessions have started, assert that both resolve to the same
+    Claude Code memory directory. Run:
+
+    ```bash
+    ls -d ~/.claude/projects/*dev-github-<pilot-repo-name> 2>/dev/null
+    ```
+
+    Exactly one directory should match — the shared slug derived
+    from the pilot repo root. Zero matches means neither session
+    registered; two matches means a session was started from the
+    wrong CWD and memory silos diverged (rule 1 violation). The
+    pilot is **not** successful if this check fails, even if
+    collision prevention passed.
+
+### Task 2.4: Capture pilot findings
+
+- **Action:** Write a short findings note (as a comment on #258 or
+  an appended section to the spec). Cover:
+  - What worked as specified.
+  - What needed clarification in the prompt template.
+  - Any failure-mode entries that should be added / removed.
+  - Any rules whose wording proved ambiguous in live use.
+- **Verification:** Findings posted; spec PR opened for any
+  amendments (or marked "no amendments needed").
+
+**Phase 2 exit criteria:** Pilot completed, findings recorded. Spec
+revised if needed. Cascade does not start until spec is stable post-
+pilot.
+
+## Phase 3: Fleet cascade
+
+**Goal:** Every active consuming repo carries the convention so any
+future parallel-agent work has the infrastructure in place.
+
+### Task 3.1: Cascade to remaining active-parallel repo
+
+- **Action:** Whichever of `the-infrastructure-mindset` /
+  `ai-research-methodology` was not the pilot: apply `.gitignore` +
+  CLAUDE.md changes. PR + merge.
+- **Verification:** Repo's CLAUDE.md and `.gitignore` updated.
+
+### Task 3.2: Cascade to the remaining fleet
+
+- **Action:** In priority order, apply the same two-file change:
+  1. `mq-rest-admin-python` (most active Python repo)
+  2. Remainder of `mq-rest-admin-*`
+  3. `standard-actions`
+  4. `standard-tooling-docker`
+  5. `standard-tooling-plugin`
+  6. `mempalace`
+- **Verification:** One PR per repo; all merged. A short checklist
+  in #258 tracks the progress.
+
+**Phase 3 exit criteria:** Every actively developed repo listed in
+the spec carries the convention.
+
+## Phase 4: Canonicalize in `standards-and-conventions`
+
+**Goal:** New repos have a reference to point at; future fleet-wide
+conversations have a single canonical doc to cite.
+
+### Task 4.1: Author the generalized write-up
+
+- **Action:** Port this spec to `standards-and-conventions`,
+  removing repo-specific paths and the rollout/retrospective sections
+  (keep the convention, rules, prompt contract, trust model, memory-
+  path implications). Reference the standard-tooling spec as the
+  implementation anchor.
+- **Verification:** `standards-and-conventions` PR merged containing
+  the generalized doc.
+
+### Task 4.2: Update the fleet's CLAUDE.md entries to reference the canonical doc
+
+- **Action:** In each repo that received the convention in Phases
+  1–3, update the CLAUDE.md section to reference the canonical
+  doc in `standards-and-conventions` (in addition to — not instead
+  of — the repo-local pointer).
+- **Verification:** Each repo's CLAUDE.md cites the canonical doc.
+
+**Phase 4 exit criteria:** Canonical doc published. Fleet CLAUDE.md
+entries cross-reference it. No automatic inheritance is implied or
+required.
+
+## Phase 5: Retrospective and feedback-memory capture
+
+**Goal:** Close out the PAAD pilot, record what was learned, and
+(once unblocked) add the agent-facing feedback memory.
+
+### Task 5.1: Retrospective notes on ai-research-methodology #129
+
+- **Action:** Add a comment or linked doc to
+  `ai-research-methodology#129` covering what worked and what
+  didn't in the PAAD spec → pushback → alignment → implementation
+  cycle for this issue. This is the second PAAD pilot; the first was
+  ai-research-methodology#135.
+- **Verification:** Comment posted on #129 referencing this spec,
+  this plan, and the pushback review.
+
+### Task 5.2: Capture feedback memory (blocked until MEMORY.md ban lifted)
+
+- **Action:** In each repo where the MEMORY.md ban has been lifted
+  (see Phase 1 Task 1.6's follow-up issue), add a feedback memory:
+  *"When told to work on issue N, your worktree is
+  `.worktrees/issue-N-<slug>/`. Do git operations there; for file
+  edits use the worktree's absolute path, for Bash file commands
+  `cd` into the worktree first or use absolute paths."*
+- **Blocker:** The MEMORY.md ban removal must land first (tracked as
+  its own follow-up issue). This task waits.
+- **Verification:** Each participating repo's memory index includes
+  the entry.
+
+### Task 5.3: Close #258
+
+- **Action:** Verify every acceptance-criteria checkbox is ticked or
+  explicitly deferred with a linked follow-up. Close the issue.
+- **Verification:** #258 closed with a link to the completed work.
+
+**Phase 5 exit criteria:** #258 closed. Retrospective landed.
+Feedback-memory entries in place in every repo that permits them.
+
+## Dependencies and blockers
+
+| Depends on | Blocks | Notes |
+|------------|--------|-------|
+| Phase 1 complete | Phases 2–5 | Nothing cascades until this repo carries the convention |
+| Phase 2 complete (pilot findings) | Phase 3 cascade | Cascade happens after pilot validates (or amends) the spec |
+| Phase 3 + 4 cross-references | Phase 4 Task 4.2 | Canonical doc must exist before repos cite it |
+| MEMORY.md ban removal issue | Phase 5 Task 5.2 | Feedback memory cannot be captured where the ban still applies |
+| No hard dependency on enforcement-tooling follow-ups | — | Enforcement is a backstop, not a gate |
+
+## Success criteria (aggregated)
+
+Mapped to the spec's acceptance criteria:
+
+- [x] Design spec authored (already complete per pushback review)
+- [x] `paad:pushback` run on spec (complete; see
+  `paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md`)
+- [ ] `paad:alignment` run between this plan and the spec
+  (next paad step after this plan is drafted)
+- [ ] Phase 1 complete (this repo)
+- [ ] Phase 2 complete (pilot)
+- [ ] Phase 3 complete (fleet cascade)
+- [ ] Phase 4 complete (canonical doc)
+- [ ] Phase 5 complete (retrospective + feedback memory)
+- [ ] All follow-up issues from Phase 1 Task 1.6 tracked (not
+  necessarily implemented; tracked is enough)

--- a/docs/specs/worktree-convention.md
+++ b/docs/specs/worktree-convention.md
@@ -1,0 +1,396 @@
+# Git Worktree Convention for Parallel AI Agent Development
+
+**Status:** Reviewed — `paad:pushback` complete; ready for `paad:alignment` and implementation planning
+**Issue:** [#258](https://github.com/wphillipmoore/standard-tooling/issues/258)
+**Related:** [#129](https://github.com/wphillipmoore/ai-research-methodology/issues/129) (PAAD integration), ai-research-methodology #135 (first PAAD pilot)
+**Author:** wphillipmoore
+**Last updated:** 2026-04-22
+**Pushback review:** [`paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md`](../../paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md)
+
+## Purpose
+
+Define a repository-agnostic convention for running multiple AI coding
+agents against the same project in parallel, without their working
+trees colliding and without losing Claude Code's shared project memory.
+
+The convention should be adopted by every actively developed repository
+in the fleet (standard-tooling, ai-research-methodology,
+the-infrastructure-mindset, mq-rest-admin-*, standards-and-conventions,
+etc.). Adoption is per-repo — each repo gets its own CLAUDE.md entry
+and `.gitignore` line. There is no automatic inheritance mechanism;
+the canonical write-up in `standards-and-conventions` is a
+human-readable reference, not a dependency.
+
+## Problem statement
+
+Claude Code derives the on-disk memory path from the working directory
+at session start (path with separators replaced, used as a slug). Two
+consequences follow:
+
+- **Identical CWD across sessions → shared memory.** Every agent sees
+  the same CLAUDE.md, the same feedback memories, the same project
+  memories.
+- **Different CWD → different memory silos.** An agent started in
+  `~/dev/github/foo-2/` has no access to what an agent in
+  `~/dev/github/foo/` has learned, and vice versa.
+
+Running two agents in a single working tree produces the failure we
+hit on 2026-04-22: one agent's uncommitted file moves broke a test the
+other agent was validating. The collision is structural, not a
+coordination lapse — nothing prevents two processes from editing the
+same file at the same time.
+
+The naive alternatives each break one of the two goals:
+
+| Approach | Isolation | Shared memory | Verdict |
+|----------|-----------|---------------|---------|
+| Sibling clones (`foo/`, `foo-2/`) | Yes | No (different CWDs) | Loses shared memory |
+| Devcontainers / containers | Yes | Yes (mount-dependent) | Heavyweight for docs/methodology work |
+| Single tree, coordinate by hand | No | Yes | Original failure mode |
+| **Git worktrees under project root** | **Yes** | **Yes** | **Proposed** |
+
+## Proposed design
+
+Use git worktrees rooted under the project's own checkout, and require
+that every Claude Code session start at the project root regardless of
+which worktree it will operate in.
+
+### Structure
+
+```text
+~/dev/github/<project>/            ← sessions ALWAYS start here
+  .git/                            ← main repo .git
+  CLAUDE.md, src/, docs/, …        ← main worktree (usually `develop`)
+  .worktrees/                      ← container for parallel worktrees
+    issue-258-worktrees/           ← worktree on feature/258-worktrees
+    issue-93-rerun/                ← worktree on feature/93-rerun
+    …
+```
+
+- `.worktrees/` sits inside the project root. This is deliberate —
+  placing it anywhere else would change the CWD slug for parallel
+  sessions and break memory sharing.
+- Each child of `.worktrees/` is a git worktree on its own branch.
+  The directory name encodes the issue number and a short slug so
+  humans and agents can disambiguate at a glance.
+- `.worktrees/` is gitignored. It is a local working convention, never
+  committed.
+
+### Rules
+
+1. **Sessions always start at the project root.** `cd
+   ~/dev/github/<project> && claude` — never `cd
+   ~/dev/github/<project>/.worktrees/<name> && claude`. This keeps
+   the memory-path slug stable and shared.
+2. **Each parallel agent is assigned exactly one worktree path.** The
+   session prompt tells the agent which worktree it owns (see
+   [Agent prompt contract](#agent-prompt-contract) below). Two
+   sub-rules govern path usage inside the agent's session:
+   - **For Read / Edit / Write tools:** always use the worktree's
+     absolute path. This is already required by those tools, but the
+     value must be the worktree path, not the main tree's path.
+   - **For Bash commands that touch files** (`grep`, `cat`, `pytest
+     tests/foo.py`, etc.): `cd` into the worktree first, or use
+     absolute paths. Relative paths resolve against the Bash
+     invocation's CWD — if the agent never `cd`-ed, that's the
+     project root, not the worktree.
+3. **The main worktree is read-only.** All edits flow through a
+   worktree on a feature branch. This is the logical endpoint of the
+   standing "no direct commits to develop" policy — if direct commits
+   to develop were already forbidden, then by extension edits at the
+   main worktree root have no legitimate destination. The same git
+   hook that refuses direct pushes to develop is the natural place
+   to refuse commits originating outside `.worktrees/*` (see
+   [Enforcement and follow-up work](#enforcement-and-follow-up-work)).
+4. **One worktree per issue.** Do not stack multiple in-flight issues
+   in one worktree. When a worktree branch lands, remove the worktree
+   before starting the next.
+5. **Worktree naming: `issue-<N>-<short-slug>`.** `<N>` is the GitHub
+   issue number; `<short-slug>` is 2–4 kebab-case tokens describing
+   the work. Shared format lets both humans and scripts match worktree
+   to issue.
+
+### Agent prompt contract
+
+The convention depends on each parallel agent being told, up front,
+which worktree it owns and how to behave inside it. A prompt that
+omits any of the fields below leaves the agent's behavior undefined;
+in the worst case, the agent defaults to the project root and
+reproduces the original collision.
+
+**Canonical prompt template** (fill in the placeholders when launching
+a parallel-agent session):
+
+```text
+You are working on issue #<N>: <issue title>.
+
+Your worktree is: <absolute-path-to-project-root>/.worktrees/issue-<N>-<slug>/
+Your branch is:   feature/<N>-<slug>
+
+Rules for this session:
+- Do all git operations from inside your worktree:
+    cd <absolute-worktree-path> && git <command>
+- For Read / Edit / Write tools, use the absolute worktree path.
+- For Bash commands that touch files, cd into the worktree first
+  or use absolute paths.
+- Do not edit files at the project root. The main worktree is
+  read-only — all changes flow through your worktree on your
+  feature branch.
+- When you need to run validation, run it from inside your worktree
+  (st-docker-run mounts the current directory).
+```
+
+All fields are required. The template is intended as a copy-paste
+starting point; an operator launching multiple parallel agents fills
+in the placeholders for each one. A future `st-worktree-prompt` helper
+could emit this text given `<issue-number>` and `<slug>` — see
+[Enforcement and follow-up work](#enforcement-and-follow-up-work).
+
+### Onboarding a new worktree
+
+When starting work on issue `N`:
+
+```bash
+cd ~/dev/github/<project>                      # always from root
+git fetch origin
+git worktree add .worktrees/issue-N-<slug> -b feature/N-<slug> origin/develop
+```
+
+Then launch a Claude Code session from the project root and give the
+agent the prompt described in
+[Agent prompt contract](#agent-prompt-contract).
+
+**Stacked worktrees (exception).** For the occasional case where work
+must stack on an unmerged parent branch, substitute the parent for
+`origin/develop` in the worktree-add command (e.g., `git worktree add
+.worktrees/issue-B-<slug> -b feature/B-<slug> feature/A-<parent>`).
+The author owns rebasing as the parent evolves. Stacking is
+discouraged as a habit — prefer to defer dependent work or integrate
+it into the parent issue; the mechanism exists only for the rare case
+where neither is viable.
+
+### Cleanup
+
+Post-merge cleanup in this fleet runs through `st-finalize-repo`.
+Worktree removal should live there too — the canonical flow becomes:
+
+```bash
+cd ~/dev/github/<project>
+st-finalize-repo                               # handles branch delete,
+                                               # remote prune, and
+                                               # worktree removal for
+                                               # the finalized branch
+```
+
+Extending `st-finalize-repo` to be worktree-aware is tracked as
+follow-up work (see
+[Enforcement and follow-up work](#enforcement-and-follow-up-work)).
+Until that lands, the interim procedure is raw git:
+
+```bash
+cd ~/dev/github/<project>
+git worktree remove .worktrees/issue-N-<slug>
+git branch -D feature/N-<slug>           # local branch, already merged upstream
+git fetch --prune                        # drop deleted remote tracking refs
+```
+
+If the worktree directory lingers after a crash or force-removed
+branch, `git worktree prune` cleans up stale metadata. A separate
+`st-worktree-prune` for abandoned branches that never merged is not
+part of this spec — add it only if the abandoned-branch case proves
+to need tooling in practice.
+
+### Failure modes
+
+| Failure | Trigger | Mitigation |
+|---------|---------|------------|
+| Agent runs git at the project root, not in its worktree | Agent forgets to `cd`; commits land on main tree's current branch | Prompt contract + CLAUDE.md convention; git hook that refuses commits from outside `.worktrees/*` (shared backstop with rule 3) |
+| Edit at the main tree root | Rule 3 ignored, or a human edit slipped in | Standing "no direct commits to develop" policy forbids this at the commit level; same git hook catches it |
+| Memory silo from starting session in the wrong directory | Session started inside `.worktrees/<name>/` instead of the root | Documentation + muscle memory; a `claude` wrapper script could refuse to launch unless CWD is a project root |
+| Agent writes to a sibling worktree or the main tree (intentional or mis-prompted) | Prompt contract ignored or misread | Git hook (same backstop) catches any such write that actually gets committed; see [Trust model](#trust-model) for the limits of isolation |
+| Stale worktrees accumulate after branch land | Author forgets the cleanup step | `st-finalize-repo` will remove the worktree as part of its post-merge flow once extended |
+| Worktree branch gets into weird state on rebase of main | Shared history diverges during long-lived worktree | Normal git hygiene: rebase the worktree's branch onto updated `develop` periodically; no special convention needed |
+
+### Trust model
+
+What the convention buys, and what it does not:
+
+- **Git-level isolation (structural).** Each worktree has its own
+  HEAD and index. A commit in one worktree cannot touch another
+  worktree's branch state. This is the guarantee that prevents the
+  2026-04-22 collision.
+- **Accidental-path-resolution isolation (structural, via rule 2).**
+  Agents using absolute worktree paths and `cd`-ed Bash cannot
+  accidentally write to the wrong tree.
+- **Filesystem sandbox (not provided).** Nothing prevents an agent
+  from writing outside its worktree if its prompt is misread or
+  ignored. The `Write` tool does not check that its target is within
+  the assigned worktree.
+
+The backstop for the filesystem-sandbox gap is the enforcement
+tooling described in
+[Enforcement and follow-up work](#enforcement-and-follow-up-work). A
+git hook that refuses commits from outside `.worktrees/*` catches any
+out-of-worktree write that actually gets committed. Uncommitted
+out-of-worktree edits remain a residual risk, caught (if at all) by
+human review.
+
+A true filesystem sandbox — devcontainers that mount only the
+assigned worktree read-write with everything else read-only — would
+close this gap but would also interact with the "sessions start at
+the root" memory-path requirement and is a larger scope expansion.
+Not proposed here.
+
+### Memory-path implications
+
+This is the load-bearing constraint for the whole design.
+
+Claude Code's memory path for a session is derived from the session's
+starting CWD. For `~/dev/github/foo/`, the slug is
+`-Users-pmoore-dev-github-foo` (or similar, platform-dependent). Two
+sessions share memory if and only if their derivation produces the
+same slug.
+
+- Starting a session at `~/dev/github/foo/` and then `cd`-ing to
+  `~/dev/github/foo/.worktrees/issue-258/` **does not** change the
+  slug. The session already registered its memory path; subsequent
+  `cd` calls are cosmetic for that session.
+- Starting a session directly at
+  `~/dev/github/foo/.worktrees/issue-258/` **does** produce a
+  different slug and therefore a separate memory silo. This is the
+  failure mode rule #1 prevents.
+- Sibling clones (`~/dev/github/foo-2/`) produce a different slug
+  even though the repo content is identical — this is why sibling
+  clones cannot share memory.
+
+The convention only works because git worktrees live *inside* the
+project root directory. Any future change that moves `.worktrees/`
+outside the root (e.g., a global `~/.worktrees/<project>/<branch>`
+layout) would re-introduce the memory split.
+
+### Rollout plan
+
+The convention is a development methodology, not a feature of any
+single repo. Rollout sequencing (tooling-first, then pilot, then
+cascade, then canonicalize):
+
+1. **standard-tooling** (this repo) — `.gitignore` entry for
+   `.worktrees/`; CLAUDE.md section describing the convention and
+   the Agent prompt contract. This lands first so the tooling repo
+   itself carries the canonical text before cascading.
+2. **Pilot in an active-parallel repo** — `the-infrastructure-mindset`
+   or `ai-research-methodology`, whichever has imminent parallel
+   work. Apply the convention end-to-end (launch parallel agents,
+   observe behavior, iterate on the prompt template or rules if the
+   pilot surfaces gaps). Pilot output feeds back into the spec.
+3. **Fleet cascade** — apply the `.gitignore` + CLAUDE.md change to
+   the remaining active consuming repos in order of likelihood of
+   needing parallel agents: other of the two active-parallel repos,
+   `mq-rest-admin-python` (most-active Python repo), then the rest
+   of `mq-rest-admin-*`, `standard-actions`, `standard-tooling-docker`,
+   `standard-tooling-plugin`, `mempalace`.
+4. **Canonicalize in `standards-and-conventions`** — add the
+   generalized write-up to the standards repo so future repos have a
+   reference. This lands **last**, reflecting what the pilot + cascade
+   actually validated. No automatic inheritance is implied — each
+   repo adopts by adding its own CLAUDE.md entry.
+5. **Agent-facing feedback memory (per-repo, where the repo permits
+   it)** — capture the rule "when told to work on issue N, your
+   worktree is `.worktrees/issue-N-<slug>/`; do git ops there, use
+   absolute paths or cd for Bash" as a feedback memory, so agents
+   onboard without re-reading CLAUDE.md each session. See
+   [Adjacent work surfaced during pushback](#adjacent-work-surfaced-during-pushback)
+   — this depends on lifting the MEMORY.md ban in repos where it
+   still exists.
+
+Each repo's rollout is a small PR (`.gitignore` line +
+CLAUDE.md paragraph); the cascade is wide but shallow.
+
+### Enforcement and follow-up work
+
+Enforcement is a safety net, not the primary mechanism. The primary
+mechanism is telling the agent correctly up front via the Agent prompt
+contract. Enforcement backstops prompt drift, prompt omission, or
+agent mis-reads.
+
+Candidate enforcement mechanisms (to be designed as follow-up work,
+tracked separately):
+
+- **Git hook.** A pre-commit (or pre-push) hook that:
+  - Refuses direct commits to `develop` (already a standing policy —
+    this spec piggybacks rather than adding).
+  - Refuses commits originating from the project root when
+    `.worktrees/*` is non-empty (or, more simply, refuses all commits
+    from the project root, since rule 3 says the main tree is
+    read-only).
+- **`st-finalize-repo` extension.** Worktree removal when finalizing
+  the branch for that worktree. Covers the cleanup failure mode
+  structurally.
+- **`st-worktree-prompt` helper.** Emits the canonical prompt
+  template given an issue number and slug, so operators don't
+  hand-author the prompt each time.
+- **Claude Code plugin.** Hooks at session start (or on work-item
+  assignment) that detect the intent to work on issue N and produce
+  the worktree + prompt automatically. Open-ended — may or may not be
+  worth building; depends on how often parallel-agent launches are
+  manual.
+
+**Design principle for all of these:** the convention works without
+them. They raise the floor on consistency; they do not gate adoption.
+
+## Out of scope
+
+- **Automated worktree provisioning for the initial adoption** (e.g.,
+  `st-worktree-add <issue-number>`). Tracked as follow-up.
+- **Devcontainer integration.** Worktrees and devcontainers are
+  orthogonal; a worktree can run inside or outside a devcontainer.
+  This spec does not prescribe.
+- **Multi-repo worktrees.** Worktrees that span repositories
+  (e.g., a coordinated change across standard-tooling and
+  ai-research-methodology) are not addressed here; each repo's
+  worktree is independent.
+- **Concurrent editing of the same file across worktrees.** Two
+  worktrees editing the same file on different branches is a
+  merge-conflict problem, not an isolation problem, and is already
+  handled by git's normal flow.
+- **Filesystem sandboxing** (devcontainer-based worktree isolation).
+  See [Trust model](#trust-model). Larger scope; not proposed here.
+
+## Adjacent work surfaced during pushback
+
+These are not part of this spec's implementation, but the pushback
+review surfaced them as coupled items that should be addressed
+separately:
+
+- **Remove the MEMORY.md ban in this repo's CLAUDE.md.** The ban was
+  added to solve a polyglot-convergence problem (getting consistent
+  agent behavior across five per-language repos via memory). The
+  author has since found feedback memory to be high-value in active
+  repositories (notably `the-infrastructure-mindset`). The ban is an
+  anachronism and should be removed here and anywhere else it lives.
+  It blocks rollout step 5 above.
+- **Deprecate the "include this doc and remember it" pattern
+  fleet-wide.** The include/reference mechanism referenced by older
+  specs (e.g., "new repos pick it up via standards-and-conventions")
+  did not work in practice — context overload. Replace with explicit
+  per-repo CLAUDE.md entries. This is the model this spec already
+  assumes.
+
+## Acceptance criteria (from #258)
+
+- [x] Design spec authored covering structure, rules, onboarding,
+  cleanup, failure modes, memory-path implications, cross-repo
+  propagation
+- [x] `paad:pushback` run on the spec; findings addressed (this
+  revision) or explicitly deferred to follow-up
+- [ ] `paad:alignment` run between spec and implementation plan
+- [ ] This repo: `.gitignore` + CLAUDE.md updated
+- [ ] Pilot in `the-infrastructure-mindset` or `ai-research-methodology`
+- [ ] Fleet cascade: other active-parallel repo, then
+  `mq-rest-admin-*`, `standard-actions`, `standard-tooling-docker`,
+  `standard-tooling-plugin`, `mempalace`
+- [ ] `standards-and-conventions`: canonical convention doc (lands
+  last, post-pilot)
+- [ ] Agent-facing feedback memory captured per-repo (blocked until
+  the MEMORY.md ban is lifted where it still exists)
+- [ ] Retrospective notes added to ai-research-methodology #129

--- a/paad/alignment-reviews/2026-04-22-worktree-convention-alignment.md
+++ b/paad/alignment-reviews/2026-04-22-worktree-convention-alignment.md
@@ -1,0 +1,125 @@
+# Alignment Review: worktree-convention
+
+**Date:** 2026-04-22
+**Commit:** `93234cc6c98436ea9c6dcfa862e89386a6fcd320`
+**Issue:** [#258](https://github.com/wphillipmoore/standard-tooling/issues/258)
+**Reviewer:** Claude (paad:alignment skill, Opus 4.7)
+**Disposition:** Plan updated in place with the one resolution.
+
+## Documents Reviewed
+
+- **Intent:** `docs/specs/worktree-convention.md` (post-pushback
+  revision)
+- **Action:** `docs/plans/worktree-convention-plan.md` (initial draft)
+- **Design:** none — the spec's **Rollout plan** section is the
+  design; no intermediate design layer.
+
+## Source Control Conflicts
+
+None. Git log was reviewed during the preceding `paad:pushback`
+pass. No new commits have landed since, so the pushback reality
+check still holds.
+
+## Alignment Summary (overview)
+
+Coverage and scope are both tight. Pushback did most of the cleanup
+work before the plan was drafted, so the plan was written against an
+already-scrubbed spec.
+
+- **Requirements coverage:** Every substantive spec requirement
+  maps to at least one plan task. Deferred items (enforcement
+  tooling, adjacent work) are explicitly tracked in Plan Task 1.6
+  rather than silently dropped.
+- **Scope compliance:** Every plan task traces back to a spec
+  requirement or an operationally-necessary wrapper (PR workflow,
+  issue bookkeeping). No scope creep, no gold-plating.
+- **Design alignment:** N/A (no intermediate design doc).
+
+## Issues Reviewed
+
+### [1] Plan Task 2.3 verification didn't assert memory sharing — the spec's load-bearing claim
+
+- **Category:** missing coverage
+- **Severity:** important
+- **Documents:** spec **Memory-path implications** section ↔ plan
+  **Task 2.3**
+- **Issue:** The spec describes memory-path sharing as *"the
+  load-bearing constraint for the whole design."* The pilot (Task
+  2.3) is the spec's designated live validation of that claim.
+  Original verification wording only checked *"without memory-silo
+  surprises"* — passive, no assertable signal. Failure-mode gap:
+  if one pilot session was started inside `.worktrees/<name>/`
+  instead of at the project root, git-level isolation would still
+  prevent collisions (both agents commit to their own branches
+  fine) while memory sharing silently failed (different slug →
+  different memory silo). The pilot could be declared successful
+  while missing the load-bearing validation.
+- **Resolution:** Plan Task 2.3 updated in-place to:
+  - Require `pwd` confirmation before launching each session (must
+    equal the pilot repo root).
+  - Split verification into two explicit checks:
+    - **Collision prevention (git-level)** — the original check.
+    - **Memory-path sharing (load-bearing claim)** — assert that
+      `ls -d ~/.claude/projects/*dev-github-<pilot-repo-name>`
+      resolves to exactly one matching directory. Zero matches
+      means neither session registered; two matches means a
+      session was started from the wrong CWD and rule 1 was
+      violated.
+  - Added an explicit statement that the pilot is **not**
+    successful if the memory-path check fails, even if collision
+    prevention passed. This prevents a "false green" pilot outcome.
+
+## Minor Observations (batched, not individually discussed)
+
+These are nitpick-tier and were explicitly skipped during the
+review. Recorded here for completeness in case they become relevant
+during implementation:
+
+- **Cleanup guidance is spec-only** — Plan 1.2 doesn't surface
+  cleanup commands in CLAUDE.md. Users at branch-land have to
+  click through to the spec. Would add 3–5 lines to CLAUDE.md.
+- **Stacked-worktree guidance is spec-only** — Intentional (it's
+  the exception case per the spec). Not flagged as a gap.
+- **Plan 1.3's dry-run verifies mechanics, not rules** — Rules are
+  validated only in Phase 2 (pilot). This is by design: Phase 1 is
+  "convention present" and Phase 2 is "convention validated."
+- **Plan 1.2's 40–80 line CLAUDE.md budget isn't in the spec** —
+  Reasonable implementation choice; doesn't contradict the spec.
+
+## Unresolved Issues
+
+None.
+
+## TDD Task Rewrite
+
+**Skipped.** Per the `paad:alignment` skill guidance: *"Skip this
+step if tasks don't involve code implementation (e.g., infrastructure
+provisioning, documentation, design work, data migrations, manual
+processes)."* Every task in the plan is one of:
+
+- `.gitignore` / CLAUDE.md / spec edits (documentation)
+- Manual dry-runs, parallel-agent pilot runs, PR workflow (manual
+  processes)
+- Issue bookkeeping, retrospective notes (manual processes)
+
+No code implementation. TDD rewrite would force a red/green/refactor
+structure onto tasks where there is no unit to test.
+
+## Alignment Summary (final)
+
+- **Requirements:** ~17 substantive items in the spec; all have
+  plan coverage or are explicitly deferred to follow-up.
+- **Tasks:** 17 plan tasks across 5 phases; every one traces to a
+  spec requirement or an operational wrapper. No orphans.
+- **Design items:** N/A.
+- **Issues found:** 1 important coverage gap (resolved) + 4 minor
+  observations (acknowledged, skipped).
+- **Status:** Aligned. Plan is ready to execute starting with
+  Phase 1 (this repo: `.gitignore` + CLAUDE.md update, follow-up
+  issues).
+
+## Related Artifacts
+
+- Spec: `docs/specs/worktree-convention.md`
+- Plan: `docs/plans/worktree-convention-plan.md`
+- Pushback review: `paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md`

--- a/paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md
+++ b/paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md
@@ -1,0 +1,245 @@
+# Pushback Review: worktree-convention.md
+
+**Date:** 2026-04-22
+**Spec:** `docs/specs/worktree-convention.md`
+**Commit:** `93234cc6c98436ea9c6dcfa862e89386a6fcd320`
+**Issue:** [#258](https://github.com/wphillipmoore/standard-tooling/issues/258)
+**Reviewer:** Claude (paad:pushback skill, Opus 4.7)
+**Disposition:** Spec updated in place with all resolutions.
+
+## Source Control Conflicts
+
+One conflict surfaced in Phase 1.
+
+### Conflict [1]: "Agent-facing feedback memory" contradicted this repo's MEMORY.md ban
+
+- **Spec assumption:** Cross-repo propagation item 4 proposed writing
+  a "per-repo feedback memory" capturing the worktree assignment rule.
+- **Actual state:** Commit `4561dcf` (#225, 2026-03-08) added an
+  "Auto-memory policy" section to CLAUDE.md forbidding MEMORY.md /
+  memory-directory writes in standard-tooling, deferring to
+  version-controlled docs. Upstream fixes
+  `standards-and-conventions#347`.
+- **Resolution:** The MEMORY.md ban is an anachronism from the
+  polyglot-convergence era (five per-language repos, trying to get
+  consistent agent behavior across them via memory). The author has
+  since found feedback memory to be high-value in active repositories
+  (`the-infrastructure-mindset`). The ban will be removed in this
+  repo as adjacent work. The spec's item 5 (renumbered during
+  revision) stands.
+- **Flagged as adjacent work** in the spec's
+  "Adjacent work surfaced during pushback" section.
+
+## Phase 1.5: Scope Shape
+
+- **Cohesion:** Single coherent feature (a methodology convention +
+  its rollout). Not flagged.
+- **Size:** Wide but shallow — each repo's change is a `.gitignore`
+  line plus a CLAUDE.md paragraph. Not flagged.
+
+## Issues Reviewed
+
+### [1] Agent prompt contract is underspecified
+
+- **Category:** omission
+- **Severity:** serious
+- **Issue:** The whole convention rests on each parallel agent being
+  told, via the session prompt, which worktree it owns. The original
+  spec described this informally. Without a canonical contract, each
+  launch gets worded differently and the load-bearing mechanism
+  fails silently — agents without a worktree assignment default to
+  the main tree and reproduce the original collision.
+- **Resolution:** Added an **Agent prompt contract** section to the
+  spec with a canonical, copy-paste prompt template. All fields
+  (issue number, absolute worktree path, branch, behavior rules)
+  are marked required. A future `st-worktree-prompt` helper is
+  flagged as follow-up. Enforcement tooling (git hook / `st-*` /
+  plugin) is tracked as a separate follow-up bucket under
+  **Enforcement and follow-up work** — with the design principle
+  that enforcement is a safety net, not the primary mechanism.
+
+### [2] "Main worktree is read-only" rule was overreaching as stated
+
+- **Category:** ambiguity / contradiction
+- **Severity:** serious
+- **Issue:** Original wording read *"read-only while parallel work is
+  in flight."* Taken literally, this forbade any edit at the project
+  root whenever any `.worktrees/*` existed — blocking unrelated
+  CLAUDE.md fixes, docs tweaks, and dependency bumps. The actual
+  failure mode was narrower: dirty state at the root + concurrent
+  readers.
+- **Resolution:** Author clarified that the repo has a standing
+  policy of **no direct commits to develop** — all changes flow
+  through feature branches via PR. Given that, the rule is not an
+  overreach; it is the logical endpoint of the existing policy. The
+  rule was reframed: *"The main worktree is read-only. All edits
+  flow through a worktree on a feature branch. This is the logical
+  endpoint of the standing 'no direct commits to develop' policy."*
+  The same git hook that refuses direct pushes to develop is the
+  natural place to refuse commits from outside `.worktrees/*`
+  (tracked under Enforcement and follow-up work).
+
+### [3] Cleanup procedure ignored the existing `st-finalize-repo`
+
+- **Category:** omission
+- **Severity:** moderate
+- **Issue:** Original Cleanup section prescribed raw `git worktree
+  remove` / `git branch -D`. This repo already ships
+  `st-finalize-repo` for post-merge cleanup (branch deletion,
+  remote pruning, and now container validation per #254). The
+  spec's recipe overlapped with and diverged from that tool — two
+  mental models, drift risk, worktree residue after
+  `st-finalize-repo` ran.
+- **Resolution:** Spec's Cleanup section now prescribes
+  `st-finalize-repo` as the canonical flow, with raw git as an
+  interim procedure until the tool is extended to be worktree-aware.
+  The `st-finalize-repo` extension is tracked under Enforcement and
+  follow-up work. A separate `st-worktree-prune` helper is **not**
+  pre-built — deferred until the abandoned-branch case (branches
+  that never merge) proves a felt need.
+
+### [4] Rollout order put the canonical write-up first, but the convention isn't settled yet
+
+- **Category:** scope imbalance / sequencing
+- **Severity:** moderate
+- **Issue:** Original rollout: standards-and-conventions → standard-tooling
+  → active consuming repos. That enshrined the canonical doc before
+  the convention had been used in anger, and put the two repos with
+  active parallel-agent work (`the-infrastructure-mindset`,
+  `ai-research-methodology`) third. Any pilot-driven refinement
+  would propagate back up as amendments.
+- **Resolution:** Reordered in the spec's **Rollout plan** section:
+  (1) standard-tooling first (docs + gitignore; tooling extensions
+  follow), (2) pilot in an active-parallel repo, (3) fleet cascade,
+  (4) canonicalize in standards-and-conventions last. Canonical doc
+  now reflects what the pilot validated rather than projecting a
+  premature standard.
+
+### [5] "Existing include/reference mechanism" claim was not accurate
+
+- **Category:** factual accuracy
+- **Severity:** moderate
+- **Issue:** Spec wording implied that new repos would automatically
+  "pick up" the convention via a standards-and-conventions
+  inheritance mechanism. No such mechanism exists in practice; each
+  repo's CLAUDE.md is hand-authored and updated manually.
+- **Resolution:** Author confirmed the include mechanism is a
+  **second anachronism**, from the same era as the MEMORY.md ban —
+  an attempt to solve polyglot-convergence via "go read this and
+  remember it" that caused context overload and did not work. The
+  spec's wording was rewritten throughout: adoption is per-repo, the
+  canonical doc is a human-readable reference, no inheritance is
+  implied. Deprecation of the include pattern fleet-wide is flagged
+  as adjacent work.
+
+### [6] "Absolute paths for file edits" rule was redundant + confusing
+
+- **Category:** ambiguity
+- **Severity:** minor
+- **Issue:** Original rule 2 said *"use absolute paths for file
+  edits."* Read/Edit/Write already require absolute paths by tool
+  contract, so the rule was a no-op for those cases. The actual
+  distinction it was trying to make was about Bash commands that
+  resolve paths against CWD.
+- **Resolution:** Split into two explicit sub-rules under rule 2:
+  (a) Read/Edit/Write must use the worktree's absolute path;
+  (b) Bash commands that touch files must `cd` into the worktree
+  first or use absolute paths. The distinction matches the actual
+  decision the agent needs to make.
+
+### [7] Stacked PRs / dependent worktrees unaddressed
+
+- **Category:** omission
+- **Severity:** minor
+- **Issue:** Spec's onboarding example branched from
+  `origin/develop`; the case where issue B depends on issue A's
+  unmerged branch was silent.
+- **Resolution:** Added one paragraph to Onboarding documenting the
+  mechanism (substitute the parent branch in the worktree-add
+  command), **explicitly framed as the exception** with a "prefer
+  to defer dependent work or integrate it into the parent" note.
+  Author emphasized: stacking is the special case, not the norm.
+
+### [8] Worktree isolation is advisory only against intentional / buggy out-of-worktree writes
+
+- **Category:** security / blast radius
+- **Severity:** minor
+- **Issue:** Git isolates branches per worktree, so *accidental
+  version-control* collisions are prevented structurally. But the
+  filesystem is not isolated — an agent can `Write` to a sibling
+  worktree or the main tree. The 2026-04-22 incident was accidental;
+  this design addresses it. It does not address "agent misreads its
+  prompt and edits a sibling worktree."
+- **Resolution:** Added a **Trust model** section to the spec that
+  explicitly names what isolation does (git-level, accidental-path)
+  and does not (filesystem sandbox) buy. The enforcement-tooling
+  git hook (refuses commits from outside `.worktrees/*`) is the
+  real backstop; uncommitted out-of-worktree edits remain a residual
+  risk caught only by review. A true filesystem sandbox (devcontainer
+  with selective mounts) is flagged as out of scope with reasoning.
+
+### [9] Shared-cache concurrency under parallel tooling (demoted, not discussed in depth)
+
+- **Category:** omission (failure modes)
+- **Severity:** minor
+- **Issue (considered):** Two worktrees running `uv sync` or
+  `st-docker-test` in parallel could race on user-global caches
+  (`~/.cache/uv`, etc.).
+- **Disposition:** Demoted after analysis. `uv` locks its cache;
+  dev-container `.venv` is per-invocation and worktree-local via
+  the mount; pytest cache is in-tree per worktree. Not added to
+  failure modes. Noted here for completeness.
+
+## Unresolved Issues
+
+None. All issues surfaced during the review were either resolved
+through spec revision or explicitly deferred to a tracked follow-up
+item with rationale.
+
+## Adjacent Work Identified
+
+The pushback surfaced two items that are not part of this spec's
+implementation but are coupled:
+
+- **Remove the MEMORY.md ban** in this repo's CLAUDE.md (and anywhere
+  else it still lives in the fleet). Blocks cross-repo propagation
+  step 5 (agent-facing feedback memory).
+- **Deprecate the "include / reference and remember" pattern**
+  fleet-wide. Replace with explicit per-repo CLAUDE.md entries — the
+  model this spec already assumes.
+
+Both are captured in the revised spec's
+**Adjacent work surfaced during pushback** section.
+
+## Follow-up Work Identified
+
+The enforcement / tooling story is intentionally not in scope for
+this spec, but the review identified concrete candidates to track
+separately:
+
+- Git hook that refuses commits from the project root (and/or from
+  outside `.worktrees/*`) when rule 3 applies.
+- `st-finalize-repo` extension: remove the worktree for the branch
+  being finalized.
+- `st-worktree-prompt` helper: emit the canonical prompt template
+  given an issue number + slug.
+- (Optional, needs-driven) `st-worktree-prune` for abandoned branches.
+- (Optional, larger scope) Claude Code plugin that produces
+  worktree + prompt automatically on work-item assignment.
+
+Captured in the revised spec's **Enforcement and follow-up work**
+section with the design principle: *the convention works without
+these; they raise the floor on consistency, they do not gate
+adoption.*
+
+## Summary
+
+- **Issues found:** 9 (8 discussed in depth; 1 demoted after analysis)
+- **Source control conflicts found:** 1 (resolved — anachronism)
+- **Issues resolved:** 9 of 9
+- **Adjacent work items flagged:** 2 (MEMORY.md ban removal;
+  deprecation of the include pattern)
+- **Follow-up work items flagged:** 4–5
+- **Spec status:** Ready for `paad:alignment` between the spec and
+  an implementation plan, and for initial implementation of rollout
+  step 1 (this repo's `.gitignore` + CLAUDE.md update).


### PR DESCRIPTION
# Pull Request

## Summary

- Land Phase 1 of the git worktree convention rollout in standard-tooling — spec, plan, PAAD pushback+alignment artifacts, .gitignore entry for .worktrees/, and CLAUDE.md section with the canonical Agent prompt contract.

## Issue Linkage

- Ref #258

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Phase 1 of a multi-repo rollout (see docs/plans/worktree-convention-plan.md). Remaining phases — pilot, fleet cascade, canonical doc in standards-and-conventions, retrospective on ai-research-methodology#129 — happen outside this repo. #258 stays open through Phase 5.
- Full PAAD cycle ran on the spec before implementation: pushback (paad/pushback-reviews/2026-04-22-worktree-convention-pushback.md) surfaced 9 issues (8 resolved, 1 demoted) and 2 anachronism-removal items; alignment (paad/alignment-reviews/2026-04-22-worktree-convention-alignment.md) found one important coverage gap which was resolved in Plan Task 2.3.
- Follow-up issues opened for deferred work: #259 (pre-commit hook to refuse commits from outside .worktrees/), #260 (st-finalize-repo worktree-aware cleanup), #261 (remove the MEMORY.md ban anachronism), #262 (deprecate the include-and-remember pattern fleet-wide), #263 (optional st-worktree-prompt helper).
- Validation: st-docker-run -- uv run st-validate-local passes (410 tests, 100% coverage, lint/typecheck/audit clean).
- Dry-run Task 1.3: git worktree add / cd / isolation / cleanup all verified during this session before committing.