### PR TITLE
fix: use uv run for validation in Python repos during finalization

### DIFF
--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -230,7 +230,11 @@ def main(argv: list[str] | None = None) -> int:
         if docker_run is not None:
             print()
             print("Running post-finalization validation via st-docker-run...")
-            cmd: tuple[str, ...] = (docker_run, "--", "st-validate-local")
+            repo_root = Path(git.repo_root())
+            if (repo_root / "pyproject.toml").is_file():
+                cmd: tuple[str, ...] = (docker_run, "--", "uv", "run", "st-validate-local")
+            else:
+                cmd = (docker_run, "--", "st-validate-local")
         elif validator is not None:
             print()
             print("Running post-finalization validation...")
@@ -248,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
         if result.returncode != 0:
             validation_failed = True
     else:
-        print("  [dry-run] st-docker-run -- st-validate-local")
+        print("  [dry-run] st-docker-run -- [uv run] st-validate-local")
 
     # Docs-publish sanity check (issue #303). Runs after validation
     # so a real validation failure stays the headline; a docs failure

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -256,6 +256,23 @@ def test_main_prefers_docker_run(tmp_path: Path) -> None:
     assert cmd[1:] == ("--", "st-validate-local")
 
 
+def test_main_docker_run_uses_uv_for_python(tmp_path: Path) -> None:
+    _make_profile(tmp_path, "library-release")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".shutil.which", side_effect=_which_docker_only),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()) as mock_sub,
+    ):
+        result = main([])
+    assert result == 0
+    cmd = mock_sub.call_args[0][0]
+    assert cmd == ("/usr/bin/st-docker-run", "--", "uv", "run", "st-validate-local")
+
+
 def test_main_falls_back_to_direct_validator(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (


### PR DESCRIPTION
# Pull Request

## Summary

- st-finalize-repo now uses uv run st-validate-local for Python consumer repos (detected via pyproject.toml) instead of bare st-validate-local, which fails because the console script lives in the project .venv, not on the container system PATH.

## Issue Linkage

- Ref #403

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -