### PR TITLE
fix: add --pull=always to docker run to prevent stale image cache

### DIFF
--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -95,6 +95,7 @@ def build_docker_args(
         "docker",
         "run",
         "--rm",
+        "--pull=always",
         "-v",
         f"{repo_root}:/workspace",
         "-w",

--- a/tests/standard_tooling/test_docker.py
+++ b/tests/standard_tooling/test_docker.py
@@ -89,7 +89,7 @@ def test_default_image_empty_with_fallback() -> None:
 def test_build_docker_args_basic(tmp_path: Path) -> None:
     with patch.dict("os.environ", {}, clear=True):
         args = build_docker_args(tmp_path, "img:1", ["echo", "hello"])
-    assert args[:3] == ["docker", "run", "--rm"]
+    assert args[:4] == ["docker", "run", "--rm", "--pull=always"]
     assert f"{tmp_path}:/workspace" in args
     assert "img:1" in args
     assert args[-2:] == ["echo", "hello"]


### PR DESCRIPTION
# Pull Request

## Summary

- Add --pull=always to docker run args to prevent stale image cache. Docker does not check the registry when a tag exists locally, which caused st-docker-run to use a stale dev-base:latest with pre-baked standard-tooling v1.4.1. The flag checks the manifest digest (sub-second) and only downloads when the image changed.

## Issue Linkage

- Ref #403

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -