### PR TITLE
docs(fleet): rewrite docs for host-install model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # Standard Tooling - Agent Instructions
 
-<!-- include: ./docs/repository-standards.md -->
-
 ## User Overrides (Optional)
 
 Always apply this repository's `AGENTS.md` as the baseline. If
@@ -28,8 +26,9 @@ MUST:
 ## Working Rules
 
 - This repository is a Python package providing shared tooling scripts.
-  Consumers resolve tools via PATH (from a sibling checkout locally,
-  or a CI checkout in workflows).
+  Consumers resolve host-side `st-*` tools via `uv tool install` and
+  in-container tools via the dev container image's pre-bake (non-Python
+  repos) or a `[tool.uv.sources]` dev dep (Python repos).
 - Test scripts with shellcheck before committing.
 - Keep scripts portable across macOS and Linux.
 - Do not add repo-specific logic; scripts must work in any consuming repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,6 @@
 This file provides guidance to Claude Code (claude.ai/code) when working in
 this repository.
 
-<!-- include: docs/repository-standards.md -->
-
 ## Parallel AI agent development
 
 This repository supports running multiple Claude Code agents in parallel via
@@ -86,34 +84,36 @@ CI checkout (GitHub Actions).
 
 **Status**: Stable (v1.x)
 
-**Canonical Standards**: This repository follows standards at
-<https://github.com/wphillipmoore/standards-and-conventions>
-(local path: `../standards-and-conventions` if available)
+**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
+— historical reference; active standards documentation lives in this
+repository under `docs/`.
 
 ## Development Commands
 
 ### Environment Setup
 
