### PR TITLE
docs: rewrite onboarding docs for Docker/plugin/worktree reality

### DIFF
--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -1,101 +1,164 @@
 # Getting Started
 
-This guide covers setting up a consuming repository to use standard-tooling.
+A five-to-ten minute quickstart for wiring up a new repository to
+use standard-tooling. For the detailed walkthrough with rationale,
+CI config, and troubleshooting, see
+[Consuming Repo Setup](guides/consuming-repo-setup.md).
 
 ## Prerequisites
 
-- Git
-- Bash (macOS or Linux)
-- [uv](https://docs.astral.sh/uv/): Python package manager
-- [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):
-  `npm install --global markdownlint-cli`
-- [shellcheck](https://www.shellcheck.net/): `brew install shellcheck`
+Install these on your host:
 
-## Initial Setup
+- **Docker** — the dev container engine
+- **uv** — Python package manager
+  ([install](https://docs.astral.sh/uv/getting-started/installation/))
+- **`gh` CLI** — GitHub CLI, authenticated
+  (`gh auth login`)
+- **macOS or Linux** (Bash)
 
-### 1. Clone standard-tooling
+Everything else — language runtimes, linters, test frameworks, all
+but one of the `st-*` tools — lives inside the dev container. The
+only `st-*` tool that runs on the host is `st-docker-run`, which
+bridges into the container.
 
-Clone standard-tooling as a sibling directory alongside your repository:
+## 1. Clone standard-tooling as a sibling
 
 ```bash
+cd ~/dev/github   # or wherever you keep your repos
 git clone https://github.com/wphillipmoore/standard-tooling.git
 ```
 
-### 2. Install the Python package
+## 2. Bootstrap the host venv
 
 ```bash
 cd standard-tooling
-uv sync
+UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
 ```
 
-This installs the `st-*` CLI tools into `.venv/bin/`.
+!!! important "The `UV_PROJECT_ENVIRONMENT` override matters"
+    Without it, `uv sync` creates a `.venv` with container-path
+    shebangs (`/workspace/.venv/...`) that don't work on the host.
+    The `.venv-host` name and the `--group dev` dependencies are
+    both required.
 
-### 3. Add standard-tooling to PATH
+This installs `st-docker-run` and the other host-side entry points
+into `.venv-host/bin/`.
 
-From your consuming repository:
+## 3. Put host tools on PATH
 
 ```bash
-export PATH="../standard-tooling/.venv/bin:$PATH"
+export PATH="$HOME/dev/github/standard-tooling/.venv-host/bin:$HOME/dev/github/standard-tooling/scripts/bin:$PATH"
 ```
 
-This makes the `st-*` CLI tools (`st-commit`, `st-submit-pr`, etc.)
-available by name.
+Add this to your shell profile so it persists across sessions.
 
-### 4. Configure git hooks
+## 4. Configure git hooks in your consuming repo
+
+From your repo:
 
 ```bash
 git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks
 ```
 
-This tells git to use the standard-tooling hooks for branch naming and commit
-message validation.
+This must be re-run once per fresh clone; it's not persisted.
 
-### 5. GitHub authentication
+## 5. Enable the Claude Code plugin
 
-Container-based tools (e.g. `st-submit-pr`) need a GitHub token to create
-pull requests. Add to your shell profile (`~/.bashrc` or `~/.zshrc`):
+Create `.claude/settings.json` in your repo:
 
-```bash
-export GH_TOKEN=$(gh auth token)
+```json
+{
+  "extraKnownMarketplaces": {
+    "standard-tooling-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "wphillipmoore/standard-tooling-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "standard-tooling@standard-tooling-marketplace": true
+  }
+}
 ```
 
-This passes your local `gh` authentication into the dev container
-automatically.
+Commit this file — it's part of the repo's reproducible setup.
 
-### 6. Create a repository profile
+!!! note "Plugin install is a known rough edge"
+    The install/update flow for the plugin itself is tracked in
+    [standard-tooling-plugin#46](https://github.com/wphillipmoore/standard-tooling-plugin/issues/46).
+    For now, this settings.json entry is enough for Claude Code to
+    discover and enable the plugin on the next session restart.
 
-Create `docs/repository-standards.md` with the required attributes:
+## 6. Create your repository profile
+
+Create `docs/repository-standards.md` with the six required
+attributes (and AI co-author entries if you'll use them):
 
 ```markdown
 # Repository Standards
 
 ## Table of Contents
 
+- [AI co-authors](#ai-co-authors)
 - [Repository profile](#repository-profile)
+
+## AI co-authors
+
+- Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 ## Repository profile
 
-- repository_type: <application|library|tooling|documentation>
-- versioning_scheme: <semver|calver|none>
-- branching_model: <library-release|application-promotion|docs-single-branch>
-- release_model: <tagged-release|continuous-deploy|none>
-- supported_release_lines: <number>
-- primary_language: <python|go|java|shell|none>
+- repository_type: library
+- versioning_scheme: semver
+- branching_model: library-release
+- release_model: tagged-release
+- supported_release_lines: 1
+- primary_language: python
 ```
 
-### 7. Verify
+Pick the values that match your repo. See
+[Consuming Repo Setup](guides/consuming-repo-setup.md) for the full
+attribute reference.
 
-Run a validator to confirm everything is wired up:
+## 7. Adopt the worktree convention
+
+Add `.worktrees/` to your `.gitignore`:
 
 ```bash
-st-repo-profile
+echo '.worktrees/' >> .gitignore
 ```
 
-## Next Steps
+Add a "Parallel AI agent development" section to your `CLAUDE.md`
+describing the convention. Every managed repo already has one you
+can copy from; the canonical source is
+[the worktree convention spec](../specs/worktree-convention.md).
 
-- Read the [Consuming Repo Setup](guides/consuming-repo-setup.md) guide for
-  detailed onboarding instructions including CI configuration
-- See the [Script Reference](reference/index.md) for documentation on each
-  tool
-- Review the [Validation Matrix](guides/validation-matrix.md) to understand
-  which checks run where
+## 8. Verify
+
+```bash
+# Host tooling reachable
+st-docker-run --help
+
+# Repo profile validates (runs inside the container)
+st-docker-run -- uv run st-repo-profile
+
+# Git hook fires on a misnamed branch
+git checkout -b bad-branch-name
+git commit --allow-empty -m "test"    # should be blocked by the hook
+git checkout -
+git branch -D bad-branch-name
+```
+
+If all three steps behave as expected, you're wired up correctly.
+
+## Next steps
+
+- **[Consuming Repo Setup](guides/consuming-repo-setup.md)** —
+  detailed walkthrough including CI workflow, markdownlint config,
+  plugin nuances, and troubleshooting.
+- **[Git Workflow](guides/git-workflow.md)** — branching, commit /
+  PR / finalize cycle, two-layer enforcement, worktrees in practice.
+- **[Worktree convention spec](../specs/worktree-convention.md)**
+  — full rationale for the parallel-agent convention, failure
+  modes, memory-path implications.

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -1,59 +1,141 @@
 # Consuming Repo Setup
 
-This guide walks through end-to-end onboarding of a new repository to
-use standard-tooling via PATH-based consumption.
+This is the full walkthrough for onboarding a new repository to use
+standard-tooling. For the one-screen quickstart, see
+[Getting Started](../getting-started.md). For how the workflow
+unfolds once you're set up, see [Git Workflow](git-workflow.md).
 
-## Prerequisites
+## Mental model — what you're installing
 
-Install the required tools:
+Standard-tooling is delivered through three coordinated surfaces.
+The setup steps below wire up each one:
 
-**macOS:**
+| Surface | What it is | How you consume it |
+|---|---|---|
+| **Host bridge** | A single host-side CLI tool, `st-docker-run`, that runs commands inside a dev container image. | `uv sync` into `.venv-host`; add its `bin/` to PATH. |
+| **Dev container** | `ghcr.io/wphillipmoore/dev-<lang>:<version>` — pre-baked images with language runtimes, validators, and every other `st-*` tool installed. | Pulled automatically by `st-docker-run`; nothing to install manually. |
+| **Claude Code plugin** | `standard-tooling-plugin` — hooks, skills, agents, and slash commands that enforce the workflow at the Claude-Code-tool level. | Declared in `.claude/settings.json`; Claude Code loads on session start. |
+
+Plus two scripted layers that aren't installed as packages but are
+expected to be present in every consuming repo:
+
+- **Local git hooks** — `scripts/lib/git-hooks/pre-commit` from
+  standard-tooling, wired via `git config core.hooksPath`.
+- **CI workflow** — the `standards-compliance` composite action
+  from `wphillipmoore/standard-actions`, invoked from your repo's
+  `.github/workflows/ci.yml`.
+
+Both of these validate the repo profile and enforce branching rules
+from two different entry points. See
+[Git Workflow → Two enforcement layers](git-workflow.md#two-enforcement-layers)
+for how they fit together.
+
+## Step 1: Host prerequisites
+
+Install on your host (macOS or Linux):
+
+**Docker** — the container engine. Docker Desktop on macOS is fine;
+Docker Engine on Linux works too.
+
+**uv** — Python package manager. Used to bootstrap the host venv and
+(inside the container) to manage Python dependencies. Install via
+the [official installer](https://docs.astral.sh/uv/getting-started/installation/).
+
+**gh** — GitHub CLI. Must be authenticated
+(`gh auth login`). Used by `st-submit-pr` to create PRs and, inside
+the container, to pass through your GitHub token for push operations.
+
+**Git and Bash** — ship with macOS by default and are standard on
+Linux.
+
+You do **not** need to install language runtimes, linters, test
+frameworks, markdownlint, shellcheck, or any `st-*` tool other than
+`st-docker-run` on the host. All of those live inside the container.
+
+## Step 2: Clone and bootstrap standard-tooling
+
+Clone standard-tooling as a sibling directory. The exact location
+doesn't matter much — just make sure you can reference it with a
+consistent relative path from your consuming repo.
 
 ```bash
-brew install shellcheck uv
-npm install --global markdownlint-cli
+cd ~/dev/github   # or wherever
+git clone https://github.com/wphillipmoore/standard-tooling.git
 ```
 
-**Linux:**
+Bootstrap the host venv:
 
 ```bash
-sudo apt-get install shellcheck
-npm install --global markdownlint-cli
-# Install uv: https://docs.astral.sh/uv/getting-started/installation/
-```
-
-## Step 1: Clone Standard-Tooling
-
-Clone the canonical source as a sibling directory:
-
-```bash
-cd ..
-git clone \
-  https://github.com/wphillipmoore/standard-tooling.git
 cd standard-tooling
-uv sync
-cd ../your-repo
+UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
 ```
 
-## Step 2: Configure PATH and Hooks
+!!! important "Why `UV_PROJECT_ENVIRONMENT=.venv-host`"
+    The project also uses a `.venv` inside the dev container (at
+    `/workspace/.venv/`). Running a plain `uv sync` on the host
+    would create that container-venv on your host filesystem, with
+    shebangs pointing at `/workspace/.venv/bin/python` — which
+    doesn't exist on your host, making every `st-*` entry point
+    unrunnable. Setting `UV_PROJECT_ENVIRONMENT=.venv-host` creates
+    a separate host-specific venv with the correct host-Python
+    shebangs, and `--group dev` pulls the dependencies
+    `st-docker-run` needs.
 
-Add standard-tooling to PATH and configure git hooks:
+This creates `.venv-host/bin/` with `st-docker-run` and a handful of
+other host-side scripts.
+
+## Step 3: PATH configuration
+
+Add two directories to your PATH:
 
 ```bash
-export PATH="../standard-tooling/.venv/bin:$PATH"
+export PATH="$HOME/dev/github/standard-tooling/.venv-host/bin:$HOME/dev/github/standard-tooling/scripts/bin:$PATH"
+```
+
+- `.venv-host/bin/` — the Python-packaged host entry points,
+  including `st-docker-run`.
+- `scripts/bin/` — grandfathered bash validators consumed via PATH.
+  Most still have `st-*` Python equivalents, but some CI paths
+  still reach for the bash versions.
+
+Add this to `~/.bashrc`, `~/.zshrc`, or your shell's equivalent so
+it persists.
+
+Optional — add `gh`'s token to your environment so it flows into
+the container automatically on `st-docker-run` invocations:
+
+```bash
+export GH_TOKEN=$(gh auth token)
+```
+
+## Step 4: Git hook setup
+
+From your consuming repo's root:
+
+```bash
 git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks
 ```
 
-!!! tip
-    Add the PATH export to your shell profile or project's setup
-    documentation so it persists across sessions.
+Adjust the relative path if standard-tooling lives somewhere other
+than the parent directory. This must be re-run per fresh clone —
+it lives in `.git/config`, which isn't versioned.
 
-## Step 3: Create the Repository Profile
+The pre-commit hook enforces:
 
-Create `docs/repository-standards.md` in your repository. This file
-is read by multiple validators for configuration.
+- Detached-HEAD commits blocked
+- Direct commits to protected branches (`develop`/`release`/`main`)
+  blocked
+- Branch names must use one of the allowed prefixes for the repo's
+  `branching_model`
+- Work branches (`feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`)
+  must include a repository issue number
 
-Required sections:
+Full reference: [Git Hooks and Validation](../../git-hooks-and-validation.md).
+
+## Step 5: Repository profile
+
+Create `docs/repository-standards.md` at your repo root. This is
+the primary configuration surface for the validators:
 
 ```markdown
 # Repository Standards
@@ -65,8 +147,7 @@ Required sections:
 
 ## AI co-authors
 
-- Co-Authored-By: your-codex <email>
-- Co-Authored-By: your-claude <email>
+- Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 ## Repository profile
 
@@ -78,69 +159,272 @@ Required sections:
 - primary_language: python
 ```
 
-## Step 4: Add CI Workflow
+Required attributes and accepted values:
 
-Use the `standard-actions` composite action in your CI workflow:
+| Attribute | Values | Notes |
+|---|---|---|
+| `repository_type` | `application`, `library`, `tooling`, `documentation` | Informational; some validators branch on this. |
+| `versioning_scheme` | `semver`, `calver`, `none` | How releases are versioned. |
+| `branching_model` | `library-release`, `application-promotion`, `docs-single-branch` | Determines which branch prefixes the pre-commit hook allows. |
+| `release_model` | `tagged-release`, `continuous-deploy`, `none` | Affects release-flow tooling expectations. |
+| `supported_release_lines` | integer (commonly `1`) | How many concurrent major lines you support. |
+| `primary_language` | `python`, `go`, `java`, `rust`, `ruby`, `shell`, `none` | Determines which per-language validators run. |
 
-```yaml
-- name: Validate standards
-  uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+The `AI co-authors` section defines which `Co-Authored-By` trailer
+values `st-commit` accepts for `--agent`. Add one line per accepted
+agent identity.
+
+Values containing `<`, `>`, or `|` are rejected as placeholders by
+`st-repo-profile`.
+
+## Step 6: Enable the Claude Code plugin
+
+Create `.claude/settings.json` in your repo:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "standard-tooling-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "wphillipmoore/standard-tooling-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "standard-tooling@standard-tooling-marketplace": true
+  }
+}
 ```
 
-The action checks out standard-tooling, adds it to PATH, and runs:
+Commit this file. It's part of your repo's reproducible
+environment — any Claude Code session opened in this repo will
+pick up the plugin via this declaration.
 
-- `st-repo-profile` -- validates the repository profile
-- `st-markdown-standards` -- validates markdown formatting
-- `st-pr-issue-linkage` -- validates PR issue linkage (on PRs only)
+What the plugin provides:
 
-See `standard-actions` for reusable workflow actions.
+- **PreToolUse hooks** on `Bash` that block raw `git commit`, raw
+  `gh pr create`, heredoc syntax, and (on repos that have adopted
+  the worktree convention) commits originating outside
+  `.worktrees/<name>/`.
+- **PostToolUse hooks** that remind you to run `st-finalize-repo`
+  after `st-submit-pr`, and that surface deprecation warnings in
+  test output.
+- **Stop hooks** that prevent session exit if a PR was submitted
+  but never finalized.
 
-## Step 5: Create Markdownlint Config
+See the plugin's own
+[Hooks reference](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md)
+for the full list.
 
-Create `.markdownlint.yaml` at the repository root:
+!!! warning "Plugin install is a known rough edge"
+    The plugin itself has not yet been cut as a proper versioned
+    release; Claude Code consumes it directly from the repo's
+    default branch. Updates can be slow to propagate and the local
+    `~/.claude/plugins/marketplaces/` and `…/cache/` directories
+    sometimes need manual refreshing. All tracked in
+    [standard-tooling-plugin#46](https://github.com/wphillipmoore/standard-tooling-plugin/issues/46).
+    The settings above are enough to get going; plan on
+    occasionally running `git pull` in
+    `~/.claude/plugins/marketplaces/standard-tooling-marketplace/`
+    if a hook seems outdated.
+
+## Step 7: Worktree convention
+
+Every managed repo adopts the worktree convention so multiple
+Claude Code agents can work in parallel without colliding. Two
+tiny changes:
+
+Add `.worktrees/` to your `.gitignore`:
+
+```bash
+echo '.worktrees/' >> .gitignore
+```
+
+Add a `## Parallel AI agent development` section to your
+`CLAUDE.md`. Every managed repo has one you can copy — they differ
+only in the repo name and example issue number. The canonical text
+lives in the worktree convention spec at
+`docs/specs/worktree-convention.md` in standard-tooling; a short
+local section in each repo's CLAUDE.md is the on-ramp, and the
+plugin's commit-block hook activates against the presence of
+`.worktrees/` in `.gitignore`.
+
+For how to actually use worktrees during development, see
+[Git Workflow → Parallel work with worktrees](git-workflow.md#parallel-work-with-worktrees).
+
+## Step 8: Markdownlint configuration
+
+Create `.markdownlint.yaml` at your repo root:
 
 ```yaml
 default: true
 no-duplicate-heading:
   siblings_only: true
+# Exempt tables and code blocks from the 80-char line-length check.
+# Wide reference tables and pasted commands legitimately exceed it.
+MD013:
+  line_length: 80
+  tables: false
+  code_blocks: false
+# Disable the table-column-style rule. Tables render correctly
+# regardless of strict pipe alignment; enforcing it adds maintenance
+# burden for no reader benefit.
+MD060: false
 ```
 
-## Step 6: Verify
+The base rule set (`default: true`) plus the three customizations
+above match what standard-tooling itself uses, so markdown files
+that pass locally will pass in CI.
+
+Optional: add `.markdownlintignore` to skip generated files:
+
+```text
+CHANGELOG.md
+releases/
+```
+
+## Step 9: CI workflow
+
+Use the `standards-compliance` composite action from
+`wphillipmoore/standard-actions`. Minimal workflow
+(`.github/workflows/ci.yml`):
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  standards-compliance:
+    name: "ci: standards-compliance"
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate standards
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+```
+
+What the composite action runs inside the `dev-base` container:
+
+- `st-repo-profile` — validates `docs/repository-standards.md`
+- `st-markdown-standards` — markdownlint + structural checks
+- `st-pr-issue-linkage` — validates PR body has an issue linkage
+  keyword (`Fixes`, `Closes`, `Resolves`, `Ref`)
+
+The `dev-base` container already has standard-tooling on PATH, so
+no further setup is needed in the workflow.
+
+See the [Three-Tier CI](three-tier-ci.md) guide if you also want
+per-language test/lint/audit tiers.
+
+## Step 10: Verify end-to-end
+
+Once the above is in place, sanity-check each layer:
 
 ```bash
-# Verify repo profile
-st-repo-profile
+# 1. Host bridge — should print st-docker-run help
+st-docker-run --help
 
-# Verify markdown
-st-markdown-standards
+# 2. Dev container — pulls an image on first run and runs a
+#    tiny command inside it
+st-docker-run -- echo "container ok"
 
-# Verify hooks work
-git checkout -b feature/1-test-setup
-echo "test" >> test.txt
-git add test.txt
-st-commit \
-  --type chore --message "test setup" --agent claude
+# 3. Repo profile — runs st-repo-profile inside the container
+st-docker-run -- uv run st-repo-profile
+
+# 4. Git hook — creating a bad branch name and trying to commit
+#    should be blocked
+git checkout -b bad-name
+git commit --allow-empty -m "test"     # expected: blocked
+git checkout -
+git branch -D bad-name
+
+# 5. Plugin hook (requires Claude Code session) — in a Claude
+#    Code session in this repo, have Claude try to run a raw
+#    `git commit`. The plugin should block it and point at
+#    st-commit.
 ```
 
-## Keeping Up to Date
+If any step fails, check the corresponding section above, then
+re-run. Common causes: PATH missing an entry, `.venv-host` built
+without the `UV_PROJECT_ENVIRONMENT` override, `.claude/settings.json`
+not committed to the branch your Claude Code session loaded.
 
-Standard-tooling is consumed via PATH, so updates are picked up
-automatically when you pull the latest version:
+## Keeping up to date
+
+Standard-tooling's host side is consumed via the sibling
+`.venv-host/` checkout. To pull updates:
 
 ```bash
 cd ../standard-tooling
 git pull
-uv sync
+UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
 ```
 
-For CI, the `standard-actions` composite action pins to a
-`standard-tooling-ref` (default: `develop`). To pin to a stable
-release, set the input:
+!!! important "Don't drop the `UV_PROJECT_ENVIRONMENT` override"
+    It applies on every sync, not just the initial bootstrap. A
+    plain `uv sync` in the standard-tooling checkout will rebuild
+    `.venv-host/` with the wrong shebangs again.
 
-```yaml
-- uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
-  with:
-    standard-tooling-ref: v1.2
+The dev container images auto-update on `st-docker-run` pulls — the
+tag is a minor version (`3.12`, `1.26`, etc.) that tracks upstream
+releases. If you need a fresh image, `docker pull
+ghcr.io/wphillipmoore/dev-<lang>:<version>` forces a refresh.
+
+The Claude Code plugin can be stale after a release; manual
+refresh:
+
+```bash
+git -C ~/.claude/plugins/marketplaces/standard-tooling-marketplace pull
+# then restart Claude Code
 ```
 
-See the [Releasing](releasing.md) guide for the full release workflow.
+## Troubleshooting
+
+- **`st-docker-run: command not found`** — `.venv-host/bin` isn't
+  on PATH, or the `UV_PROJECT_ENVIRONMENT` override was skipped
+  when bootstrapping.
+- **`st-*` commands fail with shebang errors** — `.venv-host/` was
+  built with a plain `uv sync` (no `UV_PROJECT_ENVIRONMENT=.venv-host`).
+  Remove the venv and re-bootstrap.
+- **`manifest unknown` when pulling a container image** — the tag
+  you're asking for doesn't exist on GHCR. Older docs referenced
+  `ghcr.io/wphillipmoore/dev-docs:latest` (renamed to `dev-base` in
+  standard-tooling#252); make sure your workflow files use the new
+  name.
+- **Plugin hooks don't fire** — check that `.claude/settings.json`
+  is present, committed, and syntactically valid JSON. Restart
+  Claude Code; the plugin is loaded at session start. If still
+  stuck, refresh the local plugin marketplace clone per "Keeping
+  up to date" above.
+- **Commits blocked with "originate from inside .worktrees/"** —
+  intentional. This repo has adopted the worktree convention.
+  Create a worktree for your work; see
+  [Git Workflow → Parallel work with worktrees](git-workflow.md#parallel-work-with-worktrees).
+- **`st-submit-pr` threw a `CalledProcessError` on auto-merge** —
+  expected since 2026-04-22. Auto-merge is disabled org-wide; the
+  PR itself was created successfully. Tracked in
+  [standard-tooling#268](https://github.com/wphillipmoore/standard-tooling/issues/268).
+
+For a broader troubleshooting index see
+[Git Workflow → Troubleshooting](git-workflow.md#troubleshooting).
+
+## Related
+
+- [Git Workflow](git-workflow.md) — how the per-change cycle
+  actually unfolds once setup is done
+- [Git Hooks and Validation](../../git-hooks-and-validation.md) —
+  pre-commit hook + validator reference
+- [Three-Tier CI](three-tier-ci.md) — per-language test/lint/audit
+  tier wiring
+- [Releasing](releasing.md) — release workflow
+- [Worktree convention spec](../../specs/worktree-convention.md)
+  — canonical reference for the parallel-agent convention

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -290,16 +290,13 @@ High-level summary:
 
 ## Adoption for a new repo
 
-Onboarding a brand-new repository to this workflow has its own
-guide: [Consuming Repo Setup](consuming-repo-setup.md).
+Onboarding a brand-new repository has two entry points:
 
-!!! note "Setup docs are being refreshed"
-    The existing Getting Started and Consuming Repo Setup guides
-    predate the Docker-first, plugin-aware, worktree-aware setup.
-    Use them as a starting point, but cross-reference this guide,
-    the plugin repo, and each repo's CLAUDE.md for current
-    behavior. A rewrite is tracked as Phase 2 of
-    [standard-tooling#270](https://github.com/wphillipmoore/standard-tooling/issues/270).
+- **[Getting Started](../getting-started.md)** — five-to-ten minute
+  quickstart.
+- **[Consuming Repo Setup](consuming-repo-setup.md)** — full
+  walkthrough with rationale, CI configuration, plugin nuances,
+  and troubleshooting.
 
 At a minimum, a new repo needs:
 


### PR DESCRIPTION
# Pull Request

## Summary

- Rewrite docs/site/docs/getting-started.md and docs/site/docs/guides/consuming-repo-setup.md to reflect Docker-first, plugin-aware, worktree-aware onboarding. Quickstart + full walkthrough differentiated. Removes the stale Phase-2 caveat from git-workflow.md. Closes out Phase 2 of wphillipmoore/standard-tooling#270.

## Issue Linkage

- Fixes #272

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Dogfooded the worktree convention — all work happened in .worktrees/issue-272-onboarding-rewrite/.