### PR TITLE
chore: retire st-config.toml in favor of standard-tooling.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ Shared libraries under `src/standard_tooling/lib/`:
 
 - **`git.py`** — Git subprocess wrappers
 - **`github.py`** — gh CLI subprocess wrappers
-- **`config.py`** — Parse `standard-tooling.toml` and `st-config.toml`
+- **`config.py`** — Parse `standard-tooling.toml`
 
 ### Docker Dev Images
 
@@ -232,7 +232,7 @@ Consumed via `git config core.hooksPath .githooks`:
 |---|---|---|
 | **Developer host** | `uv tool install` from git URL | Host-side commands: `st-docker-run`, `st-commit`, `st-submit-pr`, `st-prepare-release`, `st-finalize-repo` |
 | **Python project `.venv`** | `[tool.uv.sources]` dev dep + `uv sync` | `uv run st-*` inside the container for validators |
-| **Non-Python container runtime** | `st-docker-run` cache-first install per `st-config.toml` | `st-*` inside the container for non-Python consumers |
+| **Non-Python container runtime** | `st-docker-run` cache-first install per `standard-tooling.toml` | `st-*` inside the container for non-Python consumers |
 
 **Host install** (canonical):
 
@@ -251,7 +251,7 @@ git config core.hooksPath .githooks
 **CI (GitHub Actions)**: Python repos use `uv sync --group dev`
 (the dev-dep declaration); non-Python repos get `standard-tooling`
 at container runtime via `st-docker-run`'s cache-first install
-(reads `st-config.toml` for the version tag).
+(reads `standard-tooling.toml` for the version tag).
 
 ### Key Constraints
 

--- a/docs/specs/host-level-tool.md
+++ b/docs/specs/host-level-tool.md
@@ -82,7 +82,7 @@ fleet to behave consistently.
    they rely on the image's pre-bake; see principle 6.
 6. **Non-Python consumers get `standard-tooling` at container
    runtime via `st-docker-run`'s cache-first architecture.**
-   `st-docker-run` reads the repo's `st-config.toml` for the
+   `st-docker-run` reads the repo's `standard-tooling.toml` for the
    version tag, builds a per-branch cached Docker image with
    standard-tooling pre-installed, and runs commands against it.
    Dev container images no longer carry pre-baked standard-tooling.
@@ -93,7 +93,7 @@ fleet to behave consistently.
 |---|---|---|---|
 | **Developer host** | `uv tool install` from git URL (canonical); `pip install` from git URL (alternative) | Host-side commands: `st-docker-run`, `st-commit`, `st-submit-pr`, `st-prepare-release`, `st-finalize-repo` | Manual one-liner after each release |
 | **Python project `.venv`** (MUST for Python consumers) | `[tool.uv.sources]` git URL + `uv sync` | `uv run st-*` inside the container for validators: `st-validate-local`, `st-validate-local-python`, `st-markdown-standards`, etc. | `uv lock --upgrade-package standard-tooling` per repo; rolling tag means the upgrade is a no-arg re-lock |
-| **Non-Python container runtime** (cache-first) | `st-docker-run` reads `st-config.toml`, builds per-branch cached image with `pip install` from git URL | `st-*` inside the container for non-Python consumers (plugin, docker, docs) | Automatic cache rebuild when `st-config.toml` tag changes or lockfile changes |
+| **Non-Python container runtime** (cache-first) | `st-docker-run` reads `standard-tooling.toml`, builds per-branch cached image with `pip install` from git URL | `st-*` inside the container for non-Python consumers (plugin, docker, docs) | Automatic cache rebuild when `standard-tooling.toml` tag changes or lockfile changes |
 
 These targets are coordinated, not redundant. Each covers a failure
 mode the others cannot:
@@ -319,7 +319,7 @@ Ruby / Go / Rust / Java variants of `mq-rest-admin-*`) cannot
 declare `standard-tooling` as a dev dep because they have no
 `pyproject.toml` to declare in. They get `standard-tooling` at
 container runtime via `st-docker-run`'s cache-first architecture:
