### PR TITLE
chore: change license to GPL-3.0-or-later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "standard-tooling"
 version = "1.4.6"
 description = "Shared development tooling for managed repositories"
 requires-python = ">=3.12,<4.0"
-license = "GPL-3.0-only"
+license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 dependencies = []
 


### PR DESCRIPTION
# Pull Request

## Summary

- Change license from GPL-3.0-only to GPL-3.0-or-later. Consuming Python repos that declare standard-tooling as a dev dependency need its license in their pip-licenses allowlist. GPL-3.0-or-later is already allowed in those repos; GPL-3.0-only is not.

## Issue Linkage

- Ref #408

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -