### PR TITLE
refactor(validation): normalize validation stack to one container per run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,14 +129,10 @@ invoked by `st-validate-local`, it is not part of the validation pipeline.
 
 Testing is split across three tiers with increasing scope and cost:
 
-**Tier 1 — Local pre-commit (seconds):** Fast smoke tests in a single
-container. Run before every commit. No matrix.
-
-```bash
-./scripts/dev/test.sh        # pytest + 100% coverage in dev-python:3.12
-./scripts/dev/lint.sh        # ruff check + format in dev-python:3.12
-./scripts/dev/audit.sh       # uv lock --check in dev-python:3.12
-```
+**Tier 1 — Local pre-commit (seconds):** The single entry point
+`st-docker-run -- uv run st-validate-local` runs everything
+(lint, typecheck, tests, audit, common checks) inside one dev
+container. Run before every commit.
 
 **Tier 2 — Push CI (~1-2 min):** Triggers automatically on push to
 `feature/**`, `bugfix/**`, `hotfix/**`, `chore/**`. Single Python version
@@ -150,7 +146,17 @@ Workflow: `.github/workflows/ci.yml`.
 
 ### Docker-First Testing
 
-All tests can run inside containers — Docker is the only host prerequisite.
+Docker is the only host prerequisite. The validation stack uses
+exactly one container per run:
+
+- **Outer layer**: `st-docker-run` launches the dev container once
+  and runs the validation driver inside.
+- **Inner layer**: `scripts/dev/{lint,test,typecheck,audit}.sh`
+  are tiny, container-local scripts. They assume they are already
+  running inside the dev container and invoke tooling directly
+  (`uv run ruff check`, `uv run pytest`, etc.). They do **not**
+  re-containerize.
+
 Dev container images are maintained in
 [standard-tooling-docker](https://github.com/wphillipmoore/standard-tooling-docker).
 
@@ -158,21 +164,14 @@ Dev container images are maintained in
 # Build the dev image (one-time)
 cd ../standard-tooling-docker && docker/build.sh
 
-# Run unit tests in container
-./scripts/dev/test.sh
-
-# Run linter in container
-./scripts/dev/lint.sh
-
-# Run dependency audit in container
-./scripts/dev/audit.sh
+# Run the full validation pipeline in one container
+st-docker-run -- uv run st-validate-local
 ```
 
-Environment overrides:
-
-- `DOCKER_DEV_IMAGE` — override the container image
-  (default: `ghcr.io/wphillipmoore/dev-python:3.12`)
-- `DOCKER_TEST_CMD` — override the test command
+If you need to tweak what validation runs for this repo, edit
+`scripts/dev/*.sh` — those scripts are the per-repo customization
+point. Keep them container-local (no `st-docker-run`, no
+`st-docker-test`, no `DOCKER_*` env vars).
 
 ## Architecture
 

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
+# Container-local audit script.  Assumes it is invoked inside the dev
+# container by `st-validate-local`.
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check}"
-
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
-  exit 1
-fi
-exec st-docker-test
+uv sync --check --frozen --group dev
+uv lock --check

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
+# Container-local lint script.  Assumes it is invoked inside the dev
+# container by `st-validate-local` (itself launched via
+# `st-docker-run -- uv run st-validate-local`).
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
-
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
-  exit 1
-fi
-exec st-docker-test
+uv sync --frozen --group dev
+uv run ruff check
+uv run ruff format --check .

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
+# Container-local test script.  Assumes it is invoked inside the dev
+# container by `st-validate-local`.
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=standard_tooling --cov-branch --cov-fail-under=100}"
-
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
-  exit 1
-fi
-exec st-docker-test
+uv sync --frozen --group dev
+uv run pytest --cov=standard_tooling --cov-branch --cov-fail-under=100

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
+# Container-local typecheck script.  Assumes it is invoked inside the dev
+# container by `st-validate-local`.
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-ghcr.io/wphillipmoore/dev-python:3.12}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/}"
-
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Install standard-tooling: uv sync in ../standard-tooling" >&2
-  exit 1
-fi
-exec st-docker-test
+uv sync --frozen --group dev
+uv run mypy src/

--- a/src/standard_tooling/bin/validate_local.py
+++ b/src/standard_tooling/bin/validate_local.py
@@ -47,11 +47,10 @@ def _run_validator(name: str, scripts_bin: Path) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    required = {"docker": ("docker",), "st-docker-test": ("st-docker-test",)}
-    for tool, candidates in required.items():
-        if not any(shutil.which(c) for c in candidates):
-            print(f"ERROR: {tool} is required for local validation", file=sys.stderr)
-            return 1
+    # st-validate-local is designed to run inside a dev container
+    # (launched by `st-docker-run`).  No host-level docker check is
+    # appropriate — if a caller runs this on the host, the inner scripts
+    # will surface missing tooling (uv, ruff, etc.) with their own errors.
 
     root = git.repo_root()
     scripts_bin = root / "scripts" / "bin"

--- a/src/standard_tooling/bin/validate_local_common.py
+++ b/src/standard_tooling/bin/validate_local_common.py
@@ -1,23 +1,20 @@
-"""Shared checks run for all repos — containerised via docker-test.
+"""Shared validation checks run for all repos.
 
-Sets ``DOCKER_DEV_IMAGE`` and ``DOCKER_TEST_CMD`` then delegates to
-``docker_test.main()``.
+Container-local: assumes the caller (`st-validate-local`) is itself running
+inside a dev container via `st-docker-run`.  Delegates to the implementation
+in ``validate_local_common_container`` — the same work the old version
+dispatched to via ``st-docker-test``, now called directly.
 """
 
 from __future__ import annotations
 
-import os
 import sys
 
-from standard_tooling.bin import docker_test
+from standard_tooling.bin import validate_local_common_container
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    if not os.environ.get("DOCKER_DEV_IMAGE"):
-        os.environ["DOCKER_DEV_IMAGE"] = "ghcr.io/wphillipmoore/dev-python:3.14"
-    os.environ["DOCKER_TEST_CMD"] = "st-validate-local-common-container"
-
-    return docker_test.main()
+def main(argv: list[str] | None = None) -> int:
+    return validate_local_common_container.main(argv)
 
 
 if __name__ == "__main__":

--- a/tests/standard_tooling/test_validate_local.py
+++ b/tests/standard_tooling/test_validate_local.py
@@ -94,13 +94,6 @@ def test_run_validator_not_found(tmp_path: Path) -> None:
         assert _run_validator("missing", tmp_path) is True
 
 
-def _which_allows_docker(tool: str) -> str | None:
-    """Mock shutil.which: allow docker and st-docker-test, block everything else."""
-    if tool in ("docker", "st-docker-test"):
-        return f"/usr/bin/{tool}"
-    return None
-
-
 def _make_profile(tmp_path: Path, language: str) -> None:
     docs = tmp_path / "docs"
     docs.mkdir(exist_ok=True)
@@ -109,53 +102,11 @@ def _make_profile(tmp_path: Path, language: str) -> None:
     )
 
 
-def test_main_docker_missing() -> None:
-    with patch("standard_tooling.bin.validate_local.shutil.which", return_value=None):
-        result = main([])
-    assert result == 1
-
-
-def test_main_docker_test_missing() -> None:
-    def which_only_docker(tool: str) -> str | None:
-        if tool == "docker":
-            return "/usr/bin/docker"
-        return None
-
-    with patch("standard_tooling.bin.validate_local.shutil.which", side_effect=which_only_docker):
-        result = main([])
-    assert result == 1
-
-
-def test_main_st_docker_test_found() -> None:
-    """st-docker-test entry point satisfies the st-docker-test requirement."""
-
-    def which_side_effect(tool: str) -> str | None:
-        if tool in ("docker", "st-docker-test"):
-            return f"/usr/bin/{tool}"
-        return None
-
-    with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=which_side_effect,
-        ),
-        patch("standard_tooling.bin.validate_local.git.repo_root") as mock_root,
-        patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
-    ):
-        mock_root.return_value = Path("/tmp/repo")  # noqa: S108
-        result = main([])
-    assert result == 0
-
-
 def test_main_all_pass(tmp_path: Path) -> None:
     _make_profile(tmp_path, "python")
     scripts_bin = tmp_path / "scripts" / "bin"
     scripts_bin.mkdir(parents=True)
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
     ):
@@ -165,18 +116,11 @@ def test_main_all_pass(tmp_path: Path) -> None:
 
 def test_main_common_fails(tmp_path: Path) -> None:
     _make_profile(tmp_path, "python")
-    call_count = 0
 
     def mock_run_validator(name: str, scripts_bin: Path) -> bool:
-        nonlocal call_count
-        call_count += 1
         return name != "validate-local-common"
 
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",
@@ -194,10 +138,6 @@ def test_main_language_validator_fails(tmp_path: Path) -> None:
         return name != "validate-local-python"
 
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",
@@ -210,10 +150,6 @@ def test_main_language_validator_fails(tmp_path: Path) -> None:
 
 def test_main_no_profile(tmp_path: Path) -> None:
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
     ):
@@ -224,10 +160,6 @@ def test_main_no_profile(tmp_path: Path) -> None:
 def test_main_language_none(tmp_path: Path) -> None:
     _make_profile(tmp_path, "none")
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.validate_local._run_validator", return_value=True),
         patch("standard_tooling.bin.validate_local._find_validator", return_value=None),
@@ -251,10 +183,6 @@ def test_main_custom_validator_exists(tmp_path: Path) -> None:
         return True
 
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",
@@ -281,10 +209,6 @@ def test_main_custom_validator_fails(tmp_path: Path) -> None:
 
     _make_profile(tmp_path, "python")
     with (
-        patch(
-            "standard_tooling.bin.validate_local.shutil.which",
-            side_effect=_which_allows_docker,
-        ),
         patch("standard_tooling.bin.validate_local.git.repo_root", return_value=tmp_path),
         patch(
             "standard_tooling.bin.validate_local._run_validator",

--- a/tests/standard_tooling/test_validate_local_common.py
+++ b/tests/standard_tooling/test_validate_local_common.py
@@ -9,8 +9,7 @@ from standard_tooling.bin.validate_local_common import main
 
 def test_main_delegates_to_container_impl() -> None:
     with patch(
-        "standard_tooling.bin.validate_local_common."
-        "validate_local_common_container.main",
+        "standard_tooling.bin.validate_local_common.validate_local_common_container.main",
         return_value=0,
     ) as m:
         result = main()
@@ -20,8 +19,7 @@ def test_main_delegates_to_container_impl() -> None:
 
 def test_main_propagates_failure() -> None:
     with patch(
-        "standard_tooling.bin.validate_local_common."
-        "validate_local_common_container.main",
+        "standard_tooling.bin.validate_local_common.validate_local_common_container.main",
         return_value=1,
     ):
         assert main() == 1

--- a/tests/standard_tooling/test_validate_local_common.py
+++ b/tests/standard_tooling/test_validate_local_common.py
@@ -7,80 +7,21 @@ from unittest.mock import patch
 from standard_tooling.bin.validate_local_common import main
 
 
-def test_main_sets_env_and_delegates() -> None:
-    with (
-        patch("standard_tooling.bin.validate_local_common.docker_test.main", return_value=0) as m,
-        patch.dict("os.environ", {}, clear=True),
-    ):
+def test_main_delegates_to_container_impl() -> None:
+    with patch(
+        "standard_tooling.bin.validate_local_common."
+        "validate_local_common_container.main",
+        return_value=0,
+    ) as m:
         result = main()
     assert result == 0
     m.assert_called_once()
 
 
-def test_main_preserves_custom_image() -> None:
-    import os
-
-    captured: dict[str, str] = {}
-
-    def capture_env() -> int:
-        captured.update(dict(os.environ))
-        return 0
-
-    with (
-        patch(
-            "standard_tooling.bin.validate_local_common.docker_test.main",
-            side_effect=lambda *a, **k: capture_env(),
-        ),
-        patch.dict("os.environ", {"DOCKER_DEV_IMAGE": "custom:1"}, clear=True),
-    ):
-        main()
-    assert captured["DOCKER_DEV_IMAGE"] == "custom:1"
-
-
-def test_main_sets_default_image() -> None:
-    import os
-
-    captured: dict[str, str] = {}
-
-    def capture_env() -> int:
-        captured.update(dict(os.environ))
-        return 0
-
-    with (
-        patch(
-            "standard_tooling.bin.validate_local_common.docker_test.main",
-            side_effect=lambda *a, **k: capture_env(),
-        ),
-        patch.dict("os.environ", {}, clear=True),
-    ):
-        main()
-    assert captured["DOCKER_DEV_IMAGE"] == "ghcr.io/wphillipmoore/dev-python:3.14"
-
-
-def test_main_sets_cmd() -> None:
-    import os
-
-    captured: dict[str, str] = {}
-
-    def capture_env() -> int:
-        captured.update(dict(os.environ))
-        return 0
-
-    with (
-        patch(
-            "standard_tooling.bin.validate_local_common.docker_test.main",
-            side_effect=lambda *a, **k: capture_env(),
-        ),
-        patch.dict("os.environ", {}, clear=True),
-    ):
-        main()
-    assert "DOCKER_EXTRA_VOLUMES" not in captured
-    assert captured["DOCKER_TEST_CMD"] == "st-validate-local-common-container"
-
-
 def test_main_propagates_failure() -> None:
-    with (
-        patch("standard_tooling.bin.validate_local_common.docker_test.main", return_value=1),
-        patch.dict("os.environ", {}, clear=True),
+    with patch(
+        "standard_tooling.bin.validate_local_common."
+        "validate_local_common_container.main",
+        return_value=1,
     ):
         assert main() == 1


### PR DESCRIPTION
# Pull Request

## Summary

- normalize validation stack so Docker is invoked once per run, not per inner script

## Issue Linkage

- Fixes #280

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## What

Normalize the validation stack so Docker is invoked **exactly
once per validation pass**, not once per inner script.

Two clean layers now:

- **Outer (containerization)**: `st-docker-run` launches the dev
  container once.
- **Inner (repo-specific indirection)**: `scripts/dev/*.sh` run
  container-local, invoking tooling directly.

## Why

`st-validate-local` was doubly-containerized — the driver required
docker on the host, and each `scripts/dev/*.sh` re-launched a
fresh container via `st-docker-test`. That meant the documented
command `st-docker-run -- uv run st-validate-local` couldn't
actually run (docker-in-docker inside the dev-python image).

Plus — per the design intent — the `scripts/dev/*.sh` are the
per-repo customization point for validation. They should be simple
shell that assumes it's already in the container, not knowledge
about how to containerize itself.

## Changes

- `scripts/dev/{lint,test,typecheck,audit}.sh` rewritten
  container-local.
- `validate_local_common.py` stops dispatching via `docker-test`;
  delegates straight to `validate_local_common_container.main()`.
- `validate_local.py` drops the `docker` / `st-docker-test`
  precondition check.
- Tests updated (net −76 lines in `test_validate_local.py`,
  −52 lines in `test_validate_local_common.py`).
- `CLAUDE.md` "Three-Tier CI Model" and "Docker-First Testing"
  sections rewritten to reflect the new design.

## Verification

- `st-docker-run -- uv run pytest tests/ ...`: **420 passed, 100% coverage**.
- Full dogfood of `st-docker-run -- uv run st-validate-local`
  couldn't run from this worktree — hit a separate worktree+docker
  bug tracked as #281 (worktree's `.git` file points at a host
  path not mounted in the container). Orthogonal to this PR;
  reproduces on develop too. PR CI will exercise the documented
  command on a clean checkout.

## Scope

This repo only. Equivalent normalization in other tooling repos
tracked by #280's scope list:

- standard-actions, standard-tooling-plugin,
  standard-tooling-docker, standards-and-conventions,
  infrastructure-mindset, ai-research-methodology (all to be
  normalized this session).
- mq-rest-admin-* (tracking issues filed; left alone until those
  repos see active work).

Supersedes #279 (originally filed based on incorrect diagnosis).

Fixes #280. Refs #281.