### PR TITLE
fix(finalize): auto-chdir to main worktree instead of erroring

### DIFF
--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -142,17 +143,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
     if not git.is_main_worktree():
-        print(
-            "ERROR: st-finalize-repo must be run from the main worktree, not a secondary one.",
-            file=sys.stderr,
-        )
-        print(
-            "  The target branch is already checked out in the main "
-            "worktree; git will refuse to check it out a second time.",
-            file=sys.stderr,
-        )
-        print("  Run:  cd <repo-root> && st-finalize-repo", file=sys.stderr)
-        return 1
+        main_root = git.main_worktree_root()
+        print(f"Note: switching to main worktree at {main_root}")
+        os.chdir(main_root)
 
     root = git.repo_root()
 

--- a/src/standard_tooling/lib/git.py
+++ b/src/standard_tooling/lib/git.py
@@ -55,6 +55,12 @@ def is_main_worktree() -> bool:
     return git_dir == common_dir
 
 
+def main_worktree_root() -> Path:
+    """Return the root directory of the main worktree."""
+    common_dir = Path(read_output("rev-parse", "--git-common-dir")).resolve()
+    return common_dir.parent
+
+
 def current_branch() -> str:
     """Return the current branch name."""
     return read_output("rev-parse", "--abbrev-ref", "HEAD")

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -20,7 +21,6 @@ _MOD = "standard_tooling.bin.finalize_repo"
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -46,13 +46,34 @@ def test_parse_args_custom() -> None:
     assert args.dry_run is True
 
 
-def test_main_refuses_from_secondary_worktree(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch(_MOD + ".git.is_main_worktree", return_value=False):
+def test_main_auto_chdir_from_secondary_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    main_root = tmp_path / "main-wt"
+    main_root.mkdir()
+    _make_profile(main_root, "library-release")
+    secondary = tmp_path / "secondary-wt"
+    secondary.mkdir()
+    monkeypatch.chdir(secondary)
+
+    with (
+        patch(_MOD + ".git.is_main_worktree", return_value=False),
+        patch(_MOD + ".git.main_worktree_root", return_value=main_root),
+        patch(_MOD + ".git.repo_root", return_value=main_root),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", return_value=None),
+    ):
         result = main([])
-    assert result == 1
-    stderr = capsys.readouterr().err
-    assert "main worktree" in stderr
-    assert "cd <repo-root>" in stderr
+
+    assert result == 1  # no validator found, but that's after the chdir
+    out = capsys.readouterr().out
+    assert f"switching to main worktree at {main_root}" in out
+    assert Path.cwd() == main_root
 
 
 def _make_profile(tmp_path: Path, model: str) -> None:

--- a/tests/standard_tooling/test_git.py
+++ b/tests/standard_tooling/test_git.py
@@ -102,6 +102,22 @@ def test_is_main_worktree_false() -> None:
         assert git.is_main_worktree() is False
 
 
+def test_main_worktree_root_from_main() -> None:
+    with patch(
+        "standard_tooling.lib.git.read_output",
+        return_value="/repo/.git",
+    ):
+        assert git.main_worktree_root() == Path("/repo")
+
+
+def test_main_worktree_root_from_secondary() -> None:
+    with patch(
+        "standard_tooling.lib.git.read_output",
+        return_value="/repo/.git",
+    ):
+        assert git.main_worktree_root() == Path("/repo")
+
+
 def test_has_staged_changes_true() -> None:
     with patch("standard_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed(returncode=1)


### PR DESCRIPTION
# Pull Request

## Summary

- st-finalize-repo now detects when run from a secondary worktree, resolves the main worktree root via a new git.main_worktree_root() helper, chdirs there, and continues with a one-line note. Previously it errored and told the user to cd manually.

## Issue Linkage

- Fixes #340

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Added main_worktree_root() to lib/git.py — uses git rev-parse --git-common-dir, which always points to the main worktree .git directory.