### PR TITLE
chore: remove auto-close linkage keywords from st-submit-pr

### DIFF
--- a/src/standard_tooling/bin/submit_pr.py
+++ b/src/standard_tooling/bin/submit_pr.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from standard_tooling.lib import git, github
 
-ALLOWED_LINKAGES = ("Fixes", "Closes", "Resolves", "Ref")
+ALLOWED_LINKAGES = ("Ref",)
 _ISSUE_PLAIN_RE = re.compile(r"^[1-9]\d*$")
 _ISSUE_CROSS_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[1-9]\d*$")
 


### PR DESCRIPTION
# Pull Request

## Summary

- Remove auto-close linkage keywords (Fixes, Closes, Resolves) from st-submit-pr

## Issue Linkage

- Ref #356

## Testing

- markdownlint
- ci: shellcheck

## Notes

- The block-autoclose-linkage hook denies Fixes/Closes/Resolves regardless, so the CLI accepting them creates a confusing deny-after-accept UX. Remove the three auto-close keywords from ALLOWED_LINKAGES, leaving only Ref.

The default was already Ref, so no behavioral change for callers that omit --linkage.