### PR TITLE
fix(finalize): refuse to run from a secondary worktree

### DIFF
--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -39,6 +39,21 @@ def _run(args: list[str], *, dry_run: bool) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    if not git.is_main_worktree():
+        print(
+            "ERROR: st-finalize-repo must be run from the main worktree, "
+            "not a secondary one.",
+            file=sys.stderr,
+        )
+        print(
+            "  The target branch is already checked out in the main "
+            "worktree; git will refuse to check it out a second time.",
+            file=sys.stderr,
+        )
+        print("  Run:  cd <repo-root> && st-finalize-repo", file=sys.stderr)
+        return 1
+
     root = git.repo_root()
 
     try:

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -42,8 +42,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not git.is_main_worktree():
         print(
-            "ERROR: st-finalize-repo must be run from the main worktree, "
-            "not a secondary one.",
+            "ERROR: st-finalize-repo must be run from the main worktree, not a secondary one.",
             file=sys.stderr,
         )
         print(

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -6,12 +6,26 @@ from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import pytest
+
 from standard_tooling.bin.finalize_repo import main, parse_args
 
 _MOD = "standard_tooling.bin.finalize_repo"
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _main_worktree() -> Iterator[None]:
+    """Default every test to running in the main worktree.
+
+    Individual tests can override by patching is_main_worktree directly —
+    the innermost patch wins.
+    """
+    with patch(_MOD + ".git.is_main_worktree", return_value=True):
+        yield
 
 
 def test_parse_args_defaults() -> None:
@@ -24,6 +38,15 @@ def test_parse_args_custom() -> None:
     args = parse_args(["--target-branch", "main", "--dry-run"])
     assert args.target_branch == "main"
     assert args.dry_run is True
+
+
+def test_main_refuses_from_secondary_worktree(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(_MOD + ".git.is_main_worktree", return_value=False):
+        result = main([])
+    assert result == 1
+    stderr = capsys.readouterr().err
+    assert "main worktree" in stderr
+    assert "cd <repo-root>" in stderr
 
 
 def _make_profile(tmp_path: Path, model: str) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- refuse st-finalize-repo from a secondary worktree

## Issue Linkage

- Fixes #277

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## What

`st-finalize-repo` now refuses when invoked from a secondary
worktree, with a one-line message pointing at the main worktree.
It used to blow up with
`git checkout develop returned non-zero exit status 128` (develop
is already checked out in the main tree, so git refuses).

## Why

Hit live on 2026-04-23 while finalizing #276: natural instinct is
to finalize from the worktree you were working in, but that's
exactly where it fails. Error was opaque enough that a user could
easily start manually untangling git state. Guard is the correct
behavior.

Uses `git.is_main_worktree()` from #275.

## Tests

- Autouse fixture defaults every existing test to the main-
  worktree case — no behavior change for the happy path.
- New `test_main_refuses_from_secondary_worktree` explicitly
  covers the False branch, asserts exit code and message content.
- 426 tests, 100% coverage maintained.

Fixes #277.