### PR TITLE
feat(release): add st-merge-when-green and stop auto-merging PRs in st-submit-pr/st-prepare-release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,10 @@ CLI tools installed as `st-*` console scripts:
 
 - **`st-commit`** — Construct standards-compliant conventional
   commits with co-author resolution
-- **`st-submit-pr`** — Create standards-compliant PRs with auto-merge
+- **`st-submit-pr`** — Create standards-compliant PRs (manual merge)
+- **`st-merge-when-green`** — Wait for a PR's checks, then merge it
+  (release-workflow use only; normal PRs stay on the honor-system
+  manual-merge policy)
 - **`st-prepare-release`** — Automate release preparation (branch, changelog, PR)
 - **`st-finalize-repo`** — Post-merge cleanup (branch deletion, remote pruning)
 - **`st-validate-local`** — Driver for pre-PR local validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "standard-tooling"
-version = "1.2.3"
+version = "1.3.0"
 description = "Shared development tooling for managed repositories"
 requires-python = ">=3.12,<4.0"
 dependencies = []
@@ -12,6 +12,7 @@ dependencies = []
 [project.scripts]
 st-commit = "standard_tooling.bin.commit:main"
 st-submit-pr = "standard_tooling.bin.submit_pr:main"
+st-merge-when-green = "standard_tooling.bin.merge_when_green:main"
 st-prepare-release = "standard_tooling.bin.prepare_release:main"
 st-finalize-repo = "standard_tooling.bin.finalize_repo:main"
 st-validate-local = "standard_tooling.bin.validate_local:main"

--- a/src/standard_tooling/bin/merge_when_green.py
+++ b/src/standard_tooling/bin/merge_when_green.py
@@ -1,0 +1,53 @@
+"""Poll a PR's checks, then merge it when they all pass.
+
+Intentionally dumb: surfaces any check failure to the caller with a non-zero
+exit code. The caller is responsible for deciding what to do with a failure.
+
+Designed for release-workflow PRs where the agent is both author and
+reviewer and there is no human to gate the merge. For normal PRs, leave
+them to manual merge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from standard_tooling.lib import github
+
+_STRATEGIES = ("merge", "squash", "rebase")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Wait for a PR's checks to pass, then merge it.",
+    )
+    parser.add_argument("pr", help="PR URL or number")
+    parser.add_argument(
+        "--strategy",
+        choices=_STRATEGIES,
+        default="merge",
+        help="Merge strategy (default: merge)",
+    )
+    parser.add_argument(
+        "--no-delete-branch",
+        action="store_false",
+        dest="delete_branch",
+        help="Do not delete the branch on merge (default: delete)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(f"Waiting for checks to pass on {args.pr}...")
+    github.wait_for_checks(args.pr)
+    print(f"Checks passed. Merging with --{args.strategy}...")
+    github.merge(args.pr, strategy=args.strategy, delete_branch=args.delete_branch)
+    print("Merged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -1,7 +1,10 @@
-"""Automate release preparation: branch, changelog, PR, auto-merge.
+"""Automate release preparation: branch, changelog, PR.
 
 Shared script for library repositories using the library-release branching
 model. Auto-detects the ecosystem to find the version source of truth.
+
+The release PR is created but not merged — callers (typically the publish
+skill) drive the merge via ``st-merge-when-green`` once CI passes.
 
 Supported ecosystems:
   - Python: reads version from pyproject.toml
@@ -284,11 +287,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Pushing branch: {branch}")
     git.run("push", "-u", "origin", branch)
     url = _create_pr(version, args.issue)
-    github.auto_merge(url, strategy="--merge")
 
     git.run("checkout", "develop")
 
     print(f"Release {version} preparation complete.")
+    print(f"Merge when green: st-merge-when-green {url}")
     return 0
 
 

--- a/src/standard_tooling/bin/submit_pr.py
+++ b/src/standard_tooling/bin/submit_pr.py
@@ -68,12 +68,7 @@ def main(argv: list[str] | None = None) -> int:
     root = git.repo_root()
     branch = git.current_branch()
 
-    if branch.startswith("release/"):
-        target_branch = "main"
-        merge_strategy = "--merge"
-    else:
-        target_branch = "develop"
-        merge_strategy = "--squash"
+    target_branch = "main" if branch.startswith("release/") else "develop"
 
     title = args.title or git.read_output("log", "-1", "--pretty=%s")
 
@@ -91,7 +86,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.dry_run:
         print(f"=== PR Title ===\n{title}\n")
-        print(f"=== Target Branch ===\n{target_branch} (strategy: {merge_strategy})\n")
+        print(f"=== Target Branch ===\n{target_branch}\n")
         print(f"=== PR Body ===\n{pr_body}")
         return 0
 
@@ -108,9 +103,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"PR created: {pr_url}")
     finally:
         Path(tmp_path).unlink(missing_ok=True)
-
-    print(f"Enabling auto-merge ({merge_strategy})...")
-    github.auto_merge(pr_url, strategy=merge_strategy)
 
     print(f"Done. PR URL: {pr_url}")
     return 0

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -23,12 +23,23 @@ def create_pr(*, base: str, title: str, body_file: str) -> str:
     return read_output("pr", "create", "--base", base, "--title", title, "--body-file", body_file)
 
 
-def auto_merge(ref: str, *, strategy: str, delete_branch: bool = True) -> None:
-    """Enable auto-merge on a PR.
+def wait_for_checks(pr: str) -> None:
+    """Block until all required checks on ``pr`` complete; fail fast on the first red.
 
-    *strategy* must be ``--squash``, ``--merge``, or ``--rebase``.
+    Surfaces the failure via ``subprocess.CalledProcessError`` — callers are
+    responsible for deciding how to react (the release-workflow convention is
+    to stop and surface; do not retry).
     """
-    cmd = ["pr", "merge", "--auto", strategy, ref]
+    run("pr", "checks", pr, "--watch", "--fail-fast")
+
+
+def merge(pr: str, *, strategy: str, delete_branch: bool = True) -> None:
+    """Merge a PR synchronously (without ``--auto``).
+
+    ``strategy`` is one of ``"merge"``, ``"squash"``, ``"rebase"`` — passed
+    through as ``--merge``, ``--squash``, ``--rebase``.
+    """
+    cmd = ["pr", "merge", f"--{strategy}", pr]
     if delete_branch:
         cmd.append("--delete-branch")
     run(*cmd)

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -34,15 +34,23 @@ def test_create_pr_returns_url() -> None:
     assert url == "https://github.com/pr/1"
 
 
-def test_auto_merge_with_delete_branch() -> None:
+def test_wait_for_checks_passes_pr_ref() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
-        github.auto_merge("https://github.com/pr/1", strategy="--squash")
+        github.wait_for_checks("https://github.com/pr/1")
     mock_run.assert_called_once_with(
-        "pr", "merge", "--auto", "--squash", "https://github.com/pr/1", "--delete-branch"
+        "pr", "checks", "https://github.com/pr/1", "--watch", "--fail-fast"
     )
 
 
-def test_auto_merge_without_delete_branch() -> None:
+def test_merge_with_delete_branch() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
-        github.auto_merge("https://github.com/pr/1", strategy="--merge", delete_branch=False)
-    mock_run.assert_called_once_with("pr", "merge", "--auto", "--merge", "https://github.com/pr/1")
+        github.merge("https://github.com/pr/1", strategy="merge")
+    mock_run.assert_called_once_with(
+        "pr", "merge", "--merge", "https://github.com/pr/1", "--delete-branch"
+    )
+
+
+def test_merge_without_delete_branch() -> None:
+    with patch("standard_tooling.lib.github.run") as mock_run:
+        github.merge("https://github.com/pr/1", strategy="squash", delete_branch=False)
+    mock_run.assert_called_once_with("pr", "merge", "--squash", "https://github.com/pr/1")

--- a/tests/standard_tooling/test_merge_when_green.py
+++ b/tests/standard_tooling/test_merge_when_green.py
@@ -1,0 +1,69 @@
+"""Tests for standard_tooling.bin.merge_when_green."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from standard_tooling.bin.merge_when_green import main, parse_args
+
+
+def test_parse_args_defaults() -> None:
+    args = parse_args(["https://github.com/pr/1"])
+    assert args.pr == "https://github.com/pr/1"
+    assert args.strategy == "merge"
+    assert args.delete_branch is True
+
+
+def test_parse_args_strategy() -> None:
+    args = parse_args(["42", "--strategy", "squash"])
+    assert args.strategy == "squash"
+
+
+def test_parse_args_no_delete_branch() -> None:
+    args = parse_args(["42", "--no-delete-branch"])
+    assert args.delete_branch is False
+
+
+def test_parse_args_rejects_unknown_strategy() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["42", "--strategy", "ff-only"])
+
+
+def test_main_happy_path() -> None:
+    with (
+        patch("standard_tooling.bin.merge_when_green.github.wait_for_checks") as mock_wait,
+        patch("standard_tooling.bin.merge_when_green.github.merge") as mock_merge,
+    ):
+        result = main(["https://github.com/pr/1"])
+    assert result == 0
+    mock_wait.assert_called_once_with("https://github.com/pr/1")
+    mock_merge.assert_called_once_with(
+        "https://github.com/pr/1", strategy="merge", delete_branch=True
+    )
+
+
+def test_main_custom_strategy_and_no_delete() -> None:
+    with (
+        patch("standard_tooling.bin.merge_when_green.github.wait_for_checks"),
+        patch("standard_tooling.bin.merge_when_green.github.merge") as mock_merge,
+    ):
+        result = main(["42", "--strategy", "squash", "--no-delete-branch"])
+    assert result == 0
+    mock_merge.assert_called_once_with("42", strategy="squash", delete_branch=False)
+
+
+def test_main_surfaces_check_failure() -> None:
+    err = subprocess.CalledProcessError(returncode=1, cmd=["gh", "pr", "checks"])
+    with (
+        patch(
+            "standard_tooling.bin.merge_when_green.github.wait_for_checks",
+            side_effect=err,
+        ),
+        patch("standard_tooling.bin.merge_when_green.github.merge") as mock_merge,
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        main(["https://github.com/pr/1"])
+    mock_merge.assert_not_called()

--- a/tests/standard_tooling/test_prepare_release.py
+++ b/tests/standard_tooling/test_prepare_release.py
@@ -377,7 +377,6 @@ def test_main_full_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
             "standard_tooling.bin.prepare_release.github.create_pr",
             return_value="https://github.com/pr/1",
         ),
-        patch("standard_tooling.bin.prepare_release.github.auto_merge"),
     ):
         result = main(["--issue", "42"])
     assert result == 0
@@ -562,7 +561,6 @@ def test_main_full_flow_with_release_notes(tmp_path: Path, monkeypatch: pytest.M
             "standard_tooling.bin.prepare_release.github.create_pr",
             return_value="https://github.com/pr/1",
         ),
-        patch("standard_tooling.bin.prepare_release.github.auto_merge"),
     ):
         result = main(["--issue", "42"])
     assert result == 0

--- a/tests/standard_tooling/test_submit_pr.py
+++ b/tests/standard_tooling/test_submit_pr.py
@@ -140,13 +140,11 @@ def test_main_submits_pr(tmp_path: Path) -> None:
             "standard_tooling.bin.submit_pr.github.create_pr",
             return_value="https://github.com/pr/1",
         ) as mock_create_pr,
-        patch("standard_tooling.bin.submit_pr.github.auto_merge") as mock_auto_merge,
     ):
         result = main(["--issue", "42", "--summary", "Fix bug"])
     assert result == 0
     mock_git_run.assert_called_once_with("push", "-u", "origin", "feature/x")
     mock_create_pr.assert_called_once()
-    mock_auto_merge.assert_called_once_with("https://github.com/pr/1", strategy="--squash")
 
 
 def test_main_submits_pr_with_notes(tmp_path: Path) -> None:
@@ -159,7 +157,6 @@ def test_main_submits_pr_with_notes(tmp_path: Path) -> None:
             "standard_tooling.bin.submit_pr.github.create_pr",
             return_value="https://github.com/pr/1",
         ),
-        patch("standard_tooling.bin.submit_pr.github.auto_merge"),
     ):
         result = main(
             [

--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,7 @@ wheels = [
 
 [[package]]
 name = "standard-tooling"
-version = "1.2.3"
+version = "1.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Pull Request

## Summary

- add st-merge-when-green; remove auto-merge from st-submit-pr and st-prepare-release

## Issue Linkage

- Fixes #274

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## What

Step 1 of 3 for the poll-and-merge rework tracked by
[standard-tooling-plugin#57](https://github.com/wphillipmoore/standard-tooling-plugin/issues/57).

- **New CLI `st-merge-when-green <pr>`** — wraps
  `gh pr checks --watch --fail-fast` + `gh pr merge`. Intentionally
  dumb: surfaces any check failure to the caller with a non-zero
  exit. Default strategy `merge`; `--strategy squash|rebase`
  available; `--no-delete-branch` opts out of branch deletion.
- **`st-submit-pr`** — drops the final `gh pr merge --auto` call.
  Also fixes #268.
- **`st-prepare-release`** — same. Prints an `st-merge-when-green
  <url>` hint after creating the PR.
- **`lib/github.py`** — removes `auto_merge()`; adds
  `wait_for_checks()` and `merge()` helpers.

## Why

The release workflow is the one use case where there is no human
in the loop — the agent is both author and reviewer of release
and bump PRs. Org-wide auto-merge is disabled, so every
`gh pr merge --auto` call in the release path has been silently
failing since the policy change. Decision: **poll-and-merge**, not
re-enable auto-merge. Keep the "humans merge human PRs" guardrail
in place and scope the exception tightly to the release flow via
`st-merge-when-green`.

## Verification

- `st-docker-run -- uv run pytest` → **72 passed in 3.51s**.
- Manual dry-run of `st-merge-when-green --help` works as expected.
- Tests cover: happy path, custom strategy, `--no-delete-branch`,
  unknown strategy rejection, and failure propagation (the CLI
  must exit non-zero and NOT call merge when checks fail).

## Version bump

`1.2.3` → `1.3.0`. Minor because:

- Two existing CLIs change behavior (no longer attempt auto-merge).
- One new CLI entry point.

No caller breakage in the release workflow — the plugin's
`publish` skill is being rewritten in the third-step PR
(standard-tooling-plugin) to invoke `st-merge-when-green` at the
right phases.

## Next

- standard-actions v1.2.0 — `version-bump-pr` composite drops its
  `gh pr merge --auto` step; skill calls `st-merge-when-green` on
  the bump PR URL instead.
- standard-tooling-plugin `publish` skill — Phase 2 and Phase 4
  use `st-merge-when-green`.