### PR TITLE
docs(releasing): document patch/minor/major release workflow; add docs-publish sanity check (#303)

### DIFF
--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -132,7 +132,7 @@ echo '.worktrees/' >> .gitignore
 Add a "Parallel AI agent development" section to your `CLAUDE.md`
 describing the convention. Every managed repo already has one you
 can copy from; the canonical source is
-[the worktree convention spec](../specs/worktree-convention.md).
+[the worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md).
 
 ## 8. Verify
 
@@ -159,6 +159,6 @@ If all three steps behave as expected, you're wired up correctly.
   plugin nuances, and troubleshooting.
 - **[Git Workflow](guides/git-workflow.md)** — branching, commit /
   PR / finalize cycle, two-layer enforcement, worktrees in practice.
-- **[Worktree convention spec](../specs/worktree-convention.md)**
+- **[Worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)**
   — full rationale for the parallel-agent convention, failure
   modes, memory-path implications.

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -132,7 +132,7 @@ echo '.worktrees/' >> .gitignore
 Add a "Parallel AI agent development" section to your `CLAUDE.md`
 describing the convention. Every managed repo already has one you
 can copy from; the canonical source is
-[the worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md).
+[the worktree convention spec][worktree-spec].
 
 ## 8. Verify
 
@@ -159,6 +159,8 @@ If all three steps behave as expected, you're wired up correctly.
   plugin nuances, and troubleshooting.
 - **[Git Workflow](guides/git-workflow.md)** — branching, commit /
   PR / finalize cycle, two-layer enforcement, worktrees in practice.
-- **[Worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)**
+- **[Worktree convention spec][worktree-spec]**
   — full rationale for the parallel-agent convention, failure
   modes, memory-path implications.
+
+[worktree-spec]: https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -130,7 +130,7 @@ The pre-commit hook enforces:
 - Work branches (`feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`)
   must include a repository issue number
 
-Full reference: [Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md).
+Full reference: [Git Hooks and Validation][hooks-doc].
 
 ## Step 5: Repository profile
 
@@ -421,10 +421,13 @@ For a broader troubleshooting index see
 
 - [Git Workflow](git-workflow.md) — how the per-change cycle
   actually unfolds once setup is done
-- [Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md) —
+- [Git Hooks and Validation][hooks-doc] —
   pre-commit hook + validator reference
 - [Three-Tier CI](three-tier-ci.md) — per-language test/lint/audit
   tier wiring
 - [Releasing](releasing.md) — release workflow
-- [Worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+- [Worktree convention spec][worktree-spec]
   — canonical reference for the parallel-agent convention
+
+[hooks-doc]: https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md
+[worktree-spec]: https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -130,7 +130,7 @@ The pre-commit hook enforces:
 - Work branches (`feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`)
   must include a repository issue number
 
-Full reference: [Git Hooks and Validation](../../git-hooks-and-validation.md).
+Full reference: [Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md).
 
 ## Step 5: Repository profile
 
@@ -421,10 +421,10 @@ For a broader troubleshooting index see
 
 - [Git Workflow](git-workflow.md) — how the per-change cycle
   actually unfolds once setup is done
-- [Git Hooks and Validation](../../git-hooks-and-validation.md) —
+- [Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md) —
   pre-commit hook + validator reference
 - [Three-Tier CI](three-tier-ci.md) — per-language test/lint/audit
   tier wiring
 - [Releasing](releasing.md) — release workflow
-- [Worktree convention spec](../../specs/worktree-convention.md)
+- [Worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
   — canonical reference for the parallel-agent convention

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -7,7 +7,7 @@ through from branching to finalization.
 
 For per-tool detail, each `st-*` command has its own reference page.
 For the rationale behind the worktree convention,
-see [the worktree convention spec](../../../specs/worktree-convention.md).
+see [the worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md).
 
 ## At a glance
 
@@ -79,7 +79,7 @@ Claude-Code-tool level — some of which never reach a `git commit`
 close the loop.
 
 For the pre-commit-hook detail, see
-[Git Hooks and Validation](../../../git-hooks-and-validation.md).
+[Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md).
 For the plugin hook detail, see
 [standard-tooling-plugin/docs → Hooks](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md).
 
@@ -189,7 +189,7 @@ issue before the first is merged.
 
 For the full spec (rationale, trust model, failure modes, memory-path
 implications), see
-[the worktree convention](../../../specs/worktree-convention.md).
+[the worktree convention](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md).
 This section is the user-level "how to."
 
 ### When a worktree is required
@@ -359,9 +359,9 @@ clean; then proceed.
 
 ## Related
 
-- [Git Hooks and Validation](../../../git-hooks-and-validation.md)
+- [Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md)
   — pre-commit hook + validator reference
-- [Worktree convention spec](../../../specs/worktree-convention.md)
+- [Worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
   — rationale, failure modes, trust model
 - [Releasing](releasing.md) — release workflow detail
 - [standard-tooling-plugin — Hooks](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md)

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -7,7 +7,7 @@ through from branching to finalization.
 
 For per-tool detail, each `st-*` command has its own reference page.
 For the rationale behind the worktree convention,
-see [the worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md).
+see [the worktree convention spec][worktree-spec].
 
 ## At a glance
 
@@ -79,7 +79,7 @@ Claude-Code-tool level — some of which never reach a `git commit`
 close the loop.
 
 For the pre-commit-hook detail, see
-[Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md).
+[Git Hooks and Validation][hooks-doc].
 For the plugin hook detail, see
 [standard-tooling-plugin/docs → Hooks](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md).
 
@@ -189,7 +189,7 @@ issue before the first is merged.
 
 For the full spec (rationale, trust model, failure modes, memory-path
 implications), see
-[the worktree convention](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md).
+[the worktree convention][worktree-spec].
 This section is the user-level "how to."
 
 ### When a worktree is required
@@ -359,10 +359,14 @@ clean; then proceed.
 
 ## Related
 
-- [Git Hooks and Validation](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md)
+- [Git Hooks and Validation][hooks-doc]
   — pre-commit hook + validator reference
-- [Worktree convention spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+- [Worktree convention spec][worktree-spec]
   — rationale, failure modes, trust model
 - [Releasing](releasing.md) — release workflow detail
-- [standard-tooling-plugin — Hooks](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md)
+- [standard-tooling-plugin — Hooks][plugin-hooks]
   — plugin hook reference
+
+[hooks-doc]: https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/git-hooks-and-validation.md
+[worktree-spec]: https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md
+[plugin-hooks]: https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md

--- a/docs/site/docs/guides/releasing.md
+++ b/docs/site/docs/guides/releasing.md
@@ -1,84 +1,200 @@
 # Releasing
 
-This guide covers the release workflow for standard-tooling.
+This guide covers the release workflow for `standard-tooling`,
+including how patch, minor, and major versions affect both the
+release author (producer) and downstream consumers.
 
-## Release Workflow
+The model: `standard-tooling` is distributed as a host-level
+developer tool plus a dev-container pre-bake (see
+[host-level-tool spec][hlt]). Three deployment targets — developer
+host, Python project `.venv`, and dev container image — each track
+the **rolling minor tag** (e.g. `v1.3`), which is force-updated by
+`tag-and-release` on every patch release. The dev container images
+rebuild automatically on each `standard-tooling` release via a
+`repository_dispatch` trigger.
 
-### 1. Develop Changes
+[hlt]: https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/host-level-tool.md
 
-All changes start as feature PRs targeting `develop`:
+## Tag scheme — what's user-facing, what isn't
+
+Two parallel tag families exist in the repo. Consumers only see and
+use the first; the second is internal scaffolding for the changelog
+flow.
+
+| Tag pattern | Where | Purpose | User-facing? |
+|---|---|---|---|
+| `v1.3.0` | `main` | Release tag | Yes — pin in install commands |
+| `v1.3` | `main` | Rolling minor tag (force-updated each patch) | Yes — what consumers actually pin to |
+| `develop-v1.3.0` | `develop` | Boundary marker for `git-cliff`'s next-changelog scoping | No — internal |
+
+The `develop-` prefix is invisible to install / consumption; never
+pin to a `develop-v*` tag.
+
+## Patch release — the common path
+
+A patch release fixes a bug or refines an existing feature without
+adding new public surface. Versions: `v1.3.0` → `v1.3.1`.
+
+### Producer steps
+
+1. Land all the patch's changes via normal feature PRs to `develop`.
+2. Cut the release:
+
+   ```bash
+   st-prepare-release --issue <release-tracking-issue>
+   ```
+
+   This creates `release/{version}`, merges `main` to pick up prior
+   tags, generates `CHANGELOG.md` and `releases/v{version}.md`,
+   commits, pushes, opens a PR to `main`.
+3. Wait for CI green, then merge:
+
+   ```bash
+   st-merge-when-green https://github.com/wphillipmoore/standard-tooling/pull/<release-pr>
+   ```
+
+4. Post-merge automation runs:
+   - `tag-and-release` creates the release tag (`v1.3.1`).
+   - The rolling minor tag (`v1.3`) is **force-updated** to point at
+     the new release.
+   - The boundary tag (`develop-v1.3.1`) is created on `develop`.
+   - `repository_dispatch` fires a `standard-tooling-released`
+     event at `standard-tooling-docker`, which rebuilds the dev
+     images against the now-current `v1.3` tag.
+   - `version-bump-pr` opens an auto-bump PR on `develop`
+     (e.g., `1.3.1` → `1.3.2`). Merge it.
+   - The Documentation workflow publishes the new release notes to
+     the docs site under `releases/v1.3.1`.
+5. Run `st-finalize-repo` to clean up local state.
+
+### Consumer steps
+
+For most consumers, **no action is required**: the rolling `v1.3`
+tag they're already pinned to now points at the patch release. They
+get the fix on the next normal action:
+
+| Consumer | When the patch lands |
+|---|---|
+| Developer host | Manual `uv tool upgrade standard-tooling` (or `pip install --upgrade ...@v1.3`) |
+| Python repo `.venv` | `uv lock --upgrade-package standard-tooling` (typically batched with other dep bumps) |
+| Dev container image | Already rebuilt by `repository_dispatch`; new pulls of `dev-base` etc. carry the patch within the rebuild window (minutes) |
+
+## Minor release — opt-in for new features
+
+A minor release adds backwards-compatible new features. Versions:
+`v1.3.x` → `v1.4.0`.
+
+### Producer steps
+
+Same five steps as patch, with one important addition: the rolling
+minor tag changes from `v1.3` to `v1.4`. The image's pin in
+`standard-tooling-docker` and any per-repo dev-dep declarations
+**must be bumped manually** — the rolling-tag mechanism only handles
+patches within a minor.
+
+1. Cut and merge `release/v1.4.0` exactly like a patch release.
+2. **Bump `standard-tooling-docker`'s pin** in
+   [`docker/common/standard-tooling-uv.dockerfile`][docker-frag]:
+
+   ```dockerfile
+   ARG ST_TOOLING_TAG=v1.4   # was v1.3
+   ```
+
+   Open a small PR in `standard-tooling-docker`, merge it, and the
+   next image rebuild (whether triggered by your release or a
+   subsequent push there) carries the new minor.
+3. **Coordinate consumer bumps.** Each Python repo that has
+   `[tool.uv.sources]` pinning to `v1.3` needs its `pyproject.toml`
+   updated to `v1.4`. This is a per-repo decision — consumers who
+   prefer to stay on `v1.3` can keep doing so until they're ready.
+4. Update the canonical install command in `getting-started.md`
+   (and anywhere else the documentation pins a minor) to the new
+   tag.
+
+[docker-frag]: https://github.com/wphillipmoore/standard-tooling-docker/blob/develop/docker/common/standard-tooling-uv.dockerfile
+
+### Consumer steps
+
+Minor bumps are **deliberate opt-in** at every deployment target:
+
+| Consumer | What changes |
+|---|---|
+| Developer host | `uv tool install --reinstall 'standard-tooling @ git+...@v1.4'` (or update the pinned tag in their notes / shell history) |
+| Python repo `.venv` | Edit `pyproject.toml` `[tool.uv.sources]` to `tag = "v1.4"`, then `uv lock --upgrade-package standard-tooling` |
+| Dev container image | Wait for `standard-tooling-docker` to land the `ARG` bump, then pull the rebuilt image |
+
+The release author should announce the minor bump in the GitHub
+Release notes, calling out any new features and the `v1.4` pin
+update.
+
+## Major release — explicit migration
+
+A major release contains breaking changes. Versions: `v1.x.x` →
+`v2.0.0`.
+
+### Producer steps
+
+A major release is a minor release plus a deliberate breaking-change
+communication and migration window:
+
+1. Document the breaking changes BEFORE cutting the release. A
+   `docs/specs/v2-migration.md` (or similar) describing what
+   breaks, what to update, and how to recover from common issues.
+2. Cut and merge `release/v2.0.0` like a minor release. The
+   release notes prominently call out the breaking-change list and
+   link to the migration guide.
+3. Bump `standard-tooling-docker`'s `ARG ST_TOOLING_TAG=` to `v2`
+   in a separate PR — coordinate so consumers can opt in on their
+   own schedule.
+4. Notify consumer maintainers (e.g., update `standard-tooling`'s
+   release tracking issue / project board with a callout). The
+   release notes alone are not sufficient for major bumps;
+   consumers should be primed.
+
+### Consumer steps
+
+Same as a minor release in mechanics — every deployment target
+edits its `v1.x` pin to `v2` deliberately. The difference is
+**timing and risk awareness**:
+
+- Read the migration guide before bumping.
+- Stage the bump in a feature branch, run validation, fix any
+  breakages from removed APIs / changed behaviors.
+- Merge the bump PR per the consumer's normal review flow.
+
+## Documentation publication
+
+The Documentation workflow (`.github/workflows/docs.yml`) deploys
+the MkDocs site to GitHub Pages on every push to `develop` and
+`main`. It's container-based: the workflow runs inside
+`dev-base:latest` and uses
+`wphillipmoore/standard-actions/actions/docs-deploy`.
+
+**Sanity-check the docs publication.** Docs publication is async
+relative to the merge — a failure on this workflow doesn't block
+the PR. To catch silent failures, `st-finalize-repo` checks the
+status of the most recent Documentation workflow run on `develop`
+after pulling the merge. If it failed, finalize prints a warning
+with a direct link to the failure log, so you can investigate
+before moving on to the next PR.
+
+For deeper investigation, view recent runs directly:
 
 ```bash
-git checkout -b feature/42-add-new-check
-# ... make changes ...
-st-commit \
-  --type feat --message "add new check" --agent claude
-st-submit-pr \
-  --issue 42 --summary "Add new check"
+gh run list --repo wphillipmoore/standard-tooling \
+  --workflow="Documentation" --limit 5
 ```
 
-### 2. Prepare the Release
+## Release tracking artifacts
 
-Once `develop` has all changes for the release, run:
+Each release has a tracking issue (referenced as `--issue N` to
+`st-prepare-release`). Use it to:
 
-```bash
-st-prepare-release --issue 50
-```
+- Capture the rationale for the release (what's in it, what's not).
+- Document any consumer coordination required (especially for
+  minor / major bumps).
+- Link to the release PR and any follow-up issues surfaced during
+  release prep.
 
-This tool:
-
-- Creates a `release/{version}` branch from develop
-- Merges main to incorporate prior release history
-- Generates the changelog via git-cliff
-- Creates a PR to main with auto-merge enabled
-
-### 3. Post-Merge Automation
-
-After the release PR merges to main, CI automation handles:
-
-- Creating and pushing the `v{version}` tag
-- Creating the GitHub Release
-- Publishing the package artifact
-- Deploying documentation
-- Creating an automated version bump PR to develop
-
-### 4. Finalize
-
-Clean up local state:
-
-```bash
-st-finalize-repo
-```
-
-## Consuming Repo Updates
-
-Standard-tooling is consumed via PATH, so consuming repos pick up
-updates automatically when their sibling checkout is updated:
-
-```bash
-cd ../standard-tooling
-git pull
-uv sync
-```
-
-For CI, consuming repos use `standard-actions` which pins to a
-`standard-tooling-ref`. After tagging a new release, update the
-default ref in the `standards-compliance` action.
-
-## Version Detection
-
-`st-prepare-release` auto-detects the version from the project
-ecosystem:
-
-| Ecosystem | Source |
-| --------- | ------ |
-| Python | `pyproject.toml` |
-| Maven | `pom.xml` |
-| Go | `**/version.go` |
-| Fallback | `VERSION` file |
-
-## Documentation Deployment
-
-The documentation site deploys automatically on pushes to `develop`
-and `main` via `.github/workflows/docs.yml`. The version displayed
-in the site is derived from the project version using major.minor.
+The tracking issue closes when the release PR merges; follow-ups
+move to their own issues.

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -15,7 +15,10 @@ proper issue linkage, testing sections, and auto-merge configuration.
 ## Prerequisites
 
 When running inside a dev container, `GH_TOKEN` must be set so `gh` can
-authenticate. See [GitHub authentication](../../getting-started.md#5-github-authentication).
+authenticate. The
+[Getting Started prerequisites](../../getting-started.md#prerequisites)
+cover `gh auth login` and how `GH_TOKEN` flows through to the
+container.
 
 ## Usage
 

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -63,7 +63,7 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
     """
     if shutil.which("gh") is None:
         return None
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(  # noqa: S603, S607
         [
             "gh",
             "run",

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -61,11 +61,12 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
       - the latest run succeeded or is still in progress
       - the JSON response is malformed (defensive)
     """
-    if shutil.which("gh") is None:
+    gh = shutil.which("gh")
+    if gh is None:
         return None
-    result = subprocess.run(  # noqa: S603, S607
+    result = subprocess.run(  # noqa: S603
         [
-            "gh",
+            gh,
             "run",
             "list",
             "--workflow",

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -1,17 +1,24 @@
 """Finalize a repository after a PR merge.
 
 Switches to the target branch, fast-forward pulls, deletes merged local
-branches, and prunes stale remote-tracking references.
+branches, and prunes stale remote-tracking references. After
+validation succeeds, also checks the most recent Documentation
+workflow run on the target branch and surfaces a warning if it
+failed (issue #303 — docs publish is async and used to fail
+silently).
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import subprocess
 import sys
 
 from standard_tooling.lib import git, repo_profile
+
+_DOCS_WORKFLOW_NAME = "Documentation"
 
 _ETERNAL_BY_MODEL: dict[str, list[str]] = {
     "docs-single-branch": ["develop"],
@@ -35,6 +42,67 @@ def _run(args: list[str], *, dry_run: bool) -> None:
         print(f"  [dry-run] git {' '.join(args)}")
     else:
         git.run(*args)
+
+
+def _check_docs_workflow_status(target_branch: str) -> str | None:
+    """Inspect the most recent Documentation workflow run on
+    ``target_branch`` and return a one-line message if it failed,
+    None if it succeeded, is in progress, or doesn't exist.
+
+    Docs publication is async relative to the merge that triggers it,
+    so a failure here doesn't block any PR — but it does mean the
+    site is stale until the next successful run. This check surfaces
+    such failures during finalize so they can be investigated
+    immediately. Issue #303.
+
+    Returns None when:
+      - ``gh`` is not on PATH (can't query)
+      - no Documentation workflow exists in the repo
+      - the latest run succeeded or is still in progress
+      - the JSON response is malformed (defensive)
+    """
+    if shutil.which("gh") is None:
+        return None
+    result = subprocess.run(  # noqa: S603
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            _DOCS_WORKFLOW_NAME,
+            "--branch",
+            target_branch,
+            "--limit",
+            "1",
+            "--json",
+            "conclusion,databaseId,headSha,createdAt,url",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # gh failed (no workflow, no auth, network issue) — defensive
+        # silence rather than turning every finalize into a warning.
+        return None
+    stdout = result.stdout or ""
+    try:
+        runs = json.loads(stdout) if stdout.strip() else []
+    except json.JSONDecodeError:
+        return None
+    if not runs:
+        return None
+    run = runs[0]
+    conclusion = run.get("conclusion") or ""
+    if conclusion in ("", "success", "skipped", "neutral"):
+        # "" means still in_progress / queued / not_completed.
+        return None
+    sha = (run.get("headSha") or "")[:7]
+    return (
+        f"Documentation workflow run {run.get('databaseId')} on "
+        f"{target_branch} ({sha}) ended with conclusion '{conclusion}'.\n"
+        f"  {run.get('url') or ''}"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -130,6 +198,14 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("  [dry-run] st-docker-run -- st-validate-local")
 
+    # Docs-publish sanity check (issue #303). Runs after validation
+    # so a real validation failure stays the headline; a docs failure
+    # is a softer warning since docs publishing is async and doesn't
+    # block subsequent merges.
+    docs_failure: str | None = None
+    if not args.dry_run:
+        docs_failure = _check_docs_workflow_status(args.target_branch)
+
     print()
     print("Finalization complete.")
     print(f"  Branch: {args.target_branch}")
@@ -142,6 +218,20 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  The {args.target_branch} branch has issues that should be", file=sys.stderr)
         print("  fixed before creating the next PR.", file=sys.stderr)
         return 1
+
+    if docs_failure is not None:
+        print()
+        print(
+            "WARNING: most recent Documentation workflow run did not succeed.",
+            file=sys.stderr,
+        )
+        print(f"  {docs_failure}", file=sys.stderr)
+        print(
+            "  Docs publish is async — investigate before the next merge so",
+            file=sys.stderr,
+        )
+        print("  the site doesn't drift further from develop.", file=sys.stderr)
+        # Soft warning: keep exit code 0 since finalize itself succeeded.
 
     return 0
 

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
-from standard_tooling.bin.finalize_repo import main, parse_args
+from standard_tooling.bin.finalize_repo import (
+    _check_docs_workflow_status,
+    main,
+    parse_args,
+)
 
 _MOD = "standard_tooling.bin.finalize_repo"
 
@@ -248,3 +253,159 @@ def test_main_falls_back_to_direct_validator(tmp_path: Path) -> None:
     assert result == 0
     cmd = mock_sub.call_args[0][0]
     assert cmd == ("/usr/bin/st-validate-local",)
+
+
+# -- _check_docs_workflow_status (issue #303) --------------------------------
+
+
+def _gh_run_json(conclusion: str | None) -> str:
+    """Build a single-element gh run list JSON response."""
+    return json.dumps(
+        [
+            {
+                "conclusion": conclusion,
+                "databaseId": 12345,
+                "headSha": "abc123def456",
+                "createdAt": "2026-04-26T18:00:00Z",
+                "url": "https://github.com/owner/repo/actions/runs/12345",
+            }
+        ]
+    )
+
+
+def test_check_docs_workflow_returns_none_when_gh_missing() -> None:
+    with patch(_MOD + ".shutil.which", return_value=None):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_check_docs_workflow_returns_none_when_gh_fails() -> None:
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(args=(), returncode=1, stdout="", stderr="oops"),
+        ),
+    ):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_check_docs_workflow_returns_none_when_no_runs() -> None:
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(args=(), returncode=0, stdout="[]"),
+        ),
+    ):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_check_docs_workflow_returns_none_on_success() -> None:
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(
+                args=(), returncode=0, stdout=_gh_run_json("success")
+            ),
+        ),
+    ):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_check_docs_workflow_returns_none_on_in_progress() -> None:
+    # gh reports null conclusion (in_progress / queued).
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(
+                args=(), returncode=0, stdout=_gh_run_json(None)
+            ),
+        ),
+    ):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_check_docs_workflow_returns_message_on_failure() -> None:
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(
+                args=(), returncode=0, stdout=_gh_run_json("failure")
+            ),
+        ),
+    ):
+        msg = _check_docs_workflow_status("develop")
+    assert msg is not None
+    assert "12345" in msg
+    assert "develop" in msg
+    assert "abc123d" in msg  # short sha
+    assert "failure" in msg
+    assert "actions/runs/12345" in msg
+
+
+def test_check_docs_workflow_returns_none_on_malformed_json() -> None:
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(args=(), returncode=0, stdout="not json"),
+        ),
+    ):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_check_docs_workflow_returns_none_on_empty_stdout() -> None:
+    # Defensive: stdout missing entirely (None) shouldn't crash.
+    with (
+        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(args=(), returncode=0, stdout=None),
+        ),
+    ):
+        assert _check_docs_workflow_status("develop") is None
+
+
+def test_main_warns_on_docs_failure_but_returns_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
+        patch(
+            _MOD + "._check_docs_workflow_status",
+            return_value="Documentation workflow run 999 on develop (deadbee) ended with conclusion 'failure'.",
+        ),
+    ):
+        result = main([])
+    # Soft warning: finalize itself succeeded, so exit 0.
+    assert result == 0
+    stderr = capsys.readouterr().err
+    assert "Documentation workflow" in stderr
+    assert "Docs publish is async" in stderr
+
+
+def test_main_skips_docs_check_on_dry_run(tmp_path: Path) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
+        patch(
+            _MOD + "._check_docs_workflow_status",
+            return_value="should not appear",
+        ) as mock_check,
+    ):
+        result = main(["--dry-run"])
+    assert result == 0
+    mock_check.assert_not_called()

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -382,7 +382,10 @@ def test_main_warns_on_docs_failure_but_returns_zero(
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(
             _MOD + "._check_docs_workflow_status",
-            return_value="Documentation workflow run 999 on develop (deadbee) ended with conclusion 'failure'.",
+            return_value=(
+                "Documentation workflow run 999 on develop (deadbee) "
+                "ended with conclusion 'failure'."
+            ),
         ),
     ):
         result = main([])

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -305,9 +305,7 @@ def test_check_docs_workflow_returns_none_on_success() -> None:
         patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
         patch(
             _MOD + ".subprocess.run",
-            return_value=CompletedProcess(
-                args=(), returncode=0, stdout=_gh_run_json("success")
-            ),
+            return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("success")),
         ),
     ):
         assert _check_docs_workflow_status("develop") is None
@@ -319,9 +317,7 @@ def test_check_docs_workflow_returns_none_on_in_progress() -> None:
         patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
         patch(
             _MOD + ".subprocess.run",
-            return_value=CompletedProcess(
-                args=(), returncode=0, stdout=_gh_run_json(None)
-            ),
+            return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json(None)),
         ),
     ):
         assert _check_docs_workflow_status("develop") is None
@@ -332,9 +328,7 @@ def test_check_docs_workflow_returns_message_on_failure() -> None:
         patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
         patch(
             _MOD + ".subprocess.run",
-            return_value=CompletedProcess(
-                args=(), returncode=0, stdout=_gh_run_json("failure")
-            ),
+            return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("failure")),
         ),
     ):
         msg = _check_docs_workflow_status("develop")


### PR DESCRIPTION
# Pull Request

## Summary

- Release-workflow docs (patch/minor/major) + docs-publish sanity check + broken-link fixes

## Issue Linkage

- Closes #303

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Three-part fix: documents the patch/minor/major release workflow with producer + consumer views; adds a docs-publish sanity check to st-finalize-repo so silent failures surface; fixes broken cross-tree links exposed by the docs-deploy fixes in PR #205 and #207 of standard-actions.