### PR TITLE
chore: add consumer-refresh config to standard-tooling.toml

### DIFF
--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,5 +9,10 @@ primary-language = "python"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[publish]
+consumer-refresh = """\
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v<VERSION>'
+"""
+
 [dependencies]
 standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Add [publish] consumer-refresh field to standard-tooling.toml for publish skill Phase 7 hand-off.

## Issue Linkage

- Ref #425

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -