### PR TITLE
chore(version): bump version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "standard-tooling"
-version = "1.3.5"
+version = "1.4.0"
 description = "Shared development tooling for managed repositories"
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4.0"
 
 [[package]]
@@ -667,7 +667,7 @@ wheels = [
 
 [[package]]
 name = "standard-tooling"
-version = "1.3.5"
+version = "1.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Pull Request

## Summary

- Bump pyproject.toml version from 1.3.5 to 1.4.0 in preparation for the v1.4.0 release.

## Issue Linkage

- Ref #348

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -