### PR TITLE
fix(prepare-release): use --unreleased instead of --latest for release notes (#298)

### DIFF
--- a/docs/specs/host-level-tool.md
+++ b/docs/specs/host-level-tool.md
@@ -127,6 +127,20 @@ so a git-URL install against `v1.2` always resolves to the latest
 patch on the current minor. Bump to `v1.3` etc. when the publisher
 cuts a new minor and decides consumers should opt in.
 
+> **Note on tag schemes.** The repository carries two parallel tag
+> families. Consumers only see and use the first; the second is
+> internal scaffolding for the changelog flow.
+>
+> | Tag pattern | Where | Purpose | User-facing? |
+> |---|---|---|---|
+> | `v1.3.0`, `v1.3` | `main` | Release tag + rolling minor tag (the install pins target these) | Yes |
+> | `develop-v1.3.0` | `develop` | Boundary marker for `git-cliff`'s changelog scoping during the next release | No |
+>
+> The `develop-` prefix is invisible to install / consumption; it
+> only exists so `st-prepare-release` can scope the next changelog
+> diff to the right starting point. Treat any `develop-v*` tag as
+> internal — never pin to one.
+
 ### `uv tool install` vs `pip install`
 
 `uv tool install` is canonical. `pip install` is a documented

--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -222,8 +222,14 @@ def _generate_release_notes(version: str, tag: str) -> None:
     releases_dir.mkdir(exist_ok=True)
     output_file = releases_dir / f"v{version}.md"
     print(f"Generating release notes: {output_file}")
+    # `--unreleased` (not `--latest`) — at release-prep time the target
+    # boundary tag (`develop-v{version}`) does not yet exist in git, so
+    # `--latest` falls back to the previous existing tag and renders
+    # the wrong section into the file. `--unreleased` correctly scopes
+    # to commits that are not yet under any tag, which under
+    # `--tag <name>` get grouped under that label. Issue #298.
     subprocess.run(  # noqa: S603, S607
-        ("git-cliff", "--config", str(config), "--tag", tag, "--latest", "-o", str(output_file)),
+        ("git-cliff", "--config", str(config), "--tag", tag, "--unreleased", "-o", str(output_file)),
         check=True,
     )
     _normalize_trailing_newline(output_file)

--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -229,7 +229,16 @@ def _generate_release_notes(version: str, tag: str) -> None:
     # to commits that are not yet under any tag, which under
     # `--tag <name>` get grouped under that label. Issue #298.
     subprocess.run(  # noqa: S603, S607
-        ("git-cliff", "--config", str(config), "--tag", tag, "--unreleased", "-o", str(output_file)),
+        (
+            "git-cliff",
+            "--config",
+            str(config),
+            "--tag",
+            tag,
+            "--unreleased",
+            "-o",
+            str(output_file),
+        ),
         check=True,
     )
     _normalize_trailing_newline(output_file)

--- a/tests/standard_tooling/test_prepare_release.py
+++ b/tests/standard_tooling/test_prepare_release.py
@@ -489,9 +489,12 @@ def test_generate_release_notes_creates_file(
     monkeypatch.chdir(tmp_path)
     (tmp_path / RELEASE_NOTES_CONFIG).write_text("[changelog]\nbody = ''\n")
 
+    captured_cmds: list[tuple[str, ...]] = []
+
     def mock_subprocess_run(
         cmd: tuple[str, ...], **kwargs: object
     ) -> subprocess.CompletedProcess[str]:
+        captured_cmds.append(tuple(cmd))
         if "git-cliff" in cmd:
             output_idx = list(cmd).index("-o") + 1
             Path(cmd[output_idx]).write_text("# Release 1.0.0\n")
@@ -508,6 +511,13 @@ def test_generate_release_notes_creates_file(
 
     assert (tmp_path / RELEASE_NOTES_DIR / "v1.0.0.md").is_file()
     assert (tmp_path / RELEASE_NOTES_DIR / "v1.0.0.md").read_text() == "# Release 1.0.0\n"
+
+    # Pin the --unreleased flag (issue #298). At release-prep time the
+    # target boundary tag does not yet exist in git, so `--latest`
+    # would render the previous tag's section instead of the new one.
+    cliff_cmd = next(c for c in captured_cmds if "git-cliff" in c)
+    assert "--unreleased" in cliff_cmd
+    assert "--latest" not in cliff_cmd
 
 
 def test_main_full_flow_with_release_notes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Use --unreleased not --latest for release notes; spec note on dual tag scheme

## Issue Linkage

- Closes #298

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Closes #298. v1.3.0 release prep surfaced this — releases/v1.3.0.md initially rendered v1.2.2 content because --latest fell back to the most recent existing tag. Spec also clarifies the dual tag scheme (vN.M.P / vN.M consumer-facing vs develop-vN.M.P internal cliff boundary markers).