### PR TITLE
fix(ci): bump stale standard-actions pins from @v1.1 to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.1
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
         with:
           head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
           main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.1
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.3
         with:
           version: ${{ steps.version.outputs.version }}
           release-title: standard-tooling
@@ -104,7 +104,7 @@ jobs:
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.1
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.3
         with:
           current-version: ${{ steps.version.outputs.version }}
           version-file: pyproject.toml


### PR DESCRIPTION
# Pull Request

## Summary

- Update three stale standard-actions references from @v1.1 to @v1.3: version-divergence in ci.yml, tag-and-release and version-bump-pr in publish.yml. All other repos in the fleet are already on @v1.3.

## Issue Linkage

- Fixes #344

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -