### PR TITLE
fix: drop --delete-branch from st-merge-when-green; st-finalize-repo handles cleanup

### DIFF
--- a/src/standard_tooling/bin/merge_when_green.py
+++ b/src/standard_tooling/bin/merge_when_green.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from standard_tooling.lib import git, github
+from standard_tooling.lib import github
 from standard_tooling.lib.release import is_release_branch
 
 _STRATEGIES = ("merge", "squash", "rebase")
@@ -30,12 +30,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=_STRATEGIES,
         default="merge",
         help="Merge strategy (default: merge)",
-    )
-    parser.add_argument(
-        "--no-delete-branch",
-        action="store_false",
-        dest="delete_branch",
-        help="Do not delete the branch on merge (default: delete)",
     )
     return parser.parse_args(argv)
 
@@ -60,14 +54,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    delete_branch = args.delete_branch
-    if delete_branch and not git.is_main_worktree():
-        print("Note: skipping --delete-branch (worktree; st-finalize-repo handles cleanup)")
-        delete_branch = False
     print(f"Waiting for checks to pass on {args.pr}...")
     github.wait_for_checks(args.pr)
     print(f"Checks passed. Merging with --{args.strategy}...")
-    github.merge(args.pr, strategy=args.strategy, delete_branch=delete_branch)
+    github.merge(args.pr, strategy=args.strategy)
     print("Merged.")
     return 0
 

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -36,16 +36,16 @@ def wait_for_checks(pr: str) -> None:
     run("pr", "checks", pr, "--watch", "--fail-fast")
 
 
-def merge(pr: str, *, strategy: str, delete_branch: bool = True) -> None:
+def merge(pr: str, *, strategy: str) -> None:
     """Merge a PR synchronously (without ``--auto``).
 
     ``strategy`` is one of ``"merge"``, ``"squash"``, ``"rebase"`` — passed
     through as ``--merge``, ``--squash``, ``--rebase``.
+
+    Does not pass ``--delete-branch`` — branch cleanup is handled by
+    ``st-finalize-repo`` after the merge completes.
     """
-    cmd = ["pr", "merge", f"--{strategy}", pr]
-    if delete_branch:
-        cmd.append("--delete-branch")
-    run(*cmd)
+    run("pr", "merge", f"--{strategy}", pr)
 
 
 def list_project_repos(owner: str, project: str) -> list[str]:

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -42,18 +42,20 @@ def test_wait_for_checks_passes_pr_ref() -> None:
     )
 
 
-def test_merge_with_delete_branch() -> None:
+def test_merge_delegates_to_gh() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
         github.merge("https://github.com/pr/1", strategy="merge")
     mock_run.assert_called_once_with(
-        "pr", "merge", "--merge", "https://github.com/pr/1", "--delete-branch"
+        "pr", "merge", "--merge", "https://github.com/pr/1"
     )
 
 
-def test_merge_without_delete_branch() -> None:
+def test_merge_squash_strategy() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
-        github.merge("https://github.com/pr/1", strategy="squash", delete_branch=False)
-    mock_run.assert_called_once_with("pr", "merge", "--squash", "https://github.com/pr/1")
+        github.merge("https://github.com/pr/1", strategy="squash")
+    mock_run.assert_called_once_with(
+        "pr", "merge", "--squash", "https://github.com/pr/1"
+    )
 
 
 def test_list_project_repos() -> None:

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -45,17 +45,13 @@ def test_wait_for_checks_passes_pr_ref() -> None:
 def test_merge_delegates_to_gh() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
         github.merge("https://github.com/pr/1", strategy="merge")
-    mock_run.assert_called_once_with(
-        "pr", "merge", "--merge", "https://github.com/pr/1"
-    )
+    mock_run.assert_called_once_with("pr", "merge", "--merge", "https://github.com/pr/1")
 
 
 def test_merge_squash_strategy() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
         github.merge("https://github.com/pr/1", strategy="squash")
-    mock_run.assert_called_once_with(
-        "pr", "merge", "--squash", "https://github.com/pr/1"
-    )
+    mock_run.assert_called_once_with("pr", "merge", "--squash", "https://github.com/pr/1")
 
 
 def test_list_project_repos() -> None:

--- a/tests/standard_tooling/test_merge_when_green.py
+++ b/tests/standard_tooling/test_merge_when_green.py
@@ -14,17 +14,11 @@ def test_parse_args_defaults() -> None:
     args = parse_args(["https://github.com/pr/1"])
     assert args.pr == "https://github.com/pr/1"
     assert args.strategy == "merge"
