### PR TITLE
fix(docker-run): support --help and -h as program options

### DIFF
--- a/src/standard_tooling/bin/docker_run.py
+++ b/src/standard_tooling/bin/docker_run.py
@@ -19,6 +19,28 @@ from standard_tooling.lib.docker import (
     detect_language,
 )
 
+_USAGE = """\
+usage: st-docker-run [--] <command> [args...]
+
+Run a command inside the project's dev container.
+
+The project language is auto-detected to select the right Docker image;
+falls back to dev-base:latest when detection fails.
+
+options:
+  -h, --help          show this help message and exit
+
+environment variables:
+  GH_TOKEN            (required) GitHub token passed into the container
+  DOCKER_DEV_IMAGE    override the auto-detected container image
+  DOCKER_NETWORK      join a Docker network (e.g. for integration tests)
+
+examples:
+  st-docker-run -- uv run st-validate-local
+  st-docker-run -- uv run pytest tests/
+  DOCKER_DEV_IMAGE=custom:img st-docker-run -- make build
+"""
+
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
@@ -26,9 +48,15 @@ def main(argv: list[str] | None = None) -> int:
     # Split on -- separator
     if "--" in args:
         idx = args.index("--")
+        pre_separator = args[:idx]
         command = args[idx + 1 :]
     else:
+        pre_separator = args
         command = args
+
+    if {"-h", "--help"} & set(pre_separator):
+        print(_USAGE, end="")
+        return 0
 
     if not command:
         print("Usage: st-docker-run [--] <command> [args...]", file=sys.stderr)

--- a/tests/standard_tooling/test_docker_run.py
+++ b/tests/standard_tooling/test_docker_run.py
@@ -13,6 +13,47 @@ if TYPE_CHECKING:
     import pytest
 
 
+# -- help output --------------------------------------------------------------
+
+
+def test_help_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--help"]) == 0
+    out = capsys.readouterr().out
+    assert "usage: st-docker-run" in out
+    assert "GH_TOKEN" in out
+
+
+def test_h_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["-h"]) == 0
+    assert "usage: st-docker-run" in capsys.readouterr().out
+
+
+def test_help_after_separator_not_intercepted(tmp_path: Path) -> None:
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("standard_tooling.bin.docker_run.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_run.assert_docker_available"),
+        patch("standard_tooling.bin.docker_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "some-tool", "--help"])
+    args = mock_exec.call_args[0][1]
+    assert args[-2:] == ["some-tool", "--help"]
+
+
+def test_help_alone_after_separator_not_intercepted(tmp_path: Path) -> None:
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("standard_tooling.bin.docker_run.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_run.assert_docker_available"),
+        patch("standard_tooling.bin.docker_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "--help"])
+    args = mock_exec.call_args[0][1]
+    assert args[-1] == "--help"
+
+
 # -- argument parsing ---------------------------------------------------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Intercept -h/--help before the -- separator so they print usage and exit 0 instead of being passed to Docker as a container command. After --, help flags still route to the container command as before.

## Issue Linkage

- Fixes #289

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -