### PR TITLE
feat(cli): add st-check-pr-merge and branch check in st-merge-when-green

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license-files = ["LICENSE"]
 dependencies = []
 
 [project.scripts]
+st-check-pr-merge = "standard_tooling.bin.check_pr_merge:main"
 st-commit = "standard_tooling.bin.commit:main"
 st-submit-pr = "standard_tooling.bin.submit_pr:main"
 st-merge-when-green = "standard_tooling.bin.merge_when_green:main"

--- a/src/standard_tooling/bin/check_pr_merge.py
+++ b/src/standard_tooling/bin/check_pr_merge.py
@@ -1,0 +1,174 @@
+"""Check whether a gh pr merge / gh pr review --approve targets a release-workflow PR.
+
+Called by the block-agent-merge hook in standard-tooling-plugin.
+Takes the raw Bash command string, extracts the PR reference,
+resolves the branch via the GitHub API, and checks the allow-list.
+
+Exit codes follow the three-state convention (standard-tooling#373):
+  0 — allowed (release-workflow branch)
+  1 — denied (tool ran, branch not on allow-list)
+  2 — unknown (tool could not determine the answer)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import subprocess
+import sys
+
+from standard_tooling.lib import github
+from standard_tooling.lib.release import is_release_branch
+
+_CHAIN_RE = re.compile(r"\s*(?:&&|\|\||[;|])\s*")
+
+_DENY_MESSAGE = (
+    "Blocked: agents may not merge non-release PRs. The pr-workflow\n"
+    "policy requires human review and merge for feature/bugfix PRs.\n"
+    "Hand off the PR URL to the user and stop the work cycle.\n"
+    "\n"
+    "Only release-workflow PRs (release/* and chore/bump-version-*)\n"
+    "may be agent-merged, and only via st-merge-when-green from the\n"
+    "publish skill. See issue #162."
+)
+
+_GH_MERGE_FLAGS = frozenset({
+    "--squash", "--merge", "--rebase",
+    "--delete-branch", "--auto", "--disable-auto",
+    "--admin",
+})
+
+_GH_REVIEW_FLAGS = frozenset({
+    "--approve", "-a",
+    "--request-changes", "-r",
+    "--comment", "-c",
+})
+
+_GH_FLAGS_WITH_VALUE = frozenset({
+    "--repo", "-R",
+    "--body", "-b",
+    "--body-file", "-F",
+    "--subject", "-t",
+    "--match-head-commit",
+})
+
+
+def extract_pr_ref(command: str) -> tuple[str, str | None]:
+    """Extract the PR reference and optional repo from a command string.
+
+    Returns (pr_ref, repo) where repo is None if --repo was not specified.
+    Raises ValueError if no gh pr merge/review --approve is found.
+    """
+    segments = _CHAIN_RE.split(command)
+
+    for segment in segments:
+        segment = segment.strip()
+        if not segment:
+            continue
+
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            continue
+
+        result = _extract_from_tokens(tokens)
+        if result is not None:
+            return result
+
+    raise ValueError(f"No gh pr merge or gh pr review --approve found in: {command}")
+
+
+def _extract_from_tokens(tokens: list[str]) -> tuple[str, str | None] | None:
+    """Extract PR ref from a tokenized command segment."""
+    try:
+        gh_idx = tokens.index("gh")
+    except ValueError:
+        return None
+
+    rest = tokens[gh_idx + 1 :]
+    if len(rest) < 2 or rest[0] != "pr":
+        return None
+
+    subcommand = rest[1]
+
+    if subcommand == "merge":
+        return _parse_args(rest[2:], _GH_MERGE_FLAGS)
+    elif subcommand == "review":
+        if "--approve" not in rest[2:]:
+            return None
+        return _parse_args(rest[2:], _GH_REVIEW_FLAGS)
+
+    return None
+
+
+def _parse_args(
+    args: list[str], known_flags: frozenset[str]
+) -> tuple[str, str | None] | None:
+    """Walk args to find the PR ref and optional --repo value."""
+    repo: str | None = None
+    pr_ref: str | None = None
+    i = 0
+
+    while i < len(args):
+        arg = args[i]
+
+        if arg in _GH_FLAGS_WITH_VALUE and i + 1 < len(args):
+            if arg in ("--repo", "-R"):
+                repo = args[i + 1]
+            i += 2
+            continue
+
+        if arg in known_flags or arg.startswith("-"):
+            i += 1
+            continue
+
+        pr_ref = arg
+        i += 1
+
+    if pr_ref is None:
+        return None
+
+    return (pr_ref, repo)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Check whether a PR merge/approval targets a release-workflow branch.",
+    )
+    parser.add_argument("command", help="Raw Bash command string to check")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        pr_ref, repo = extract_pr_ref(args.command)
+    except ValueError:
+        return 0
+
+    try:
+        api_args = ["pr", "view", pr_ref]
+        if repo:
+            api_args.extend(["--repo", repo])
+        api_args.extend(["--json", "headRefName", "--jq", ".headRefName"])
+        branch = github.read_output(*api_args)
+    except subprocess.CalledProcessError as exc:
+        detail = getattr(exc, "stderr", None) or str(exc)
+        print(
+            f"Could not resolve PR branch: {detail}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if is_release_branch(branch):
+        return 0
+
+    print(_DENY_MESSAGE, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/standard_tooling/bin/check_pr_merge.py
+++ b/src/standard_tooling/bin/check_pr_merge.py
@@ -33,25 +33,42 @@ _DENY_MESSAGE = (
     "publish skill. See issue #162."
 )
 
-_GH_MERGE_FLAGS = frozenset({
-    "--squash", "--merge", "--rebase",
-    "--delete-branch", "--auto", "--disable-auto",
-    "--admin",
-})
+_GH_MERGE_FLAGS = frozenset(
+    {
+        "--squash",
+        "--merge",
+        "--rebase",
+        "--delete-branch",
+        "--auto",
+        "--disable-auto",
+        "--admin",
+    }
+)
 
-_GH_REVIEW_FLAGS = frozenset({
-    "--approve", "-a",
-    "--request-changes", "-r",
-    "--comment", "-c",
-})
+_GH_REVIEW_FLAGS = frozenset(
+    {
+        "--approve",
+        "-a",
+        "--request-changes",
+        "-r",
+        "--comment",
+        "-c",
+    }
+)
 
-_GH_FLAGS_WITH_VALUE = frozenset({
-    "--repo", "-R",
-    "--body", "-b",
-    "--body-file", "-F",
-    "--subject", "-t",
-    "--match-head-commit",
-})
+_GH_FLAGS_WITH_VALUE = frozenset(
+    {
+        "--repo",
+        "-R",
+        "--body",
+        "-b",
+        "--body-file",
+        "-F",
+        "--subject",
+        "-t",
+        "--match-head-commit",
+    }
+)
 
 
 def extract_pr_ref(command: str) -> tuple[str, str | None]:
@@ -102,9 +119,7 @@ def _extract_from_tokens(tokens: list[str]) -> tuple[str, str | None] | None:
     return None
 
 
-def _parse_args(
-    args: list[str], known_flags: frozenset[str]
-) -> tuple[str, str | None] | None:
+def _parse_args(args: list[str], known_flags: frozenset[str]) -> tuple[str, str | None] | None:
     """Walk args to find the PR ref and optional --repo value."""
     repo: str | None = None
     pr_ref: str | None = None

--- a/src/standard_tooling/bin/merge_when_green.py
+++ b/src/standard_tooling/bin/merge_when_green.py
@@ -44,8 +44,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
     branch = github.read_output(
-        "pr", "view", args.pr,
-        "--json", "headRefName", "--jq", ".headRefName",
+        "pr",
+        "view",
+        args.pr,
+        "--json",
+        "headRefName",
+        "--jq",
+        ".headRefName",
     )
     if not is_release_branch(branch):
         print(

--- a/src/standard_tooling/bin/merge_when_green.py
+++ b/src/standard_tooling/bin/merge_when_green.py
@@ -14,6 +14,7 @@ import argparse
 import sys
 
 from standard_tooling.lib import git, github
+from standard_tooling.lib.release import is_release_branch
 
 _STRATEGIES = ("merge", "squash", "rebase")
 
@@ -41,6 +42,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    branch = github.read_output(
+        "pr", "view", args.pr,
+        "--json", "headRefName", "--jq", ".headRefName",
+    )
+    if not is_release_branch(branch):
+        print(
+            f"Error: st-merge-when-green is only for release-workflow PRs. "
+            f"Branch '{branch}' does not match release/* or chore/bump-version-*.",
+            file=sys.stderr,
+        )
+        return 1
+
     delete_branch = args.delete_branch
     if delete_branch and not git.is_main_worktree():
         print("Note: skipping --delete-branch (worktree; st-finalize-repo handles cleanup)")

--- a/src/standard_tooling/lib/release.py
+++ b/src/standard_tooling/lib/release.py
@@ -1,0 +1,12 @@
+"""Release-workflow branch identification."""
+
+from __future__ import annotations
+
+import fnmatch
+
+_RELEASE_BRANCH_PATTERNS = ("release/*", "chore/bump-version-*")
+
+
+def is_release_branch(branch: str) -> bool:
+    """Return True if the branch matches a release-workflow pattern."""
+    return any(fnmatch.fnmatch(branch, p) for p in _RELEASE_BRANCH_PATTERNS)

--- a/tests/standard_tooling/test_check_pr_merge.py
+++ b/tests/standard_tooling/test_check_pr_merge.py
@@ -65,6 +65,26 @@ class TestExtractPrRef:
         ref, repo = extract_pr_ref("echo 42 | gh pr merge 42")
         assert ref == "42"
 
+    def test_empty_segment(self) -> None:
+        ref, repo = extract_pr_ref("&& gh pr merge 42")
+        assert ref == "42"
+
+    def test_malformed_quoting(self) -> None:
+        with pytest.raises(ValueError):
+            extract_pr_ref("gh pr merge 'unclosed 42")
+
+    def test_review_without_approve(self) -> None:
+        with pytest.raises(ValueError):
+            extract_pr_ref("gh pr review --comment 42")
+
+    def test_unknown_subcommand(self) -> None:
+        with pytest.raises(ValueError):
+            extract_pr_ref("gh pr close 42")
+
+    def test_no_pr_ref(self) -> None:
+        with pytest.raises(ValueError):
+            extract_pr_ref("gh pr merge --squash")
+
 
 class TestMain:
     """End-to-end tests for main() (Task 3)."""

--- a/tests/standard_tooling/test_check_pr_merge.py
+++ b/tests/standard_tooling/test_check_pr_merge.py
@@ -108,8 +108,15 @@ class TestMain:
             rc = main(["gh pr merge --repo o/r 42"])
         assert rc == 1
         mock.assert_called_once_with(
-            "pr", "view", "42", "--repo", "o/r",
-            "--json", "headRefName", "--jq", ".headRefName",
+            "pr",
+            "view",
+            "42",
+            "--repo",
+            "o/r",
+            "--json",
+            "headRefName",
+            "--jq",
+            ".headRefName",
         )
 
     def test_api_failure(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/standard_tooling/test_check_pr_merge.py
+++ b/tests/standard_tooling/test_check_pr_merge.py
@@ -1,0 +1,154 @@
+"""Tests for standard_tooling.bin.check_pr_merge."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from standard_tooling.bin.check_pr_merge import extract_pr_ref, main
+
+_MOD = "standard_tooling.bin.check_pr_merge"
+
+
+class TestExtractPrRef:
+    """Tests for extract_pr_ref (Task 2)."""
+
+    def test_simple_number(self) -> None:
+        ref, repo = extract_pr_ref("gh pr merge 42")
+        assert ref == "42"
+        assert repo is None
+
+    def test_url(self) -> None:
+        url = "https://github.com/o/r/pull/364"
+        ref, repo = extract_pr_ref(f"gh pr merge {url}")
+        assert ref == url
+        assert repo is None
+
+    def test_flags_before_ref(self) -> None:
+        ref, repo = extract_pr_ref("gh pr merge --squash 364")
+        assert ref == "364"
+
+    def test_multiple_flags_before_ref(self) -> None:
+        url = "https://github.com/o/r/pull/99"
+        ref, repo = extract_pr_ref(f"gh pr merge --merge --delete-branch {url}")
+        assert ref == url
+
+    def test_review_approve_number(self) -> None:
+        ref, repo = extract_pr_ref("gh pr review --approve 42")
+        assert ref == "42"
+
+    def test_review_approve_with_body(self) -> None:
+        url = "https://github.com/o/r/pull/77"
+        ref, repo = extract_pr_ref(f'gh pr review --approve --body "lgtm" {url}')
+        assert ref == url
+
+    def test_repo_flag(self) -> None:
+        ref, repo = extract_pr_ref("gh pr merge --repo o/r 42")
+        assert ref == "42"
+        assert repo == "o/r"
+
+    def test_chained_and(self) -> None:
+        ref, repo = extract_pr_ref("echo hi && gh pr merge 42")
+        assert ref == "42"
+
+    def test_chained_semicolon(self) -> None:
+        ref, repo = extract_pr_ref("echo hi; gh pr merge 42")
+        assert ref == "42"
+
+    def test_no_match(self) -> None:
+        with pytest.raises(ValueError):
+            extract_pr_ref("gh issue list")
+
+    def test_piped(self) -> None:
+        ref, repo = extract_pr_ref("echo 42 | gh pr merge 42")
+        assert ref == "42"
+
+
+class TestMain:
+    """End-to-end tests for main() (Task 3)."""
+
+    @staticmethod
+    def _mock_branch(branch: str):
+        """Return a context manager that mocks gh pr view to return a branch."""
+        return patch(
+            f"{_MOD}.github.read_output",
+            return_value=branch,
+        )
+
+    def test_allowed_release_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("release/1.4.9"):
+            rc = main(["gh pr merge 42"])
+        assert rc == 0
+
+    def test_allowed_bump_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("chore/bump-version-1.4.10"):
+            rc = main(["gh pr merge 99"])
+        assert rc == 0
+
+    def test_blocked_feature_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/42-foo"):
+            rc = main(["gh pr merge 42"])
+        assert rc == 1
+        assert "may not merge non-release PRs" in capsys.readouterr().err
+
+    def test_flags_before_ref(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/1-x"):
+            rc = main(["gh pr merge --squash 364"])
+        assert rc == 1
+
+    def test_url_format(self) -> None:
+        with self._mock_branch("release/2.0.0"):
+            rc = main(["gh pr merge https://github.com/o/r/pull/364"])
+        assert rc == 0
+
+    def test_repo_flag_denied(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/1-x") as mock:
+            rc = main(["gh pr merge --repo o/r 42"])
+        assert rc == 1
+        mock.assert_called_once_with(
+            "pr", "view", "42", "--repo", "o/r",
+            "--json", "headRefName", "--jq", ".headRefName",
+        )
+
+    def test_api_failure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        err = subprocess.CalledProcessError(returncode=1, cmd=["gh"], stderr="API error")
+        with patch(f"{_MOD}.github.read_output", side_effect=err):
+            rc = main(["gh pr merge 42"])
+        assert rc == 2
+        assert "API error" in capsys.readouterr().err or "Could not" in capsys.readouterr().err
+
+    def test_review_approve_denied(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/1-x"):
+            rc = main(["gh pr review --approve 42"])
+        assert rc == 1
+
+    def test_review_approve_allowed(self) -> None:
+        with self._mock_branch("release/1.0.0"):
+            rc = main(["gh pr review --approve 42"])
+        assert rc == 0
+
+    def test_chained_and(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/1-x"):
+            rc = main(["echo hi && gh pr merge 42"])
+        assert rc == 1
+
+    def test_chained_semicolon(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/1-x"):
+            rc = main(["echo hi; gh pr merge 42"])
+        assert rc == 1
+
+    def test_piped(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with self._mock_branch("feature/1-x"):
+            rc = main(["echo 42 | gh pr merge 42"])
+        assert rc == 1
+
+    def test_repo_flag_allowed(self) -> None:
+        with self._mock_branch("release/1.0.0"):
+            rc = main(["gh pr merge --repo o/r 42"])
+        assert rc == 0
+
+    def test_no_match(self) -> None:
+        rc = main(["gh issue list"])
+        assert rc == 0

--- a/tests/standard_tooling/test_merge_when_green.py
+++ b/tests/standard_tooling/test_merge_when_green.py
@@ -35,8 +35,14 @@ def test_parse_args_rejects_unknown_strategy() -> None:
 _MOD = "standard_tooling.bin.merge_when_green"
 
 
+def _mock_branch(branch: str = "release/1.0.0"):
+    """Return a patch that mocks github.read_output to return a branch name."""
+    return patch(f"{_MOD}.github.read_output", return_value=branch)
+
+
 def test_main_happy_path() -> None:
     with (
+        _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(f"{_MOD}.github.merge") as mock_merge,
@@ -51,6 +57,7 @@ def test_main_happy_path() -> None:
 
 def test_main_custom_strategy_and_no_delete() -> None:
     with (
+        _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
@@ -64,6 +71,7 @@ def test_main_skips_delete_branch_in_worktree(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     with (
+        _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.git.is_main_worktree", return_value=False),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
@@ -78,6 +86,7 @@ def test_main_skips_delete_branch_in_worktree(
 
 def test_main_worktree_respects_explicit_no_delete() -> None:
     with (
+        _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.git.is_main_worktree", return_value=False),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
@@ -90,6 +99,7 @@ def test_main_worktree_respects_explicit_no_delete() -> None:
 def test_main_surfaces_check_failure() -> None:
     err = subprocess.CalledProcessError(returncode=1, cmd=["gh", "pr", "checks"])
     with (
+        _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(
             f"{_MOD}.github.wait_for_checks",
@@ -100,3 +110,41 @@ def test_main_surfaces_check_failure() -> None:
     ):
         main(["https://github.com/pr/1"])
     mock_merge.assert_not_called()
+
+
+def test_release_branch_allowed() -> None:
+    with (
+        _mock_branch("release/1.4.9"),
+        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main(["https://github.com/pr/1"])
+    assert result == 0
+    mock_merge.assert_called_once()
+
+
+def test_bump_branch_allowed() -> None:
+    with (
+        _mock_branch("chore/bump-version-1.4.10"),
+        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main(["https://github.com/pr/1"])
+    assert result == 0
+    mock_merge.assert_called_once()
+
+
+def test_feature_branch_blocked(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        _mock_branch("feature/42-foo"),
+        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main(["https://github.com/pr/1"])
+    assert result == 1
+    mock_wait.assert_not_called()
+    mock_merge.assert_not_called()
+    assert "only for release-workflow PRs" in capsys.readouterr().err

--- a/tests/standard_tooling/test_release.py
+++ b/tests/standard_tooling/test_release.py
@@ -1,0 +1,49 @@
+"""Tests for standard_tooling.lib.release."""
+
+from __future__ import annotations
+
+import pytest
+
+from standard_tooling.lib.release import is_release_branch
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "release/1.4.9",
+        "release/2.0.0",
+        "release/0.1.0",
+    ],
+)
+def test_release_branch_allowed(branch: str) -> None:
+    assert is_release_branch(branch) is True
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "chore/bump-version-1.4.10",
+        "chore/bump-version-0.1.1",
+        "chore/bump-version-2.0.1",
+    ],
+)
+def test_bump_branch_allowed(branch: str) -> None:
+    assert is_release_branch(branch) is True
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "feature/42-foo",
+        "bugfix/99-bar",
+        "chore/update-deps",
+        "hotfix/critical",
+        "main",
+        "develop",
+        "release",
+        "chore/bump-version",
+        "",
+    ],
+)
+def test_non_release_branch_denied(branch: str) -> None:
+    assert is_release_branch(branch) is False


### PR DESCRIPTION
# Pull Request

## Summary

- Add st-check-pr-merge and branch check in st-merge-when-green

## Issue Linkage

- Ref #375

## Testing

- markdownlint
- ci: shellcheck

## Notes

- New `st-check-pr-merge` command and defense-in-depth branch check in `st-merge-when-green`, implementing the standard-tooling side of the block-agent-merge feature (standard-tooling-plugin#162).

Changes:
- New `lib/release.py` with shared `is_release_branch()` helper
- New `bin/check_pr_merge.py`: takes a raw Bash command string, extracts the PR reference, resolves the branch via GitHub API, checks the allow-list. Three-state exit codes per #373 (0=allowed, 1=denied, 2=unknown)
- Modified `bin/merge_when_green.py`: verifies the target branch matches release/* or chore/bump-version-* before proceeding
- Entry point registered in pyproject.toml
- 40 new tests (15 for release helper, 25 for check_pr_merge, plus 3 new + 5 updated for merge_when_green)