-each repo's `st-config.toml` declares the version tag, and
+each repo's `standard-tooling.toml` declares the version tag, and
 `st-docker-run` builds a per-branch cached image with
 standard-tooling pre-installed (see
 [Cache-first runtime install](#cache-first-runtime-install)).
@@ -332,18 +332,18 @@ per-branch cached image strategy, implemented in
 [#362](https://github.com/wphillipmoore/standard-tooling/issues/362).
 
 Each consuming repo declares its standard-tooling version in
-`st-config.toml` at the repo root:
+`standard-tooling.toml` under `[dependencies]`:
 
 ```toml
-[standard-tooling]
-tag = "v1.4"
+[dependencies]
+standard-tooling = "v1.4"
 ```
 
 `st-docker-run` reads this file, builds (or reuses) a per-branch
 Docker image with standard-tooling pre-installed via `pip install`
 from the git URL at that tag, and runs the user's command against
 the cached image. Cache invalidation is automatic: when
-`st-config.toml` or the project's lockfile changes, the cached
+`standard-tooling.toml` or the project's lockfile changes, the cached
 image is rebuilt on next invocation.
 
 This decouples `standard-tooling` releases from dev container image
@@ -372,7 +372,7 @@ into one of the two existing paths:
 - **Non-Python consumer CI** — uses the cache-first runtime path.
   Workflows invoke `st-docker-run` from the runner, which builds
   (or reuses) a cached image with standard-tooling installed per
-  `st-config.toml`. CI runners are ephemeral and cannot reuse
+  `standard-tooling.toml`. CI runners are ephemeral and cannot reuse
   cached images across runs, so each CI run pays the one-time
   install cost (~5-10s).
 
@@ -729,7 +729,7 @@ remains a real cost but is mitigated here because:
 
 Under the cache-first model, a new `standard-tooling` release does
 not automatically propagate to non-Python consumers. Each repo's
-`st-config.toml` must be updated to reference the new tag. This is
+`standard-tooling.toml` must be updated to reference the new tag. This is
 deliberate — explicit version control per repo rather than implicit
 propagation through image rebuilds. The tradeoff is a manual step
 per repo per release versus the previous model's silent staleness
@@ -770,8 +770,9 @@ window during image rebuilds.
       `standard-tooling`. Non-Python consumers get it at container
       runtime via `st-docker-run`'s cache-first architecture.
       (Completed in [#362](https://github.com/wphillipmoore/standard-tooling/issues/362).)
-- [x] All consuming repos have `st-config.toml` declaring the
-      standard-tooling version tag. (Completed in #362 Phase 2b.)
+- [x] All consuming repos have `standard-tooling.toml` declaring the
+      standard-tooling version tag. (Completed in #362 Phase 2b,
+      migrated from `st-config.toml` in #363.)
 - [ ] `standards-compliance` (and any other `standard-actions`
       composite that clones `standard-tooling` or puts
       `scripts/bin/` on `PATH`) is updated to rely on the Python

--- a/src/standard_tooling/bin/docker_run.py
+++ b/src/standard_tooling/bin/docker_run.py
@@ -35,7 +35,7 @@ environment variables:
   GH_TOKEN                (required) GitHub token passed into the container
   DOCKER_DEV_IMAGE        override the auto-detected container image
   DOCKER_NETWORK          join a Docker network (e.g. for integration tests)
-  ST_DOCKER_INSTALL_TAG   override the standard-tooling version tag from st-config.toml
+  ST_DOCKER_INSTALL_TAG   override the standard-tooling version tag from standard-tooling.toml
 
 examples:
   st-docker-run -- uv run st-validate-local

--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -1,4 +1,4 @@
-"""Read per-repo configuration from ``standard-tooling.toml`` and ``st-config.toml``."""
+"""Read per-repo configuration from ``standard-tooling.toml``."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import os
 import re
 import tomllib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -104,35 +104,13 @@ def read_config(repo_root: Path) -> StConfig:
     return StConfig(project=project, dependencies=dict(deps))
 
 
-_CONFIG_FILE = "st-config.toml"
-
-
-def read_st_config(repo_root: Path) -> dict[str, Any]:
-    """Parse and return the contents of ``st-config.toml``."""
-    config_path = repo_root / _CONFIG_FILE
-    if not config_path.is_file():
-        raise SystemExit(
-            f"ERROR: {_CONFIG_FILE} not found at {repo_root}.\n"
-            f"Every repo must have an {_CONFIG_FILE}."
-        )
-    try:
-        with config_path.open("rb") as f:
-            return tomllib.load(f)
-    except tomllib.TOMLDecodeError as exc:
-        raise SystemExit(f"ERROR: {_CONFIG_FILE} at {repo_root} is not valid TOML: {exc}") from exc
-
-
 def st_install_tag(repo_root: Path) -> str:
-    """Return the ``standard-tooling.tag`` value for runtime install.
+    """Return the ``[dependencies].standard-tooling`` value for runtime install.
 
     Checks ``ST_DOCKER_INSTALL_TAG`` env var first (override).
     """
     override = os.environ.get("ST_DOCKER_INSTALL_TAG")
     if override:
         return override
-    config = read_st_config(repo_root)
-    st = config.get("standard-tooling", {})
-    tag = st.get("tag")
-    if not tag:
-        raise SystemExit(f"ERROR: {_CONFIG_FILE} missing 'standard-tooling.tag' field.")
-    return str(tag)
+    cfg = read_config(repo_root)
+    return cfg.dependencies["standard-tooling"]

--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
 _ST_GIT_URL = "https://github.com/wphillipmoore/standard-tooling"
 
 _CACHE_FILES: dict[str, list[str]] = {
-    "python": ["uv.lock", "st-config.toml"],
-    "ruby": ["Gemfile.lock", "st-config.toml"],
-    "rust": ["Cargo.lock", "st-config.toml"],
-    "go": ["go.sum", "st-config.toml"],
-    "java": ["pom.xml", "st-config.toml"],
+    "python": ["uv.lock", "standard-tooling.toml"],
+    "ruby": ["Gemfile.lock", "standard-tooling.toml"],
+    "rust": ["Cargo.lock", "standard-tooling.toml"],
+    "go": ["go.sum", "standard-tooling.toml"],
+    "java": ["pom.xml", "standard-tooling.toml"],
 }
-_DEFAULT_CACHE_FILES = ["st-config.toml"]
+_DEFAULT_CACHE_FILES = ["standard-tooling.toml"]
 
 _WARMUP_COMMANDS: dict[str, str] = {
     "python": "uv sync --group dev",

--- a/st-config.toml
+++ b/st-config.toml
@@ -1,2 +1,0 @@
-[standard-tooling]
-tag = "v1.4"

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -7,66 +7,43 @@ from unittest.mock import patch
 
 import pytest
 
-from standard_tooling.lib.config import ConfigError, read_config, read_st_config, st_install_tag
+from standard_tooling.lib.config import ConfigError, read_config, st_install_tag
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-# -- read_st_config -----------------------------------------------------------
-
-
-def test_read_valid_config(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
-    config = read_st_config(tmp_path)
-    assert config["standard-tooling"]["tag"] == "v1.4"
-
-
-def test_read_missing_file(tmp_path: Path) -> None:
-    with pytest.raises(SystemExit, match="st-config.toml not found"):
-        read_st_config(tmp_path)
-
-
-def test_read_empty_file(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text("")
-    assert read_st_config(tmp_path) == {}
-
-
-def test_read_malformed_toml(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text("[invalid\n")
-    with pytest.raises(SystemExit):
-        read_st_config(tmp_path)
-
-
 # -- st_install_tag -----------------------------------------------------------
+
+_INSTALL_TAG_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+"""
 
 
 def test_tag_from_config(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_INSTALL_TAG_TOML)
     with patch.dict("os.environ", {}, clear=True):
         assert st_install_tag(tmp_path) == "v1.4"
 
 
-def test_tag_missing_section(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text("[other]\nkey = 1\n")
+def test_tag_missing_file(tmp_path: Path) -> None:
     with (
         patch.dict("os.environ", {}, clear=True),
-        pytest.raises(SystemExit, match="missing 'standard-tooling.tag'"),
-    ):
-        st_install_tag(tmp_path)
-
-
-def test_tag_missing_field(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text("[standard-tooling]\nother = 1\n")
-    with (
-        patch.dict("os.environ", {}, clear=True),
-        pytest.raises(SystemExit, match="missing 'standard-tooling.tag'"),
+        pytest.raises(FileNotFoundError),
     ):
         st_install_tag(tmp_path)
 
 
 def test_env_override(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_INSTALL_TAG_TOML)
     with patch.dict("os.environ", {"ST_DOCKER_INSTALL_TAG": "v2.0"}, clear=True):
         assert st_install_tag(tmp_path) == "v2.0"
 

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -21,40 +21,52 @@ if TYPE_CHECKING:
 
     import pytest
 
+_VALID_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "go"
+
+[dependencies]
+standard-tooling = "v1.4"
+"""
+
 
 # -- cache_sensitive_files ----------------------------------------------------
 
 
 def test_cache_files_python(tmp_path: Path) -> None:
     (tmp_path / "uv.lock").write_text("lock\n")
-    (tmp_path / "st-config.toml").write_text("[standard-tooling]\n")
+    (tmp_path / "standard-tooling.toml").write_text("[standard-tooling]\n")
     files = cache_sensitive_files(tmp_path, "python")
     names = [f.name for f in files]
     assert "uv.lock" in names
-    assert "st-config.toml" in names
+    assert "standard-tooling.toml" in names
 
 
 def test_cache_files_go(tmp_path: Path) -> None:
     (tmp_path / "go.sum").write_text("sum\n")
-    (tmp_path / "st-config.toml").write_text("[standard-tooling]\n")
+    (tmp_path / "standard-tooling.toml").write_text("[standard-tooling]\n")
     files = cache_sensitive_files(tmp_path, "go")
     names = [f.name for f in files]
     assert "go.sum" in names
-    assert "st-config.toml" in names
+    assert "standard-tooling.toml" in names
 
 
 def test_cache_files_unknown_language(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text("[standard-tooling]\n")
+    (tmp_path / "standard-tooling.toml").write_text("[standard-tooling]\n")
     files = cache_sensitive_files(tmp_path, "")
     assert len(files) == 1
-    assert files[0].name == "st-config.toml"
+    assert files[0].name == "standard-tooling.toml"
 
 
 def test_cache_files_missing_lockfile(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text("[standard-tooling]\n")
+    (tmp_path / "standard-tooling.toml").write_text("[standard-tooling]\n")
     files = cache_sensitive_files(tmp_path, "go")
     assert len(files) == 1
-    assert files[0].name == "st-config.toml"
+    assert files[0].name == "standard-tooling.toml"
 
 
 # -- compute_cache_hash -------------------------------------------------------
@@ -148,7 +160,7 @@ def test_ensure_returns_base_when_no_files(tmp_path: Path) -> None:
 
 
 def test_ensure_returns_existing_cache_on_hash_match(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     cached_tag = "ghcr.io/r/dev-go:1.26--feature-42--"
     files = cache_sensitive_files(tmp_path, "go")
     expected_hash = compute_cache_hash(files)
@@ -167,7 +179,7 @@ def test_ensure_returns_existing_cache_on_hash_match(tmp_path: Path) -> None:
 
 
 def test_ensure_rebuilds_on_hash_mismatch(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     stale_tag = "ghcr.io/r/dev-go:1.26--feature-42--oldold00"
     new_tag = "ghcr.io/r/dev-go:1.26--feature-42--"
 
@@ -196,7 +208,7 @@ def test_ensure_rebuilds_on_hash_mismatch(tmp_path: Path) -> None:
 
 
 def test_ensure_builds_on_cache_miss(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
 
     with (
         patch("standard_tooling.lib.git.current_branch") as mock_branch,
@@ -252,7 +264,7 @@ def test_clean_branch_images_docker_error() -> None:
 
 
 def test_build_cached_image_success(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=0, stdout="abc123\n")
     start_result = MagicMock(returncode=0)
     commit_result = MagicMock(returncode=0)
@@ -278,7 +290,7 @@ def test_build_cached_image_success(tmp_path: Path) -> None:
 
 
 def test_build_cached_image_create_fails(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=1, stderr="no space")
     with patch("standard_tooling.lib.docker_cache.subprocess.run", return_value=create_result):
         result = _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
@@ -286,7 +298,7 @@ def test_build_cached_image_create_fails(tmp_path: Path) -> None:
 
 
 def test_build_cached_image_start_fails(tmp_path: Path) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=0, stdout="abc123\n")
     start_result = MagicMock(returncode=1)
     rm_result = MagicMock(returncode=0)
@@ -310,7 +322,7 @@ def test_build_cached_image_start_fails(tmp_path: Path) -> None:
 def test_build_cached_image_warmup_printed(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=0, stdout="abc123\n")
     ok = MagicMock(returncode=0)
 
@@ -328,7 +340,7 @@ def test_build_cached_image_warmup_printed(
 def test_build_cached_image_no_warmup_for_unknown_lang(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=0, stdout="abc123\n")
     ok = MagicMock(returncode=0)
 

--- a/tests/standard_tooling/test_docker_cache_cli.py
+++ b/tests/standard_tooling/test_docker_cache_cli.py
@@ -12,6 +12,18 @@ if TYPE_CHECKING:
 
     import pytest
 
+_VALID_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "go"
+
+[dependencies]
+standard-tooling = "v1.4"
+"""
+
 
 # -- no subcommand ------------------------------------------------------------
 
@@ -108,7 +120,7 @@ def test_build_no_caching(tmp_path: Path, capsys: pytest.CaptureFixture[str]) ->
 def test_status_no_cache_with_expected_tag(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     with (
         patch("standard_tooling.bin.docker_cache.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.docker_cache.git.current_branch", return_value="feature/42"),
@@ -125,7 +137,7 @@ def test_status_no_cache_with_expected_tag(
 
 
 def test_status_current(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     from standard_tooling.lib.docker_cache import cache_sensitive_files, compute_cache_hash
 
     files = cache_sensitive_files(tmp_path, "go")
@@ -146,7 +158,7 @@ def test_status_current(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
 
 
 def test_status_stale(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    (tmp_path / "st-config.toml").write_text('[standard-tooling]\ntag = "v1.4"\n')
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     cached = ("ghcr.io/r/dev-go:1.26--feature-42--oldold00", "oldold00")
     with (
         patch("standard_tooling.bin.docker_cache.git.repo_root", return_value=tmp_path),


### PR DESCRIPTION
# Pull Request

## Summary

- Phase 4 of the standard-tooling.toml migration: retire st-config.toml.

- Rewrite st_install_tag() to read from standard-tooling.toml via read_config()
- Delete read_st_config() and the _CONFIG_FILE constant
- Update docker_cache.py cache file references from st-config.toml to standard-tooling.toml
- Update host-level-tool spec references
- Update CLAUDE.md and docker_run.py help text
- Rewrite tests to use standard-tooling.toml format
- Delete st-config.toml from the repository

## Issue Linkage

- Ref #363

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -