### PR TITLE
fix(git): set ST_COMMIT_CONTEXT=1 in git.run for commit calls (#295)

### DIFF
--- a/src/standard_tooling/bin/commit.py
+++ b/src/standard_tooling/bin/commit.py
@@ -11,7 +11,6 @@ admits the resulting commit.
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import sys
 import tempfile
@@ -42,13 +41,6 @@ _ISSUE_REQUIRED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _ISSUE_FORMAT_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9.-]*$")
 _WORKTREE_SCOPED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _WORKTREES_DIRNAME = ".worktrees"
-
-# Env-var contract with `.githooks/pre-commit`. The gate admits any
-# `git commit` that runs with this variable set to "1"; st-commit sets
-# it just before invoking git commit. See docs/specs/host-level-tool.md
-# "Git hooks" section.
-_GATE_ENV_VAR = "ST_COMMIT_CONTEXT"
-_GATE_ENABLED_VALUE = "1"
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -194,9 +186,10 @@ def main(argv: list[str] | None = None) -> int:
         tmp_path = f.name
 
     try:
-        # Set the env-var gate signal so `.githooks/pre-commit` admits the
-        # resulting `git commit`. See docs/specs/host-level-tool.md.
-        os.environ[_GATE_ENV_VAR] = _GATE_ENABLED_VALUE
+        # `git.run` sets ST_COMMIT_CONTEXT=1 in the subprocess env when
+        # the first arg is "commit", so the `.githooks/pre-commit` gate
+        # admits the resulting commit. See lib/git.py and
+        # docs/specs/host-level-tool.md "Git hooks".
         git.run("commit", "--file", tmp_path)
     finally:
         Path(tmp_path).unlink(missing_ok=True)

--- a/src/standard_tooling/lib/git.py
+++ b/src/standard_tooling/lib/git.py
@@ -2,13 +2,31 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
+# Env-var contract with `.githooks/pre-commit`. Any internal caller
+# that runs `git commit` via this helper is by definition an
+# st-* tool invocation — admit it via the gate. See
+# docs/specs/host-level-tool.md "Git hooks".
+_GATE_ENV_VAR = "ST_COMMIT_CONTEXT"
+_GATE_ENABLED_VALUE = "1"
+
 
 def run(*args: str) -> None:
-    """Run a git command and raise on failure."""
-    subprocess.run(("git", *args), check=True)  # noqa: S603, S607
+    """Run a git command and raise on failure.
+
+    When the first positional arg is ``"commit"``, automatically sets
+    ``ST_COMMIT_CONTEXT=1`` in the subprocess environment so the
+    repository's pre-commit gate admits the commit. This makes the
+    env-var contract a property of the helper rather than something
+    every internal caller has to remember (issue #295).
+    """
+    env = None
+    if args and args[0] == "commit":
+        env = {**os.environ, _GATE_ENV_VAR: _GATE_ENABLED_VALUE}
+    subprocess.run(("git", *args), check=True, env=env)  # noqa: S603, S607
 
 
 def read_output(*args: str) -> str:

--- a/tests/standard_tooling/test_commit.py
+++ b/tests/standard_tooling/test_commit.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -24,7 +23,6 @@ def _commit_environment(
     is_main_worktree: bool = False,
     branching_model: str | None = None,
     has_staged: bool = True,
-    captured_env: dict[str, str | None] | None = None,
 ) -> Iterator[None]:
     """Set up mocks for `commit.main()`.
 
@@ -32,14 +30,9 @@ def _commit_environment(
     profile (branching_model resolves from disk if profile is written),
     valid `feature/42-test` branch, staged changes present.
 
-    `captured_env` (if provided) is updated with the value of
-    `os.environ.get("ST_COMMIT_CONTEXT")` at the moment `git.run` is
-    invoked, so tests can pin Task 1.2's contract.
+    The ST_COMMIT_CONTEXT=1 contract is pinned in test_git.py — it's
+    `git.run`'s responsibility under issue #295.
     """
-
-    def _capture_run(*args: str) -> None:
-        if captured_env is not None and args[:2] == ("commit", "--file"):
-            captured_env["ST_COMMIT_CONTEXT"] = os.environ.get("ST_COMMIT_CONTEXT")
 
     if branching_model is not None:
         docs = tmp_path / "docs"
@@ -60,7 +53,7 @@ def _commit_environment(
             "standard_tooling.bin.commit.git.has_staged_changes",
             return_value=has_staged,
         ),
-        patch("standard_tooling.bin.commit.git.run", side_effect=_capture_run),
+        patch("standard_tooling.bin.commit.git.run"),
         patch(
             "standard_tooling.bin.commit.repo_profile.resolve_co_author",
             return_value=co_author,
@@ -367,20 +360,7 @@ def test_validate_admits_main_worktree_feature_commit_without_worktrees_dir(
 
 
 # --------------------------------------------------------------------------
-# Task 1.2 — st-commit sets ST_COMMIT_CONTEXT=1 before invoking git commit
-# --------------------------------------------------------------------------
-
-
-def test_st_commit_sets_st_commit_context_env_var(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The env-var gate (`.githooks/pre-commit`) reads ST_COMMIT_CONTEXT.
-    `st-commit` must set it to "1" before invoking `git commit`, otherwise
-    the gate rejects the commit. Contract is documented in
-    docs/specs/host-level-tool.md and is load-bearing for the fleet.
-    """
-    monkeypatch.delenv("ST_COMMIT_CONTEXT", raising=False)
-    captured: dict[str, str | None] = {}
-    with _commit_environment(tmp_path, branch="feature/42-test", captured_env=captured):
-        assert main(_DEFAULT_ARGS) == 0
-    assert captured.get("ST_COMMIT_CONTEXT") == "1"
+# Task 1.2 — `git.run` is responsible for setting ST_COMMIT_CONTEXT=1
+# (issue #295 moved the contract from commit.py to lib/git.py). The
+# pinning test for that contract lives in tests/standard_tooling/test_git.py;
+# commit.py just calls `git.run("commit", ...)` and trusts the helper.

--- a/tests/standard_tooling/test_git.py
+++ b/tests/standard_tooling/test_git.py
@@ -14,10 +14,57 @@ def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedPro
 
 
 def test_run_delegates_to_subprocess() -> None:
+    """Non-commit commands run with env=None (inherit parent env)."""
     with patch("standard_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed()
         git.run("status")
-    mock_run.assert_called_once_with(("git", "status"), check=True)
+    mock_run.assert_called_once_with(("git", "status"), check=True, env=None)
+
+
+def test_run_sets_st_commit_context_for_commit() -> None:
+    """`git commit` calls must set ST_COMMIT_CONTEXT=1 in the subprocess
+    env so the repo's pre-commit gate (.githooks/pre-commit) admits the
+    commit. This is the contract that lets every internal `st-*` tool
+    pass through the gate without touching its own commit-time
+    plumbing. Issue #295.
+    """
+    with patch("standard_tooling.lib.git.subprocess.run") as mock_run:
+        mock_run.return_value = _completed()
+        git.run("commit", "-m", "msg")
+    args, kwargs = mock_run.call_args
+    assert args == (("git", "commit", "-m", "msg"),)
+    assert kwargs["check"] is True
+    assert kwargs["env"] is not None
+    assert kwargs["env"]["ST_COMMIT_CONTEXT"] == "1"
+
+
+def test_run_does_not_mutate_parent_env_for_commit() -> None:
+    """The env-var contract is propagated via subprocess env, not by
+    mutating `os.environ`. Verify the parent process is unaffected.
+    """
+    import os as _os
+
+    parent_value = _os.environ.get("ST_COMMIT_CONTEXT")
+    try:
+        _os.environ.pop("ST_COMMIT_CONTEXT", None)
+        with patch("standard_tooling.lib.git.subprocess.run") as mock_run:
+            mock_run.return_value = _completed()
+            git.run("commit", "-m", "msg")
+        assert "ST_COMMIT_CONTEXT" not in _os.environ
+    finally:
+        if parent_value is not None:
+            _os.environ["ST_COMMIT_CONTEXT"] = parent_value
+
+
+def test_run_does_not_set_st_commit_context_for_non_commit() -> None:
+    """`git status`, `git push`, etc. should not get ST_COMMIT_CONTEXT
+    set — only `git commit` triggers the gate-admit path.
+    """
+    with patch("standard_tooling.lib.git.subprocess.run") as mock_run:
+        mock_run.return_value = _completed()
+        git.run("push", "origin", "main")
+    _args, kwargs = mock_run.call_args
+    assert kwargs["env"] is None
 
 
 def test_read_output_returns_stripped_stdout() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Centralize ST_COMMIT_CONTEXT=1 in git.run; fix internal commit callers

## Issue Linkage

- Closes #295

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Phase 1 (#292) introduced the gate but only patched st-commit. st-prepare-release and any other internal git.run('commit', ...) caller hit the gate and fail. This change makes git.run set ST_COMMIT_CONTEXT=1 in the subprocess env when args[0] == 'commit', so all internal callers are admitted automatically. Required for Phase 2 (v1.3.0 release prep) to succeed.