### PR TITLE
fix: add --break-system-packages to pip install in docker cache build

### DIFF
--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -92,7 +92,10 @@ def _build_cached_image(
 ) -> str:
     """Build a cached image with standard-tooling installed."""
     tag = st_install_tag(repo_root)
-    pip_install = f"pip install --quiet 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
+    pip_install = (
+        f"pip install --quiet --break-system-packages"
+        f" 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
+    )
     warmup = _WARMUP_COMMANDS.get(lang)
     setup = f"{pip_install} && {warmup}" if warmup else pip_install
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add --break-system-packages to pip install in docker cache build to fix PEP 668 failures on non-Python containers

## Issue Linkage

- Ref #427

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -