### PR TITLE
feat: refuse feature-branch commits from main worktree (#259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,11 @@ full rationale, trust model, failure modes, and memory-path implications.
      or use absolute paths.
 3. **The main worktree is read-only.** All edits flow through a worktree
    on a feature branch — the logical endpoint of the standing
-   "no direct commits to develop" policy.
+   "no direct commits to develop" policy. The repo's pre-commit hook
+   (`scripts/lib/git-hooks/pre-commit`) enforces this: when a
+   `.worktrees/` directory is present, it refuses commits on
+   `feature/**`, `bugfix/**`, `hotfix/**`, or `chore/**` branches that
+   originate from the main worktree.
 4. **One worktree per issue.** Don't stack in-flight issues. When a
    branch lands, remove the worktree before starting the next.
 5. **Naming: `issue-<N>-<short-slug>`.** `<N>` is the GitHub issue

--- a/src/standard_tooling/bin/pre_commit_hook.py
+++ b/src/standard_tooling/bin/pre_commit_hook.py
@@ -1,7 +1,9 @@
 """Pre-commit hook enforcing branch naming conventions.
 
-Blocks detached HEAD, direct commits to protected branches, and
-validates branch names against the repository's branching model.
+Blocks detached HEAD, direct commits to protected branches, validates
+branch names against the repository's branching model, and — for repos
+that have adopted the worktree convention — refuses feature-branch
+commits from the main worktree.
 """
 
 from __future__ import annotations
@@ -30,6 +32,8 @@ _BRANCHING_MODELS: dict[str, tuple[str, str]] = {
 
 _ISSUE_REQUIRED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _ISSUE_FORMAT_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9.-]*$")
+_WORKTREE_SCOPED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
+_WORKTREES_DIRNAME = ".worktrees"
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
@@ -91,6 +95,38 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         )
         print("Expected format: {type}/{issue}-{description}", file=sys.stderr)
         print("Example: feature/42-add-caching", file=sys.stderr)
+        return 1
+
+    if (
+        _WORKTREE_SCOPED_RE.search(current_branch)
+        and (root / _WORKTREES_DIRNAME).is_dir()
+        and git.is_main_worktree()
+    ):
+        print(
+            "ERROR: feature-branch commits from the main worktree are forbidden "
+            f"({current_branch}).",
+            file=sys.stderr,
+        )
+        print(
+            "The main worktree is read-only under the worktree convention; "
+            "edits flow through a worktree on a feature branch.",
+            file=sys.stderr,
+        )
+        print("To proceed:", file=sys.stderr)
+        print(
+            f"  cd {root}/{_WORKTREES_DIRNAME}/<issue-N-slug>  "
+            "# if a worktree already exists for this branch",
+            file=sys.stderr,
+        )
+        print(
+            f"  git worktree add {_WORKTREES_DIRNAME}/issue-N-<slug> "
+            f"-b {current_branch} origin/develop  # to create one",
+            file=sys.stderr,
+        )
+        print(
+            "See docs/specs/worktree-convention.md for the full convention.",
+            file=sys.stderr,
+        )
         return 1
 
     return 0

--- a/src/standard_tooling/lib/git.py
+++ b/src/standard_tooling/lib/git.py
@@ -24,6 +24,19 @@ def repo_root() -> Path:
     return Path(read_output("rev-parse", "--show-toplevel"))
 
 
+def is_main_worktree() -> bool:
+    """Return True when the CWD belongs to the main worktree.
+
+    Secondary worktrees have a ``.git`` file whose git-dir points into
+    ``.git/worktrees/<name>/``, while the main worktree's git-dir is
+    ``.git`` itself — ``--git-dir`` and ``--git-common-dir`` are equal
+    only for the main worktree.
+    """
+    git_dir = Path(read_output("rev-parse", "--git-dir")).resolve()
+    common_dir = Path(read_output("rev-parse", "--git-common-dir")).resolve()
+    return git_dir == common_dir
+
+
 def current_branch() -> str:
     """Return the current branch name."""
     return read_output("rev-parse", "--abbrev-ref", "HEAD")

--- a/tests/standard_tooling/test_git.py
+++ b/tests/standard_tooling/test_git.py
@@ -39,6 +39,22 @@ def test_current_branch_returns_name() -> None:
     assert result == "feature/test"
 
 
+def test_is_main_worktree_true() -> None:
+    with patch(
+        "standard_tooling.lib.git.read_output",
+        side_effect=["/repo/.git", "/repo/.git"],
+    ):
+        assert git.is_main_worktree() is True
+
+
+def test_is_main_worktree_false() -> None:
+    with patch(
+        "standard_tooling.lib.git.read_output",
+        side_effect=["/repo/.git/worktrees/feature-x", "/repo/.git"],
+    ):
+        assert git.is_main_worktree() is False
+
+
 def test_has_staged_changes_true() -> None:
     with patch("standard_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed(returncode=1)

--- a/tests/standard_tooling/test_pre_commit_hook.py
+++ b/tests/standard_tooling/test_pre_commit_hook.py
@@ -201,3 +201,87 @@ def test_application_promotion_hotfix_needs_issue(tmp_path: Path) -> None:
         patch("standard_tooling.bin.pre_commit_hook.git.repo_root", return_value=tmp_path),
     ):
         assert main() == 1
+
+
+def test_main_worktree_feature_commit_refused_when_worktrees_dir_exists(tmp_path: Path) -> None:
+    _write_profile(tmp_path, "library-release")
+    (tmp_path / ".worktrees").mkdir()
+    with (
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.current_branch",
+            return_value="feature/42-add-caching",
+        ),
+        patch("standard_tooling.bin.pre_commit_hook.git.repo_root", return_value=tmp_path),
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.is_main_worktree",
+            return_value=True,
+        ),
+    ):
+        assert main() == 1
+
+
+def test_secondary_worktree_feature_commit_allowed(tmp_path: Path) -> None:
+    _write_profile(tmp_path, "library-release")
+    (tmp_path / ".worktrees").mkdir()
+    with (
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.current_branch",
+            return_value="feature/42-add-caching",
+        ),
+        patch("standard_tooling.bin.pre_commit_hook.git.repo_root", return_value=tmp_path),
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.is_main_worktree",
+            return_value=False,
+        ),
+    ):
+        assert main() == 0
+
+
+def test_main_worktree_feature_commit_allowed_without_worktrees_dir(tmp_path: Path) -> None:
+    _write_profile(tmp_path, "library-release")
+    with (
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.current_branch",
+            return_value="feature/42-add-caching",
+        ),
+        patch("standard_tooling.bin.pre_commit_hook.git.repo_root", return_value=tmp_path),
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.is_main_worktree",
+            return_value=True,
+        ),
+    ):
+        assert main() == 0
+
+
+def test_main_worktree_release_branch_allowed_even_with_worktrees_dir(tmp_path: Path) -> None:
+    _write_profile(tmp_path, "library-release")
+    (tmp_path / ".worktrees").mkdir()
+    with (
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.current_branch",
+            return_value="release/1.2.3",
+        ),
+        patch("standard_tooling.bin.pre_commit_hook.git.repo_root", return_value=tmp_path),
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.is_main_worktree",
+            return_value=True,
+        ),
+    ):
+        assert main() == 0
+
+
+def test_main_worktree_bugfix_commit_refused(tmp_path: Path) -> None:
+    _write_profile(tmp_path, "library-release")
+    (tmp_path / ".worktrees").mkdir()
+    with (
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.current_branch",
+            return_value="bugfix/99-fix-parsing",
+        ),
+        patch("standard_tooling.bin.pre_commit_hook.git.repo_root", return_value=tmp_path),
+        patch(
+            "standard_tooling.bin.pre_commit_hook.git.is_main_worktree",
+            return_value=True,
+        ),
+    ):
+        assert main() == 1


### PR DESCRIPTION
# Pull Request

## Summary

- refuse feature-branch commits from main worktree (#259)

## Issue Linkage

- Closes #259

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

- Extends `pre_commit_hook.py` to refuse commits on `feature/**`, `bugfix/**`, `hotfix/**`, or `chore/**` from the main worktree when a `.worktrees/` directory is present at the repo root.
- Adds `git.is_main_worktree()` helper that compares `--git-dir` vs `--git-common-dir` (equal in the main worktree; different in secondary worktrees).
- Updates `CLAUDE.md` rule 3 to reference the hook as the enforcement backstop.
- Adds five new unit tests covering: refuse in main worktree, allow in secondary worktree, allow in main worktree when `.worktrees/` is absent (backward-compat opt-in), allow `release/*` branches even with `.worktrees/` present, refuse on `bugfix/*` branches.

## Design notes

- **Opt-in signal**: presence of `.worktrees/` at the repo root. This keeps the hook backward-compatible across the fleet while the rollout plan in `docs/specs/worktree-convention.md` cascades to other repos. Repos that have not yet adopted the convention are unaffected until they create `.worktrees/`.
- Protected branches (`develop`, `release`, `main`) remain handled by the earlier check and are unaffected by the new rule.
- Error message names the exact next actions (cd into existing worktree, or `git worktree add`).

## Test plan

- [x] Unit tests pass locally (23 passed — 18 existing + 5 new).
- [x] `ruff check` / `ruff format --check` clean on edited files.
- [x] `st-markdown-standards` clean on `CLAUDE.md`.
- [ ] CI (Tier 2 push + Tier 3 PR) runs full validation in a clean environment.