### PR TITLE
chore: remove MEMORY.md ban from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,6 @@ this repository.
 
 <!-- include: docs/repository-standards.md -->
 
-## Auto-memory policy
-
-**Do NOT use MEMORY.md.** Never write to MEMORY.md or any file under the
-memory directory. All behavioral rules, conventions, and workflow instructions
-belong in managed, version-controlled documentation (CLAUDE.md, AGENTS.md,
-skills, or docs/). If you want to persist something, tell the human what you
-would save and let them decide where it belongs.
-
 ## Parallel AI agent development
 
 This repository supports running multiple Claude Code agents in parallel via


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the 'Auto-memory policy' section from CLAUDE.md. The ban originated in #225 (2026-03-08) to solve a polyglot-convergence problem across per-language repos but has since become overly broad. Feedback memory is high-value in active repositories, and the worktree convention's Phase 5 (agent-facing feedback memory per repo, #258) assumes memory is available.

## Issue Linkage

- Closes #261

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Scope: this repo only. If the ban exists in other fleet repos, each needs its own removal PR (see #258 rollout plan). Residual concerns about cross-repo memory drift can be addressed separately with guidance about *what* to save rather than a blanket ban.