### PR TITLE
docs(specs): add host-level-tool spec, plan, pushback, and alignment artifacts

### DIFF
--- a/docs/plans/host-level-tool-plan.md
+++ b/docs/plans/host-level-tool-plan.md
@@ -1,0 +1,735 @@
+# Implementation Plan: `standard-tooling` as a host-level developer tool
+
+**Status:** Draft — awaiting `paad:alignment` against the spec
+**Spec:** [`docs/specs/host-level-tool.md`](../specs/host-level-tool.md)
+**Issue:** [#286](https://github.com/wphillipmoore/standard-tooling/issues/286)
+**Pushback review:**
+[`paad/pushback-reviews/2026-04-24-host-level-tool-pushback.md`](../../paad/pushback-reviews/2026-04-24-host-level-tool-pushback.md)
+**Last updated:** 2026-04-25
+
+## Scope
+
+This plan covers implementation of the host-level-tool distribution
+model as defined in the spec. Work spans four repositories
+(`standard-tooling`, `standard-tooling-docker`, `standard-actions`,
+and each consumer) plus a docs sweep, sequenced in seven phases:
+
+1. Code work in `standard-tooling` (move checks, env-var gate, delete
+   the old hook).
+2. Cut a `standard-tooling` release that makes the new behavior
+   available to consumers.
+3. `standard-tooling-docker`: pin image build to rolling tag, wire
+   release-triggered rebuild.
+4. `standard-actions`: update `standards-compliance` (and any
+   sibling composites) to stop cloning `standard-tooling` and
+   instead use the dev container or `uv sync --group dev`.
+5. Python consumer migration (`ai-research-methodology`).
+6. Non-Python consumer migration (plugin, docker repo's own consumer
+   role, docs, standards repo).
+7. Docs sweep and plugin error-message update.
+
+Each phase has observable completion criteria. The plan assumes the
+fleet-of-one operational model: producer and consumer are the same
+person, fail-forward is the default rollback strategy.
+
+## Out of scope for this plan
+
+- **Consumer lockfile-bump automation** (dependabot / renovate /
+  scheduled refresh PRs). Spec defers; if the manual cadence
+  becomes friction, file a follow-up.
+- **A pure-devcontainer install model.** Rejected in the spec under
+  "Host install vs devcontainer-only" tradeoff.
+- **Publishing `standard-tooling` to PyPI.** Explicitly rejected.
+- **Re-introducing `[tool.uv.sources]` for non-Python repos.**
+  Architecturally impossible (no `pyproject.toml`); the spec's
+  whole point is that non-Python repos consume via the image.
+
+## Phase 1: Code work in `standard-tooling`
+
+**Goal:** This repo no longer ships an `st-pre-commit-hook` entry
+point or a `scripts/lib/git-hooks/` directory. All commit-context
+checks live in `st-commit`. The new env-var-plus-`GIT_REFLOG_ACTION`
+gate is in `.githooks/pre-commit` and `core.hooksPath` is rewired to
+point at it.
+
+### Task 1.1: Move the five checks from `pre_commit_hook.py` into `commit.py`
+
+**Requirement:** Spec "Migration / standard-tooling itself" step 1;
+six-principle item 5 (single source of truth for commit-context
+policy lives in `st-commit`).
+
+#### RED — write ten failing tests in `tests/standard_tooling/test_commit.py`
+
+For each of the five checks, write one rejection-path test and one
+happy-path test:
+
+1. **Detached HEAD:** monkeypatch `git.current_branch()` → `"HEAD"`;
+   assert `commit.main()` returns non-zero with `"detached HEAD"`
+   in stderr. Happy path: any normal branch name passes the check.
+2. **Protected branches:** monkeypatch → `"develop"` (and
+   `"release"`, `"main"`); assert non-zero with
+   `"direct commits ... forbidden"`. Happy path: `"feature/42-x"`
+   passes.
+3. **Branch prefix:** monkeypatch → `"random-name"` with
+   `repo_profile.branching_model = "library-release"`; assert
+   non-zero with `"must use ... feature/*, bugfix/*, ..."`. Happy
+   path: `"feature/42-x"` matches the model's regex and passes.
+4. **Issue number:** monkeypatch → `"feature/no-number"`; assert
+   non-zero with `"must include a repo issue number"`. Happy path:
+   `"feature/42-x"` passes.
+5. **Worktree convention:** in a tmp repo with `.worktrees/` and
+   `git.is_main_worktree()` returning True, monkeypatch →
+   `"feature/42-test"`; assert non-zero with
+   `"feature-branch commits from the main worktree are forbidden"`.
+   Happy path: same branch from a secondary worktree passes.
+
+**Expected failure:** All ten tests fail because `commit.py`
+currently has no validation logic — `main()` goes straight from
+arg parsing to `git.has_staged_changes()`.
+
+**If any pass unexpectedly:** validation has been partially moved
+(e.g., a stray earlier commit). `git diff src/standard_tooling/bin/commit.py`
+to see what's already there; adjust scope rather than add duplicate
+logic.
+
+#### GREEN — port each check from `pre_commit_hook.py` verbatim
+
+Add a `_validate_commit_context(root: Path) -> int` helper at the
+top of `commit.py`, and call it first in `main()` (before
+`git.has_staged_changes()`). Lift the constants
+(`_PROTECTED_BRANCHES`, `_BRANCHING_MODELS`, `_ISSUE_REQUIRED_RE`,
+`_ISSUE_FORMAT_RE`, `_WORKTREE_SCOPED_RE`, `_WORKTREES_DIRNAME`)
+verbatim from `pre_commit_hook.py`. The five checks return 1 with
+the same `print(... file=sys.stderr)` patterns; helper returns 0
+when all pass; `main()` propagates the non-zero return.
+
+**Constraints:**
+
+- Byte-identical behavior to the existing hook. The existing
+  `tests/standard_tooling/test_pre_commit_hook.py` is the spec for
+  this — a green run there (post-migration, before its deletion in
+  Task 1.4) is the reference.
+- Don't introduce exceptions for control flow. Preserve the
+  print-and-return-1 pattern.
+- No premature consolidation of the five `print/return` blocks —
+  REFACTOR will decide.
+
+#### REFACTOR
+
+Run `pytest` in green state. Then look for:
+
+- **Duplicated constants/regexes** between `pre_commit_hook.py`
+  (still present until Task 1.4) and `commit.py`. If Task 1.4 lands
+  in the same PR (it should), skip extraction — the duplication
+  vanishes when the hook file is deleted. If 1.4 is split across
+  PRs, promote shared symbols to a new `lib/branch_rules.py`.
+- **The `print/return 1` boilerplate.** Five blocks share the
+  shape `print(REASON, file=sys.stderr); print(HINT, file=sys.stderr);
+  return 1`. A small `_reject(reason: str, hint: str) -> int`
+  helper would tighten it. Apply only if the diff makes
+  `commit.py` shorter on net.
+- **Naming.** `_validate_commit_context` is fine; verify it doesn't
+  shadow an existing name in the module.
+
+### Task 1.2: Have `st-commit` set `ST_COMMIT_CONTEXT=1`
+
+**Requirement:** Spec "Migration / standard-tooling itself" step 2;
+"Consequences" subsection: "`st-commit` must always set
+`ST_COMMIT_CONTEXT=1` before calling `git commit`. A unit test
+pinning this behavior is a requirement of the migration —
+forgetting it in a future refactor would break every commit
+fleet-wide."
+
+#### RED — write a failing test pinning the env-var contract
+
+In `tests/standard_tooling/test_commit.py`, add a test that:
+
+- Calls `monkeypatch.delenv("ST_COMMIT_CONTEXT", raising=False)` to
+  start from a known-clean state.
+- Monkeypatches `standard_tooling.bin.commit.git.run` with a
+  callable that captures `os.environ.get("ST_COMMIT_CONTEXT")` at
+  the moment of invocation.
+- Drives `commit.main()` past validation (use the happy-path
+  monkeypatches from Task 1.1's tests) and past
+  `has_staged_changes` (return True).
+- Asserts the captured value is `"1"` (string, not the integer or
+  bool).
+
+**Expected failure:** Captured value is `None` — `commit.py` does
+not yet set the env var.
+
+**If it passes unexpectedly:** the test runner inherited
+`ST_COMMIT_CONTEXT=1` from the developer's shell. The
+`monkeypatch.delenv` call should prevent this; if it's still
+passing, the test is wrong (asserting against inherited
+environment) — fix the test before claiming green.
+
+#### GREEN — set the env var immediately before `git.run("commit", ...)`
+
+In `commit.py`'s `main()`, just before
+`git.run("commit", "--file", tmp_path)`:
+
+```python
+os.environ["ST_COMMIT_CONTEXT"] = "1"
+```
+
+Add `import os` at the top if not already imported.
+
+**Constraints:**
+
+- Mutate `os.environ` directly. The subprocess started by
+  `git.run` inherits the parent process environment by default;
+  no per-call env handling needed.
+- Don't unset the var after the call — the process is exiting.
+- Don't make this conditional on success of validation; by the
+  time we reach the `git.run` call, all five checks have passed,
+  so the env var is set unconditionally at that point.
+
+#### REFACTOR
+
+- `grep -rn ST_COMMIT_CONTEXT src/` — should match exactly one
+  Python source location (this `os.environ` line). Document the
+  contract via a short inline comment naming
+  `.githooks/pre-commit` as the consumer of the signal.
+- Consider promoting `"ST_COMMIT_CONTEXT"` and `"1"` to module
+  constants. **Skip this** — the only Python-side reference is
+  this single line, and the bash gate doesn't share constants
+  across language boundaries. Premature.
+
+### Task 1.3: Add `.githooks/pre-commit` (the new gate)
+
+**Requirement:** Spec "Migration / standard-tooling itself" step 4;
+"Decision: `st-commit` is the enforcement point; the hook is a
+gate."
+
+#### RED — write a shell-driven test exercising the gate's three branches
+
+In a new file `tests/standard_tooling/test_pre_commit_gate.py`,
+write three pytest tests that invoke the gate script directly via
+`subprocess.run(["bash", str(GATE_PATH)], env=...)`:
+
+1. **Admit by env var:** `env={"ST_COMMIT_CONTEXT": "1", "PATH":
+   os.environ["PATH"]}`. Assert `returncode == 0`, empty stderr.
+2. **Admit by `GIT_REFLOG_ACTION`:** parametrized over each
+   admitted value — `"amend"`, `"cherry-pick"`, `"revert"`,
+   `"rebase -i"`, `"rebase --continue"`, `"merge develop"`. Assert
+   each yields `returncode == 0`.
+3. **Reject:** `env={"PATH": os.environ["PATH"]}` (no
+   `ST_COMMIT_CONTEXT`, no `GIT_REFLOG_ACTION`). Assert
+   `returncode == 1`; assert stderr contains
+   `"raw 'git commit' is blocked"`.
+
+If `GATE_PATH = REPO_ROOT / ".githooks" / "pre-commit"` does not
+exist, mark the tests as `pytest.skip` with reason
+`"gate not yet implemented (RED phase)"` — that is the RED state.
+
+**Expected failure:** All three tests skip (gate file absent).
+
+**If they pass unexpectedly:** the file already exists from a
+partial earlier commit. Verify `git ls-files .githooks/` and
+either complete Task 1.3 or remove duplicate work.
+
+#### GREEN — write the gate file
+
+Create `.githooks/pre-commit` with the bash from the spec's
+"Decision" section, byte-identical:
+
+```bash
+#!/usr/bin/env bash
+# Admit st-commit-driven commits.
+if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then exit 0; fi
+# Admit derived-commit workflows that legitimately invoke `git commit`
+# without going through st-commit (amend, rebase, cherry-pick, revert,
+# merge-conflict resolution). GIT_REFLOG_ACTION is set by git itself.
+case "${GIT_REFLOG_ACTION:-}" in
+  amend|cherry-pick|revert|rebase*|merge*) exit 0 ;;
+esac
+echo "ERROR: raw 'git commit' is blocked. Use 'st-commit' instead." >&2
+echo "See docs/repository-standards.md" >&2
+exit 1
+```
+
+`chmod +x .githooks/pre-commit`. Re-run the tests; the three
+tests should now pass instead of skip.
+
+**Constraints:**
+
+- Match the spec's bash byte-for-byte. A future spec/plan diff
+  must be straightforward to read.
+- No clever bash. No POSIX-only rewrites — bash 4+ is fine; this
+  hook runs on developer machines with current bash.
+
+#### REFACTOR
+
+- `shellcheck .githooks/pre-commit` exits 0. The repo's validation
+  pipeline catches this anyway, but verify here for fast feedback.
+- If the test file has copy-paste of the env-construction
+  boilerplate, factor a `_run_gate(env: dict) -> CompletedProcess`
+  helper.
+- The gate references `docs/repository-standards.md` as the
+  pointer doc. Once `standard-tooling-plugin#87` lands a structured
+  config (`st-config.{yml,toml}`), this URL will need updating;
+  leave a `# TODO(plugin#87): point at st-config doc` comment in
+  the bash file as a tombstone for that follow-up.
+
+#### Manual sanity checks (out-of-test verification)
+
+After the test suite is green:
+
+- `git config core.hooksPath .githooks` then attempt a raw
+  `git commit -m "test"` — rejected with the gate's error.
+- `git commit --amend --no-edit` — admitted (`GIT_REFLOG_ACTION`
+  is `amend`).
+- `st-commit --type test --message "test" --agent claude`
+    after staging a change — admitted (`ST_COMMIT_CONTEXT=1`).
+
+### Task 1.4: Delete the old hook artifacts
+
+- **Action:**
+  - `git rm src/standard_tooling/bin/pre_commit_hook.py`
+  - Remove the `st-pre-commit-hook` line from `[project.scripts]` in
+    `pyproject.toml`.
+  - `git rm scripts/lib/git-hooks/pre-commit` (and remove the empty
+    `scripts/lib/git-hooks/` directory if it becomes empty —
+    `rmdir scripts/lib/git-hooks` succeeds).
+  - Delete `tests/standard_tooling/test_pre_commit_hook.py` (or rename and gut to
+    cover the moved logic — depends on whether the new tests in 1.1
+    duplicate or extend it; prefer the rename + gut path to preserve
+    git history).
+- **Verification:**
+  - `find . -name pre_commit_hook.py -not -path './.venv/*'` returns
+    nothing (top-level repo, not the venv).
+  - `grep -n st-pre-commit-hook pyproject.toml` returns nothing.
+  - `git status` shows the deletions staged.
+  - `uv pip install -e .` rebuilds without the entry point.
+
+### Task 1.5: Rewire this repo's `core.hooksPath`
+
+- **Action:** Update this repo's local `core.hooksPath` setting:
+  `git config core.hooksPath .githooks`. Update CLAUDE.md and
+  README.md instructions to reference `.githooks` instead of
+  `scripts/lib/git-hooks` (this is part of Phase 7's broader sweep,
+  but doing it now keeps this repo consistent at every commit).
+- **Verification:** `git config --get core.hooksPath` returns
+  `.githooks`. Raw `git commit` is rejected by the new gate.
+
+### Task 1.6: Validate the full pipeline locally
+
+- **Action:** Run `st-docker-run -- uv run st-validate-local`
+  inside the worktree. Confirm tests pass, lint passes, typecheck
+  passes.
+- **Verification:** `st-validate-local` exits 0.
+- **Sub-check — dev-tree override survives the changes.** From the
+  main worktree:
+
+  ```bash
+  UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+  PATH="$PWD/.venv-host/bin:$PATH" which st-docker-run    # → .venv-host/bin/...
+  PATH="$PWD/.venv-host/bin:$PATH" st-docker-run --help   # → exits 0
+  ```
+
+  Confirms Principle 4 from the spec (dev-tree override via PATH
+  ordering against `.venv-host`) still works after the Phase 1
+  code changes. Nothing in Phase 1 should break this, but verifying
+  closes the loop on the pushback resolution that restored
+  `.venv-host`.
+
+### Task 1.7: Open the PR, get it merged, `st-finalize-repo`
+
+- **Action:** Standard PR workflow. PR body references #286,
+  summarizes the consolidation, and lists the deleted entry point so
+  reviewers (future-you) understand the surface change.
+- **Verification:** PR merged to `develop`; `st-finalize-repo` run.
+
+**Phase 1 exit criteria:** `pre_commit_hook.py` deleted, new gate
+in place, this repo passes its own validation, PR merged.
+
+## Phase 2: Cut a `standard-tooling` release
+
+**Goal:** Consumers can pin to a tagged version that contains the
+new behavior. Without a release, the rolling minor tag points at
+old code and consumers cannot adopt.
+
+### Task 2.1: Bump version, prepare release
+
+- **Action:** Cut `v1.3.0`. The `pyproject.toml` version is already
+  at `1.3.0`; confirm `st-prepare-release` produces a release branch
+  and changelog targeting that version.
+- **Release-notes content:** Call out the `st-pre-commit-hook`
+  entry-point removal as a clean break. Strictly this is a public-
+  API change that would warrant `v2.0.0`, but no in-fleet consumer
+  invokes the entry point directly (all wire `core.hooksPath` at
+  `scripts/lib/git-hooks/pre-commit`, which is also being deleted).
+  Documenting the removal in the release notes is the cost of the
+  fleet-of-one fail-forward stance.
+- **Verification:** Release branch + PR opened; PR title reflects
+  `v1.3.0`; release notes mention the entry-point removal.
+
+### Task 2.2: Merge release PR; tags published
+
+- **Action:** Merge release PR. `tag-and-release` composite creates
+  `v1.3.0`, force-updates rolling minor tag to `v1.3`.
+- **Verification:**
+  - `git ls-remote --tags origin | grep -E 'v1\.3'` shows
+    `v1.3.0` and `v1.3`.
+  - GitHub Release for `v1.3.0` exists.
+
+### Task 2.3: Confirm consumers can install the new version
+
+- **Action:** On a clean shell, run
+  `uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'`.
+  Verify `st-commit` is on `PATH` and rejects malformed branches /
+  raw `git commit`.
+- **Verification:** Sanity-check transcript captured (or just
+  validated mentally — fleet-of-one).
+
+**Phase 2 exit criteria:** `v1.3.0` released; rolling `v1.3` tag
+exists; install from the rolling tag yields the new behavior.
+
+## Phase 3: `standard-tooling-docker` — image policy
+
+**Goal:** Dev container images stop drifting against
+`standard-tooling`. Each `standard-tooling` release triggers a
+rebuild that produces images carrying the released version.
+
+This phase is owned by `standard-tooling-docker#51` and the work
+happens in that repo. The plan items below are the scope this spec
+imposes on that issue.
+
+### Task 3.1: Switch pre-bake to pin the rolling minor tag
+
+- **Action:** In
+  `standard-tooling-docker/docker/common/standard-tooling-uv.dockerfile`,
+  replace:
+
+  ```dockerfile
+  RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling \
+      && uv pip install --system /tmp/standard-tooling \
+      && rm -rf /tmp/standard-tooling
+  ```
+
+  with:
+
+  ```dockerfile
+  RUN pip install --no-cache-dir \
+      'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'
+  ```
+
+  Bump the pin tag (`v1.3` here, future minors later) when the
+  publisher decides consumers should opt in to a new minor.
+- **Verification:** Local image build succeeds; inside the container,
+  `st-validate-local --version` (if available; otherwise
+  `pip show standard-tooling`) reports `v1.3.x`.
+
+### Task 3.2: Wire release-triggered rebuild
+
+- **Action:** In `standard-tooling-docker`, add a workflow listening
+  on `repository_dispatch` (event type: `standard-tooling-released`
+  or similar). The workflow rebuilds and publishes the dev images.
+  Mirror with a workflow change in `standard-tooling`'s release
+  pipeline that fires the dispatch event after `tag-and-release`
+  completes.
+- **Verification:**
+  - Manually trigger the dispatch (`gh api -X POST
+    /repos/wphillipmoore/standard-tooling-docker/dispatches -f
+    event_type=standard-tooling-released`); confirm the rebuild
+    workflow runs.
+  - Cut a `standard-tooling` patch release and confirm the
+    standard-tooling-docker workflow fires automatically.
+
+### Task 3.3: Verify image freshness post-rebuild
+
+- **Action:** After Phase 2's release and Phase 3 wiring lands,
+  pull the latest `dev-base` (or `dev-python`) image and confirm
+  it carries `standard-tooling v1.3.x`.
+- **Verification:**
+
+  ```bash
+  docker pull ghcr.io/wphillipmoore/dev-base:latest
+  docker run --rm ghcr.io/wphillipmoore/dev-base:latest \
+      pip show standard-tooling | grep Version
+  ```
+
+  reports `v1.3.x`.
+
+**Phase 3 exit criteria:** Dockerfile pinned to rolling tag; release
+dispatch wired; freshly-rebuilt images carry the released version.
+
+## Phase 4: `standards-compliance` — stop cloning `standard-tooling`
+
+**Goal:** The `standards-compliance` composite action (and any
+sibling composite that bootstraps `standard-tooling` onto the
+runner) stops cloning the repo and adding `scripts/bin/` to `PATH`.
+That `scripts/bin/` directory no longer exists, and the spec's
+position is that CI uses one of the two existing distribution paths.
+
+This phase is owned by a new issue to be filed against
+`standard-actions`.
+
+### Task 4.1: File the `standard-actions` issue
+
+- **Action:** File an issue in `wphillipmoore/standard-actions`
+  describing the work: replace the clone-and-PATH-prepend pattern
+  in `actions/standards-compliance/action.yml` with one of:
+  - For Python repos: rely on the consumer's own `uv sync --group
+    dev` step (if the action runs after that step, no install is
+    needed).
+  - For non-Python repos: run the action's steps inside the dev
+    container image (`jobs.<name>.container:` or invoke
+    `st-docker-run` from the runner). The image's pre-baked
+    `standard-tooling` is on `PATH`.
+  Reference this spec and #286.
+- **Verification:** Issue filed, linked from #286.
+
+### Task 4.2: Implement and merge
+
+- **Action:** Per the new issue's scope. PR against `standard-actions`.
+- **Verification:** Updated `standards-compliance` runs green
+  against at least one Python consumer (`ai-research-methodology`)
+  and one non-Python consumer (e.g., `standard-tooling-plugin`).
+
+### Task 4.3: Audit other composites
+
+- **Action:** `grep -r "standard-tooling" actions/` in
+  `standard-actions`. For each composite that clones or PATH-pre-
+  pends, apply the same fix or document why it doesn't apply.
+- **Verification:** `grep` returns no actions cloning
+  `standard-tooling`; remaining references are documentation only.
+
+**Phase 4 exit criteria:** `standards-compliance` no longer clones
+`standard-tooling`; CI in both Python and non-Python consumers runs
+green against the updated action.
+
+## Phase 5: Python consumer migration
+
+**Goal:** Every Python consumer declares `standard-tooling` as a
+dev dep, drops sibling-checkout wiring, and vendors the new gate.
+
+### Task 5.1: `ai-research-methodology`
+
+- **Action:**
+  1. Add to `pyproject.toml`:
+
+     ```toml
+     [dependency-groups]
+     dev = [
+         "standard-tooling",
+         # … other dev deps …
+     ]
+     [tool.uv.sources]
+     standard-tooling = { git = "https://github.com/wphillipmoore/standard-tooling", tag = "v1.3" }
+     ```
+
+  2. `uv sync --group dev`; commit `pyproject.toml` + `uv.lock`.
+  3. Vendor `.githooks/pre-commit` (the env-var-plus-
+     `GIT_REFLOG_ACTION` gate, copied verbatim from the spec).
+     `chmod +x .githooks/pre-commit`.
+  4. Update repo's `core.hooksPath` instructions in CLAUDE.md /
+     README to point at `.githooks` instead of
+     `../standard-tooling/scripts/lib/git-hooks`.
+  5. Remove `.venv-host` references and any sibling-checkout
+     bootstrap from CLAUDE.md / docs / `scripts/`.
+- **Verification:**
+  - Fresh clone: `git config core.hooksPath .githooks && uv sync
+    --group dev && st-docker-run -- uv run st-validate-local` runs
+    green.
+  - Raw `git commit -m "test"` is refused.
+  - `git commit --amend --no-edit` is admitted.
+
+### Task 5.2: Other Python consumers
+
+- **Action:** Apply the same five-step change to
+  `mq-rest-admin-python` when it re-enters active development. Not
+  required to land in this implementation cycle since the repo is
+  currently dormant.
+- **Verification:** Tracked under #288.
+
+**Phase 5 exit criteria:** `ai-research-methodology` migrated; CI
+green; sibling-checkout references removed.
+
+## Phase 6: Non-Python consumer migration
+
+**Goal:** Every non-Python consumer vendors the new gate and drops
+sibling-checkout wiring. They rely on the dev container image's
+pre-bake (which Phase 3 now keeps fresh).
+
+### Task 6.1: `standard-tooling-plugin`
+
+- **Action:**
+  1. Vendor `.githooks/pre-commit`. `chmod +x`.
+  2. Update repo's `core.hooksPath` instructions.
+  3. Remove sibling-checkout / `.venv-host` references from CLAUDE.md
+     and docs.
+  4. **Phase 7 link:** update `hooks/scripts/validate-on-edit.sh`'s
+     error-message URL from the sibling-checkout bootstrap guide to
+     the new spec / getting-started doc. (Tracked under Phase 7
+     Task 7.3 if not done here.)
+- **Verification:**
+  - Fresh clone, set `core.hooksPath`, raw `git commit` refused.
+  - Plugin's PostToolUse hook still fires correctly.
+  - **Image pre-bake provenance check** (matches spec verification
+    language for non-Python consumers):
+
+    ```bash
+    st-docker-run -- which st-validate-local    # → /usr/local/bin/... (image pre-bake)
+    st-docker-run -- pip show standard-tooling  # → Version: v1.3.x
+    ```
+
+    Confirms `st-*` inside the container comes from the image and
+    that the image is current — catches the silent-stale-image
+    failure mode that motivated `standard-tooling-docker#51`.
+
+### Task 6.2: `standard-tooling-docker` (consumer role)
+
+- **Action:** Same gate-vendor + sibling-checkout cleanup as 6.1.
+  This is separate from the Phase 3 work — that was the repo
+  *publishing* the images; this is the repo *using* `st-*` in its
+  own dev workflow.
+- **Verification:** Same as 6.1, including the image-pre-bake
+  provenance check.
+
+### Task 6.3: `the-infrastructure-mindset`
+
+- **Action:** Same gate-vendor + sibling-checkout cleanup as 6.1.
+- **Verification:** Same as 6.1, including the image-pre-bake
+  provenance check.
+
+### Task 6.4: `standards-and-conventions`
+
+- **Action:** Same gate-vendor + sibling-checkout cleanup as 6.1.
+- **Verification:** Same as 6.1, including the image-pre-bake
+  provenance check.
+
+### Task 6.5: `mq-rest-admin-*` non-Python variants (deferred)
+
+- **Action:** Same gate-vendor + cleanup. Apply when each variant
+  re-enters active development. Tracked under #288.
+- **Verification:** Per-variant when each lands.
+
+**Phase 6 exit criteria:** All currently active non-Python
+consumers migrated; CI green; sibling-checkout references removed.
+
+## Phase 7: Docs sweep and plugin error-message update
+
+**Goal:** No stale references to `scripts/lib/git-hooks`,
+`../standard-tooling/.venv-host/bin`, or sibling-checkout patterns
+remain anywhere in the fleet's documentation.
+
+This phase is the substance of #288.
+
+### Task 7.1: `standard-tooling`'s own docs
+
+- **Action:** Sweep this repo:
+
+  ```bash
+  grep -rln "scripts/lib/git-hooks\|\.venv-host/bin\|\.\./standard-tooling/" CLAUDE.md README.md docs/
+  ```
+
+  For each match, rewrite to use the new gate / `.githooks/` /
+  host-level install model.
+- **Verification:** The grep above returns zero matches.
+
+### Task 7.2: Each consumer repo's docs
+
+- **Action:** Same grep + sweep in every consumer repo touched in
+  Phases 5–6. Each repo's CLAUDE.md gets its own rewrite to match
+  the new model.
+- **Verification:** Per-repo grep returns zero matches.
+
+### Task 7.3: Plugin `validate-on-edit.sh` error message
+
+- **Action:** Update
+  `standard-tooling-plugin/hooks/scripts/validate-on-edit.sh`'s
+  `additionalContext` string to reference the new install path
+  (`uv tool install ...`) and the new spec / getting-started doc.
+- **Verification:** Trigger the failure mode (rename `st-docker-run`
+  off `PATH` temporarily); confirm the error message points at the
+  new doc.
+
+### Task 7.4: Update `docs/specs/git-url-dev-dependency.md`
+
+- **Action:** Delete the file. The pushback report
+  (`paad/pushback-reviews/2026-04-24-git-url-dev-dependency-pushback.md`)
+  preserves the rejection record; the file itself is no longer
+  needed.
+- **Verification:** `git rm docs/specs/git-url-dev-dependency.md`;
+  the references-from list in `host-level-tool.md` updated to drop
+  the broken link.
+
+### Task 7.5: Rewrite the canonical getting-started narrative
+
+- **Action:** In `docs/site/docs/getting-started.md` (and any
+  consumer repo equivalent), replace the install / bootstrap
+  section with the four-step flow from the spec's
+  [First-time developer setup](../specs/host-level-tool.md#first-time-developer-setup)
+  section: install `uv` → `uv tool install standard-tooling` →
+  confirm → per-repo `core.hooksPath` + `uv sync --group dev`
+  (Python only). This is a **narrative rewrite**, not a
+  find-and-replace — the doc must read as a coherent install
+  walkthrough for a new developer, not a patchwork of edited
+  paragraphs.
+- **Verification:** A fresh reader following the doc top-to-bottom
+  on a clean machine ends with `st-docker-run --help` working and
+  the new repo's `.githooks/pre-commit` enforcement active. Spec
+  acceptance line "Getting-started docs updated to the four-step
+  flow" can be checked.
+
+**Phase 7 exit criteria:** Fleet-wide grep for the legacy patterns
+returns zero matches **and** the canonical getting-started narrative
+reflects the four-step flow.
+
+## Closeout
+
+### Task 8.1: Close #286
+
+- **Action:** Verify all spec acceptance criteria are checked.
+  Close #286 with a comment linking to the spec, plan, and
+  pushback report.
+- **Verification:** #286 closed.
+
+### Task 8.2: Close / update related issues
+
+- **Action:**
+  - Close `standard-tooling-docker#51` (resolved by Phase 3).
+  - Close the `standard-actions` issue from Task 4.1 (resolved by
+    Phase 4).
+  - Update #288 (docs sweep) to reflect actual completion (most of
+    its work happens in Phase 7).
+- **Verification:** Issue states match reality.
+
+## Dependencies and blockers
+
+| Depends on | Blocks | Notes |
+|------------|--------|-------|
+| Phase 1 complete | Phase 2 (release) | Can't release without the code |
+| Phase 2 complete | Phases 3, 5, 6 | Consumers and image pin can't reference a tag that doesn't exist yet |
+| Phase 3 complete | Phase 6 | Non-Python consumers depend on fresh images |
+| Phase 4 complete | Phase 6 (CI) | Non-Python CI breaks until `standards-compliance` updated |
+| Phases 5 + 6 + 4 | Phase 7 | Docs sweep can lag the migration but should not lead it |
+
+Phases 3, 4, 5 can run in parallel after Phase 2; only the
+respective Phase 6 sub-tasks are gated by their predecessors.
+
+## Success criteria (aggregated, mapped to spec acceptance criteria)
+
+- [x] Spec drafted and pushback-reviewed (complete; see
+  pushback report)
+- [ ] `paad:alignment` run between this plan and the spec
+  (next paad step)
+- [ ] Phase 1 complete: `pre_commit_hook.py` deleted, env-var gate
+  in place, repo self-validates
+- [ ] Phase 2 complete: `v1.3.0` released; rolling `v1.3` tag
+  exists
+- [ ] Phase 3 complete: `standard-tooling-docker` pins rolling tag;
+  release dispatch wired; rebuilt images carry released version
+- [ ] Phase 4 complete: `standards-compliance` no longer clones
+  `standard-tooling`; CI green for both Python and non-Python
+  consumers
+- [ ] Phase 5 complete: `ai-research-methodology` declares dev dep,
+  vendors gate, removes sibling-checkout refs
+- [ ] Phase 6 complete: plugin / docker repo / docs / standards
+  repo each vendor gate, remove sibling-checkout refs
+- [ ] Phase 7 complete: fleet-wide grep returns zero stale
+  references
+- [ ] #286, `standard-tooling-docker#51`, and the new
+  `standard-actions` issue closed; #288 updated

--- a/docs/specs/host-level-tool.md
+++ b/docs/specs/host-level-tool.md
@@ -1,0 +1,788 @@
+# `standard-tooling` as a host-level developer tool
+
+**Status:** Draft — pending `paad:pushback`
+**Issue:** [#286](https://github.com/wphillipmoore/standard-tooling/issues/286)
+**Supersedes:** `docs/specs/git-url-dev-dependency.md` (rejected 2026-04-24)
+**Rejection record:**
+[`paad/pushback-reviews/2026-04-24-git-url-dev-dependency-pushback.md`](../../paad/pushback-reviews/2026-04-24-git-url-dev-dependency-pushback.md)
+**Author:** wphillipmoore
+**Last updated:** 2026-04-24
+
+## Purpose
+
+Define the canonical distribution model for `standard-tooling` across
+the managed fleet. The tool must be available on every active
+developer's host — in any repo, in any language — without per-repo
+bootstrap bespoke to each consumer.
+
+This spec intentionally reaches across repo boundaries:
+`standard-tooling-docker` and `standard-tooling-plugin` are child
+repositories of `standard-tooling` (factored out for build and
+deployment reasons, not because they are logically independent). This
+spec dictates the distribution contract they implement.
+
+## Problem statement
+
+`standard-tooling` provides host-side CLI tools (`st-docker-run`,
+`st-commit`, `st-submit-pr`, `st-prepare-release`, `st-validate-local`,
+etc.) used across the entire fleet. It is **not** on PyPI and will not
+be (first-party tooling, not a public library).
+
+Two prior distribution approaches both failed:
+
+1. **Sibling-checkout + `.venv-host/bin`** — assumes every consumer has
+   `../standard-tooling` cloned and bootstrapped. Produced repeated
+   "tool not found on PATH" failures when developers or agents forgot
+   the bootstrap step. This is the failure mode that motivated
+   `plugin#69`.
+2. **Per-repo git-URL dev dependency via `[tool.uv.sources]`**
+   (rejected 2026-04-24) — assumes every consumer has a
+   `pyproject.toml`. Of the 5 non-deferred consumers, only 1 is a
+   Python project. The pattern could not reach the fleet.
+
+A further wrinkle — surfaced during #286 spec work and tracked in
+[standard-tooling-docker#51](https://github.com/wphillipmoore/standard-tooling-docker/issues/51) —
+is that `standard-tooling` is **also** pre-baked into the dev
+container images. Today the images `git clone -b develop && uv pip
+install --system` at build time, so every image carries a
+point-in-time copy of `standard-tooling` that drifts from the host
+version between image rebuilds. Post-merge validation has been
+silently failing against stale image copies. Any new distribution
+model has to treat the container image as a deployment target, not an
+implementation detail.
+
+## Decision
+
+`standard-tooling` has **three coordinated deployment targets** with
+one shared source of truth (the rolling minor tag on the
+`standard-tooling` repo). All three must track that tag for the
+fleet to behave consistently.
+
+### Six principles
+
+1. **Host-level tier.** `standard-tooling` lives on the host alongside
+   `git`, `gh`, `uv`. It is on `PATH` because the developer's machine
+   has it, not because any repo declares it.
+2. **Host install via `uv tool install`.** Canonical mechanism across
+   macOS and Linux. Puts console scripts at `~/.local/bin/` (the
+   same directory `uv`'s official installer configures on `PATH`).
+   `standard-tooling` is not on PyPI; install is from the GitHub git
+   URL.
+3. **Upgrade is manual and documented.** A one-liner run after each
+   release. Shell-startup auto-detection / auto-update is **explicitly
+   rejected** (invisible mutation of the dev environment is
+   anti-debug).
+4. **Dev-tree override via `PATH` ordering.** When testing an
+   unreleased version, prepend the local checkout's venv to `PATH`
+   for the shell. No framework, no flags.
+5. **Python consumers MUST declare `standard-tooling` as a dev dep.**
+   Pinned to the rolling minor tag via `[tool.uv.sources]`. This
+   makes the project's `.venv` — not the image's pre-bake — the
+   source of `st-*` inside the container, eliminating drift between
+   the repo and the image. Non-Python consumers cannot declare, so
+   they rely on the image's pre-bake; see principle 6.
+6. **The dev container image tracks the rolling minor tag and
+   rebuilds on every `standard-tooling` release.** The image's
+   pre-baked `standard-tooling` is the sole `st-*` source for
+   non-Python consumers, so the image cannot be allowed to drift.
+   The image build pins to `v{major.minor}` (not `develop`) and
+   rebuilds are triggered by `standard-tooling`'s release pipeline.
+
+## Deployment targets
+
+| Target | Install mechanism | Who uses it | Freshness mechanism |
+|---|---|---|---|
+| **Developer host** | `uv tool install` from git URL (canonical); `pip install` from git URL (alternative) | Host-side commands: `st-docker-run`, `st-commit`, `st-submit-pr`, `st-prepare-release`, `st-finalize-repo` | Manual one-liner after each release |
+| **Python project `.venv`** (MUST for Python consumers) | `[tool.uv.sources]` git URL + `uv sync` | `uv run st-*` inside the container for validators: `st-validate-local`, `st-validate-local-python`, `st-markdown-standards`, etc. | `uv lock --upgrade-package standard-tooling` per repo; rolling tag means the upgrade is a no-arg re-lock |
+| **Dev container image** (pre-bake) | `pip install` from git URL pinned to rolling minor tag, baked into image at build time | `st-*` inside the container for non-Python consumers (plugin, docker, docs) | Automated image rebuild on every `standard-tooling` release, pulling the current rolling tag |
+
+These targets are coordinated, not redundant. Each covers a failure
+mode the others cannot:
+
+- Without the **host install**, `st-docker-run` cannot launch a
+  container in the first place; nothing else matters.
+- Without the **project `.venv` declaration**, Python consumers run
+  whatever version was in the image at build time — which is exactly
+  the drift problem in #51.
+- Without the **image pre-bake**, non-Python consumers (plugin,
+  docker, docs) have no `st-*` on PATH inside the container at all.
+
+Consistency across the fleet means all Python consumers take the same
+path (project `.venv`) and all non-Python consumers take the other
+(image pre-bake). Mixing — some Python repos declare, others rely on
+the image — is explicitly forbidden because it creates two debugging
+surfaces where one suffices. See
+[Why MUST, not SHOULD](#why-must-not-should).
+
+## Canonical install (host)
+
+```bash
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.2'
+```
+
+`v1.2` is the rolling minor tag. `standard-actions`'
+[`tag-and-release`](https://github.com/wphillipmoore/standard-actions/blob/main/actions/publish/tag-and-release/action.yml)
+force-updates it on every patch release (`git tag -f v1.2 HEAD`),
+so a git-URL install against `v1.2` always resolves to the latest
+patch on the current minor. Bump to `v1.3` etc. when the publisher
+cuts a new minor and decides consumers should opt in.
+
+### `uv tool install` vs `pip install`
+
+`uv tool install` is canonical. `pip install` is a documented
+alternative, not a replacement.
+
+| | `uv tool install` (canonical) | `pip install` (alternative) |
+|---|---|---|
+| Install target | Isolated venv at `~/.local/share/uv/tools/standard-tooling/` | Whatever Python env `pip` runs from |
+| Scripts land in | `~/.local/bin/` (the path `uv`'s official installer already configures) | `bin/` of the Python env `pip` runs from |
+| Dep isolation | Fully isolated | Shared with the containing env |
+| macOS system Python | Works | Works (user-owned Framework Python) |
+| Linux system Python | Works | Fails without `sudo` or `--break-system-packages` (PEP 668) |
+| `uv` installed standalone (no Python env) | Works | No applicable target env |
+| Uninstall | `uv tool uninstall standard-tooling` | `pip uninstall standard-tooling` |
+
+**Why `uv tool install` is canonical:**
+
+- **Cross-platform without caveats.** Works identically on macOS
+  and Linux. No `--user` vs system-wide decision, no PEP 668
+  exception flags, no `sudo`.
+- **Matches the `uv` installation pattern.** Developers install
+  `uv` via the official installer, which configures `~/.local/bin`
+  on `PATH`. `uv tool install` drops console scripts into the
+  exact same directory, so `standard-tooling` scripts are on `PATH`
+  automatically.
+- **Zero pollution of the developer's Python environments.**
+  `standard-tooling` and its transitive deps live in their own
+  venv, invisible to any other Python work on the machine.
+- **Self-upgrading.** `uv tool upgrade standard-tooling` is a
+  shorter, tag-aware one-liner than the `pip install --upgrade`
+  equivalent.
+
+Developers or CI environments that prefer — or already have — a
+`pip`-based install may use `pip install` with the same git URL,
+accepting the platform caveats above. The existing primary-developer
+machine, which has `standard-tooling` installed via `pip` into
+Framework Python, is a valid alternative install and does not need
+to migrate.
+
+## Upgrade (host)
+
+Run after each `standard-tooling` release:
+
+```bash
+uv tool upgrade standard-tooling
+```
+
+`uv tool upgrade` re-resolves the git reference, pulls the current
+tip of the rolling minor tag (`v1.2` today), and rebuilds the
+isolated venv. No need to repeat the full git URL — uv remembers
+the source from the initial `uv tool install`.
+
+For `pip install` users:
+
+```bash
+pip install --upgrade 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.2'
+```
+
+`--upgrade` is required for `pip` to re-resolve the git reference;
+without it, pip sees the package already installed and skips. The
+`v1.2` pin ensures resolution picks up the latest patch on the
+current minor.
+
+### Why not auto-upgrade
+
+Shell-startup hooks, cron jobs, or post-release auto-install were
+considered and explicitly rejected:
+
+- **Invisible mutation.** The developer's `PATH` contents changing
+  without their awareness breaks reproducibility during debugging.
+- **Failure mode inversion.** An auto-upgrade that partially fails
+  leaves the host in a state the developer didn't initiate and
+  doesn't know how to diagnose.
+- **Release cadence is low-frequency.** Manual upgrade is a small
+  tax paid a handful of times per year.
+
+The release announcement (GitHub release notes) includes the upgrade
+one-liner, so the action is copy-paste.
+
+## Dev-tree override (host)
+
+Testing an unreleased version of `standard-tooling` from a local
+checkout is the **one case** where host-side venv bootstrapping
+survives. This is an unusual workflow — hit only when developing
+`standard-tooling` itself or running an ad-hoc host-side integration
+test against pre-release code. The normal path is `uv tool install`
+described above.
+
+The override uses a dedicated host-side venv named `.venv-host`
+(not `.venv`):
+
+```bash
+cd ~/dev/github/standard-tooling
+UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+export PATH="$PWD/.venv-host/bin:$PATH"      # shell-local override
+which st-docker-run                           # confirms override wins
+```
+
+`PATH` ordering alone handles the override — the shell picks the
+first match. Unset the `PATH` export (or open a fresh shell) to
+revert to the host-installed version.
+
+### Why `.venv-host`, not `.venv`
+
+The `standard-tooling` repo is itself developed and validated inside
+the dev container. Inside the container, `uv sync` populates `.venv/`
+with shebangs pointing at the container's Python
+(`/workspace/.venv/...`). Those binaries cannot run on the host — the
+shebang path doesn't resolve to a host executable.
+
+If the host override used `.venv/`, host-side `uv sync` would
+overwrite the container's venv (breaking container validation) or
+vice versa. Separating the two under `.venv-host/` is the structural
+fix, not a workaround: host-Python and container-Python shebangs are
+different interpreters, and must live in different directories.
+
+`.venv-host` therefore survives specifically and only as the
+dev-tree-override venv for this repo (and, by extension, any Python
+consumer that needs to test unreleased `standard-tooling` from a
+sibling checkout). It is **not** the normal install mechanism —
+that remains `uv tool install` as described under
+[Canonical install](#canonical-install-host).
+
+## Python consumer dev-dep declaration (required)
+
+Every Python consumer MUST declare `standard-tooling` as a dev dep:
+
+```toml
+# pyproject.toml
+[dependency-groups]
+dev = [
+    "standard-tooling",
+    # … other dev deps …
+]
+
+[tool.uv.sources]
+standard-tooling = { git = "https://github.com/wphillipmoore/standard-tooling", tag = "v1.2" }
+```
+
+After `uv sync --group dev`, `.venv/bin/st-*` contains the pinned
+version. Inside the container, `uv run st-validate-local` resolves
+against `.venv/` and the image's pre-bake is not consulted.
+
+### Why MUST, not SHOULD
+
+Uniformity across Python repos is load-bearing. If repo A declares
+the dev dep and repo B does not:
+
+- Repo A runs the tag-pinned version from `.venv/`.
+- Repo B runs the image's pre-baked copy.
+- Debugging "why does validation behave differently in A vs B?"
+  becomes a multi-source version-archaeology exercise.
+
+The freshness guarantee this spec is trying to deliver —
+"`st-validate-local` runs the version the pin says" — only holds
+fleet-wide if every Python consumer takes the same path. Optional
+adoption guarantees some repos fall off.
+
+### Keeping lockfiles current
+
+The rolling-minor tag means `uv lock --upgrade-package
+standard-tooling` resolves to the current tip of `v1.2`. Consumers
+bump their lockfile by running that command and committing `uv.lock`.
+
+The cadence for these bumps is left to each consumer. Automation
+(dependabot, scheduled refresh PRs) is desirable but out of scope
+for this spec. What IS in scope: pinning to the rolling minor tag
+rather than a fixed patch tag, so the bump is a no-arg re-lock and
+does not require editing `pyproject.toml`.
+
+### Non-Python consumers
+
+Non-Python consumers (`standard-tooling-plugin`, `standard-tooling-docker`,
+`the-infrastructure-mindset`, `standards-and-conventions`, and the
+Ruby / Go / Rust / Java variants of `mq-rest-admin-*`) cannot
+declare `standard-tooling` as a dev dep because they have no
+`pyproject.toml` to declare in. They rely on the dev container
+image's pre-bake; freshness is the image's responsibility (see
+[Dev container image policy](#dev-container-image-policy)).
+
+## Dev container image policy
+
+The dev container images maintained in
+[`standard-tooling-docker`](https://github.com/wphillipmoore/standard-tooling-docker)
+are the distribution channel for non-Python consumers. Under this
+spec, those images MUST:
+
+1. **Pin `standard-tooling` to the rolling minor tag** at image
+   build time. The current pre-bake script (`git clone -b develop &&
+   uv pip install --system`) tracks develop branch tip, which drifts
+   from releases. The replacement pins to the tag:
+
+   ```dockerfile
+   RUN pip install --no-cache-dir \
+       'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.2'
+   ```
+
+2. **Rebuild automatically on every `standard-tooling` release.** A
+   release of `standard-tooling` triggers a rebuild of the dev
+   images, so the next `docker pull` of `dev-base` / `dev-python` /
+   etc. contains the newly-released `standard-tooling`.
+
+   Mechanism (owned by `standard-tooling-docker`): likely a
+   `repository_dispatch` fired by `standard-tooling`'s release
+   workflow, or a GitHub Actions workflow in
+   `standard-tooling-docker` that watches the rolling tag. The
+   exact mechanism is `standard-tooling-docker`'s call; this spec
+   only requires the behavior.
+
+This closes the loop for non-Python consumers: a new
+`standard-tooling` release produces new images within the rebuild
+cycle, and non-Python repos pull fresh `st-*` on next container
+launch.
+
+Implementation tracked in
+[standard-tooling-docker#51](https://github.com/wphillipmoore/standard-tooling-docker/issues/51),
+which this spec unblocks.
+
+## CI install path
+
+CI is not a separate deployment target. Every consumer's CI falls
+into one of the two existing paths:
+
+- **Python consumer CI** — uses the project `.venv` path. A workflow
+  step that runs `uv sync --group dev` installs `standard-tooling`
+  from the dev-dep declaration, exactly as on a developer's host.
+  No separate install step.
+- **Non-Python consumer CI** — uses the dev container image path.
+  Workflows run inside the `dev-base` / `dev-python` / etc. image
+  (either via `jobs.<name>.container:` or by invoking
+  `st-docker-run` from the runner), and the image's pre-baked
+  `standard-tooling` is on `PATH`. No separate install step.
+
+Consequently: the `standards-compliance` composite action in
+[`standard-actions`](https://github.com/wphillipmoore/standard-actions)
+must stop cloning `standard-tooling` and adding `scripts/bin/` to
+`PATH`. That path is a transitional artifact from before the
+container pre-bake existed; under this spec, `standards-compliance`
+either runs inside the dev container (non-Python case) or relies on
+the consumer's own `uv sync --group dev` (Python case). Updating the
+action is part of this spec's rollout (see
+[Acceptance criteria](#acceptance-criteria)).
+
+The same principle applies to any other `standard-actions` composite
+that currently bootstraps `standard-tooling` onto the runner: if the
+work can run inside the dev container, that's the canonical path; if
+the consumer is Python, `uv sync --group dev` covers it. No CI
+workflow should need a bespoke `uv tool install`.
+
+## Git hooks
+
+The pre-commit gate moves from git hook content to `st-commit`
+itself, with a thin hook that enforces `st-commit` as the only legal
+path to a commit.
+
+### Decision: `st-commit` is the enforcement point; the hook is a gate
+
+**All commit-context checks live in `st-commit`.** Branch-name
+validation, protected-branch refusal, issue-number requirement, and
+worktree-convention enforcement (the rules currently in
+`src/standard_tooling/bin/pre_commit_hook.py`) move into
+`src/standard_tooling/bin/commit.py`. `st-commit` becomes the single
+source of truth for commit-time policy.
+
+**The git hook becomes a trivial gate.** Its only job is to refuse
+any `git commit` that did not go through `st-commit`. `st-commit`
+sets the environment variable `ST_COMMIT_CONTEXT=1` before invoking
+`git commit --file`; the hook checks for that variable and rejects
+otherwise.
+
+Every managed repo checks in the following bash gate:
+
+```bash
+# .githooks/pre-commit
+#!/usr/bin/env bash
+# Admit st-commit-driven commits.
+if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then exit 0; fi
+# Admit derived-commit workflows that legitimately invoke `git commit`
+# without going through st-commit (amend, rebase, cherry-pick, revert,
+# merge-conflict resolution). GIT_REFLOG_ACTION is set by git itself.
+case "${GIT_REFLOG_ACTION:-}" in
+  amend|cherry-pick|revert|rebase*|merge*) exit 0 ;;
+esac
+echo "ERROR: raw 'git commit' is blocked. Use 'st-commit' instead." >&2
+echo "See docs/repository-standards.md" >&2
+exit 1
+```
+
+And enables it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The gate has no dependency on the host install of
+`standard-tooling`, no Python tooling, no entry-point resolution. It
+is pure bash, identical in every repo in every language.
+
+### Why this shape
+
+- **Fleet-wide enforcement.** The gate fires for humans, agents, and
+  CI alike. The plugin's existing `block-raw-git-commit` PreToolUse
+  hook covers agents earlier in the loop, but the git hook is the
+  backstop that catches anything the plugin does not.
+- **One source of truth.** Adding, removing, or changing a
+  commit-context check means editing one Python file (`commit.py`),
+  not coordinating across a hook module and a wrapper.
+- **Ecosystem-neutral.** Pure bash, no Python dependency. Works
+  identically in the Python plugin repo, the Dockerfiles repo, the
+  markdown docs repo, and every `mq-rest-admin-*` language variant.
+- **Distribution-stable.** No shim that calls an entry point, so no
+  failure mode where the host install is missing but the shim is
+  present.
+
+### Consequences
+
+- **`st-pre-commit-hook` entry point is removed.** Its logic moves
+  entirely into `st-commit`; the entry point itself and
+  `src/standard_tooling/bin/pre_commit_hook.py` are deleted.
+  `scripts/lib/git-hooks/pre-commit` (the in-repo hook file that
+  execs the entry point) is also removed.
+- **`st-commit` must always set `ST_COMMIT_CONTEXT=1`** before
+  calling `git commit`. A unit test pinning this behavior is a
+  requirement of the migration — forgetting it in a future refactor
+  would break every commit fleet-wide.
+- **Derived-commit workflows are admitted automatically.** The gate
+  recognizes `GIT_REFLOG_ACTION` values set by `git` itself during
+  `--amend`, `rebase`, `cherry-pick`, `revert`, and
+  merge-conflict-resolution commits. These fire the pre-commit hook
+  but should not be treated as raw `git commit -m "..."` for
+  enforcement purposes. No user action required.
+- **Escape hatch:** `ST_COMMIT_CONTEXT=1 git commit -m "..."` will
+  pass the gate. This is deliberate — the env var is an in-band
+  signal, and anyone who sets it manually accepts the cost of
+  skipping `st-commit`'s content checks. Document it as the break
+  glass.
+
+### Check inventory
+
+The five checks currently in `pre_commit_hook.py`, all moving into
+`st-commit`:
+
+1. Reject commits from detached HEAD.
+2. Reject direct commits to `develop` / `release` / `main`.
+3. Validate branch prefix against the repo's branching model (from
+   `docs/repository-standards.md`).
+4. Require issue number in `feature|bugfix|hotfix|chore/` branches.
+5. Refuse feature-branch commits from the main worktree when
+   `.worktrees/` exists (per worktree convention rule 3).
+
+All five are preserved. Earlier pruning of #1 and #2 was considered
+when they lived in a standalone hook module; now that they share a
+file with message formatting, the cost of keeping them is trivial,
+so no pruning is proposed here. Revisit in a separate issue if they
+prove to be noise.
+
+## Fail-loud enforcement
+
+Two layers already exist; no new trip-wires are proposed here.
+
+**Layer 1 — Agent sessions: plugin `validate-on-edit.sh`.** The
+Claude Code plugin's `PostToolUse` hook for `Write`/`Edit`
+dispatches validation through `st-docker-run`. On missing
+`st-docker-run`, it emits a `hookSpecificOutput` with a clear
+install pointer and exits 2. This covers every agent session that
+has the plugin installed.
+
+**Layer 2 — Shell-level: `command not found`.** When a human or CI
+script invokes `st-docker-run` without the host install, the shell
+itself fails with exit 127 and a clear error. Downstream `st-*`
+tools fail immediately at the first call, with the shell-level
+diagnostic pointing directly at the missing command.
+
+These two layers together cover the realistic failure surface:
+
+- Agent-driven editing (most of the traffic) → plugin hook catches it.
+- Human or CI invocation → shell's built-in `command not found`.
+
+A third layer — per-consumer trip-wires in each repo's task runner —
+was considered and is **not** proposed. Adding bespoke "is
+standard-tooling installed?" checks to each consumer duplicates what
+the shell already does. If the two existing layers prove
+insufficient in practice (measured against real failures, not
+speculative ones), revisit in a follow-up spec.
+
+The error message in `validate-on-edit.sh` currently points at the
+sibling-checkout bootstrap guide. Updating it to reference this spec
+is tracked in issue #288 (the docs + workarounds sweep), not here.
+
+## Scope
+
+### In-scope consumers
+
+Every repo that currently uses any `st-*` command:
+
+- **Python consumers** (MUST declare dev dep):
+  - `ai-research-methodology`
+  - `mq-rest-admin-python` (when it re-enters active development)
+- **Non-Python consumers** (rely on image pre-bake):
+  - `standard-tooling-plugin`
+  - `standard-tooling-docker`
+  - `the-infrastructure-mindset`
+  - `standards-and-conventions`
+  - `mq-rest-admin-ruby`, `-go`, `-rust`, `-java`, `-common`,
+    `-dev-environment`, `-template` (all when the family re-enters
+    active development)
+
+**`standard-tooling` itself is a distinct case.** It doesn't (and
+can't) declare itself as a dev dep in its own `pyproject.toml`;
+`uv sync --group dev` inside the dev container installs the repo
+editably into `/workspace/.venv/`, so `uv run st-*` resolves against
+the repo's own source. The dev-dep declaration pattern applies to
+*other* Python consumers; for this repo, the self-hosting is a
+consequence of the package itself.
+
+### Out-of-scope
+
+- **Publishing `standard-tooling` to PyPI.** Explicitly rejected.
+- **The specific automation mechanism for image rebuild-on-release.**
+  `repository_dispatch`, scheduled polling, or another pattern — all
+  are acceptable; the spec only requires the behavior. Mechanism
+  chosen in `standard-tooling-docker#51`.
+- **Automation of consumer lockfile bumps.** Manual
+  `uv lock --upgrade-package standard-tooling` is the baseline; any
+  dependabot / renovate / scheduled-PR layer is separate work.
+- **Bash validators under `scripts/bin/`.** That directory
+  (referenced in legacy `CLAUDE.md` text) no longer exists — all
+  validation has migrated to Python entry points that ship via the
+  host install and container pre-bake.
+- **Bundled bash scripts under `scripts/lib/`.** Only `git-hooks/`
+  needs consumer access, and the shim approach above covers it.
+
+## Migration per consumer
+
+See issue #288 for the full rollout checklist. At spec level, each
+consumer's migration has these steps:
+
+### `standard-tooling` itself (this spec's code work, before fleet rollout)
+
+1. Move the five branch/context checks from
+   `src/standard_tooling/bin/pre_commit_hook.py` into
+   `src/standard_tooling/bin/commit.py`.
+2. Have `st-commit` set `ST_COMMIT_CONTEXT=1` in the environment
+   before invoking `git commit --file`. Add a unit test pinning
+   this behavior.
+3. Delete `src/standard_tooling/bin/pre_commit_hook.py`, remove the
+   `st-pre-commit-hook` entry point from `pyproject.toml`, and
+   delete `scripts/lib/git-hooks/pre-commit`.
+4. Ship this repo's own `.githooks/pre-commit` as the
+   env-var-plus-GIT_REFLOG_ACTION gate.
+
+### Python consumers
+
+1. Add `standard-tooling` to `[dependency-groups].dev` and declare
+   the git-URL source in `[tool.uv.sources]` (snippet in
+   [Python consumer dev-dep declaration](#python-consumer-dev-dep-declaration-required)).
+2. Run `uv sync --group dev`; commit `pyproject.toml` + `uv.lock`.
+3. Replace any existing `core.hooksPath` setting and hook file with
+   the new `.githooks/pre-commit` env-var gate.
+4. Remove sibling-checkout and PATH-hack references from docs,
+   bootstrap scripts, and CI. (`.venv-host` is retained only in
+   `standard-tooling` itself for the dev-tree-override case; it
+   should not appear in any other consumer.)
+5. Verify: `st-docker-run -- uv run st-validate-local` works in a
+   fresh clone after `uv sync --group dev`; raw `git commit` is
+   refused with the gate's error.
+
+### Non-Python consumers
+
+1. Replace any existing `core.hooksPath` setting and hook file with
+   the new `.githooks/pre-commit` env-var gate.
+2. Remove sibling-checkout and PATH-hack references from docs,
+   bootstrap scripts, and CI. (Non-Python consumers have no legit
+   reason to hold a `.venv-host`; it belongs only to
+   `standard-tooling` itself.)
+3. Verify: host-installed `st-*` is on PATH; the image's pre-baked
+   `st-*` is what runs inside the container; raw `git commit` is
+   refused with the gate's error.
+
+### `standard-tooling-docker` (child repo, this spec's work)
+
+1. Replace `git clone -b develop && uv pip install --system` with
+   `pip install 'standard-tooling @ git+…@v1.2'` in the common
+   fragment.
+2. Wire release-triggered rebuilds per
+   [`standard-tooling-docker#51`](https://github.com/wphillipmoore/standard-tooling-docker/issues/51).
+3. Remove the `/opt/standard-tooling/.venv/` layout if still present
+   (it predates uv's system-wide install pattern).
+
+## First-time developer setup
+
+The canonical onboarding flow for a new developer on a new machine:
+
+```bash
+# 1. Install uv (if not already present)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. Install standard-tooling
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.2'
+
+# 3. Confirm (~/.local/bin is already on PATH via uv's installer)
+which st-docker-run
+st-docker-run --help
+
+# 4. For each repo cloned:
+cd ~/dev/github/<repo>
+git config core.hooksPath .githooks
+uv sync --group dev       # only for Python repos
+```
+
+No sibling checkout. No `.venv-host` bootstrap. No custom install
+path.
+
+## Tradeoffs captured
+
+### Rolling-tag pin vs. fixed-tag pin
+
+- **Rolling `v1.2`** (chosen, all three deployment targets): patches
+  flow forward on the next manual action (upgrade / re-lock /
+  rebuild). A broken patch affects every consumer on that minor —
+  but `standard-tooling`'s release gates and the deliberate
+  non-automatic propagation mean the blast radius is one action at
+  a time.
+- **Fixed `v1.2.2`**: never floats. Every patch requires explicit
+  action at every deployment target. Rejected for friction.
+
+### Major-version bumps
+
+The rolling tag is `v{major.minor}` (`v1.2`), not `v{major}` — there
+is no rolling `v1` or `v2` tag. When `standard-tooling` cuts `v2.0`,
+nothing at the three deployment targets moves automatically: the
+developer host's `uv tool install ...@v1.2` keeps resolving against
+`v1.2`; Python consumers' `pyproject.toml` pin keeps them on `v1.2`;
+the dev container image's Dockerfile pin keeps pre-baking `v1.2`.
+Crossing a major boundary is a deliberate, explicit edit at each
+target (bump `v1.2` → `v2.0` in the consumer's `pyproject.toml`,
+the image's Dockerfile, and the developer's `uv tool install`
+command). This is the point: major bumps are gated, not broadcast.
+
+### `uv tool install` vs `pip install`
+
+Covered in [Canonical install](#canonical-install-host).
+
+### Host install vs devcontainer-only
+
+A pure devcontainer model ("never install `standard-tooling` on the
+host") was considered and rejected:
+
+- `st-docker-run` is the host → container bridge. It has to exist
+  on the host to launch the container.
+- Git hooks fire on the host, not inside the container.
+- Interactive `st-commit` / `st-submit-pr` flows need host-side
+  `gh` authentication.
+
+The canonical `uv tool install` path satisfies this by keeping
+`standard-tooling` in its own isolated venv — the host still has
+Python, but no shared state between `standard-tooling` and any
+other Python project on the machine.
+
+### Uniform requirement for Python consumers
+
+Covered in [Why MUST, not SHOULD](#why-must-not-should). The
+consistency cost of optional adoption exceeds the per-repo cost of
+a two-line `pyproject.toml` addition and a lockfile bump.
+
+### Lockfile-bump overhead
+
+Every patch of `standard-tooling` requires Python consumers to run
+`uv lock --upgrade-package standard-tooling` and commit the
+lockfile to pick up the patch inside the container. This is the
+same concern pushback item #4 raised against the prior spec; it
+remains a real cost but is mitigated here because:
+
+- The rolling-minor pin means the re-lock is a no-arg command
+  (no `pyproject.toml` editing, no version picking).
+- The cost is per-repo-per-release, not per-repo-per-commit.
+- The payoff (deterministic `.venv/bin/` contents inside the
+  container, no silent drift against a stale image) is directly
+  load-bearing.
+- Automation (dependabot etc.) is the obvious follow-up if the
+  manual cadence becomes a friction point.
+
+### Image rebuild cadence
+
+The spec requires release-triggered image rebuilds, but there is
+always *some* window between `standard-tooling` tagging a release
+and the image being rebuilt and pushed. During that window,
+non-Python consumers pulling a fresh container get the
+previous-release image. Mitigations:
+
+- The window is minutes-to-hours for CI-driven rebuilds, not days.
+- Non-Python consumers are docs / plugin / Dockerfiles repos where
+  the consequence of running a one-release-behind validator is
+  usually trivial.
+- Python consumers (the majority of active code) are insulated from
+  this window entirely via the project `.venv` path.
+
+## Acceptance criteria
+
+- [ ] This spec lands; `paad:pushback` run and findings addressed.
+- [ ] `docs/specs/git-url-dev-dependency.md` deleted (the pushback
+      report preserves the rejection record).
+- [ ] `CLAUDE.md` and every file under `docs/` updated to match
+      this spec. Specifically: the Consumption Model and Host
+      bootstrap sections rewritten; all `scripts/lib/git-hooks`
+      references replaced with `.githooks` + the env-var-plus-
+      GIT_REFLOG_ACTION gate; all sibling-checkout
+      (`../standard-tooling/scripts/lib/git-hooks`,
+      `../standard-tooling/.venv-host/bin`) references removed;
+      the worktree-convention block's hook-enforcement mention
+      updated to the new gate. Greps to verify nothing remains:
+      `grep -r "scripts/lib/git-hooks\|\.venv-host/bin\|\.\./standard-tooling/" CLAUDE.md docs/`.
+      (Tracked in #288.)
+- [ ] Getting-started docs updated to the four-step flow in
+      [First-time developer setup](#first-time-developer-setup).
+      (Tracked in #288.)
+- [ ] Each Python consumer has `standard-tooling` declared as a
+      dev dep via `[tool.uv.sources]` on the rolling minor tag.
+      (Tracked in #288.)
+- [ ] Five pre-commit checks moved from `pre_commit_hook.py` into
+      `commit.py`; `st-commit` sets `ST_COMMIT_CONTEXT=1`;
+      `st-pre-commit-hook` entry point and its source file
+      deleted. (Code change in this repo, not #288.)
+- [ ] Each in-scope consumer has the `.githooks/pre-commit`
+      env-var gate checked in and `.venv-host` / sibling-checkout
+      references removed. (Tracked in #288.)
+- [ ] Plugin `validate-on-edit.sh` error message updated to point
+      at this spec. (Tracked in #288.)
+- [ ] `standard-tooling-docker` image build pins to the rolling
+      minor tag. (Tracked in
+      [standard-tooling-docker#51](https://github.com/wphillipmoore/standard-tooling-docker/issues/51).)
+- [ ] `standard-tooling-docker` rebuilds automatically on every
+      `standard-tooling` release. (Tracked in
+      [standard-tooling-docker#51](https://github.com/wphillipmoore/standard-tooling-docker/issues/51).)
+- [ ] `standards-compliance` (and any other `standard-actions`
+      composite that clones `standard-tooling` or puts
+      `scripts/bin/` on `PATH`) is updated to rely on the Python
+      `uv sync --group dev` path or the dev container image
+      pre-bake. (Tracked in a new `standard-actions` issue to be
+      filed under #288.)
+
+## References
+
+- Rolling-tag behavior:
+  [`standard-actions` `tag-and-release`](https://github.com/wphillipmoore/standard-actions/blob/main/actions/publish/tag-and-release/action.yml)
+- `pip install` from VCS:
+  <https://pip.pypa.io/en/stable/topics/vcs-support/>
+- `uv tool install`:
+  <https://docs.astral.sh/uv/guides/tools/#installing-tools>
+- uv sources (git URL + tag):
+  <https://docs.astral.sh/uv/concepts/projects/dependencies/#git>
+- Git `core.hooksPath`:
+  <https://git-scm.com/docs/githooks#_description>
+- Rejected predecessor:
+  [`docs/specs/git-url-dev-dependency.md`](git-url-dev-dependency.md)
+  and
+  [pushback report](../../paad/pushback-reviews/2026-04-24-git-url-dev-dependency-pushback.md)
+- Image-staleness context:
+  [standard-tooling-docker#51](https://github.com/wphillipmoore/standard-tooling-docker/issues/51)

--- a/paad/alignment-reviews/2026-04-25-host-level-tool-alignment.md
+++ b/paad/alignment-reviews/2026-04-25-host-level-tool-alignment.md
@@ -1,0 +1,146 @@
+# Alignment Review: host-level-tool
+
+**Date:** 2026-04-25
+**Commit at review time:** 1af4f36
+**Branch:** `feature/286-host-level-tool` (worktree:
+`.worktrees/issue-286-host-level-tool/`)
+
+## Documents Reviewed
+
+- **Intent:** `docs/specs/host-level-tool.md`
+- **Action:** `docs/plans/host-level-tool-plan.md`
+- **Design:** none
+
+## Source Control Conflicts
+
+**None — no conflicts with recent changes.** Repo state at 1af4f36
+matches all assumptions in both documents (rolling tag mechanics,
+image pre-bake script, current `commit.py` and `pre_commit_hook.py`
+contents, `scripts/bin/` removal, `validate-on-edit.sh` error text).
+
+## Issues Reviewed
+
+### [1] Plan references incorrect test file paths
+
+- **Category:** missing coverage (factual error)
+- **Severity:** Important
+- **Documents:** Plan Phase 1 Tasks 1.1 and 1.4
+- **Issue:** Plan referenced `tests/bin/test_commit.py` and
+  `tests/bin/test_pre_commit_hook.py`. Actual paths are
+  `tests/standard_tooling/test_commit.py` and
+  `tests/standard_tooling/test_pre_commit_hook.py`. The
+  `tests/bin/` directory does not exist in the repo.
+- **Resolution:** Both path references corrected in-place in the
+  plan.
+
+### [2] Phase 2 Task 2.1 has confused version-bump guidance
+
+- **Category:** ambiguity (in plan)
+- **Severity:** Minor
+- **Documents:** Plan Phase 2 Task 2.1
+- **Issue:** Original text described "bump from 1.3.0 to 1.3.0
+  (already there)" with a confusing fallback to a `1.2.3` patch
+  scenario. Also did not address the strict-semver question raised
+  by removing the `st-pre-commit-hook` entry point (technically a
+  breaking change worthy of `v2.0.0`).
+- **Resolution:** Option A — clean `v1.3.0` bump documented;
+  release notes call out the entry-point removal as a clean break;
+  the strict-semver-vs-fleet-of-one tradeoff is named explicitly.
+  Convoluted fallback text removed.
+
+### [3] Phase 7 doesn't explicitly call out the four-step getting-started flow
+
+- **Category:** missing coverage
+- **Severity:** Minor
+- **Documents:** Spec acceptance criterion ↔ Plan Phase 7
+- **Issue:** Spec acceptance criterion calls out "Getting-started
+  docs updated to the four-step flow in [First-time developer
+  setup]." Plan's Phase 7 is described as a generic grep-and-rewrite
+  sweep, which would catch removal of stale references but does not
+  ensure the new four-step narrative actually appears in the canonical
+  getting-started doc.
+- **Resolution:** Option A — added Task 7.5 "Rewrite the canonical
+  getting-started narrative" with a verification that a fresh reader
+  on a clean machine can follow the doc top-to-bottom and end with
+  working `st-docker-run --help`. Phase 7 exit criteria expanded
+  to require the new narrative.
+
+### [4] Phase 1 lacks dev-tree override verification
+
+- **Category:** missing coverage (verification gap)
+- **Severity:** Minor
+- **Documents:** Spec Principle 4 / Dev-tree override section ↔
+  Plan Phase 1
+- **Issue:** The `.venv-host` dev-tree override survived as a
+  spec requirement after pushback issue [1]. Plan's Phase 1 changes
+  code paths but never verifies the override workflow still works
+  after those changes — silent breakage risk.
+- **Resolution:** Option A — Task 1.6 ("Validate the full pipeline
+  locally") gained a sub-check that exercises
+  `UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev` and the
+  PATH-prepended override, with explicit verification that
+  `which st-docker-run` resolves to `.venv-host/bin/...`.
+
+### [5] Phase 6 verification doesn't match spec verification language
+
+- **Category:** missing coverage
+- **Severity:** Minor
+- **Documents:** Spec "Migration / Non-Python consumers" ↔ Plan
+  Phase 6 Tasks 6.1-6.4
+- **Issue:** Spec verification step requires confirming the image's
+  pre-baked `st-*` is what runs inside the container — the
+  operationally meaningful check that catches stale-image silent
+  failures (the `standard-tooling-docker#51` failure mode). Plan
+  Tasks 6.1-6.4 omitted this check, only verifying `core.hooksPath`
+  setup and plugin hook firing.
+- **Resolution:** Option A — Task 6.1 verification expanded with
+  an "Image pre-bake provenance check" subsection (`st-docker-run
+  -- which st-validate-local` + `pip show standard-tooling`).
+  Tasks 6.2-6.4 reference the same check by phrase ("Same as 6.1,
+  including the image-pre-bake provenance check").
+
+## Unresolved Issues
+
+None. All five issues addressed; document edits applied in-place
+to `docs/plans/host-level-tool-plan.md`.
+
+## TDD Rewrite
+
+After alignment was confirmed, Phase 1 Tasks 1.1, 1.2, and 1.3
+(the code-implementation tasks) were rewritten in red/green/refactor
+format per the alignment skill's TDD step. Other phases
+(infrastructure provisioning, docs sweep, migration, process) were
+not TDD-amenable and remain in original task format.
+
+The TDD rewrites pin behavior contracts that the spec emphasizes:
+
+- **Task 1.1 RED:** ten failing tests in
+  `tests/standard_tooling/test_commit.py` covering one rejection
+  - one happy path for each of the five branch/context checks.
+- **Task 1.2 RED:** failing test asserting
+  `os.environ["ST_COMMIT_CONTEXT"] == "1"` is captured at the
+  moment `git.run("commit", ...)` is invoked (the spec's required
+  unit test).
+- **Task 1.3 RED:** failing test invoking the gate via
+  `subprocess.run(["bash", ".githooks/pre-commit"], env=...)`,
+  exercising admit-by-env, admit-by-`GIT_REFLOG_ACTION`, and reject
+  branches.
+
+REFACTOR sections in each task name specific candidates for
+consolidation (constants extraction, helper functions) and also
+specific candidates for *not* refactoring (e.g., promoting
+`"ST_COMMIT_CONTEXT"` to a constant — premature given a single
+Python reference).
+
+## Alignment Summary
+
+- **Spec acceptance criteria:** 9 total, 9 addressed in the plan
+- **Spec migration steps (across 4 tracks):** ~16 total, all
+  addressed
+- **Spec six principles:** 6 total, 6 mapped to plan phases
+- **Plan tasks:** 30+ total, all trace to spec requirements;
+  none orphaned
+- **Plan tasks rewritten in TDD format:** 3 (Tasks 1.1, 1.2, 1.3)
+- **Status:** **Aligned.** Plan is ready for implementation pending
+  commit/PR/merge of the spec + plan + pushback report + alignment
+  report bundle.

--- a/paad/pushback-reviews/2026-04-24-host-level-tool-pushback.md
+++ b/paad/pushback-reviews/2026-04-24-host-level-tool-pushback.md
@@ -1,0 +1,201 @@
+# Pushback Review: host-level-tool
+
+**Date:** 2026-04-24
+**Spec:** `docs/specs/host-level-tool.md` (replacement for the rejected
+`docs/specs/git-url-dev-dependency.md`)
+**Commit at review time:** 1af4f36
+**Branch:** `feature/286-host-level-tool` (worktree:
+`.worktrees/issue-286-host-level-tool/`)
+**Related issue:** #286
+**Outcome:** **Spec accepted after nine resolutions applied in-place.**
+
+## TL;DR
+
+Nine issues surfaced across feasibility, contradictions, ambiguity,
+and omissions. All nine were resolved by direct edits to the spec.
+One was dismissed as not applicable (rollback plan — fleet-of-one
+fails forward). The remaining eight produced targeted rewrites,
+two of them material: the dev-tree override mechanism changed
+(`.venv-host` restored after the initial draft tried to retire it),
+and the canonical host install flipped from `pip install` to
+`uv tool install` (cross-platform compatibility, PEP 668 avoidance).
+
+The spec is ready for implementation.
+
+## Source Control Conflicts
+
+**None — no conflicts with recent changes.** The spec's concrete
+references all match current repo state as of commit 1af4f36:
+
+- Rolling minor tag `v1.2` exists on the remote (latest patch
+  `v1.2.2`); `v1.3` does not (pyproject reads `1.3.0` but no release
+  cut).
+- `standard-actions` `tag-and-release` force-updates the rolling
+  minor tag on every patch release.
+- Dev container images pre-bake via `git clone -b develop && uv pip
+  install --system` in
+  `standard-tooling-docker/docker/common/standard-tooling-uv.dockerfile`.
+- `src/standard_tooling/bin/pre_commit_hook.py` contains the five
+  branch/context checks the spec relocates.
+- `src/standard_tooling/bin/commit.py` does no validation today
+  (only message formatting).
+- `standard-tooling-plugin/hooks/scripts/validate-on-edit.sh`
+  error text still points at the sibling-checkout bootstrap guide.
+- `scripts/bin/` no longer exists (removed in commit 32654cb).
+
+## Issues Reviewed
+
+### [1] Dev-tree override conflicts with this repo's dual-venv pattern
+
+- **Category:** contradictions
+- **Severity:** serious
+- **Issue:** The draft's dev-tree override ran `uv sync --group dev`
+  against `.venv/` on the host. But this repo's CLAUDE.md and
+  bootstrap model define `.venv/` as the dev container's venv —
+  shebangs point at `/workspace/.venv/...` and don't resolve on the
+  host. Host-side `uv sync` would overwrite the container venv and
+  vice versa. The spec asserted `.venv-host` "was always a
+  workaround," but the shebang problem is structural.
+- **Resolution:** Option A — `.venv-host` restored specifically and
+  only as the dev-tree-override venv for this repo (and any sibling
+  checkout testing unreleased `standard-tooling`). The spec now
+  includes a "Why `.venv-host`, not `.venv`" subsection explaining
+  the shebang reasoning. Migration text adjusted so only
+  `standard-tooling` itself retains `.venv-host`; consumers remove
+  it.
+
+### [2] `pip install` into base Python env may require sudo / --user on Linux
+
+- **Category:** feasibility
+- **Severity:** moderate
+- **Issue:** The draft's canonical install was `pip install` into
+  the base Python env. Works on macOS Framework Python (user-owned),
+  but on Linux with system Python it needs `sudo`, `--user`, or
+  `--break-system-packages` (PEP 668). Also fails the "same env that
+  hosts uv" framing when `uv` is installed via the standalone
+  installer (no Python env to install into).
+- **Resolution:** Option A — canonical install flipped to
+  `uv tool install`. `pip install` demoted to "documented
+  alternative." Comparison table rewritten to show platform
+  behavior, including PEP 668. The primary-developer machine's
+  existing `pip`-based install remains valid and does not need
+  migration.
+
+### [3] `git commit --amend` / `rebase` blocked by the env-var gate
+
+- **Category:** feasibility
+- **Severity:** moderate
+- **Issue:** The draft's five-line gate rejected any `git commit`
+  without `ST_COMMIT_CONTEXT=1`. But several legitimate workflows
+  (`--amend`, `rebase -i` with reword/edit/squash, `cherry-pick`,
+  `revert`, merge-conflict resolution) invoke `git commit` without
+  going through `st-commit`. The original `pre_commit_hook.py`
+  didn't have this problem because it checked branch state, not
+  invocation source.
+- **Resolution:** Option A — gate expanded to admit
+  `GIT_REFLOG_ACTION` values (`amend`, `cherry-pick`, `revert`,
+  `rebase*`, `merge*`) set by git itself during these derived-commit
+  workflows. The gate grew from five lines to ten. Raw
+  `git commit -m "..."` (which runs with `GIT_REFLOG_ACTION=commit`)
+  remains blocked.
+
+### [4] CI install path for non-Python consumers unspecified
+
+- **Category:** omissions
+- **Severity:** moderate
+- **Issue:** The draft covered three deployment targets (host,
+  Python project `.venv`, dev container image) but didn't address
+  CI runners in consumer repos. The `standards-compliance`
+  composite action in `standard-actions` currently clones
+  `standard-tooling` and adds `scripts/bin/` to PATH — but
+  `scripts/bin/` no longer exists.
+- **Resolution:** CI collapses into the two existing targets
+  (Python: `uv sync --group dev`; non-Python: dev container image
+  pre-bake). No new install mechanism needed. The spec now requires
+  `standards-compliance` (and any other `standard-actions`
+  composite bootstrapping `standard-tooling` onto runners) to stop
+  cloning the repo and instead rely on one of the two existing
+  paths. Added a "CI install path" section and a new acceptance
+  criterion.
+
+### [5] `standard-tooling` listed as Python consumer that MUST declare itself
+
+- **Category:** ambiguity
+- **Severity:** minor
+- **Issue:** The scope section listed `standard-tooling` itself
+  under "Python consumers (MUST declare dev dep)" — a circular
+  reference; the repo can't declare itself as a git-URL dev dep.
+  It's self-hosted via `uv sync --group dev` (editable install of
+  the repo itself into `.venv/` inside the container).
+- **Resolution:** Option A — `standard-tooling` pulled out of the
+  "Python consumers" list and given a distinct paragraph explaining
+  the self-hosted case and why no declaration is needed.
+
+### [6] Rollback plan not documented
+
+- **Category:** omissions
+- **Severity:** minor
+- **Issue:** The draft specified coordinated changes across three
+  repos (`standard-tooling`, `standard-tooling-docker`,
+  `standard-actions`) plus a consumer sweep. No documented plan
+  for "we merged this and something breaks, now what?"
+- **Resolution:** **Dismissed.** Fleet-of-one; the producer and
+  consumer are the same person. Standard practice is fail-forward.
+  The individual-developer-impact scale makes big-bang migration
+  acceptable, and a formal rollback plan would be overhead for a
+  single-contributor project.
+
+### [7] CLAUDE.md stale hook references
+
+- **Category:** omissions
+- **Severity:** minor
+- **Issue:** The draft's acceptance criterion for CLAUDE.md updates
+  named only "Consumption Model and Host bootstrap sections," but
+  the file has hook references scattered in other sections
+  (worktree convention block, Git Hooks subsection). Parallel stale
+  references exist in `docs/git-hooks-and-validation.md`,
+  `docs/site/docs/guides/git-workflow.md`, and
+  `docs/site/docs/guides/consuming-repo-setup.md`.
+- **Resolution:** Option A — acceptance criterion broadened to
+  cover all stale `scripts/lib/git-hooks`, `.venv-host` (as a
+  consumer install mechanism), and sibling-checkout references
+  across CLAUDE.md and all of `docs/`. Verification grep embedded
+  in the AC itself.
+
+### [8] "Minimal" runtime deps description is inaccurate
+
+- **Category:** ambiguity
+- **Severity:** minor (wording)
+- **Issue:** An earlier draft said `standard-tooling`'s runtime deps
+  are "minimal"; actually `pyproject.toml` reads `dependencies = []`
+  (zero deps — stdlib only).
+- **Resolution:** Resolved incidentally during issue [2] — the
+  `pip install` vs `uv tool install` comparison was rewritten to
+  remove the "minimal deps" phrasing entirely.
+
+### [9] Major-version bump behavior not explicit
+
+- **Category:** ambiguity
+- **Severity:** minor
+- **Issue:** The spec extensively discussed the rolling **minor**
+  tag `v1.2` but didn't address behavior at a **major** bump
+  (`v1.x` → `v2.0`). The rolling tag is `v{major.minor}`, not
+  `v{major}`, so major bumps are opt-in at every deployment target
+  — correct behavior but undocumented.
+- **Resolution:** Option A — added a "Major-version bumps"
+  subsection under Tradeoffs explaining the intended behavior: no
+  automatic propagation across major boundaries; explicit edits at
+  each target to move.
+
+## Unresolved Issues
+
+None. All nine were addressed.
+
+## Summary
+
+- **Issues found:** 9
+- **Issues resolved:** 8 (1 additionally dismissed as not applicable)
+- **Unresolved:** 0
+- **Spec status:** **Ready for implementation.** The spec can now be
+  committed and #286 closed once the code work in the migration
+  section lands.


### PR DESCRIPTION
# Pull Request

## Summary

- Replace rejected git-URL dev-dep direction with host-level-tool spec; add plan + pushback + alignment artifacts

## Issue Linkage

- Closes #286

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Spec, implementation plan, pushback report, and alignment report for #286. Supersedes the rejected docs/specs/git-url-dev-dependency.md (PR #285, rejection #287). Closes the spec-work scope of #286; implementation phases tracked under #288 and standard-tooling-docker#51, plus a new standard-actions issue to be filed during Phase 4. No code changes.