### PR TITLE
chore(ci): restore ci-security ref to @v1.4 after standard-actions 1.4.2 release (#379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
     with:
       language: python
       run-standards: ${{ inputs.run-release-gates || 'true' }}


### PR DESCRIPTION
# Pull Request

## Summary

- restore ci-security ref to @v1.4 after standard-actions 1.4.2 release

## Issue Linkage

- Ref #379

## Testing

- markdownlint
- ci: shellcheck

## Notes

- standard-actions v1.4.2 shipped the install step fix. Restores the pinned ref from the temporary @develop override added in PR #377.