### PR TITLE
docs(spec): fix spec-plan alignment issues from pushback review

### DIFF
--- a/docs/plans/decouple-st-from-images-plan.md
+++ b/docs/plans/decouple-st-from-images-plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Decouple standard-tooling from dev container images
 
-**Status:** Draft — awaiting `paad:alignment` against the spec
+**Status:** Phase 1 complete — awaiting release
 **Spec:** [`docs/specs/decouple-st-from-images-plan.md`](../specs/decouple-st-from-images-plan.md)
 **Issue:** [#362](https://github.com/wphillipmoore/standard-tooling/issues/362)
 **Pushback review:**
@@ -11,14 +11,13 @@
 
 This plan covers the full implementation of removing pre-baked
 `standard-tooling` from dev container images and replacing it with
-transparent runtime installation via `st-docker-run`, plus per-branch
-image caching via a new `st-docker-cache` command.
+cache-first per-branch Docker images built by `st-docker-run`, plus
+a new `st-docker-cache` command for explicit cache management.
 
 Work spans `standard-tooling` (primary), `standard-tooling-docker`,
-and all consuming repos, sequenced in six phases:
+and all consuming repos, sequenced in five phases:
 
-1. Runtime install wrapping + `st-config.toml` reader (standard-tooling)
-1b. `st-docker-cache` command (standard-tooling)
+1. Cache-first `st-docker-run` + `st-docker-cache` (standard-tooling) **DONE**
 2b. Bootstrap `st-config.toml` in all consuming repos
 2. Strip standard-tooling from images (standard-tooling-docker)
 3. Remove dispatch/verify pipeline (standard-tooling)
@@ -38,6 +37,10 @@ fleet-of-one operational model.
 - **Private repo auth.** The runtime install uses unauthenticated
   HTTPS, matching the current image build pattern. `standard-tooling`
   is a public repository.
+- **`docker.warmup` and `docker.cache-files` config overrides.** The
+  spec mentions these as future `st-config.toml` fields. Phase 1
+  uses hardcoded language-to-file and language-to-warmup mappings.
+  Config overrides are deferred to follow-up work if needed.
 
 ## Prerequisites
 
@@ -49,452 +52,61 @@ Before starting Phase 1:
 
 ---
 
-## Phase 1: Add runtime install to `st-docker-run`
+## Phase 1: Cache-first `st-docker-run` + `st-docker-cache`  DONE
 
 **Repo:** standard-tooling
-**Branch:** `feature/362-decouple-st-from-images` (this worktree)
-**Issue:** #362
+**Branch:** `feature/362-decouple-st-from-images`
+**PR:** [#364](https://github.com/wphillipmoore/standard-tooling/pull/364)
 
-### Step 1.1: Implement `st-config.toml` reader
+Shipped as a single PR. 473 tests, 100% coverage.
 
-**File:** `src/standard_tooling/lib/config.py` (new)
+### What shipped
 
-Create a minimal config reader with two public functions:
+| File | Change |
+|---|---|
+| `src/standard_tooling/lib/config.py` | New. `st-config.toml` reader: `read_st_config()`, `st_install_tag()`. |
+| `src/standard_tooling/lib/docker_cache.py` | New. Cache engine: `cache_sensitive_files()`, `compute_cache_hash()`, `find_cached_image()`, `ensure_cached_image()`, `_build_cached_image()`, `clean_branch_images()`. |
+| `src/standard_tooling/bin/docker_cache.py` | New. `st-docker-cache` CLI: `build`, `clean`, `status`, `clean-all` subcommands. |
+| `src/standard_tooling/bin/docker_run.py` | Modified. Three-way image selection: `DOCKER_DEV_IMAGE` env → Python base → non-Python `ensure_cached_image()`. |
+| `src/standard_tooling/bin/finalize_repo.py` | Modified. Calls `clean_branch_images()` after branch deletion (skipped in dry-run). |
+| `st-config.toml` | New. `[standard-tooling] tag = "v1.4"`. |
+| `pyproject.toml` | Modified. Registered `st-docker-cache` console script. |
+| `tests/standard_tooling/test_config.py` | New. 9 tests. |
+| `tests/standard_tooling/test_docker_cache.py` | New. 27 tests. |
+| `tests/standard_tooling/test_docker_cache_cli.py` | New. 12 tests. |
+| `tests/standard_tooling/test_docker_run.py` | Modified. 4 new cache-aware tests. |
+| `tests/standard_tooling/test_finalize_repo.py` | Modified. Mocked `clean_branch_images` + 1 new test. |
 
-- `read_st_config(repo_root: Path) -> dict` — reads and parses
-  `st-config.toml` from the repo root. Raises `SystemExit` if the
-  file is missing.
-- `st_install_tag(repo_root: Path) -> str` — returns the
-  `standard-tooling.tag` value. Checks `ST_DOCKER_INSTALL_TAG` env
-  var first (override). Raises `SystemExit` if the field is missing.
+### Design decision: cache-first, not per-command wrapping
 
-Implementation details:
+The original plan described wrapping each command with
+`bash -c "pip install ... && <command>"`. During implementation this
+was rejected in favor of the cache-first approach:
 
-```python
-import os
-import tomllib
-from pathlib import Path
+- Install standard-tooling **once** when building the cached image
+- Run commands **directly** against the cached image (no wrapping)
+- Hash-based invalidation rebuilds automatically when lockfiles or
+  `st-config.toml` change
 
-_CONFIG_FILE = "st-config.toml"
+Per-command wrapping was never implemented. The spec's rejected
+alternatives section documents this decision.
 
-def read_st_config(repo_root: Path) -> dict:
-    config_path = repo_root / _CONFIG_FILE
-    if not config_path.is_file():
-        raise SystemExit(
-            f"ERROR: {_CONFIG_FILE} not found at {repo_root}.\n"
-            f"Every repo must have an {_CONFIG_FILE}."
-        )
-    with config_path.open("rb") as f:
-        return tomllib.load(f)
+### Completion criteria (all met)
 
-def st_install_tag(repo_root: Path) -> str:
-    override = os.environ.get("ST_DOCKER_INSTALL_TAG")
-    if override:
-        return override
-    config = read_st_config(repo_root)
-    st = config.get("standard-tooling", {})
-    tag = st.get("tag")
-    if not tag:
-        raise SystemExit(
-            f"ERROR: {_CONFIG_FILE} missing 'standard-tooling.tag' field."
-        )
-    return tag
-```
-
-**Completion:** Unit tests pass (see step 1.5).
-
-### Step 1.2: Add wrapping functions to `docker.py`
-
-**File:** `src/standard_tooling/lib/docker.py`
-
-Add three items at module level:
-
-1. A constant: `_ST_GIT_URL = "https://github.com/wphillipmoore/standard-tooling"`
-2. `needs_runtime_st_install(lang: str) -> bool` — returns `False`
-   for `"python"` and when `ST_DOCKER_SKIP_INSTALL=1`; `True`
-   otherwise.
-3. `wrap_command_for_st_install(command: list[str], lang: str,
-   repo_root: Path) -> list[str]` — if runtime install is needed,
-   returns `["bash", "-c", "pip install --quiet '<url>@<tag>' &&
-   <shlex.join(command)>"]`. Otherwise returns command unchanged.
-
-New imports needed: `import shlex` and
-`from standard_tooling.lib.config import st_install_tag`.
-
-**Completion:** Unit tests pass (see step 1.5).
-
-### Step 1.3: Wire wrapping into `docker_run.py`
-
-**File:** `src/standard_tooling/bin/docker_run.py`
-
-Changes to `main()`:
-
-1. After `lang = detect_language(repo_root)` (current line 74), add:
-   ```python
-   from standard_tooling.lib.docker import (
-       needs_runtime_st_install,
-       wrap_command_for_st_install,
-   )
-   container_command = wrap_command_for_st_install(command, lang, repo_root)
-   ```
-   Move this import to the top of the file with the existing docker
-   imports.
-
-2. Pass `container_command` instead of `command` to
-   `build_docker_args()` (current line 87).
-
-3. Update diagnostic output (lines 77-83). After the existing
-   `Image:` line, add an `Install:` line:
-   - Non-Python: `Install:  runtime (pip install standard-tooling@<tag>)`
-   - Python: `Install:  skipped (Python repos use dev deps)`
-
-### Step 1.4: Update `_USAGE` in `docker_run.py`
-
-**File:** `src/standard_tooling/bin/docker_run.py`
-
-Add two env vars to the `_USAGE` string's environment variables
-section:
-
-```text
-  ST_DOCKER_INSTALL_TAG  override the standard-tooling version tag from st-config.toml
-  ST_DOCKER_SKIP_INSTALL set to 1 to skip the runtime standard-tooling install
-```
-
-### Step 1.5: Write tests
-
-#### `tests/standard_tooling/test_config.py` (new)
-
-Test `read_st_config`:
-- Missing `st-config.toml` raises `SystemExit` with descriptive message.
-- Empty/malformed YAML raises `SystemExit` or returns empty dict
-  (verify behavior of `tomllib.load` on edge cases).
-- Valid file returns parsed dict.
-
-Test `st_install_tag`:
-- Valid config returns the tag string.
-- Missing `standard-tooling` key raises `SystemExit`.
-- Missing `tag` field raises `SystemExit`.
-- `ST_DOCKER_INSTALL_TAG` env var overrides file value (use
-  `monkeypatch.setenv`).
-- `ST_DOCKER_INSTALL_TAG` env var takes precedence even when file
-  is missing (env var is checked first).
-
-Use `tmp_path` fixture to create temporary `st-config.toml` files
-for each test case.
-
-#### `tests/standard_tooling/test_docker.py` (existing)
-
-Add tests for `needs_runtime_st_install`:
-- `"go"`, `"ruby"`, `"rust"`, `"java"`, `""` all return `True`.
-- `"python"` returns `False`.
-- With `ST_DOCKER_SKIP_INSTALL=1` set, all languages return `False`.
-
-Add tests for `wrap_command_for_st_install`:
-- Non-Python language wraps command with `bash -c "pip install ... &&
-  <command>"`.
-- Python language returns command unchanged.
-- Multi-token commands are joined correctly via `shlex.join` (verify
-  quoting of args with spaces).
-- `ST_DOCKER_SKIP_INSTALL=1` returns command unchanged regardless
-  of language.
-
-Mock `st_install_tag` in wrapping tests to avoid needing a real
-`st-config.toml`.
-
-#### `tests/standard_tooling/test_docker_run.py` (existing)
-
-Add integration-level tests for `main()`:
-- Non-Python repo with valid `st-config.toml`: verify the docker args
-  list contains `bash -c "pip install ... && <command>"`.
-- Python repo: verify the docker args end with the original command
-  (no wrapping).
-
-These tests need to mock `os.execvp` (already done in existing
-tests) and provide a `st-config.toml` in the temp repo fixture.
-
-### Step 1.6: Add `st-config.toml` to this repo
-
-**File:** `st-config.toml` (new, at repo root)
-
-```toml
-[standard-tooling]
-tag = "v1.4"
-```
-
-This repo is a Python project — the runtime install is skipped. The
-file exists for consistency and to exercise the reader in tests.
-
-### Step 1.7: Validate
-
-Run `st-docker-run -- uv run st-validate-local`. All tests must
-pass with 100% coverage.
-
-**Phase 1 completion criteria:**
-- All new and existing tests pass.
 - `st-config.toml` exists at repo root.
-- `st-docker-run` wraps non-Python commands with `pip install`.
-- `st-docker-run` skips wrapping for Python repos.
-- `ST_DOCKER_INSTALL_TAG` and `ST_DOCKER_SKIP_INSTALL` work.
-- Backward-compatible: wrapping against current images (with
-  pre-baked st) no-ops or upgrades harmlessly.
-
----
-
-## Phase 1b: Add `st-docker-cache` command
-
-**Repo:** standard-tooling
-**Branch:** separate feature branch (must merge after Phase 1)
-**Issue:** #362 (or sub-issue if needed)
-
-### Step 1b.0: Create branch
-
-Create `feature/362-docker-cache` from `develop` after Phase 1 has
-merged. Phase 1b depends on `config.py` and the runtime install
-fallback from Phase 1.
-
-### Step 1b.1: Implement cache hash computation
-
-**File:** `src/standard_tooling/lib/docker_cache.py` (new)
-
-Core library functions:
-
-- `_CACHE_FILES: dict[str, list[str]]` — maps language to lockfile
-  names. Always includes `st-config.toml`. Unknown language gets only
-  `st-config.toml`.
-
-  ```python
-  _CACHE_FILES = {
-      "python": ["uv.lock", "st-config.toml"],
-      "ruby": ["Gemfile.lock", "st-config.toml"],
-      "rust": ["Cargo.lock", "st-config.toml"],
-      "go": ["go.sum", "st-config.toml"],
-      "java": ["pom.xml", "st-config.toml"],
-  }
-  _DEFAULT_CACHE_FILES = ["st-config.toml"]
-  ```
-
-- `cache_sensitive_files(repo_root: Path, lang: str) -> list[Path]`
-  — returns resolved paths of cache-sensitive files that exist.
-  Checks `st-config.toml` for `docker.cache-files` override first.
-
-- `compute_cache_hash(files: list[Path]) -> str` — SHA-256 over
-  sorted file contents, returns first 8 hex chars.
-
-- `_sanitize_branch(branch: str) -> str` — replace `/` with `-`,
-  strip characters invalid in Docker tags.
-
-- `cache_image_tag(base_image: str, branch: str, hash: str) -> str`
-  — constructs the tag per the naming convention:
-  `<base-tag>--<sanitized-branch>--<hash>`.
-
-- `find_cached_image(base_image: str, branch: str) -> tuple[str,
-  str] | None` — queries `docker images` for an image matching the
-  base+branch pattern. Returns `(tag, hash)` or None.
-
-- `_WARMUP_COMMANDS: dict[str, str]` — default warmup per language.
-
-  ```python
-  _WARMUP_COMMANDS = {
-      "python": "uv sync --group dev",
-      "ruby": "bundle install --jobs 4",
-      "rust": "cargo fetch && cargo build --lib",
-      "go": "go mod download && go build ./...",
-      "java": "./mvnw dependency:resolve",
-  }
-  ```
-
-- `warmup_command(repo_root: Path, lang: str) -> str | None` —
-  returns the warmup command. Checks `st-config.toml` for
-  `docker.warmup` override first. Returns None for unknown languages
-  with no override.
-
-### Step 1b.2: Implement `st-docker-cache` CLI
-
-**File:** `src/standard_tooling/bin/docker_cache.py` (new)
-
-Entry point with four subcommands via `argparse` sub-parsers:
-
-#### `build` subcommand
-
-1. Determine repo root, language, branch, base image.
-2. Compute cache hash from `cache_sensitive_files()`.
-3. Check for existing cached image via `find_cached_image()`.
-4. If image exists and hash matches: print "Cache is current" and
-   exit.
-5. If no match: build a new cached image:
-   a. Determine install command: for non-Python, `pip install
-      --quiet 'standard-tooling @ git+<url>@<tag>'`. For Python:
-      skip (warmup handles it).
-   b. Determine warmup command from `warmup_command()`.
-   c. Construct the full setup command: `<install> && <warmup>`
-      (or just `<warmup>` for Python).
-   d. Run `docker run --rm` from the base image with the repo
-      mounted at `/workspace`, execute the setup command. Capture
-      the container ID by using `docker create` + `docker start`
-      + `docker wait` instead of `docker run --rm`, so we can
-      commit.
-
-      Revised sequence:
-      ```
-      docker create -v <repo>:/workspace -w /workspace <base> \
-          bash -c "<setup_command>"
-      docker start -a <container_id>
-      docker commit <container_id> <cache_tag>
-      docker rm <container_id>
-      ```
-   e. Remove old cached image for this branch if hash changed
-      (`docker rmi <old_tag>`).
-6. Print summary: base image, branch, hash, cache tag.
-
-#### `clean` subcommand
-
-1. Find cached image for current branch via `find_cached_image()`.
-2. If found: `docker rmi <tag>`. Print confirmation.
-3. If not found: print "No cached image for this branch."
-
-#### `status` subcommand
-
-1. Find cached image for current branch.
-2. If found: print tag, hash, creation time (from `docker inspect`).
-3. If not found: print "No cached image."
-
-#### `clean-all` subcommand
-
-1. List all Docker images matching the `st-docker-cache` naming
-   pattern (images with `--` separators in their tags).
-2. Remove each one.
-3. Print count of removed images.
-
-### Step 1b.3: Add cache-aware image selection to `docker.py`
-
-**File:** `src/standard_tooling/lib/docker.py`
-
-Add function:
-
-```python
-def cached_image_for_branch(
-    repo_root: Path, lang: str,
-) -> str | None:
-    """Return cached image tag for current branch, or None."""
-    from standard_tooling.lib.docker_cache import find_cached_image
-    from standard_tooling.lib import git as _git
-
-    branch = _git.current_branch()
-    base = default_image(lang, fallback=True)
-    result = find_cached_image(base, branch)
-    return result[0] if result else None
-```
-
-### Step 1b.4: Wire cache lookup into `docker_run.py`
-
-**File:** `src/standard_tooling/bin/docker_run.py`
-
-In `main()`, after `detect_language()` and before the
-`DOCKER_DEV_IMAGE` check:
-
-1. Call `cached_image_for_branch(repo_root, lang)`.
-2. If a cached image is returned:
-   - Use it as the image (skip `default_image()` and
-     `DOCKER_DEV_IMAGE`).
-   - Skip runtime install wrapping (the cache already has st
-     installed).
-   - Print `Image: <tag> (cached)` in diagnostics.
-3. If no cached image: fall through to existing logic (base image +
-   runtime install wrapping from Phase 1).
-
-### Step 1b.5: Add cache cleanup to `st-finalize-repo`
-
-**File:** `src/standard_tooling/bin/finalize_repo.py`
-
-In the branch deletion loop (after line 202: `deleted.append(branch)`),
-add cache cleanup:
-
-```python
-# Clean up any cached Docker image for the deleted branch.
-from standard_tooling.lib.docker_cache import find_cached_image
-from standard_tooling.lib.docker import default_image
-# ... determine lang from detect_language if needed, or clean by
-# branch name pattern across all base images.
-```
-
-Implementation note: `find_cached_image` needs the base image tag,
-but at finalize time we may not know the language of the deleted
-branch. Simpler approach: add a `clean_branch_images(branch: str)`
-function to `docker_cache.py` that removes ALL cached images whose
-tag contains `--<sanitized-branch>--`, regardless of base image.
-This avoids needing language detection during cleanup.
-
-### Step 1b.6: Register console script
-
-**File:** `pyproject.toml`
-
-Add entry to `[project.scripts]`:
-
-```toml
-st-docker-cache = "standard_tooling.bin.docker_cache:main"
-```
-
-### Step 1b.7: Write tests
-
-**File:** `tests/standard_tooling/test_docker_cache.py` (new)
-
-Hash computation:
-- Same file contents produce same hash.
-- Different file contents produce different hash.
-- Changing `st-config.toml` changes the hash.
-- Missing files are excluded from hash (not an error).
-- Correct lockfile selected for each language.
-- Unknown language hashes only `st-config.toml`.
-- `docker.cache-files` override in `st-config.toml` is respected.
-
-Image tag construction:
-- Branch name sanitization (slashes, special chars).
-- Tag format matches convention:
-  `<base>--<branch>--<hash>`.
-
-Subcommands (mock Docker CLI calls via `subprocess`):
-- `build` with no existing cache creates a new image.
-- `build` with current cache is a no-op.
-- `build` with stale cache removes old, creates new.
-- `clean` removes the image for the current branch.
-- `clean` with no cache prints message, exits 0.
-- `clean-all` removes all managed images.
-- `status` reports image info when cache exists.
-- `status` reports "no cache" when none exists.
-
-Integration with `docker_run.py`:
-- Cache hit: `main()` uses cached image, no runtime install.
-- Cache miss: `main()` falls back to base image + runtime install.
-
-Integration with `finalize_repo.py`:
-- Branch deletion triggers cache cleanup for that branch.
-
-Warmup command:
-- Default warmup selected per language.
-- `docker.warmup` override in `st-config.toml` is respected.
-- Unknown language with no override returns None (build still
-  installs st, just skips warmup).
-
-### Step 1b.8: Validate
-
-Run `st-docker-run -- uv run st-validate-local`. All tests must
-pass with 100% coverage.
-
-**Phase 1b completion criteria:**
-- `st-docker-cache build` creates a derived image with st + deps.
-- `st-docker-cache clean` removes it.
-- `st-docker-cache status` reports cache state.
-- `st-docker-cache clean-all` removes all cached images.
-- `st-docker-run` uses cached image when available.
-- `st-docker-run` falls back to runtime install when no cache.
-- `st-finalize-repo` cleans cached images for deleted branches.
+- `st-docker-run` uses cached images for non-Python repos.
+- `st-docker-run` skips caching for Python repos.
+- `st-docker-cache build|clean|status|clean-all` all work.
+- `st-finalize-repo` cleans cached images on branch deletion.
+- `ST_DOCKER_INSTALL_TAG` overrides the tag from config.
+- `DOCKER_DEV_IMAGE` overrides the base image (skips cache).
 - All tests pass, 100% coverage.
 
 ---
 
-## Release: Phase 1 + 1b
+## Release: Phase 1
 
-After both phases are merged to `develop`:
+After Phase 1 has merged to `develop`:
 
 1. Run `st-prepare-release` to create the release PR.
 2. Merge the release PR. `publish.yml` tags and releases.
@@ -503,7 +115,7 @@ After both phases are merged to `develop`:
    ```bash
    uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
    ```
-5. Verify: `st-docker-run --help` shows new env vars;
+5. Verify: `st-docker-run --help` shows `ST_DOCKER_INSTALL_TAG`;
    `st-docker-cache --help` works.
 
 **Gate:** Phases 2b, 2, and 3 do not start until this release is on
@@ -537,7 +149,7 @@ tag = "v1.4"
 6. `ai-research-methodology`
 
 For `mq-rest-admin-*` repos: defer until they re-enter active
-development. The runtime install path only fires when `st-docker-run`
+development. The cache build path only fires when `st-docker-run`
 is used, which only happens during active development.
 
 Each repo: create branch, add file, validate, PR, merge, finalize.
@@ -548,13 +160,13 @@ After all repos have `st-config.toml`:
 
 - Pick a non-Python repo (e.g., `standard-tooling-docker`).
 - Run `st-docker-run -- st-validate-local` (or equivalent).
-- Confirm the runtime install fires and the command succeeds.
+- Confirm the cache build fires and the command succeeds.
 
 **Phase 2b completion criteria:**
 - All actively-used repos have `st-config.toml` committed.
-- `st-docker-run` reads the config and installs st at runtime for
-  non-Python repos (even though images still have the pre-bake —
-  the install is a no-op).
+- `st-docker-run` reads the config and builds cached images for
+  non-Python repos (even though base images still have the pre-bake —
+  the install in the cached image is a no-op or harmless upgrade).
 
 ---
 
@@ -588,7 +200,7 @@ In each Dockerfile template, remove the `@include` line:
 
 Confirm `docker/common/python-support.dockerfile` still installs
 `python3-minimal`, `python3-pip`, and `yamllint`. These are still
-needed: `pip` for runtime install, `yamllint` for
+needed: `pip` for the cached image build, `yamllint` for
 `st-validate-local-common-container`.
 
 ### Step 2.4: Remove `repository_dispatch` trigger
@@ -613,7 +225,7 @@ Images rebuild on push to main and manual trigger only.
 4. Verify `st-validate-local` is NOT on PATH:
    `docker run --rm <image> which st-validate-local` (should fail)
 5. Verify `st-docker-run -- st-validate-local` works against a
-   non-Python repo (runtime install provides `st-*`).
+   non-Python repo (cached image build provides `st-*`).
 
 ### Step 2.6: PR, merge, finalize
 
@@ -623,8 +235,7 @@ Standard PR workflow. Images rebuild automatically on push to main.
 - All 6 images build without standard-tooling pre-baked.
 - `pip` available in all images.
 - `st-*` tools NOT on PATH in any image.
-- `st-docker-run` runtime install provides `st-*` for non-Python
-  repos.
+- `st-docker-run` cache build provides `st-*` for non-Python repos.
 - `repository_dispatch` trigger removed.
 
 ---
@@ -682,21 +293,21 @@ Sections to rewrite (line numbers approximate — verify before
 editing):
 
 1. **Principle 6** (~line 84): change from image-rebuild language to
-   runtime install language. New text should say `st-docker-run`
-   transparently installs standard-tooling at container runtime for
-   non-Python repos.
+   cache-first language. New text should say `st-docker-run`
+   transparently builds per-branch cached images with
+   standard-tooling installed for non-Python repos.
 
 2. **Deployment targets table** (~line 93): replace the "Dev
-   container image (pre-bake)" row. New row describes runtime
-   install via `st-docker-run` for non-Python consumers.
+   container image (pre-bake)" row. New row describes cached image
+   build via `st-docker-run` for non-Python consumers.
 
 3. **Non-Python consumers** (~line 316): update to describe the
-   runtime install mechanism instead of image pre-bake.
+   cache-first mechanism instead of image pre-bake.
 
 4. **Dev container image policy** (~line 326): rewrite. Images no
    longer contain standard-tooling. Non-Python images provide
    `python3` and `pip` via `python-support.dockerfile` for the
-   runtime install.
+   cached image build.
 
 5. **Image rebuild cadence tradeoff** (~line 725): remove or
    rewrite. No rebuild-freshness window exists anymore.
@@ -704,8 +315,8 @@ editing):
 6. **Acceptance criteria** (~line 743): remove items related to
    image pre-bake and automated rebuild. Add items for:
    - `st-config.toml` required in all consuming repos.
-   - `st-docker-run` transparently installs st at runtime.
-   - `st-docker-cache` provides per-branch image caching.
+   - `st-docker-run` transparently builds cached images at runtime.
+   - `st-docker-cache` provides explicit cache management.
 
 ### Step 4.2: Update `CLAUDE.md`
 
@@ -716,7 +327,7 @@ image" row:
 
 | Target | Install mechanism | Who uses it |
 |---|---|---|
-| **Dev container image** | ~~Pre-baked at image build time~~ Runtime install by `st-docker-run` for non-Python repos | `st-*` inside the container for non-Python consumers |
+| **Dev container image** | ~~Pre-baked at image build time~~ Cache-first build by `st-docker-run` for non-Python repos | `st-*` inside the container for non-Python consumers |
 
 Also add `st-docker-cache` to the CLI tools list in the Architecture
 section.
@@ -734,7 +345,7 @@ Run `st-docker-run -- uv run st-validate-local`.
 Standard PR workflow.
 
 **Phase 4 completion criteria:**
-- All docs reflect the new runtime install model.
+- All docs reflect the new cache-first model.
 - No references to pre-baked standard-tooling in images.
 - No references to `repository_dispatch` for image rebuilds.
 
@@ -755,3 +366,8 @@ File separate issues for:
 3. **Update branch-workflow and pr-workflow skills** in
    standard-tooling-plugin to invoke `st-docker-cache build` after
    branch creation and recognize `st-config.toml` as a config source.
+
+4. **`docker.warmup` and `docker.cache-files` config overrides.**
+   Allow `st-config.toml` to override the default warmup command and
+   cache-sensitive file list per repo. Only needed if the hardcoded
+   defaults prove insufficient.

--- a/docs/specs/decouple-st-from-images-plan.md
+++ b/docs/specs/decouple-st-from-images-plan.md
@@ -384,7 +384,7 @@ implemented.
 
 **Repo:** standard-tooling-docker
 **Branch type:** feature
-**Depends on:** Phase 1 released and host-upgraded
+**Depends on:** Phase 1 released and host-upgraded + Phase 2b complete
 
 #### 2.1 Delete dockerfile fragments
 
@@ -509,20 +509,20 @@ Key sections to rewrite:
 
 - **Principle 6** (line 84-89): change from "The dev container image
   tracks the rolling minor tag and rebuilds on every standard-tooling
-  release" to "`st-docker-run` transparently installs standard-tooling
-  at container runtime for non-Python repos. The version matches the
-  host-installed minor."
+  release" to "`st-docker-run` transparently builds per-branch cached
+  images with standard-tooling installed for non-Python repos."
 - **Deployment targets table** (line 93-97): replace the "Dev container
-  image" row with the runtime install mechanism.
+  image" row with the cache-first mechanism.
 - **Dev container image policy** (lines 326-359): rewrite. Images no
   longer contain standard-tooling. Non-Python images require
   `python3` and `pip` via `python-support.dockerfile`.
 - **Image rebuild cadence tradeoff** (lines 725-738): remove or
   rewrite. There is no longer a rebuild-freshness window.
 - **Non-Python consumers** (lines 316-322): update to describe the
-  runtime install mechanism instead of image pre-bake.
+  cache-first mechanism instead of image pre-bake.
 - **Acceptance criteria** (lines 743-784): remove items related to
-  image pre-bake and automated rebuild. Add items for runtime install.
+  image pre-bake and automated rebuild. Add items for cache-first
+  per-branch images.
 
 #### 4.2 Update `CLAUDE.md`
 
@@ -600,6 +600,6 @@ runs commands directly.
 Mount a persistent Docker volume (`st-pip-cache:/root/.cache/pip`) to
 cache the pip download across container runs. Rejected: caches only
 the download, not the installed state. The per-branch image caching
-via `st-docker-cache` (Phase 1b) captures all installed state —
+via `st-docker-cache` (Phase 1) captures all installed state —
 standard-tooling, project deps, compiled artifacts — in a single
 derived image, eliminating runtime install overhead entirely.

--- a/docs/specs/decouple-st-from-images-plan.md
+++ b/docs/specs/decouple-st-from-images-plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Decouple standard-tooling from dev container images
 
-**Status:** Draft
+**Status:** Phase 1 complete — awaiting release
 **Spec:** [`docs/specs/host-level-tool.md`](../specs/host-level-tool.md)
 (this plan rewrites Principle 6 and the "Dev container image policy"
 section of the spec)
@@ -146,7 +146,7 @@ declared in `st-config.toml`):
 | Rust | `Cargo.lock`, `st-config.toml` |
 | Go | `go.sum`, `st-config.toml` |
 | Java | `pom.xml`, `st-config.toml` |
-| Unknown | `st-config.toml` only (use `docker.cache-files` override for custom projects) |
+| Unknown | `st-config.toml` only |
 
 `st-config.toml` is always included because a change to
 `standard-tooling.tag` requires reinstalling standard-tooling in
@@ -182,19 +182,8 @@ For non-Python repos, standard-tooling is installed via pip before the
 warmup. For Python repos, standard-tooling comes in via `uv sync` as
 part of the warmup.
 
-The default can be overridden in `st-config.toml`:
-
-```toml
-[standard-tooling]
-tag = "v1.4"
-
-[docker]
-warmup = "cargo fetch && cargo build --release --lib"
-cache-files = ["Cargo.lock", "st-config.toml"]
-```
-
-Auto-detection is the default; `st-config.toml` is the override. Most
-repos need zero additional config.
+Language detection is automatic via `detect_language()`. Most repos
+need zero additional config beyond `st-config.toml`.
 
 #### Lifecycle integration
 
@@ -220,25 +209,28 @@ st-docker-cache clean-all # Remove all st-docker-cache images (nuclear option)
 
 #### Fallback behavior
 
-When no cached image exists, `st-docker-run` falls back to the base
-image with the runtime `pip install` wrapping described earlier in
-this plan. This means:
+When no cached image exists for the current branch,
+`ensure_cached_image()` auto-builds one on first use — there is no
+separate "uncached" code path. The build happens once per branch (or
+when the hash changes), then all subsequent `st-docker-run`
+invocations reuse the cached image.
 
-- Repos that never run `st-docker-cache build` still work — they just
-  pay the runtime install cost on every invocation.
-- A missing or stale cache is a performance issue, not a correctness
-  issue.
+If the build itself fails (e.g., network error during `pip install`),
+`st-docker-run` falls back to the base image without
+standard-tooling installed. This means the `st-*` tools won't be on
+PATH, and validation commands will fail — surfacing the problem
+immediately rather than silently degrading.
 
 Cached images are local to the developer's Docker daemon. CI always
-uses the base image with runtime install — ephemeral runners cannot
-meaningfully benefit from local image caching.
+uses the base image — ephemeral runners cannot meaningfully benefit
+from local image caching.
 
 ### Env var overrides
 
 | Variable | Effect |
 |---|---|
 | `ST_DOCKER_INSTALL_TAG` | Override the tag from `st-config.toml` (e.g., for testing a pre-release) |
-| `ST_DOCKER_SKIP_INSTALL` | Set to `1` to skip the runtime install entirely (escape hatch for custom images) |
+| `DOCKER_DEV_IMAGE` | Override the base image entirely (existing; skips cache lookup) |
 
 ### Known limitations
 
@@ -256,7 +248,7 @@ must embed credentials (e.g.,
 
 | Repo | Change |
 |---|---|
-| **standard-tooling** | Add `st-config.toml` reader, `st-docker-cache` command, runtime install wrapping in `docker.py` and `docker_run.py`; update `st-finalize-repo` to clean cached images; remove docker dispatch from `publish.yml`; delete `verify-docker-images.yml`; update spec and docs |
+| **standard-tooling** | Add `st-config.toml` reader, `st-docker-cache` command, cache-aware image selection in `docker_run.py`; update `st-finalize-repo` to clean cached images; remove docker dispatch from `publish.yml`; delete `verify-docker-images.yml`; update spec and docs |
 | **standard-tooling-docker** | Delete both `standard-tooling-*.dockerfile` fragments; remove `@include` lines from all 6 Dockerfiles; remove `repository_dispatch` trigger from `docker-publish.yml`; add `st-config.toml` |
 | **standard-tooling-plugin** | Add `st-config.toml` |
 | **standard-actions** | Add `st-config.toml` |
@@ -265,7 +257,7 @@ must embed credentials (e.g.,
 ### What does NOT change
 
 - **`docker_test.py`** — test commands (`go test`, `bundle exec rake`,
-  etc.) do not invoke `st-*` tools. No wrapping needed.
+  etc.) do not invoke `st-*` tools. No caching needed.
 - **`docker_docs.py`** — runs `mkdocs`, not `st-*` tools.
 - **`python-support.dockerfile`** — still needed in non-Python images
   for `pip` (used by the runtime install) and `yamllint` (used directly
@@ -289,8 +281,7 @@ must embed credentials (e.g.,
 ### Sequencing
 
 ```text
-Phase 1  (st-config.toml + runtime install wrapping — standard-tooling)
-Phase 1b (st-docker-cache command — standard-tooling)
+Phase 1  (st-config.toml + cache-first st-docker-run + st-docker-cache — standard-tooling)  ✓ DONE
     │
     ▼
   release + host upgrade
@@ -307,264 +298,87 @@ Phase 1b (st-docker-cache command — standard-tooling)
 Phase 4 (update spec and docs — standard-tooling)
 ```
 
-Phase 1 and 1b can be developed in parallel (separate branches);
-Phase 1 must merge first (1b depends on `config.py` and the runtime
-install fallback). Together they provide both correctness (any repo
-works without a cache) and speed (cached repos skip all install
-overhead).
+Phase 1 shipped as a single PR (#364) combining the config reader,
+cache library, `st-docker-cache` CLI, cache-aware `st-docker-run`,
+and `st-finalize-repo` integration.
 
 Phase 1 must release before Phases 2/2b/3 start. The new
 `st-docker-run` must be on the host before images lose their
 pre-baked copy and before repos are required to have `st-config.toml`.
 
-Phase 1 is backward-compatible: the `pip install` wrapping runs
-against current images and no-ops (the pre-baked version satisfies
-the requirement). `st-config.toml` is added to this repo in Phase 1
-but is only required by the new wrapping code path — Python repos
-(like this one) skip the install, so missing config in other repos
-does not break until Phase 2b lands.
+Phase 1 is backward-compatible: `ensure_cached_image()` builds a
+cached image that includes standard-tooling via `pip install` on top
+of the base image. Against current images (with the pre-bake), the
+install is a no-op or harmless upgrade. `st-config.toml` is added to
+this repo in Phase 1 but is only required by the cache build path —
+Python repos (like this one) skip caching entirely, so missing config
+in other repos does not break until Phase 2b lands.
 
 Phase 2b must complete for all actively-used non-Python repos before
-Phase 2 merges. Without `st-config.toml`, the runtime install path
+Phase 2 merges. Without `st-config.toml`, the cache build path
 errors — so stripping the pre-bake before config files exist breaks
 non-Python repos. Phase 3 is independent and can run in parallel
 with 2b.
 
 Phase 4 is a docs-only follow-up after the functional work lands.
 
-### Phase 1: Add runtime install to `st-docker-run`
+### Phase 1: Cache-first `st-docker-run` + `st-docker-cache`  ✓ DONE
 
 **Repo:** standard-tooling
-**Branch type:** feature
+**Branch:** `feature/362-decouple-st-from-images`
+**PR:** [#364](https://github.com/wphillipmoore/standard-tooling/pull/364)
 
-#### 1.1 Implement `st-config.toml` reader
+Shipped as a single PR combining the config reader, cache library,
+`st-docker-cache` CLI, cache-aware `st-docker-run`, and
+`st-finalize-repo` cache cleanup. 473 tests, 100% coverage.
 
-File: `src/standard_tooling/lib/config.py` (new)
+#### What shipped
 
-Minimal config reader for `st-config.toml`. Reads the file from the
-repo root, parses TOML, returns a typed config object. For this phase,
-the only field is `standard-tooling.tag`.
+**`src/standard_tooling/lib/config.py`** (new) — `st-config.toml`
+reader. Two public functions: `read_st_config()` parses the file,
+`st_install_tag()` returns the `standard-tooling.tag` value (with
+`ST_DOCKER_INSTALL_TAG` env var override).
 
-```python
-import tomllib
-from pathlib import Path
+**`src/standard_tooling/lib/docker_cache.py`** (new) — cache
+lifecycle engine. Key functions:
 
-_CONFIG_FILE = "st-config.toml"
+- `cache_sensitive_files()` — returns lockfile + `st-config.toml`
+  paths based on language
+- `compute_cache_hash()` — SHA-256 over sorted file contents (first
+  8 hex chars)
+- `find_cached_image()` — queries `docker images` for matching tag
+- `ensure_cached_image()` — the main entry point: returns cached
+  image if hash matches, auto-builds if miss or stale, returns base
+  image unchanged for Python repos
+- `_build_cached_image()` — `docker create` + `docker start` +
+  `docker commit` workflow (pip install + language warmup)
+- `clean_branch_images()` — removes all cached images for a branch
 
-def read_st_config(repo_root: Path) -> dict:
-    config_path = repo_root / _CONFIG_FILE
-    if not config_path.is_file():
-        raise SystemExit(
-            f"ERROR: {_CONFIG_FILE} not found at {repo_root}.\n"
-            f"Every repo must have an {_CONFIG_FILE}."
-        )
-    with config_path.open("rb") as f:
-        return tomllib.load(f)
+**`src/standard_tooling/bin/docker_cache.py`** (new) — `st-docker-cache`
+CLI with four subcommands: `build`, `clean`, `status`, `clean-all`.
 
-def st_install_tag(repo_root: Path) -> str:
-    tag = os.environ.get("ST_DOCKER_INSTALL_TAG")
-    if tag:
-        return tag
-    config = read_st_config(repo_root)
-    st = config.get("standard-tooling", {})
-    tag = st.get("tag")
-    if not tag:
-        raise SystemExit(
-            f"ERROR: {_CONFIG_FILE} missing 'standard-tooling.tag' field."
-        )
-    return tag
-```
+**`src/standard_tooling/bin/docker_run.py`** (modified) — three-way
+image selection: `DOCKER_DEV_IMAGE` env override → Python uses base
+image directly → non-Python calls `ensure_cached_image()`. Tracks
+`image_source` for diagnostic output.
 
-#### 1.2 Add wrapping functions to `docker.py`
+**`src/standard_tooling/bin/finalize_repo.py`** (modified) — calls
+`clean_branch_images()` after each branch deletion (skipped in
+dry-run mode).
 
-File: `src/standard_tooling/lib/docker.py`
+**`st-config.toml`** (new) — repo-root config for this repo.
 
-Add at module level:
+**`pyproject.toml`** (modified) — registered `st-docker-cache`
+console script.
 
-```python
-import shlex
-from standard_tooling.lib.config import st_install_tag
+#### Design note: no per-command wrapping
 
-_ST_GIT_URL = "https://github.com/wphillipmoore/standard-tooling"
-
-def needs_runtime_st_install(lang: str) -> bool:
-    if os.environ.get("ST_DOCKER_SKIP_INSTALL") == "1":
-        return False
-    return lang != "python"
-
-def wrap_command_for_st_install(
-    command: list[str], lang: str, repo_root: Path,
-) -> list[str]:
-    if not needs_runtime_st_install(lang):
-        return command
-    tag = st_install_tag(repo_root)
-    install = (
-        f"pip install --quiet"
-        f" 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
-    )
-    return ["bash", "-c", f"{install} && {shlex.join(command)}"]
-```
-
-#### 1.3 Call the wrapper in `docker_run.py`
-
-File: `src/standard_tooling/bin/docker_run.py`
-
-After `detect_language` and before `build_docker_args`:
-
-```python
-from standard_tooling.lib.docker import wrap_command_for_st_install
-
-container_command = wrap_command_for_st_install(command, lang, repo_root)
-```
-
-Pass `container_command` (not `command`) to `build_docker_args`.
-
-Add diagnostic output:
-
-```text
-Language: go
-Image:    ghcr.io/wphillipmoore/dev-go:1.26
-Install:  runtime (pip install standard-tooling@v1.4)
-Command:  st-validate-local
----
-```
-
-For Python repos: `Install:  skipped (Python repos use dev deps)`.
-
-#### 1.4 Update `_USAGE` in `docker_run.py`
-
-Add `ST_DOCKER_INSTALL_TAG` and `ST_DOCKER_SKIP_INSTALL` to the
-environment variables section.
-
-#### 1.5 Write tests
-
-File: `tests/standard_tooling/test_config.py` (new)
-
-- Missing `st-config.toml` → `SystemExit`
-- Missing `standard-tooling.tag` field → `SystemExit`
-- Valid file returns tag string
-- `ST_DOCKER_INSTALL_TAG` env var overrides file
-
-File: `tests/standard_tooling/test_docker.py`
-
-- `needs_runtime_st_install("go")` → `True`
-- `needs_runtime_st_install("ruby")` → `True`
-- `needs_runtime_st_install("rust")` → `True`
-- `needs_runtime_st_install("java")` → `True`
-- `needs_runtime_st_install("")` → `True`
-- `needs_runtime_st_install("python")` → `False`
-- `ST_DOCKER_SKIP_INSTALL=1` → `False` for all languages
-- `wrap_command_for_st_install(["st-validate-local"], "go", repo_root)`
-  → wraps with `bash -c "pip install ... && st-validate-local"`
-- `wrap_command_for_st_install(["uv", "run", "st-validate-local"], "python", repo_root)`
-  → returns input unchanged
-- Multi-token command joins correctly via `shlex.join`
-
-File: `tests/standard_tooling/test_docker_run.py`
-
-- Non-Python repo with `st-config.toml`: `main(["--", "st-validate-local"])`
-  produces docker args containing `bash -c "pip install ... && st-validate-local"`
-- Python repo: `main(["--", "uv", "run", "st-validate-local"])` produces
-  docker args ending with `uv run st-validate-local` (no wrapping)
-
-#### 1.6 Add `st-config.toml` to this repo
-
-File: `st-config.toml` (new, at repo root)
-
-```toml
-[standard-tooling]
-tag = "v1.4"
-```
-
-This repo is a Python project, so the runtime install is skipped
-during normal validation. But the config file should be present for
-consistency and to exercise the reader in tests.
-
-#### 1.7 Validate and release
-
-Run `st-docker-run -- uv run st-validate-local` (100% coverage
-required). Cut a patch release. Upgrade the host install.
-
-### Phase 1b: Add `st-docker-cache` command
-
-**Repo:** standard-tooling
-**Branch type:** feature
-**Can develop in parallel with Phase 1; must merge after Phase 1**
-
-#### 1b.1 Implement `st-docker-cache` CLI
-
-File: `src/standard_tooling/bin/docker_cache.py` (new)
-
-Entry point: `st-docker-cache`. Subcommands:
-
-- **`build`** — Compute the lockfile hash for the current branch.
-  If no cached image exists with that hash, build one: `docker run`
-  from the base image with the repo mounted, `pip install
-  standard-tooling@<tag>`, run the language-specific warmup command,
-  then `docker commit` the container as a new image tagged with the
-  naming convention. Remove the old cached image for this branch if
-  the hash changed.
-- **`clean`** — Remove the cached image for the current branch.
-- **`status`** — Print whether a cached image exists, the hash, and
-  the image age.
-- **`clean-all`** — Remove all `st-docker-cache`-managed images.
-
-#### 1b.2 Add cache-aware image selection to `docker.py`
-
-File: `src/standard_tooling/lib/docker.py`
-
-Add a function that checks whether a cached image exists for the
-current branch and returns it. `st-docker-run` calls this before
-falling back to the base image:
-
-```python
-def cached_image(repo_root: Path, branch: str, lang: str) -> str | None:
-    """Return the cached image tag if one exists, else None."""
-    ...
-```
-
-#### 1b.3 Wire cache lookup into `docker_run.py`
-
-File: `src/standard_tooling/bin/docker_run.py`
-
-Before the existing `default_image()` call, check for a cached image.
-If found, use it directly (skip runtime install wrapping). Diagnostic
-output:
-
-```text
-Language: go
-Image:    dev-go:1.26--feature-362-decouple--a1b2c3d4 (cached)
-Command:  st-validate-local
----
-```
-
-#### 1b.4 Add cache cleanup to `st-finalize-repo`
-
-File: `src/standard_tooling/bin/finalize_repo.py`
-
-After branch deletion, call `st-docker-cache clean` for the deleted
-branch (or invoke the cleanup function directly).
-
-#### 1b.5 Write tests
-
-File: `tests/standard_tooling/test_docker_cache.py` (new)
-
-- Hash computation deterministic for same inputs
-- Hash changes when lockfile content changes
-- Hash changes when `st-config.toml` changes
-- Correct lockfile selected per language
-- `build` creates a Docker image with expected tag
-- `clean` removes the image for the current branch
-- `clean-all` removes all managed images
-- `status` reports correct state
-- Cache hit in `docker_run.py` skips runtime install wrapping
-- Cache miss in `docker_run.py` falls back to runtime install
-
-#### 1b.6 Register console script
-
-File: `pyproject.toml`
-
-Add `st-docker-cache` to `[project.scripts]`.
+The original plan described wrapping each command with
+`bash -c "pip install ... && <command>"`. This was rejected during
+implementation in favor of the cache-first approach — install
+standard-tooling once when building the cached image, then run
+commands directly against it. Per-command wrapping was never
+implemented.
 
 ### Phase 2: Strip standard-tooling from images
 
@@ -727,13 +541,13 @@ superseded by this plan.
 
 ## Backward compatibility
 
-Phase 1 is fully backward-compatible. The runtime install wrapping
-runs `pip install` inside containers that already have standard-tooling
-pre-baked. The install either no-ops (same version) or upgrades
-(newer version on the tag). No consumer-visible behavior change.
+Phase 1 is fully backward-compatible. `ensure_cached_image()` builds
+a cached image by running `pip install` on top of the base image.
+Against current images (with the pre-bake), the install is a no-op
+or harmless upgrade. No consumer-visible behavior change.
 
 The one risk window: a developer with the OLD `st-docker-run`
-(pre-wrapping) pulling NEW images (without pre-bake). Non-Python repos
+(pre-cache) pulling NEW images (without pre-bake). Non-Python repos
 would fail because `st-*` is not on PATH and nothing installs it.
 
 Mitigation: the fleet-of-one model means a single developer upgrading
@@ -770,6 +584,16 @@ version at runtime. Rejected: the consuming repo must own the version
 pin, not the host. A host upgrade would silently change what every
 repo installs in the container. `st-config.toml` gives each repo
 durable, version-controlled control.
+
+### Per-command `pip install` wrapping
+
+Wrap each `st-docker-run` command with
+`bash -c "pip install standard-tooling@<tag> && <command>"` so every
+invocation installs standard-tooling before running. Rejected during
+implementation: pays the install cost on every invocation (~5-10s),
+breaks interactive commands, and is unnecessary once per-branch image
+caching exists. The cache-first approach installs once per branch and
+runs commands directly.
 
 ### Named Docker volume for pip cache
 


### PR DESCRIPTION
# Pull Request

## Summary

- Update spec and plan to reflect cache-first implementation

## Issue Linkage

- Ref #362

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Updates both spec and plan documents to reflect the cache-first
architecture that shipped in PR #364.

### Spec changes

- Remove `ST_DOCKER_SKIP_INSTALL` (never implemented)
- Remove unimplemented `docker.warmup` and `docker.cache-files` config
  override sections
- Rewrite fallback behavior for cache-first (no per-command wrapping)
- Update "What changes" table for cache-aware image selection
- Replace Phase 1+1b with single completed Phase 1 section
- Add "Per-command pip install wrapping" to rejected alternatives
- Fix Phase 2 depends-on to include Phase 2b
- Fix Phase 4.1 to use cache-first language instead of "runtime install"
- Fix stale "Phase 1b" reference in rejected alternatives

### Plan changes

- Collapse Phase 1+1b into single completed phase with what actually shipped
- Add design decision note: cache-first, not per-command wrapping
- Add completion criteria (all met)
- Add release gate section
- Update remaining phases for cache-first language

### Alignment

Ran `/paad:alignment` between spec and plan. Three issues found and
resolved in the second commit.