-    assert args.delete_branch is True
 
 
 def test_parse_args_strategy() -> None:
     args = parse_args(["42", "--strategy", "squash"])
     assert args.strategy == "squash"
-
-
-def test_parse_args_no_delete_branch() -> None:
-    args = parse_args(["42", "--no-delete-branch"])
-    assert args.delete_branch is False
 
 
 def test_parse_args_rejects_unknown_strategy() -> None:
@@ -43,7 +37,6 @@ def _mock_branch(branch: str = "release/1.0.0"):
 def test_main_happy_path() -> None:
     with (
         _mock_branch("release/1.0.0"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -51,56 +44,25 @@ def test_main_happy_path() -> None:
     assert result == 0
     mock_wait.assert_called_once_with("https://github.com/pr/1")
     mock_merge.assert_called_once_with(
-        "https://github.com/pr/1", strategy="merge", delete_branch=True
+        "https://github.com/pr/1", strategy="merge"
     )
 
 
-def test_main_custom_strategy_and_no_delete() -> None:
+def test_main_custom_strategy() -> None:
     with (
         _mock_branch("release/1.0.0"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
-        result = main(["42", "--strategy", "squash", "--no-delete-branch"])
+        result = main(["42", "--strategy", "squash"])
     assert result == 0
-    mock_merge.assert_called_once_with("42", strategy="squash", delete_branch=False)
-
-
-def test_main_skips_delete_branch_in_worktree(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    with (
-        _mock_branch("release/1.0.0"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=False),
-        patch(f"{_MOD}.github.wait_for_checks"),
-        patch(f"{_MOD}.github.merge") as mock_merge,
-    ):
-        result = main(["https://github.com/pr/1"])
-    assert result == 0
-    mock_merge.assert_called_once_with(
-        "https://github.com/pr/1", strategy="merge", delete_branch=False
-    )
-    assert "skipping --delete-branch" in capsys.readouterr().out
-
-
-def test_main_worktree_respects_explicit_no_delete() -> None:
-    with (
-        _mock_branch("release/1.0.0"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=False),
-        patch(f"{_MOD}.github.wait_for_checks"),
-        patch(f"{_MOD}.github.merge") as mock_merge,
-    ):
-        result = main(["42", "--no-delete-branch"])
-    assert result == 0
-    mock_merge.assert_called_once_with("42", strategy="merge", delete_branch=False)
+    mock_merge.assert_called_once_with("42", strategy="squash")
 
 
 def test_main_surfaces_check_failure() -> None:
     err = subprocess.CalledProcessError(returncode=1, cmd=["gh", "pr", "checks"])
     with (
         _mock_branch("release/1.0.0"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(
             f"{_MOD}.github.wait_for_checks",
             side_effect=err,
@@ -115,7 +77,6 @@ def test_main_surfaces_check_failure() -> None:
 def test_release_branch_allowed() -> None:
     with (
         _mock_branch("release/1.4.9"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -127,7 +88,6 @@ def test_release_branch_allowed() -> None:
 def test_bump_branch_allowed() -> None:
     with (
         _mock_branch("chore/bump-version-1.4.10"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -139,7 +99,6 @@ def test_bump_branch_allowed() -> None:
 def test_feature_branch_blocked(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         _mock_branch("feature/42-foo"),
-        patch(f"{_MOD}.git.is_main_worktree", return_value=True),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):

--- a/tests/standard_tooling/test_merge_when_green.py
+++ b/tests/standard_tooling/test_merge_when_green.py
@@ -43,9 +43,7 @@ def test_main_happy_path() -> None:
         result = main(["https://github.com/pr/1"])
     assert result == 0
     mock_wait.assert_called_once_with("https://github.com/pr/1")
-    mock_merge.assert_called_once_with(
-        "https://github.com/pr/1", strategy="merge"
-    )
+    mock_merge.assert_called_once_with("https://github.com/pr/1", strategy="merge")
 
 
 def test_main_custom_strategy() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Drop --delete-branch from st-merge-when-green to fix worktree failures

## Issue Linkage

- Ref #371

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Dropped --delete-branch from st-merge-when-green and github.merge(). Branch cleanup is already handled by st-finalize-repo after merge, and --delete-branch caused spurious failures when worktrees had develop checked out (gh tries to switch branches locally, which fails when the target is checked out in another worktree).

Also removes the --no-delete-branch CLI flag, the worktree skip logic, and the git.is_main_worktree import — all now unnecessary.