### PR TITLE
chore(cli): change st-submit-pr default linkage from Fixes to Ref

### DIFF
--- a/src/standard_tooling/bin/submit_pr.py
+++ b/src/standard_tooling/bin/submit_pr.py
@@ -26,7 +26,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--summary", required=True, help="One-line PR summary")
     parser.add_argument(
-        "--linkage", default="Fixes", choices=ALLOWED_LINKAGES, help="Issue linkage keyword"
+        "--linkage", default="Ref", choices=ALLOWED_LINKAGES, help="Issue linkage keyword"
     )
     parser.add_argument("--notes", default="", help="Additional notes")
     parser.add_argument("--title", default="", help="PR title (default: latest commit subject)")

--- a/tests/standard_tooling/test_submit_pr.py
+++ b/tests/standard_tooling/test_submit_pr.py
@@ -40,7 +40,7 @@ def test_parse_args_required() -> None:
     args = parse_args(["--issue", "42", "--summary", "Fix bug"])
     assert args.issue == "42"
     assert args.summary == "Fix bug"
-    assert args.linkage == "Fixes"
+    assert args.linkage == "Ref"
     assert args.dry_run is False
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Change st-submit-pr default --linkage from Fixes to Ref, aligning with the plugin-side block-autoclose-linkage hook that rejects Fixes/Closes/Resolves

## Issue Linkage

- Ref #356

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -