### PR TITLE
fix(finalize): use 'git branch -D' for already-vetted merged branches (#307)

### DIFF
--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -156,8 +156,14 @@ def main(argv: list[str] | None = None) -> int:
     for branch in git.merged_branches(args.target_branch):
         if branch in eternal:
             continue
+        # `git branch -D` (force) rather than `-d` because `--merged`
+        # already vetted these branches as reachable from the target;
+        # `-d`'s redundant safety check rejects branches whose tips
+        # were rewritten by rebase + force-push during a CI fixup loop
+        # (the upstream-tracking ref is gone after `fetch --prune`).
+        # Trusting our own filter avoids the disagreement. Issue #307.
         print(f"  Deleting merged branch: {branch}")
-        _run(["branch", "-d", branch], dry_run=args.dry_run)
+        _run(["branch", "-D", branch], dry_run=args.dry_run)
         deleted.append(branch)
 
     print("Pruning stale remote-tracking references...")

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -92,7 +92,7 @@ def test_main_library_release(tmp_path: Path) -> None:
         result = main([])
     assert result == 0
     mock_run.assert_any_call("checkout", "develop")
-    mock_run.assert_any_call("branch", "-d", "feature/x")
+    mock_run.assert_any_call("branch", "-D", "feature/x")
 
 
 def test_main_already_on_target(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Use 'git branch -D' for already-vetted merged branches

## Issue Linkage

- Closes #307

## Testing

- markdownlint
- ci: shellcheck

## Notes

- One-line src change + one-test-line update. Eliminates the recurring finalize crash on rebased feature branches.