### PR TITLE
feat: add next-cycle-deps pattern to release branch allow-list

### DIFF
--- a/src/standard_tooling/lib/release.py
+++ b/src/standard_tooling/lib/release.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 
-_RELEASE_BRANCH_PATTERNS = ("release/*", "chore/bump-version-*")
+_RELEASE_BRANCH_PATTERNS = ("release/*", "chore/bump-version-*", "chore/*-next-cycle-deps-*")
 
 
 def is_release_branch(branch: str) -> bool:

--- a/tests/standard_tooling/test_release.py
+++ b/tests/standard_tooling/test_release.py
@@ -34,6 +34,17 @@ def test_bump_branch_allowed(branch: str) -> None:
 @pytest.mark.parametrize(
     "branch",
     [
+        "chore/42-next-cycle-deps-1.4.10",
+        "chore/99-next-cycle-deps-2.0.1",
+    ],
+)
+def test_next_cycle_deps_branch_allowed(branch: str) -> None:
+    assert is_release_branch(branch) is True
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
         "feature/42-foo",
         "bugfix/99-bar",
         "chore/update-deps",
@@ -42,6 +53,7 @@ def test_bump_branch_allowed(branch: str) -> None:
         "develop",
         "release",
         "chore/bump-version",
+        "chore/next-cycle-deps",
         "",
     ],
 )


### PR DESCRIPTION
# Pull Request

## Summary

- Add next-cycle-deps to release branch allow-list

## Issue Linkage

- Ref #382

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Cross-repo sub-issue for standard-tooling-plugin#165.

Expands `is_release_branch()` to match `chore/*-next-cycle-deps-*` branches, allowing the publish skill's Phase 5 dependency update PRs to be agent-merged via `st-merge-when-green`.

Changes:
- Added `chore/*-next-cycle-deps-*` to `_RELEASE_BRANCH_PATTERNS` in `lib/release.py`
- Added 2 positive test cases and 1 negative edge case to `test_release.py`