### PR TITLE
refactor: unify release-cycle branches under release/ prefix

### DIFF
--- a/src/standard_tooling/bin/check_pr_merge.py
+++ b/src/standard_tooling/bin/check_pr_merge.py
@@ -28,9 +28,9 @@ _DENY_MESSAGE = (
     "policy requires human review and merge for feature/bugfix PRs.\n"
     "Hand off the PR URL to the user and stop the work cycle.\n"
     "\n"
-    "Only release-workflow PRs (release/* and chore/bump-version-*)\n"
-    "may be agent-merged, and only via st-merge-when-green from the\n"
-    "publish skill. See issue #162."
+    "Only release-workflow PRs (release/*) may be agent-merged,\n"
+    "and only via st-merge-when-green from the publish skill.\n"
+    "See issue #162."
 )
 
 _GH_MERGE_FLAGS = frozenset(

--- a/src/standard_tooling/bin/merge_when_green.py
+++ b/src/standard_tooling/bin/merge_when_green.py
@@ -49,7 +49,7 @@ def main(argv: list[str] | None = None) -> int:
     if not is_release_branch(branch):
         print(
             f"Error: st-merge-when-green is only for release-workflow PRs. "
-            f"Branch '{branch}' does not match release/* or chore/bump-version-*.",
+            f"Branch '{branch}' does not start with release/*.",
             file=sys.stderr,
         )
         return 1

--- a/src/standard_tooling/lib/release.py
+++ b/src/standard_tooling/lib/release.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import fnmatch
-
-_RELEASE_BRANCH_PATTERNS = ("release/*", "chore/bump-version-*", "chore/*-next-cycle-deps-*")
-
 
 def is_release_branch(branch: str) -> bool:
-    """Return True if the branch matches a release-workflow pattern."""
-    return any(fnmatch.fnmatch(branch, p) for p in _RELEASE_BRANCH_PATTERNS)
+    """Return True if the branch is part of the release workflow.
+
+    All release-cycle branches use the ``release/`` prefix.
+    """
+    return branch.startswith("release/")

--- a/tests/standard_tooling/test_check_pr_merge.py
+++ b/tests/standard_tooling/test_check_pr_merge.py
@@ -103,7 +103,7 @@ class TestMain:
         assert rc == 0
 
     def test_allowed_bump_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with self._mock_branch("chore/bump-version-1.4.10"):
+        with self._mock_branch("release/bump-version-1.4.10"):
             rc = main(["gh pr merge 99"])
         assert rc == 0
 

--- a/tests/standard_tooling/test_merge_when_green.py
+++ b/tests/standard_tooling/test_merge_when_green.py
@@ -85,7 +85,7 @@ def test_release_branch_allowed() -> None:
 
 def test_bump_branch_allowed() -> None:
     with (
-        _mock_branch("chore/bump-version-1.4.10"),
+        _mock_branch("release/bump-version-1.4.10"),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):

--- a/tests/standard_tooling/test_release.py
+++ b/tests/standard_tooling/test_release.py
@@ -13,6 +13,10 @@ from standard_tooling.lib.release import is_release_branch
         "release/1.4.9",
         "release/2.0.0",
         "release/0.1.0",
+        "release/bump-version-1.4.10",
+        "release/bump-version-0.1.1",
+        "release/42-next-cycle-deps-1.4.10",
+        "release/99-next-cycle-deps-2.0.1",
     ],
 )
 def test_release_branch_allowed(branch: str) -> None:
@@ -22,38 +26,15 @@ def test_release_branch_allowed(branch: str) -> None:
 @pytest.mark.parametrize(
     "branch",
     [
-        "chore/bump-version-1.4.10",
-        "chore/bump-version-0.1.1",
-        "chore/bump-version-2.0.1",
-    ],
-)
-def test_bump_branch_allowed(branch: str) -> None:
-    assert is_release_branch(branch) is True
-
-
-@pytest.mark.parametrize(
-    "branch",
-    [
-        "chore/42-next-cycle-deps-1.4.10",
-        "chore/99-next-cycle-deps-2.0.1",
-    ],
-)
-def test_next_cycle_deps_branch_allowed(branch: str) -> None:
-    assert is_release_branch(branch) is True
-
-
-@pytest.mark.parametrize(
-    "branch",
-    [
         "feature/42-foo",
         "bugfix/99-bar",
         "chore/update-deps",
+        "chore/bump-version-1.4.10",
+        "chore/42-next-cycle-deps-1.4.10",
         "hotfix/critical",
         "main",
         "develop",
         "release",
-        "chore/bump-version",
-        "chore/next-cycle-deps",
         "",
     ],
 )


### PR DESCRIPTION
# Pull Request

## Summary

- Unify release-cycle branches under release/ prefix for simpler allow-list

## Issue Linkage

- Ref #382

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Simplify is_release_branch() from a three-pattern fnmatch allow-list to a single prefix check: branch.startswith("release/"). All release-cycle branches now use the release/ prefix: release/<version> (existing), release/bump-version-<next> (was chore/bump-version-*), and release/<N>-next-cycle-deps-<version> (was chore/*-next-cycle-deps-*).

This is the standard-tooling side of the change. Cross-repo changes needed:
- standard-actions: version-bump-pr composite must create release/bump-version-* instead of chore/bump-version-*
- standard-tooling-plugin: publish skill branch name references, block-agent-merge spec