### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
     with:
       language: python
       run-standards: ${{ inputs.run-release-gates || 'true' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: python3 -c "import tomllib; from pathlib import Path; v=tomllib.loads(Path('pyproject.toml').read_text())['project']['version']; print('.'.join(v.split('.')[:2]))"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #329

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Pins ci-security.yml and docs-deploy to the @v1.3 rolling minor tag. Existing @v1.1 pins (release-gates/version-divergence, publish/tag-and-release, publish/version-bump-pr) are intentionally left as-is per the migration plan in standard-actions#145.