### PR TITLE
docs: add consolidated git-workflow guide as canonical entry point

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,13 @@
 default: true
 no-duplicate-heading:
   siblings_only: true
+# MD013 (line-length): exempt tables and code blocks. Wide reference
+# tables and pasted commands commonly exceed 80 columns.
+MD013:
+  line_length: 80
+  tables: false
+  code_blocks: false
+# MD060 (table-column-style): tables render correctly regardless of
+# strict column alignment; enforcing visual alignment adds maintenance
+# burden for no reader benefit.
+MD060: false

--- a/docs/git-hooks-and-validation.md
+++ b/docs/git-hooks-and-validation.md
@@ -1,5 +1,12 @@
 # Git Hooks and Validation
 
+> **Looking for the overall workflow?** See
+> [Git Workflow](site/docs/guides/git-workflow.md) for the
+> big-picture guide covering branching, commit/PR/finalize cycle,
+> worktrees, and both enforcement layers together. This page is the
+> detailed reference for the pre-commit git hook and the local
+> validators only.
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -17,7 +24,7 @@
 
 ## Overview
 
-This repository enforces code quality through two complementary
+This repository enforces code quality through three complementary
 entry points that share a common set of validators:
 
 - **Git hooks** run locally on every commit, providing
@@ -25,6 +32,13 @@ entry points that share a common set of validators:
 - **CI workflows** run the same validators on pull requests,
   ensuring standards are enforced even when hooks are not
   installed.
