### PR TITLE
fix: reject invocation from secondary worktree instead of os.chdir

### DIFF
--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -145,8 +144,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not git.is_main_worktree():
         main_root = git.main_worktree_root()
-        print(f"Note: switching to main worktree at {main_root}")
-        os.chdir(main_root)
+        print(
+            f"ERROR: st-finalize-repo must be run from the main worktree at {main_root},\n"
+            "  not from a secondary worktree. The script removes worktrees during cleanup\n"
+            "  and cannot safely do so when the calling shell's CWD is inside one.",
+            file=sys.stderr,
+        )
+        return 1
 
     root = git.repo_root()
 

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import pytest
 

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -46,34 +46,23 @@ def test_parse_args_custom() -> None:
     assert args.dry_run is True
 
 
-def test_main_auto_chdir_from_secondary_worktree(
+def test_main_rejects_secondary_worktree(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     main_root = tmp_path / "main-wt"
     main_root.mkdir()
-    _make_profile(main_root, "library-release")
-    secondary = tmp_path / "secondary-wt"
-    secondary.mkdir()
-    monkeypatch.chdir(secondary)
 
     with (
         patch(_MOD + ".git.is_main_worktree", return_value=False),
         patch(_MOD + ".git.main_worktree_root", return_value=main_root),
-        patch(_MOD + ".git.repo_root", return_value=main_root),
-        patch(_MOD + ".git.current_branch", return_value="develop"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.read_output", return_value=""),
-        patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", return_value=None),
     ):
         result = main([])
 
-    assert result == 1  # no validator found, but that's after the chdir
-    out = capsys.readouterr().out
-    assert f"switching to main worktree at {main_root}" in out
-    assert Path.cwd() == main_root
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "must be run from the main worktree" in err
+    assert str(main_root) in err
 
 
 def _make_profile(tmp_path: Path, model: str) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Reject st-finalize-repo invocation from secondary worktree

## Issue Linkage

- Ref #381

## Testing

- markdownlint
- ci: shellcheck

## Notes

- When `st-finalize-repo` is called from inside a secondary worktree, it uses
`os.chdir()` to switch to the main worktree root. This changes the Python
process CWD but not the calling shell's CWD. When the script later removes
the worktree directory, the shell's CWD becomes invalid, producing a spurious
`pwd: error retrieving current directory` on stderr.

Since a child process fundamentally cannot change its parent shell's CWD,
the `os.chdir` approach cannot work. Replace it with an early error exit
that tells the user to run from the main worktree instead.