### PR TITLE
chore(ci): upgrade standard-actions from @v1.3 to @v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
     with:
       language: python
       run-standards: ${{ inputs.run-release-gates || 'true' }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
         with:
           head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
           main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
         with:
           version-command: python3 -c "import tomllib; from pathlib import Path; v=tomllib.loads(Path('pyproject.toml').read_text())['project']['version']; print('.'.join(v.split('.')[:2]))"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.3
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
         with:
           version: ${{ steps.version.outputs.version }}
           release-title: standard-tooling
@@ -104,7 +104,7 @@ jobs:
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.3
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
         with:
           current-version: ${{ steps.version.outputs.version }}
           version-file: pyproject.toml


### PR DESCRIPTION
## Summary

- Upgrade all standard-actions workflow references from `@v1.3` to `@v1.4`

## What changed in v1.4

- Trivy table-to-stdout output for CI visibility
- Trivy bump to 0.70.0
- CI action pin updates (create-github-app-token v3, attest-build-provenance v4)
- Workflow cleanups

Ref wphillipmoore/standard-actions#245
