### PR TITLE
feat(validate-local): add yamllint to canonical validation; pin rules in .yamllint (#302)

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,50 @@
+# Canonical yamllint config for this repo.
+#
+# Read by both `st-validate-local` (via the new yamllint check in
+# `validate_local_common_container.py`) and the plugin's
+# `validate-on-edit` hook (yamllint auto-discovers `.yamllint` in the
+# project root). Keeps both layers aligned. Issue #302.
+#
+# Tuned for GitHub Actions workflow files and project YAML (mkdocs,
+# markdownlint, issue templates). Stricter rules would flag
+# pre-existing-and-fine content (e.g., GHA `on:` keys, long lines
+# carrying URLs or python-c expressions in workflow `run:` blocks),
+# turning every edit into a yak-shave. Where rules are relaxed below,
+# rationale is in-line.
+
+extends: default
+
+rules:
+  # GHA workflow files don't lead with `---`. Disabling rather than
+  # fighting the convention.
+  document-start: disable
+
+  # GHA's `on:` key is YAML's truthy-value (it parses as `True`). The
+  # default rule flags it; we exclude it. Other unintentional truthy
+  # values (yes/no/on/off) still flagged.
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+    check-keys: false
+
+  # 80 chars is too tight for workflow `run:` blocks that carry shell
+  # commands and URLs. 120 is generous enough for the legitimate cases
+  # we have on develop today, except for `.github/workflows/`, which
+  # carries inline `python3 -c "..."` expressions as composite-action
+  # inputs (an unavoidable GHA pattern — input values must be single
+  # strings, can't be split across lines). For workflow files,
+  # disabling line-length entirely.
+  # Per-rule ignore for `.github/workflows/`: workflows carry inline
+  # `python3 -c "..."` expressions as composite-action inputs (an
+  # unavoidable GHA pattern — input values must be single strings,
+  # can't be split across lines). The glob form matches both absolute
+  # and relative path invocations.
+  line-length:
+    max: 120
+    level: error
+    ignore: |
+      **/.github/workflows/**
+      .github/workflows/**
+
+  # Default trailing-spaces / empty-lines / etc. settings are fine.

--- a/src/standard_tooling/bin/validate_local_common_container.py
+++ b/src/standard_tooling/bin/validate_local_common_container.py
@@ -4,18 +4,16 @@ Called by ``validate-local-common`` via ``docker-test``.  Runs:
   1. Repository profile validation
   2. Markdown standards validation
   3. shellcheck on all shell scripts under ``scripts/``
+  4. yamllint on YAML files under ``.github/`` and ``docs/`` (issue #302)
 """
 
 from __future__ import annotations
 
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from standard_tooling.bin import markdown_standards, repo_profile_cli
-
-if TYPE_CHECKING:
-    from pathlib import Path
 from standard_tooling.lib import git
 
 
@@ -32,6 +30,45 @@ def _find_shell_files(repo_root: Path) -> list[str]:
         if path.suffix == ".sh" or "git-hooks" in path.parts or "bin" in path.parts:
             files.append(str(path))
     return sorted(files)
+
+
+_YAML_EXTS = frozenset({".yml", ".yaml"})
+_YAML_SKIP_DIRS = frozenset({".worktrees", ".venv", ".venv-host", "node_modules"})
+
+
+def _find_yaml_files(repo_root: Path) -> list[str]:
+    """Discover YAML files we care about: workflows, issue templates,
+    repo-root config files (.markdownlint.yaml etc.), and
+    docs/site/mkdocs.yml. Skips vendored / venv / worktree paths.
+    The yamllint config lives at the repo root (`.yamllint`).
+    """
+    files: list[str] = []
+
+    # Repo-root level YAML config files (e.g., .markdownlint.yaml).
+    for path in repo_root.iterdir():
+        if path.is_file() and path.suffix in _YAML_EXTS:
+            files.append(str(path))
+
+    # .github/ tree (workflows, issue templates, etc.).
+    github_dir = repo_root / ".github"
+    if github_dir.is_dir():
+        for path in github_dir.rglob("*"):
+            if path.is_file() and path.suffix in _YAML_EXTS:
+                files.append(str(path))
+
+    # docs/site/mkdocs.yml.
+    mkdocs = repo_root / "docs" / "site" / "mkdocs.yml"
+    if mkdocs.is_file():
+        files.append(str(mkdocs))
+
+    # Filter out anything that wandered into a skipped subtree.
+    filtered: list[str] = []
+    for f in files:
+        rel_parts = set(Path(f).relative_to(repo_root).parts)
+        if rel_parts & _YAML_SKIP_DIRS:
+            continue
+        filtered.append(f)
+    return sorted(set(filtered))
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
@@ -52,6 +89,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         print(f"Running: shellcheck ({len(shell_files)} files)")
         result = subprocess.run(  # noqa: S603
             ["shellcheck", *shell_files],  # noqa: S607
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    yaml_files = _find_yaml_files(repo_root)
+    if yaml_files:
+        print(f"Running: yamllint ({len(yaml_files)} files)")
+        result = subprocess.run(  # noqa: S603
+            ["yamllint", *yaml_files],  # noqa: S607
             check=False,
         )
         if result.returncode != 0:

--- a/src/standard_tooling/bin/validate_local_common_container.py
+++ b/src/standard_tooling/bin/validate_local_common_container.py
@@ -33,14 +33,17 @@ def _find_shell_files(repo_root: Path) -> list[str]:
 
 
 _YAML_EXTS = frozenset({".yml", ".yaml"})
-_YAML_SKIP_DIRS = frozenset({".worktrees", ".venv", ".venv-host", "node_modules"})
 
 
 def _find_yaml_files(repo_root: Path) -> list[str]:
-    """Discover YAML files we care about: workflows, issue templates,
-    repo-root config files (.markdownlint.yaml etc.), and
-    docs/site/mkdocs.yml. Skips vendored / venv / worktree paths.
-    The yamllint config lives at the repo root (`.yamllint`).
+    """Discover YAML files we care about: repo-root config
+    (.markdownlint.yaml etc.), `.github/` tree (workflows, issue
+    templates), and `docs/site/mkdocs.yml`. The yamllint config lives
+    at the repo root (`.yamllint`).
+
+    Vendored paths (`.worktrees`, `.venv`, `.venv-host`,
+    `node_modules`) are excluded by construction — discovery only
+    walks the listed locations, never venv/worktree subtrees.
     """
     files: list[str] = []
 
@@ -61,14 +64,7 @@ def _find_yaml_files(repo_root: Path) -> list[str]:
     if mkdocs.is_file():
         files.append(str(mkdocs))
 
-    # Filter out anything that wandered into a skipped subtree.
-    filtered: list[str] = []
-    for f in files:
-        rel_parts = set(Path(f).relative_to(repo_root).parts)
-        if rel_parts & _YAML_SKIP_DIRS:
-            continue
-        filtered.append(f)
-    return sorted(set(filtered))
+    return sorted(set(files))
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001

--- a/src/standard_tooling/bin/validate_local_common_container.py
+++ b/src/standard_tooling/bin/validate_local_common_container.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from standard_tooling.bin import markdown_standards, repo_profile_cli
 from standard_tooling.lib import git
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _find_shell_files(repo_root: Path) -> list[str]:

--- a/tests/standard_tooling/test_validate_local_common_container.py
+++ b/tests/standard_tooling/test_validate_local_common_container.py
@@ -217,8 +217,12 @@ def test_find_yaml_files_mkdocs(tmp_path: Path) -> None:
 
 
 def test_find_yaml_files_skips_worktrees_and_venv(tmp_path: Path) -> None:
-    # Files in skipped subtrees must not appear, even though they have a
-    # YAML extension.
+    # Files inside vendored / worktree subtrees must not appear in the
+    # result. By design this is excluded structurally — discovery walks
+    # only `repo_root/.github`, `repo_root/docs/site/mkdocs.yml`, and
+    # `repo_root` itself; it never recurses into `.venv`, `.worktrees`,
+    # `.venv-host`, or `node_modules`. This test pins that behavior so a
+    # future "expand discovery" change can't regress it silently.
     for skip in (".worktrees", ".venv", ".venv-host", "node_modules"):
         nested = tmp_path / skip / ".github" / "workflows"
         nested.mkdir(parents=True)

--- a/tests/standard_tooling/test_validate_local_common_container.py
+++ b/tests/standard_tooling/test_validate_local_common_container.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from standard_tooling.bin.validate_local_common_container import (
     _find_shell_files,
+    _find_yaml_files,
     main,
 )
 
@@ -152,6 +153,133 @@ def test_main_shellcheck_fails(tmp_path: Path) -> None:
     scripts = tmp_path / "scripts" / "dev"
     scripts.mkdir(parents=True)
     (scripts / "lint.sh").write_text("#!/bin/bash\n")
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.markdown_standards.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        ),
+    ):
+        assert main() == 1
+
+
+# -- _find_yaml_files --------------------------------------------------------
+
+
+def test_find_yaml_files_none(tmp_path: Path) -> None:
+    assert _find_yaml_files(tmp_path) == []
+
+
+def test_find_yaml_files_repo_root(tmp_path: Path) -> None:
+    (tmp_path / ".markdownlint.yaml").write_text("default: true\n")
+    (tmp_path / ".yamllint").write_text("extends: default\n")  # no .yml/.yaml suffix
+    result = _find_yaml_files(tmp_path)
+    assert len(result) == 1
+    assert result[0].endswith(".markdownlint.yaml")
+
+
+def test_find_yaml_files_github_workflows(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: CI\n")
+    (workflows / "release.yaml").write_text("name: Release\n")
+    result = _find_yaml_files(tmp_path)
+    assert len(result) == 2
+
+
+def test_find_yaml_files_github_issue_templates(tmp_path: Path) -> None:
+    templates = tmp_path / ".github" / "ISSUE_TEMPLATE"
+    templates.mkdir(parents=True)
+    (templates / "issue.yml").write_text("name: Issue\n")
+    result = _find_yaml_files(tmp_path)
+    assert any(p.endswith("issue.yml") for p in result)
+
+
+def test_find_yaml_files_mkdocs(tmp_path: Path) -> None:
+    docs_site = tmp_path / "docs" / "site"
+    docs_site.mkdir(parents=True)
+    (docs_site / "mkdocs.yml").write_text("site_name: docs\n")
+    result = _find_yaml_files(tmp_path)
+    assert len(result) == 1
+    assert result[0].endswith("mkdocs.yml")
+
+
+def test_find_yaml_files_skips_worktrees_and_venv(tmp_path: Path) -> None:
+    # Files in skipped subtrees must not appear, even though they have a
+    # YAML extension.
+    for skip in (".worktrees", ".venv", ".venv-host", "node_modules"):
+        nested = tmp_path / skip / ".github" / "workflows"
+        nested.mkdir(parents=True)
+        (nested / "ci.yml").write_text("name: CI\n")
+    # And a real workflow at the proper path:
+    real = tmp_path / ".github" / "workflows"
+    real.mkdir(parents=True)
+    (real / "ci.yml").write_text("name: CI\n")
+    result = _find_yaml_files(tmp_path)
+    assert len(result) == 1
+    assert ".worktrees" not in result[0]
+    assert ".venv" not in result[0]
+
+
+def test_find_yaml_files_sorted_and_deduped(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "b.yml").write_text("name: b\n")
+    (workflows / "a.yml").write_text("name: a\n")
+    result = _find_yaml_files(tmp_path)
+    assert result == sorted(result)
+    assert len(result) == len(set(result))
+
+
+# -- main: yamllint path -----------------------------------------------------
+
+
+def test_main_yamllint_runs(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: CI\n")
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.markdown_standards.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    # Only yamllint runs (no shell files in this fixture).
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == "yamllint"
+
+
+def test_main_yamllint_fails(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: CI\n")
 
     with (
         patch(


### PR DESCRIPTION
# Pull Request

## Summary

- Add yamllint to canonical validation; pin rules in .yamllint

## Issue Linkage

- Closes #302

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Closes #302. Adds .yamllint config (auto-discovered by yamllint, so plugin hook + canonical validation use the same ruleset) and integrates yamllint into st-validate-local-common alongside the existing checks. Net effect: develop can no longer acquire yamllint violations silently.