-This repository uses a **dual-venv** model:
+Host-side `st-*` tools are installed via `uv tool install` (see
+[Consumption Model](#consumption-model)). For developing
+standard-tooling itself, there is also a **dev-tree override** using
+a local `.venv-host`:
 
 - **`.venv`** — Created inside dev containers. Shebang paths reference
   `/workspace/.venv/...` and do not work on the host.
-- **`.venv-host`** — Created on the host for bootstrap tools like
-  `st-docker-run`. Shebang paths reference the real host Python.
+- **`.venv-host`** — Dev-tree override venv for testing unreleased
+  code on the host. Not the normal install mechanism.
 
 ```bash
-# Host bootstrap (one-time) — provides st-docker-run on the host
+# Dev-tree override (standard-tooling development only)
 UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+export PATH="$(pwd)/.venv-host/bin:$PATH"
 
 # Enable the pre-commit gate (refuses raw `git commit`; admits st-commit)
 git config core.hooksPath .githooks
-
-# Put host tools on PATH
-export PATH="$(pwd)/.venv-host/bin:$PATH"
 ```
 
-After the host venv is set up, use `st-docker-run` to run all commands
-inside the dev container. See [Validation](#validation) below.
+After host tools are available, use `st-docker-run` to run all
+commands inside the dev container. See [Validation](#validation)
+below.
 
 ### Validation
 
@@ -227,36 +227,32 @@ Consumed via `git config core.hooksPath .githooks`:
 
 ### Consumption Model
 
-**Dev containers** (primary): All `st-*` entry points are pre-installed in
-the dev container images (`dev-python`, `dev-java`, `dev-go`, `dev-rust`,
-`dev-ruby`, `dev-base`). No local setup required.
+`standard-tooling` has three coordinated deployment targets (see
+`docs/specs/host-level-tool.md` for the full spec):
 
-**Host bootstrap** (for `st-docker-run`): The host needs `st-docker-run`
-to bridge into containers. Consuming repos locate it by searching:
+| Target | Install mechanism | Who uses it |
+|---|---|---|
+| **Developer host** | `uv tool install` from git URL | Host-side commands: `st-docker-run`, `st-commit`, `st-submit-pr`, `st-prepare-release`, `st-finalize-repo` |
+| **Python project `.venv`** | `[tool.uv.sources]` dev dep + `uv sync` | `uv run st-*` inside the container for validators |
+| **Dev container image** | Pre-baked at image build time | `st-*` inside the container for non-Python consumers |
 
-1. `../standard-tooling/.venv-host/bin/st-docker-run` (sibling checkout)
-2. `st-docker-run` on PATH (installed globally)
-
-One-time setup in the `standard-tooling` checkout:
+**Host install** (canonical):
 
 ```bash
-UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
 ```
 
-**Git hooks** (any consuming repo): each repo vendors its own
-`.githooks/pre-commit` (the env-var gate from this repo's spec) and
-points its `core.hooksPath` at it:
+**Git hooks** (any consuming repo): each repo checks in its own
+`.githooks/pre-commit` (an env-var gate that admits `st-commit` and
+rejects raw `git commit`) and enables it once per clone:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-**CI (GitHub Actions)**: under the host-level-tool spec, CI uses
-the same two paths as developers — Python repos via `uv sync --group
-dev` (the dev-dep declaration), non-Python repos via the dev
-container image's pre-baked `standard-tooling`. The
-`standards-compliance` composite action no longer clones
-`standard-tooling` onto runners.
+**CI (GitHub Actions)**: Python repos use `uv sync --group dev`
+(the dev-dep declaration); non-Python repos use the dev container
+image's pre-baked `standard-tooling`.
 
 ### Key Constraints
 

--- a/docs/git-hooks-and-validation.md
+++ b/docs/git-hooks-and-validation.md
@@ -41,26 +41,33 @@ entry points that share a common set of validators:
   [Validation Matrix](#validation-matrix) below.
 
 All hooks and validators are managed by standard-tooling.
-Consuming repositories resolve them via PATH from a sibling
-checkout (local) or CI checkout (GitHub Actions).
+Consuming repositories resolve host-side `st-*` tools via
+`uv tool install` and in-container validators via the dev
+container image's pre-bake or a Python dev-dep declaration.
 
 ## Git Hooks
 
 ### Enabling Hooks
 
-Point Git at the managed hooks directory:
+Point Git at the repo's hooks directory:
 
 ```bash
-git config core.hooksPath scripts/lib/git-hooks
+git config core.hooksPath .githooks
 ```
 
 This must be run once per clone. It is not persisted across
-fresh clones.
+fresh clones. Every managed repo checks in a `.githooks/pre-commit`
+env-var gate that admits `st-commit`-driven commits and rejects
+raw `git commit`.
 
 ### pre-commit
 
-The pre-commit hook runs five checks in order. Any failure
-blocks the commit.
+The pre-commit hook is an env-var gate: it admits commits
+driven by `st-commit` (which sets `ST_COMMIT_CONTEXT=1`) and
+derived workflows (`amend`, `cherry-pick`, `revert`, `rebase`,
+`merge`), and rejects everything else. The five commit-context
+checks below live in `st-commit` itself and run before `git
+commit` is invoked.
 
 **1. Detached HEAD check** — Commits on a detached HEAD are
 blocked unconditionally. Create a named branch first.
@@ -69,7 +76,7 @@ blocked unconditionally. Create a named branch first.
 `release`, and `main` are forbidden. These branches accept
 changes only through pull requests.
 
-**3. Branching model lookup** — The hook reads
+**3. Branching model lookup** — `st-commit` reads
 `branching_model` from `docs/repository-standards.md` to
 determine which branch prefixes are allowed.
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -48,7 +48,7 @@ Hard gates (required status checks on `develop`):
 
 Local hard gates (pre-commit hooks):
 
-- Branch naming enforcement (`scripts/lib/git-hooks/pre-commit`):
+- Branch naming enforcement (`.githooks/pre-commit` gate + `st-commit`):
   branching-model-aware prefix validation.
 
 ## Commit and PR scripts

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -16,53 +16,36 @@ Install these on your host:
   (`gh auth login`)
 - **macOS or Linux** (Bash)
 
-Everything else — language runtimes, linters, test frameworks, all
-but one of the `st-*` tools — lives inside the dev container. The
-only `st-*` tool that runs on the host is `st-docker-run`, which
-bridges into the container.
+Everything else — language runtimes, linters, test frameworks, and
+most `st-*` tools — lives inside the dev container. The host-side
+`st-*` tools (`st-docker-run`, `st-commit`, `st-submit-pr`, etc.)
+are installed via `uv tool install`.
 
-## 1. Clone standard-tooling as a sibling
-
-```bash
-cd ~/dev/github   # or wherever you keep your repos
-git clone https://github.com/wphillipmoore/standard-tooling.git
-```
-
-## 2. Bootstrap the host venv
+## 1. Install standard-tooling on the host
 
 ```bash
-cd standard-tooling
-UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
 ```
 
-!!! important "The `UV_PROJECT_ENVIRONMENT` override matters"
-    Without it, `uv sync` creates a `.venv` with container-path
-    shebangs (`/workspace/.venv/...`) that don't work on the host.
-    The `.venv-host` name and the `--group dev` dependencies are
-    both required.
-
-This installs `st-docker-run` and the other host-side entry points
-into `.venv-host/bin/`.
-
-## 3. Put host tools on PATH
+This installs all `st-*` console scripts into `~/.local/bin/`,
+which `uv`'s installer already puts on `PATH`.
 
 ```bash
-export PATH="$HOME/dev/github/standard-tooling/.venv-host/bin:$HOME/dev/github/standard-tooling/scripts/bin:$PATH"
+which st-docker-run    # should resolve to ~/.local/bin/st-docker-run
+st-docker-run --help   # should print usage
 ```
 
-Add this to your shell profile so it persists across sessions.
+## 2. Configure git hooks in your consuming repo
 
-## 4. Configure git hooks in your consuming repo
-
-From your repo:
+Every managed repo checks in a `.githooks/pre-commit` env-var gate
+(see [Consuming Repo Setup](guides/consuming-repo-setup.md) for
+the gate content). Enable it once per clone:
 
 ```bash
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks
+git config core.hooksPath .githooks
 ```
 
-This must be re-run once per fresh clone; it's not persisted.
-
-## 5. Enable the Claude Code plugin
+## 3. Enable the Claude Code plugin
 
 Create `.claude/settings.json` in your repo:
 
@@ -90,7 +73,7 @@ Commit this file — it's part of the repo's reproducible setup.
     For now, this settings.json entry is enough for Claude Code to
     discover and enable the plugin on the next session restart.
 
-## 6. Create your repository profile
+## 4. Create your repository profile
 
 Create `docs/repository-standards.md` with the six required
 attributes (and AI co-author entries if you'll use them):
@@ -121,7 +104,7 @@ Pick the values that match your repo. See
 [Consuming Repo Setup](guides/consuming-repo-setup.md) for the full
 attribute reference.
 
-## 7. Adopt the worktree convention
+## 5. Adopt the worktree convention
 
 Add `.worktrees/` to your `.gitignore`:
 
@@ -134,7 +117,7 @@ describing the convention. Every managed repo already has one you
 can copy from; the canonical source is
 [the worktree convention spec][worktree-spec].
 
-## 8. Verify
+## 6. Verify
 
 ```bash
 # Host tooling reachable
@@ -143,14 +126,11 @@ st-docker-run --help
 # Repo profile validates (runs inside the container)
 st-docker-run -- uv run st-repo-profile
 
-# Git hook fires on a misnamed branch
-git checkout -b bad-branch-name
-git commit --allow-empty -m "test"    # should be blocked by the hook
-git checkout -
-git branch -D bad-branch-name
+# Git hook blocks raw git commit
+git commit --allow-empty -m "test"    # should be blocked by the gate
 ```
 
-If all three steps behave as expected, you're wired up correctly.
+If all three behave as expected, you're wired up correctly.
 
 ## Next steps
 

--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -68,7 +68,7 @@ Environment overrides:
 
 !!! tip
     Build the dev images locally before first use:
-    `cd ../standard-tooling && docker/build.sh`
+    `cd ../standard-tooling-docker && docker/build.sh`
 
 The `.githooks` pre-commit gate runs `st-validate-local` on every commit,
 which dispatches to the per-language scripts above. Hook bypass

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -12,15 +12,16 @@ The setup steps below wire up each one:
 
 | Surface | What it is | How you consume it |
 |---|---|---|
-| **Host bridge** | A single host-side CLI tool, `st-docker-run`, that runs commands inside a dev container image. | `uv sync` into `.venv-host`; add its `bin/` to PATH. |
+| **Host tools** | `st-docker-run`, `st-commit`, `st-submit-pr`, and other host-side CLI tools. | `uv tool install` from the standard-tooling git URL; scripts land in `~/.local/bin/`. |
 | **Dev container** | `ghcr.io/wphillipmoore/dev-<lang>:<version>` — pre-baked images with language runtimes, validators, and every other `st-*` tool installed. | Pulled automatically by `st-docker-run`; nothing to install manually. |
 | **Claude Code plugin** | `standard-tooling-plugin` — hooks, skills, agents, and slash commands that enforce the workflow at the Claude-Code-tool level. | Declared in `.claude/settings.json`; Claude Code loads on session start. |
 
-Plus two scripted layers that aren't installed as packages but are
-expected to be present in every consuming repo:
+Plus two layers that aren't installed as packages but are expected
+to be present in every consuming repo:
 
-- **Local git hooks** — `scripts/lib/git-hooks/pre-commit` from
-  standard-tooling, wired via `git config core.hooksPath`.
+- **Local git hooks** — a `.githooks/pre-commit` env-var gate
+  checked into the repo, wired via `git config core.hooksPath
+  .githooks`.
 - **CI workflow** — the `standards-compliance` composite action
   from `wphillipmoore/standard-actions`, invoked from your repo's
   `.github/workflows/ci.yml`.
@@ -37,9 +38,10 @@ Install on your host (macOS or Linux):
 **Docker** — the container engine. Docker Desktop on macOS is fine;
 Docker Engine on Linux works too.
 
-**uv** — Python package manager. Used to bootstrap the host venv and
-(inside the container) to manage Python dependencies. Install via
-the [official installer](https://docs.astral.sh/uv/getting-started/installation/).
+**uv** — Python package manager. Used to install `standard-tooling`
+on the host and (inside the container) to manage Python
+dependencies. Install via the
+[official installer](https://docs.astral.sh/uv/getting-started/installation/).
 
 **gh** — GitHub CLI. Must be authenticated
 (`gh auth login`). Used by `st-submit-pr` to create PRs and, inside
@@ -49,57 +51,25 @@ the container, to pass through your GitHub token for push operations.
 Linux.
 
 You do **not** need to install language runtimes, linters, test
-frameworks, markdownlint, shellcheck, or any `st-*` tool other than
-`st-docker-run` on the host. All of those live inside the container.
+frameworks, markdownlint, or shellcheck on the host. All of those
+live inside the container.
 
-## Step 2: Clone and bootstrap standard-tooling
-
-Clone standard-tooling as a sibling directory. The exact location
-doesn't matter much — just make sure you can reference it with a
-consistent relative path from your consuming repo.
+## Step 2: Install standard-tooling
 
 ```bash
-cd ~/dev/github   # or wherever
-git clone https://github.com/wphillipmoore/standard-tooling.git
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
 ```
 
-Bootstrap the host venv:
+This installs all `st-*` console scripts into `~/.local/bin/`,
+which `uv`'s official installer already configures on `PATH`. No
+sibling checkout, no custom PATH entries, no venv bootstrapping.
+
+Verify:
 
 ```bash
-cd standard-tooling
-UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+which st-docker-run    # should resolve to ~/.local/bin/st-docker-run
+st-docker-run --help   # should print usage
 ```
-
-!!! important "Why `UV_PROJECT_ENVIRONMENT=.venv-host`"
-    The project also uses a `.venv` inside the dev container (at
-    `/workspace/.venv/`). Running a plain `uv sync` on the host
-    would create that container-venv on your host filesystem, with
-    shebangs pointing at `/workspace/.venv/bin/python` — which
-    doesn't exist on your host, making every `st-*` entry point
-    unrunnable. Setting `UV_PROJECT_ENVIRONMENT=.venv-host` creates
-    a separate host-specific venv with the correct host-Python
-    shebangs, and `--group dev` pulls the dependencies
-    `st-docker-run` needs.
-
-This creates `.venv-host/bin/` with `st-docker-run` and a handful of
-other host-side scripts.
-
-## Step 3: PATH configuration
-
-Add two directories to your PATH:
-
-```bash
-export PATH="$HOME/dev/github/standard-tooling/.venv-host/bin:$HOME/dev/github/standard-tooling/scripts/bin:$PATH"
-```
-
-- `.venv-host/bin/` — the Python-packaged host entry points,
-  including `st-docker-run`.
-- `scripts/bin/` — grandfathered bash validators consumed via PATH.
-  Most still have `st-*` Python equivalents, but some CI paths
-  still reach for the bash versions.
-
-Add this to `~/.bashrc`, `~/.zshrc`, or your shell's equivalent so
-it persists.
 
 Optional — add `gh`'s token to your environment so it flows into
 the container automatically on `st-docker-run` invocations:
@@ -108,31 +78,46 @@ the container automatically on `st-docker-run` invocations:
 export GH_TOKEN=$(gh auth token)
 ```
 
-## Step 4: Git hook setup
+!!! note "Dev-tree override for standard-tooling development"
+    If you are developing standard-tooling itself and want to test
+    unreleased code on the host, use the `.venv-host` dev-tree
+    override described in the standard-tooling `CLAUDE.md`. This
+    does not apply to consuming repos.
 
-From your consuming repo's root:
+## Step 3: Git hook setup
+
+Every managed repo checks in a `.githooks/pre-commit` env-var gate.
+Create it in your repo:
 
 ```bash
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks
+#!/usr/bin/env bash
+# Admit st-commit-driven commits.
+if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then exit 0; fi
+# Admit derived-commit workflows (amend, cherry-pick, revert, rebase, merge).
+case "${GIT_REFLOG_ACTION:-}" in
+  amend|cherry-pick|revert|rebase*|merge*) exit 0 ;;
+esac
+echo "ERROR: raw 'git commit' is blocked. Use 'st-commit' instead." >&2
+echo "See docs/repository-standards.md" >&2
+exit 1
 ```
 
-Adjust the relative path if standard-tooling lives somewhere other
-than the parent directory. This must be re-run per fresh clone —
-it lives in `.git/config`, which isn't versioned.
+Save this as `.githooks/pre-commit`, make it executable, and commit
+it. Then enable the hook once per clone:
 
-The pre-commit hook enforces:
+```bash
+chmod +x .githooks/pre-commit
+git config core.hooksPath .githooks
+```
 
-- Detached-HEAD commits blocked
-- Direct commits to protected branches (`develop`/`release`/`main`)
-  blocked
-- Branch names must use one of the allowed prefixes for the repo's
-  `branching_model`
-- Work branches (`feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`)
-  must include a repository issue number
+The gate admits commits from `st-commit` (which sets
+`ST_COMMIT_CONTEXT=1`) and from derived workflows like rebase and
+cherry-pick. All branch/context checks (detached HEAD, protected
+branches, branch prefix, issue number) live in `st-commit` itself.
 
 Full reference: [Git Hooks and Validation][hooks-doc].
 
-## Step 5: Repository profile
+## Step 4: Repository profile
 
 Create `docs/repository-standards.md` at your repo root. This is
 the primary configuration surface for the validators:
@@ -165,7 +150,7 @@ Required attributes and accepted values:
 |---|---|---|
 | `repository_type` | `application`, `library`, `tooling`, `documentation` | Informational; some validators branch on this. |
 | `versioning_scheme` | `semver`, `calver`, `none` | How releases are versioned. |
-| `branching_model` | `library-release`, `application-promotion`, `docs-single-branch` | Determines which branch prefixes the pre-commit hook allows. |
+| `branching_model` | `library-release`, `application-promotion`, `docs-single-branch` | Determines which branch prefixes `st-commit` allows. |
 | `release_model` | `tagged-release`, `continuous-deploy`, `none` | Affects release-flow tooling expectations. |
 | `supported_release_lines` | integer (commonly `1`) | How many concurrent major lines you support. |
 | `primary_language` | `python`, `go`, `java`, `rust`, `ruby`, `shell`, `none` | Determines which per-language validators run. |
@@ -177,7 +162,7 @@ agent identity.
 Values containing `<`, `>`, or `|` are rejected as placeholders by
 `st-repo-profile`.
 
-## Step 6: Enable the Claude Code plugin
+## Step 5: Enable the Claude Code plugin
 
 Create `.claude/settings.json` in your repo:
 
@@ -229,7 +214,7 @@ for the full list.
     `~/.claude/plugins/marketplaces/standard-tooling-marketplace/`
     if a hook seems outdated.
 
-## Step 7: Worktree convention
+## Step 6: Worktree convention
 
 Every managed repo adopts the worktree convention so multiple
 Claude Code agents can work in parallel without colliding. Two
@@ -253,7 +238,7 @@ plugin's commit-block hook activates against the presence of
 For how to actually use worktrees during development, see
 [Git Workflow → Parallel work with worktrees](git-workflow.md#parallel-work-with-worktrees).
 
-## Step 8: Markdownlint configuration
+## Step 7: Markdownlint configuration
 
 Create `.markdownlint.yaml` at your repo root:
 
@@ -284,7 +269,7 @@ CHANGELOG.md
 releases/
 ```
 
-## Step 9: CI workflow
+## Step 8: CI workflow
 
 Use the `standards-compliance` composite action from
 `wphillipmoore/standard-actions`. Minimal workflow
@@ -325,12 +310,12 @@ no further setup is needed in the workflow.
 See the [CI Architecture](ci-architecture.md) guide if you also want
 per-language test/lint/audit tiers.
 
-## Step 10: Verify end-to-end
+## Step 9: Verify end-to-end
 
 Once the above is in place, sanity-check each layer:
 
 ```bash
-# 1. Host bridge — should print st-docker-run help
+# 1. Host tools — should print st-docker-run help
 st-docker-run --help
 
 # 2. Dev container — pulls an image on first run and runs a
@@ -340,12 +325,8 @@ st-docker-run -- echo "container ok"
 # 3. Repo profile — runs st-repo-profile inside the container
 st-docker-run -- uv run st-repo-profile
 
-# 4. Git hook — creating a bad branch name and trying to commit
-#    should be blocked
-git checkout -b bad-name
+# 4. Git hook — raw git commit should be blocked by the gate
 git commit --allow-empty -m "test"     # expected: blocked
-git checkout -
-git branch -D bad-name
 
 # 5. Plugin hook (requires Claude Code session) — in a Claude
 #    Code session in this repo, have Claude try to run a raw
@@ -354,25 +335,21 @@ git branch -D bad-name
 ```
 
 If any step fails, check the corresponding section above, then
-re-run. Common causes: PATH missing an entry, `.venv-host` built
-without the `UV_PROJECT_ENVIRONMENT` override, `.claude/settings.json`
-not committed to the branch your Claude Code session loaded.
+re-run. Common causes: `uv tool install` not run,
+`.claude/settings.json` not committed to the branch your Claude
+Code session loaded.
 
 ## Keeping up to date
 
-Standard-tooling's host side is consumed via the sibling
-`.venv-host/` checkout. To pull updates:
+After each `standard-tooling` release, upgrade the host tools:
 
 ```bash
-cd ../standard-tooling
-git pull
-UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+uv tool upgrade standard-tooling
 ```
 
-!!! important "Don't drop the `UV_PROJECT_ENVIRONMENT` override"
-    It applies on every sync, not just the initial bootstrap. A
-    plain `uv sync` in the standard-tooling checkout will rebuild
-    `.venv-host/` with the wrong shebangs again.
+`uv tool upgrade` re-resolves the git reference, pulls the current
+tip of the rolling minor tag, and rebuilds the isolated tool venv.
+No need to repeat the full git URL.
 
 The dev container images auto-update on `st-docker-run` pulls — the
 tag is a minor version (`3.12`, `1.26`, etc.) that tracks upstream
@@ -389,12 +366,9 @@ git -C ~/.claude/plugins/marketplaces/standard-tooling-marketplace pull
 
 ## Troubleshooting
 
-- **`st-docker-run: command not found`** — `.venv-host/bin` isn't
-  on PATH, or the `UV_PROJECT_ENVIRONMENT` override was skipped
-  when bootstrapping.
-- **`st-*` commands fail with shebang errors** — `.venv-host/` was
-  built with a plain `uv sync` (no `UV_PROJECT_ENVIRONMENT=.venv-host`).
-  Remove the venv and re-bootstrap.
+- **`st-docker-run: command not found`** — `uv tool install` has
+  not been run, or `~/.local/bin` is not on PATH. Re-run the install
+  command from Step 2 and confirm `which st-docker-run` resolves.
 - **`manifest unknown` when pulling a container image** — the tag
   you're asking for doesn't exist on GHCR. Older docs referenced
   `ghcr.io/wphillipmoore/dev-docs:latest` (renamed to `dev-base` in
@@ -413,6 +387,9 @@ git -C ~/.claude/plugins/marketplaces/standard-tooling-marketplace pull
   expected since 2026-04-22. Auto-merge is disabled org-wide; the
   PR itself was created successfully. Tracked in
   [standard-tooling#268](https://github.com/wphillipmoore/standard-tooling/issues/268).
+- **"raw 'git commit' is blocked"** — the `.githooks/pre-commit`
+  gate is working as intended. Use `st-commit` instead of raw `git
+  commit`.
 
 For a broader troubleshooting index see
 [Git Workflow → Troubleshooting](git-workflow.md#troubleshooting).

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -69,7 +69,7 @@ mechanisms. Both exist; they complement each other.
 
 | Layer | Where it runs | Catches |
 |---|---|---|
-| **Pre-commit git hook** | `scripts/lib/git-hooks/pre-commit` in standard-tooling; consumed via `git config core.hooksPath`. Fires on every `git commit`, regardless of how it was invoked. | Detached HEAD • direct commits to protected branches • wrong branch prefix • missing issue number in branch name |
+| **Pre-commit git hook** | `.githooks/pre-commit` checked into each repo; enabled via `git config core.hooksPath .githooks`. The hook is an env-var gate that admits `st-commit`-driven commits and rejects raw `git commit`. The five branch/context checks live in `st-commit` itself. | Detached HEAD • direct commits to protected branches • wrong branch prefix • missing issue number in branch name |
 | **Plugin PreToolUse hooks** | Delivered by the [`standard-tooling-plugin`](https://github.com/wphillipmoore/standard-tooling-plugin). Fires on Claude Code's `Bash`/`Write`/`Edit` tool invocations. | Raw `git commit` (forces `st-commit`) • Raw `gh pr create` (forces `st-submit-pr`) • commits originating from outside `.worktrees/*` on repos that have adopted the worktree convention • heredoc syntax in CLI args • associative-array bashisms |
 
 **Why both?** The pre-commit hook catches anyone (human or agent)
@@ -302,8 +302,8 @@ At a minimum, a new repo needs:
 
 1. `docs/repository-standards.md` with the six required attributes
    (see the existing setup guide).
-2. `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`
-   (or equivalent path) so the pre-commit hook fires.
+2. A `.githooks/pre-commit` env-var gate checked into the repo, plus
+   `git config core.hooksPath .githooks` (once per clone).
 3. `.claude/settings.json` enabling the `standard-tooling` plugin
    so the plugin hooks fire in Claude Code sessions.
 4. `.worktrees/` in `.gitignore` and a Parallel-AI-agent-development
@@ -353,9 +353,8 @@ The plugin's `validate-on-edit` hook expects those validators on
 PATH. Some are only installed inside the dev container image, not on
 the host. Hook-level PATH discovery is tracked in
 [standard-tooling#265](https://github.com/wphillipmoore/standard-tooling/issues/265).
-Workaround: run the validator explicitly with an absolute path
-(`.venv-host/bin/st-markdown-standards …`) to confirm the file is
-clean; then proceed.
+Workaround: run the validator explicitly via `st-docker-run` to
+confirm the file is clean; then proceed.
 
 ## Related
 

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -15,8 +15,8 @@ commits, PRs, releases, and validation alongside bash validators and git hooks
 `st-repo-profile`, `st-markdown-standards`,
 `st-pr-issue-linkage`, validation drivers
 
-**Git hooks** (`scripts/lib/git-hooks/`):
-Branch naming enforcement, commit message validation
+**Git hooks** (`.githooks/`):
+Env-var gate that admits `st-commit` and blocks raw `git commit`
 
 ## Design Principles
 
@@ -24,18 +24,22 @@ Branch naming enforcement, commit message validation
 - **shellcheck clean** -- all shell scripts pass shellcheck
 - **No repo-specific logic** -- every script works in any consuming
   repository
-- **PATH-based consumption** -- consuming repos add standard-tooling to
-  PATH rather than copying files
+- **Host-level install** -- `uv tool install` puts `st-*` on PATH;
+  no sibling checkout required
 
 ## How It Works
 
-1. Standard-tooling is cloned as a sibling directory (local development)
-   or checked out in CI (GitHub Actions).
-2. The Python package is installed via `uv sync`, making `st-*` CLI
-   tools available in `.venv/bin/`.
-3. `.venv/bin/` is added to PATH.
-4. Git hooks are configured to point at `scripts/lib/git-hooks/`.
-5. Consuming repos call tools by bare name -- no file copying or syncing.
+1. `standard-tooling` is installed on the developer's host via
+   `uv tool install`, placing `st-*` scripts in `~/.local/bin/`.
+2. `st-docker-run` bridges host commands into dev container images
+   where language runtimes and validators live.
+3. Python consumers also declare `standard-tooling` as a dev dep
+   via `[tool.uv.sources]` so `uv run st-*` inside the container
+   resolves the pinned version.
+4. Each repo checks in a `.githooks/pre-commit` env-var gate,
+   enabled via `git config core.hooksPath .githooks`.
+5. Consuming repos call tools by bare name -- no file copying or
+   syncing.
 
 ## Quick Links
 

--- a/docs/site/docs/reference/hooks/pre-commit.md
+++ b/docs/site/docs/reference/hooks/pre-commit.md
@@ -1,14 +1,17 @@
 # pre-commit
 
-**Path:** `scripts/lib/git-hooks/pre-commit`
+**Path:** `.githooks/pre-commit`
 
-Enforces branch naming conventions before allowing a commit. Reads the
-`branching_model` attribute from `docs/repository-standards.md` to
-determine allowed branch prefixes.
+The pre-commit hook is an env-var gate that admits `st-commit`-driven
+commits (via `ST_COMMIT_CONTEXT=1`) and derived workflows (amend,
+cherry-pick, revert, rebase, merge), and rejects raw `git commit`.
+
+The five branch/context checks below live in `st-commit` itself and
+run before `git commit` is invoked:
 
 ## Checks
 
-The hook runs five checks in order:
+`st-commit` runs five checks in order:
 
 ### 1. Detached HEAD
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fleet-wide documentation sweep for the standard-tooling repo itself (first phase of #288). Rewrites all docs to reflect the host-level-tool spec (#286):

- **Host install model**: Replace sibling-checkout + `.venv-host` bootstrap with `uv tool install` as the canonical host install mechanism across all consumer-facing docs (getting-started, consuming-repo-setup, git-workflow, index).
- **Git hooks**: Replace all `scripts/lib/git-hooks/pre-commit` references with `.githooks/pre-commit` env-var gate. Document that branch/context checks live in `st-commit`, not the hook.
- **Deprecate include-and-remember**: Remove `<!-- include: -->` directives from CLAUDE.md and AGENTS.md.
- **Standards reference**: Downgrade aspirational `standards-and-conventions` ref to historical/informational.
- **Misc fixes**: Fix stale `../standard-tooling` docker ref in ci-architecture.md, update pre-commit reference page, update site index.

10 files changed, net -35 lines. All validation passes (421 tests, 100% coverage).

Fixes #288 (standard-tooling sweep only; consumer repo sweeps are subsequent work).

## Issue Linkage

- Ref #288

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -