### PR TITLE
fix(packaging): declare GPL-3.0-only license metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ name = "standard-tooling"
 version = "1.3.4"
 description = "Shared development tooling for managed repositories"
 requires-python = ">=3.12,<4.0"
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
 dependencies = []
 
 [project.scripts]


### PR DESCRIPTION
# Pull Request

## Summary

- declare GPL-3.0-only license metadata in pyproject.toml

## Issue Linkage

- Fixes #320

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ai-research-methodology Phase 5 migration is blocked on this — once merged + released as v1.3.5, the consumer side can pin to it via uv lock --upgrade-package standard-tooling and unblock https://github.com/wphillipmoore/ai-research-methodology/issues/171.