+- **Claude Code plugin hooks** (delivered by
+  [`standard-tooling-plugin`](https://github.com/wphillipmoore/standard-tooling-plugin))
+  enforce a subset of the same rules at the agent-tool level —
+  catching problems before they reach the `git commit` that the
+  pre-commit hook would evaluate. Covered in detail in the plugin
+  repo; summarized under
+  [Validation Matrix](#validation-matrix) below.
 
 All hooks and validators are managed by standard-tooling.
 Consuming repositories resolve them via PATH from a sibling
@@ -148,18 +162,36 @@ as a list item.
 
 The following table shows where each validation runs:
 
-- **pre-commit**: runs locally before each commit
+- **pre-commit**: runs locally on every `git commit`
+- **plugin**: PreToolUse/PostToolUse hooks from
+  [`standard-tooling-plugin`](https://github.com/wphillipmoore/standard-tooling-plugin)
+  fire when Claude Code invokes Bash / Write / Edit tools. Catches
+  patterns earlier than a `git commit` would — including ones that
+  never reach git (e.g., raw `gh pr create`, heredoc escaping bugs).
 - **CI**: runs in GitHub Actions on pull requests
 
-| Validation             | pre-commit | CI  |
-|------------------------|:----------:|:---:|
-| Detached HEAD          | yes        |     |
-| Protected branch       | yes        |     |
-| Branch prefix          | yes        |     |
-| Issue number in branch | yes        |     |
-| Repository profile     |            | yes |
-| Markdown standards     |            | yes |
-| PR issue linkage       |            | yes |
+| Validation                          | pre-commit | plugin | CI  |
+|-------------------------------------|:----------:|:------:|:---:|
+| Detached HEAD                       | yes        |        |     |
+| Protected branch (commit on `develop`/`main`) | yes | yes | |
+| Branch prefix                       | yes        |        |     |
+| Issue number in branch              | yes        |        |     |
+| Raw `git commit` forbidden          |            | yes    |     |
+| Raw `gh pr create` forbidden        |            | yes    |     |
+| Heredoc in CLI args forbidden       |            | yes    |     |
+| Commit must originate from `.worktrees/*` | | yes (adopted repos) | |
+| MEMORY.md writes                    |            | *(removed 2026-04-23; formerly plugin)* | |
+| Repository profile                  |            |        | yes |
+| Markdown standards                  |            |        | yes |
+| PR issue linkage                    |            |        | yes |
+
+The pre-commit hook and plugin hook for protected-branch commits
+overlap deliberately: the plugin catches the case where Claude Code
+tries to invoke `git commit`/`st-commit` at all, and the pre-commit
+hook catches everything else (direct human `git commit`, scripts,
+etc.). Their rules are similar but not identical — see
+[Git Workflow → Two enforcement layers](site/docs/guides/git-workflow.md#two-enforcement-layers)
+for the coordinated view.
 
 ## Configuration Points
 

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -350,7 +350,7 @@ PR itself was created successfully. See
 [standard-tooling#268](https://github.com/wphillipmoore/standard-tooling/issues/268)
 for the planned fix.
 
-### I can't find `st-markdown-standards` / `shfmt` / `yamllint` during a PostToolUse hook
+### Validator-not-on-PATH errors during PostToolUse
 
 The plugin's `validate-on-edit` hook expects those validators on
 PATH. Some are only installed inside the dev container image, not on

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -1,0 +1,371 @@
+# Git Workflow
+
+This is the single entry point for how we do git across every managed
+repository. It covers the overall shape of the workflow, the two
+enforcement layers that back it up, and the per-change cycle you walk
+through from branching to finalization.
+
+For per-tool detail, each `st-*` command has its own reference page.
+For the rationale behind the worktree convention,
+see [the worktree convention spec](../../../specs/worktree-convention.md).
+
+## At a glance
+
+```text
+new issue  →  branch  →  commit  →  PR  →  (human review)  →  merge  →  finalize
+                  │         │        │                                      │
+                  ▼         ▼        ▼                                      ▼
+            feature/<N>  st-commit  st-submit-pr                    st-finalize-repo
+```
+
+- One issue per branch. Branch name encodes the issue number.
+- `st-commit` builds standards-compliant commit messages. **Raw
+  `git commit` is blocked.**
+- `st-submit-pr` creates the PR with issue linkage. **Raw
+  `gh pr create` is blocked.**
+- Merging is **manual**. Auto-merge is disabled org-wide as of
+  2026-04-22.
+- After merge, `st-finalize-repo` pulls develop, deletes the merged
+  branch, and prunes remote refs.
+
+For parallel work on multiple issues, use the worktree convention
+(below) — every session starts at the project root, each concurrent
+agent gets its own worktree under `.worktrees/`.
+
+## Branching model
+
+Every repository's branching model is declared in
+`docs/repository-standards.md` under the `branching_model`
+attribute. Three models are supported:
+
+| Model | Prefixes allowed | Typical use |
+|---|---|---|
+| `library-release` | `feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`, `release/*` | Libraries / packages that cut versioned releases |
+| `application-promotion` | `feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`, `promotion/*` | Apps that promote through environments |
+| `docs-single-branch` | `feature/*`, `bugfix/*`, `chore/*` | Docs-only repos |
+
+Protected branches — `main`, `develop`, and (for `library-release`)
+`release` — do **not** accept direct commits. All changes go
+through PRs against the appropriate integration branch (typically
+`develop`).
+
+Work branches must include the issue number in the name:
+
+```text
+feature/42-add-caching
+bugfix/101-fix-null-pointer
+chore/256-bump-dependency-versions
+```
+
+Pattern: `^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9-]*$`.
+
+The `release/*` and `promotion/*` prefixes are created by automated
+workflows and are exempt from the issue-number rule.
+
+## Two enforcement layers
+
+The branching, commit, and PR rules are enforced by two distinct
+mechanisms. Both exist; they complement each other.
+
+| Layer | Where it runs | Catches |
+|---|---|---|
+| **Pre-commit git hook** | `scripts/lib/git-hooks/pre-commit` in standard-tooling; consumed via `git config core.hooksPath`. Fires on every `git commit`, regardless of how it was invoked. | Detached HEAD • direct commits to protected branches • wrong branch prefix • missing issue number in branch name |
+| **Plugin PreToolUse hooks** | Delivered by the [`standard-tooling-plugin`](https://github.com/wphillipmoore/standard-tooling-plugin). Fires on Claude Code's `Bash`/`Write`/`Edit` tool invocations. | Raw `git commit` (forces `st-commit`) • Raw `gh pr create` (forces `st-submit-pr`) • commits originating from outside `.worktrees/*` on repos that have adopted the worktree convention • heredoc syntax in CLI args • associative-array bashisms |
+
+**Why both?** The pre-commit hook catches anyone (human or agent)
+running git directly. The plugin catches patterns at the
+Claude-Code-tool level — some of which never reach a `git commit`
+(like `gh pr create`, or heredocs in gh commands). Together they
+close the loop.
+
+For the pre-commit-hook detail, see
+[Git Hooks and Validation](../../../git-hooks-and-validation.md).
+For the plugin hook detail, see
+[standard-tooling-plugin/docs → Hooks](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md).
+
+## Developing a change
+
+The common path, for work that isn't running in parallel:
+
+### 1. Branch from the integration branch
+
+```bash
+git fetch origin develop
+git checkout -b feature/42-add-caching origin/develop
+```
+
+The pre-commit hook enforces the prefix and issue-number rule when
+you try to commit, so name the branch correctly now.
+
+### 2. Commit with `st-commit`
+
+```bash
+st-commit \
+  --type feat \
+  --scope cache \
+  --message "cache computed results" \
+  --body "Adds an LRU cache to the computation pipeline..." \
+  --agent claude
+```
+
+`st-commit`:
+
+- Validates the commit type against conventional-commit standards
+  (`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`,
+  `build`).
+- Resolves the AI agent's `Co-Authored-By` trailer from
+  `docs/repository-standards.md`.
+- Invokes `git commit` under the hood — triggering the pre-commit
+  git hook, which checks the branching rules.
+
+**Multi-line bodies go in a file**, not a heredoc. The plugin blocks
+heredocs in CLI args because they cause escaping bugs:
+
+```bash
+st-commit --type feat --message "…" --body "$(cat /tmp/body.txt)" --agent claude
+```
+
+See the [st-commit reference](../reference/dev/commit.md) for the
+full flag list.
+
+### 3. Submit the PR with `st-submit-pr`
+
+```bash
+st-submit-pr \
+  --issue 42 \
+  --summary "Add LRU cache to pipeline" \
+  --linkage Fixes \
+  --notes "$(cat /tmp/pr-notes.txt)"
+```
+
+`st-submit-pr`:
+
+- Pushes the current branch to `origin`.
+- Constructs a standards-compliant PR body with issue linkage
+  (`Fixes #42`, `Closes`, `Resolves`, or `Ref`).
+- Creates the PR via `gh pr create` under the hood.
+
+!!! note "Auto-merge is disabled"
+    As of 2026-04-22 all managed repos have `allow_auto_merge=false`.
+    `st-submit-pr` still tries to enable auto-merge after PR creation
+    and will print a non-fatal `CalledProcessError` traceback — the
+    PR itself is created successfully and simply waits for a human
+    merge. Removing that call is tracked in
+    [standard-tooling#268](https://github.com/wphillipmoore/standard-tooling/issues/268).
+
+See the [st-submit-pr reference](../reference/dev/submit-pr.md).
+
+### 4. Wait for review, merge manually
+
+Once CI is green and a reviewer approves, merge through the GitHub
+UI (squash merge for feature PRs). No automated merge will happen.
+
+### 5. Finalize with `st-finalize-repo`
+
+```bash
+st-finalize-repo
+```
+
+This:
+
+- Switches back to the integration branch (`develop`).
+- Pulls the latest.
+- Deletes the merged local feature branch.
+- Prunes stale remote-tracking refs.
+- Runs post-merge validation via `st-docker-run` to catch any
+  regression introduced by the merge.
+
+Run this immediately after the PR merges. A Stop hook in the plugin
+will remind you if you try to end the session with an unsubmitted
+or unfinalized PR still dangling.
+
+See the [st-finalize-repo reference](../reference/dev/finalize-repo.md).
+
+## Parallel work with worktrees
+
+Use the worktree convention when running **more than one agent in
+the same repo at the same time**, or when you want to start a second
+issue before the first is merged.
+
+For the full spec (rationale, trust model, failure modes, memory-path
+implications), see
+[the worktree convention](../../../specs/worktree-convention.md).
+This section is the user-level "how to."
+
+### When a worktree is required
+
+- Two or more Claude Code sessions are going to work concurrently
+  on the same repo.
+- The main working tree at the project root is serving as the
+  "canonical state" for one agent while another starts work.
+
+### When a worktree is optional but recommended
+
+- Any feature branch, even for solo sequential work. The convention
+  keeps the main tree clean; once the plugin-level CWD check is
+  active (release tracked in
+  [standard-tooling-plugin#46](https://github.com/wphillipmoore/standard-tooling-plugin/issues/46))
+  committing from the main tree will be blocked.
+
+### Creating a worktree for an issue
+
+From the project root:
+
+```bash
+git fetch origin develop
+git worktree add \
+  .worktrees/issue-42-add-caching \
+  -b feature/42-add-caching \
+  origin/develop
+```
+
+Directory layout:
+
+```text
+~/dev/github/<repo>/                      ← session starts here
+  .git/
+  CLAUDE.md, src/, docs/, …               ← main worktree (develop)
+  .worktrees/                             ← gitignored, local-only
+    issue-42-add-caching/                 ← your worktree, on feature/42-…
+    issue-101-fix-npe/                    ← another agent's worktree
+```
+
+### Launching a session with a worktree assignment
+
+**Always start the Claude Code session at the project root**, not
+inside the worktree. The session's initial CWD determines the memory
+slug; starting inside a worktree creates a separate memory silo and
+loses shared project context.
+
+Then give the agent the canonical prompt (a template lives in each
+repo's CLAUDE.md under "Parallel AI agent development → Agent prompt
+contract"):
+
+```text
+You are working on issue #42: Add LRU cache to pipeline.
+
+Your worktree is: /Users/pmoore/dev/github/<repo>/.worktrees/issue-42-add-caching/
+Your branch is:   feature/42-add-caching
+
+Rules for this session:
+- Do all git operations from inside your worktree:
+    cd <absolute-worktree-path> && git <command>
+- For Read / Edit / Write tools, use the absolute worktree path.
+- For Bash commands that touch files, cd into the worktree first
+  or use absolute paths.
+- Do not edit files at the project root. The main worktree is
+  read-only — all changes flow through your worktree on your
+  feature branch.
+- When you need to run validation, run it from inside your worktree
+  (st-docker-run mounts the current directory).
+```
+
+### Cleanup after merge
+
+`st-finalize-repo` will handle worktree removal once
+[standard-tooling#260](https://github.com/wphillipmoore/standard-tooling/issues/260)
+lands. Until then, do it by hand alongside the usual finalization:
+
+```bash
+cd ~/dev/github/<repo>
+git worktree remove .worktrees/issue-42-add-caching
+git branch -D feature/42-add-caching    # usually already deleted
+git fetch --prune                        # usually already pruned
+```
+
+## Releasing
+
+Release flow is covered in its own guide:
+[Releasing](releasing.md).
+
+High-level summary:
+
+1. Accumulate feature PRs on `develop`.
+2. Run `st-prepare-release --issue <N>` to cut a `release/<version>`
+   branch, generate the changelog, and open a PR to `main`.
+3. Merge the release PR manually. CI auto-tags, creates the GitHub
+   Release, publishes the package artifact, and opens a
+   version-bump PR back to `develop`.
+4. `st-finalize-repo` as usual.
+
+## Adoption for a new repo
+
+Onboarding a brand-new repository to this workflow has its own
+guide: [Consuming Repo Setup](consuming-repo-setup.md).
+
+!!! note "Setup docs are being refreshed"
+    The existing Getting Started and Consuming Repo Setup guides
+    predate the Docker-first, plugin-aware, worktree-aware setup.
+    Use them as a starting point, but cross-reference this guide,
+    the plugin repo, and each repo's CLAUDE.md for current
+    behavior. A rewrite is tracked as Phase 2 of
+    [standard-tooling#270](https://github.com/wphillipmoore/standard-tooling/issues/270).
+
+At a minimum, a new repo needs:
+
+1. `docs/repository-standards.md` with the six required attributes
+   (see the existing setup guide).
+2. `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`
+   (or equivalent path) so the pre-commit hook fires.
+3. `.claude/settings.json` enabling the `standard-tooling` plugin
+   so the plugin hooks fire in Claude Code sessions.
+4. `.worktrees/` in `.gitignore` and a Parallel-AI-agent-development
+   section in CLAUDE.md so the worktree convention applies.
+
+## Troubleshooting
+
+### A hook blocked me. Which one, and why?
+
+The hook that fired will print a reason. Common signals:
+
+| Message fragment | Source | What to do |
+|---|---|---|
+| `"Raw git commit is blocked. Use st-commit"` | plugin | Use `st-commit` with the appropriate flags |
+| `"Raw gh pr create is blocked. Use st-submit-pr"` | plugin | Use `st-submit-pr` |
+| `"Heredoc syntax (<<EOF) is blocked"` | plugin | Write your multi-line content to a `/tmp/…` file, pass it via `$(cat <file>)` or `--body-file` |
+| `"Commits must originate from inside .worktrees/<name>/"` | plugin (on repos that have adopted the worktree convention) | Create a worktree for your work and `cd` into it |
+| `"Commits on protected branch \"develop\" are blocked"` | plugin or pre-commit | Create a feature branch with the issue number in its name |
+| `"direct commits to protected branches are forbidden"` | pre-commit git hook | Same — you're on `develop`/`release`/`main` directly |
+| `"branch name must use {prefixes}"` | pre-commit | Rename the branch to `feature/42-<slug>` or similar |
+| `"branch name must include a repo issue number"` | pre-commit | Add the issue number to the branch name |
+| `"detached HEAD is not allowed for commits"` | pre-commit | Create a named branch before committing |
+
+### My plugin cache is stale
+
+Until plugin release automation is fully stood up
+([standard-tooling-plugin#46](https://github.com/wphillipmoore/standard-tooling-plugin/issues/46)),
+the plugin is consumed from a local checkout and its cache under
+`~/.claude/plugins/cache/standard-tooling-marketplace/`. If you're
+running an old version of a hook:
+
+```bash
+git -C ~/.claude/plugins/marketplaces/standard-tooling-marketplace pull
+# then restart Claude Code
+```
+
+### `st-submit-pr` threw a CalledProcessError on auto-merge
+
+Expected since 2026-04-22 — auto-merge is disabled org-wide. The
+PR itself was created successfully. See
+[standard-tooling#268](https://github.com/wphillipmoore/standard-tooling/issues/268)
+for the planned fix.
+
+### I can't find `st-markdown-standards` / `shfmt` / `yamllint` during a PostToolUse hook
+
+The plugin's `validate-on-edit` hook expects those validators on
+PATH. Some are only installed inside the dev container image, not on
+the host. Hook-level PATH discovery is tracked in
+[standard-tooling#265](https://github.com/wphillipmoore/standard-tooling/issues/265).
+Workaround: run the validator explicitly with an absolute path
+(`.venv-host/bin/st-markdown-standards …`) to confirm the file is
+clean; then proceed.
+
+## Related
+
+- [Git Hooks and Validation](../../../git-hooks-and-validation.md)
+  — pre-commit hook + validator reference
+- [Worktree convention spec](../../../specs/worktree-convention.md)
+  — rationale, failure modes, trust model
+- [Releasing](releasing.md) — release workflow detail
+- [standard-tooling-plugin — Hooks](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md)
+  — plugin hook reference

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
           - st-finalize-repo: reference/dev/finalize-repo.md
           - st-validate-local: reference/dev/validate-local.md
   - Guides:
+      - Git Workflow: guides/git-workflow.md
       - Consuming Repo Setup: guides/consuming-repo-setup.md
       - Three-Tier CI: guides/three-tier-ci.md
       - Validation Matrix: guides/validation-matrix.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add a single canonical Git Workflow guide at docs/site/docs/guides/git-workflow.md covering branching, commit/PR/finalize, two-layer enforcement (pre-commit hook + plugin), worktree convention as user-facing how-to, and troubleshooting. Refactors git-hooks-and-validation.md to add a top pointer and a plugin column in the validation matrix.

## Issue Linkage

- Fixes #270

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Phase 1 of #270. Phase 2 (getting-started.md + consuming-repo-setup.md rewrites) is deferred to a follow-up issue to keep this PR scoped. Dogfooded the worktree convention for authoring — work happened in .worktrees/issue-270-git-workflow-doc/ with the main tree read-only.