### PR TITLE
chore(lint): fix S607 noqa, duplicate pytest import, and pip reference in releasing guide

### DIFF
--- a/docs/site/docs/guides/releasing.md
+++ b/docs/site/docs/guides/releasing.md
@@ -75,7 +75,7 @@ get the fix on the next normal action:
 
 | Consumer | When the patch lands |
 |---|---|
-| Developer host | Manual `uv tool upgrade standard-tooling` (or `pip install --upgrade ...@v1.3`) |
+| Developer host | Manual `uv tool upgrade standard-tooling` |
 | Python repo `.venv` | `uv lock --upgrade-package standard-tooling` (typically batched with other dep bumps) |
 | Dev container image | Already rebuilt by `repository_dispatch`; new pulls of `dev-base` etc. carry the patch within the rebuild window (minutes) |
 

--- a/docs/specs/host-level-tool.md
+++ b/docs/specs/host-level-tool.md
@@ -91,9 +91,9 @@ fleet to behave consistently.
 
 | Target | Install mechanism | Who uses it | Freshness mechanism |
 |---|---|---|---|
-| **Developer host** | `uv tool install` from git URL (canonical); `pip install` from git URL (alternative) | Host-side commands: `st-docker-run`, `st-commit`, `st-submit-pr`, `st-prepare-release`, `st-finalize-repo` | Manual one-liner after each release |
+| **Developer host** | `uv tool install` from git URL | Host-side commands: `st-docker-run`, `st-commit`, `st-submit-pr`, `st-prepare-release`, `st-finalize-repo` | Manual one-liner after each release |
 | **Python project `.venv`** (MUST for Python consumers) | `[tool.uv.sources]` git URL + `uv sync` | `uv run st-*` inside the container for validators: `st-validate-local`, `st-validate-local-python`, `st-markdown-standards`, etc. | `uv lock --upgrade-package standard-tooling` per repo; rolling tag means the upgrade is a no-arg re-lock |
-| **Non-Python container runtime** (cache-first) | `st-docker-run` reads `standard-tooling.toml`, builds per-branch cached image with `pip install` from git URL | `st-*` inside the container for non-Python consumers (plugin, docker, docs) | Automatic cache rebuild when `standard-tooling.toml` tag changes or lockfile changes |
+| **Non-Python container runtime** (cache-first) | `st-docker-run` reads `standard-tooling.toml`, builds per-branch cached image with `uv tool install` from git URL | `st-*` inside the container for non-Python consumers (plugin, docker, docs) | Automatic cache rebuild when `standard-tooling.toml` tag changes or lockfile changes |
 
 These targets are coordinated, not redundant. Each covers a failure
 mode the others cannot:
@@ -141,45 +141,6 @@ cuts a new minor and decides consumers should opt in.
 > diff to the right starting point. Treat any `develop-v*` tag as
 > internal — never pin to one.
 
-### `uv tool install` vs `pip install`
-
-`uv tool install` is canonical. `pip install` is a documented
-alternative, not a replacement.
-
-| | `uv tool install` (canonical) | `pip install` (alternative) |
-|---|---|---|
-| Install target | Isolated venv at `~/.local/share/uv/tools/standard-tooling/` | Whatever Python env `pip` runs from |
-| Scripts land in | `~/.local/bin/` (the path `uv`'s official installer already configures) | `bin/` of the Python env `pip` runs from |
-| Dep isolation | Fully isolated | Shared with the containing env |
-| macOS system Python | Works | Works (user-owned Framework Python) |
-| Linux system Python | Works | Fails without `sudo` or `--break-system-packages` (PEP 668) |
-| `uv` installed standalone (no Python env) | Works | No applicable target env |
-| Uninstall | `uv tool uninstall standard-tooling` | `pip uninstall standard-tooling` |
-
-**Why `uv tool install` is canonical:**
-
-- **Cross-platform without caveats.** Works identically on macOS
-  and Linux. No `--user` vs system-wide decision, no PEP 668
-  exception flags, no `sudo`.
-- **Matches the `uv` installation pattern.** Developers install
-  `uv` via the official installer, which configures `~/.local/bin`
-  on `PATH`. `uv tool install` drops console scripts into the
-  exact same directory, so `standard-tooling` scripts are on `PATH`
-  automatically.
-- **Zero pollution of the developer's Python environments.**
-  `standard-tooling` and its transitive deps live in their own
-  venv, invisible to any other Python work on the machine.
-- **Self-upgrading.** `uv tool upgrade standard-tooling` is a
-  shorter, tag-aware one-liner than the `pip install --upgrade`
-  equivalent.
-
-Developers or CI environments that prefer — or already have — a
-`pip`-based install may use `pip install` with the same git URL,
-accepting the platform caveats above. The existing primary-developer
-machine, which has `standard-tooling` installed via `pip` into
-Framework Python, is a valid alternative install and does not need
-to migrate.
-
 ## Upgrade (host)
 
 Run after each `standard-tooling` release:
@@ -192,17 +153,6 @@ uv tool upgrade standard-tooling
 tip of the rolling minor tag (`v1.2` today), and rebuilds the
 isolated venv. No need to repeat the full git URL — uv remembers
 the source from the initial `uv tool install`.
-
-For `pip install` users:
-
-```bash
-pip install --upgrade 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.2'
-```
-
-`--upgrade` is required for `pip` to re-resolve the git reference;
-without it, pip sees the package already installed and skips. The
-`v1.2` pin ensures resolution picks up the latest patch on the
-current minor.
 
 ### Why not auto-upgrade
 
@@ -340,7 +290,7 @@ standard-tooling = "v1.4"
 ```
 
 `st-docker-run` reads this file, builds (or reuses) a per-branch
-Docker image with standard-tooling pre-installed via `pip install`
+Docker image with standard-tooling pre-installed via `uv tool install`
 from the git URL at that tag, and runs the user's command against
 the cached image. Cache invalidation is automatic: when
 `standard-tooling.toml` or the project's lockfile changes, the cached
@@ -625,7 +575,7 @@ consumer's migration has these steps:
 ### `standard-tooling-docker` (child repo, this spec's work)
 
 1. Replace `git clone -b develop && uv pip install --system` with
-   `pip install 'standard-tooling @ git+…@v1.2'` in the common
+   `uv tool install 'standard-tooling @ git+…@v1.2'` in the common
    fragment.
 2. Wire release-triggered rebuilds per
    [`standard-tooling-docker#51`](https://github.com/wphillipmoore/standard-tooling-docker/issues/51).
@@ -681,10 +631,6 @@ Crossing a major boundary is a deliberate, explicit edit at each
 target (bump `v1.2` → `v2.0` in the consumer's `pyproject.toml`,
 the image's Dockerfile, and the developer's `uv tool install`
 command). This is the point: major bumps are gated, not broadcast.
-
-### `uv tool install` vs `pip install`
-
-Covered in [Canonical install](#canonical-install-host).
 
 ### Host install vs devcontainer-only
 
@@ -784,8 +730,6 @@ window during image rebuilds.
 
 - Rolling-tag behavior:
   [`standard-actions` `tag-and-release`](https://github.com/wphillipmoore/standard-actions/blob/main/actions/publish/tag-and-release/action.yml)
-- `pip install` from VCS:
-  <https://pip.pypa.io/en/stable/topics/vcs-support/>
 - `uv tool install`:
   <https://docs.astral.sh/uv/guides/tools/#installing-tools>
 - uv sources (git URL + tag):

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -89,17 +88,13 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
     immediately. Issue #303.
 
     Returns None when:
-      - ``gh`` is not on PATH (can't query)
       - no Documentation workflow exists in the repo
       - the latest run succeeded or is still in progress
       - the JSON response is malformed (defensive)
     """
-    gh = shutil.which("gh")
-    if gh is None:
-        return None
     result = subprocess.run(  # noqa: S603
         [
-            gh,
+            "gh",
             "run",
             "list",
             "--workflow",
@@ -224,29 +219,13 @@ def main(argv: list[str] | None = None) -> int:
 
     validation_failed = False
     if not args.dry_run:
-        docker_run = shutil.which("st-docker-run")
-        validator = shutil.which("st-validate-local")
-
-        if docker_run is not None:
-            print()
-            print("Running post-finalization validation via st-docker-run...")
-            repo_root = Path(git.repo_root())
-            if (repo_root / "pyproject.toml").is_file():
-                cmd: tuple[str, ...] = (docker_run, "--", "uv", "run", "st-validate-local")
-            else:
-                cmd = (docker_run, "--", "st-validate-local")
-        elif validator is not None:
-            print()
-            print("Running post-finalization validation...")
-            cmd = (validator,)
+        print()
+        print("Running post-finalization validation via st-docker-run...")
+        repo_root = Path(git.repo_root())
+        if (repo_root / "pyproject.toml").is_file():
+            cmd: tuple[str, ...] = ("st-docker-run", "--", "uv", "run", "st-validate-local")
         else:
-            print()
-            print(
-                "ERROR: neither st-docker-run nor st-validate-local found on PATH.",
-                file=sys.stderr,
-            )
-            print("  Ensure standard-tooling is installed and on PATH.", file=sys.stderr)
-            return 1
+            cmd = ("st-docker-run", "--", "st-validate-local")
 
         result = subprocess.run(cmd, check=False)  # noqa: S603
         if result.returncode != 0:
@@ -278,7 +257,7 @@ def main(argv: list[str] | None = None) -> int:
     if docs_failure is not None:
         print()
         print(
-            "WARNING: most recent Documentation workflow run did not succeed.",
+            "ERROR: most recent Documentation workflow run did not succeed.",
             file=sys.stderr,
         )
         print(f"  {docs_failure}", file=sys.stderr)
@@ -287,7 +266,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         print("  the site doesn't drift further from develop.", file=sys.stderr)
-        # Soft warning: keep exit code 0 since finalize itself succeeded.
+        return 1
 
     return 0
 

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -3,9 +3,8 @@
 Switches to the target branch, fast-forward pulls, deletes merged local
 branches, and prunes stale remote-tracking references. After
 validation succeeds, also checks the most recent Documentation
-workflow run on the target branch and surfaces a warning if it
-failed (issue #303 — docs publish is async and used to fail
-silently).
+workflow run on the target branch and fails if it did not succeed
+(issue #303 — docs publish is async and used to fail silently).
 """
 
 from __future__ import annotations
@@ -249,7 +248,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if validation_failed:
         print()
-        print("WARNING: post-finalization validation failed.", file=sys.stderr)
+        print("ERROR: post-finalization validation failed.", file=sys.stderr)
         print(f"  The {args.target_branch} branch has issues that should be", file=sys.stderr)
         print("  fixed before creating the next PR.", file=sys.stderr)
         return 1

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -92,7 +92,7 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
       - the JSON response is malformed (defensive)
     """
     result = subprocess.run(  # noqa: S603
-        [
+        [  # noqa: S607
             "gh",
             "run",
             "list",

--- a/src/standard_tooling/bin/markdown_standards.py
+++ b/src/standard_tooling/bin/markdown_standards.py
@@ -8,7 +8,6 @@ Structural checks (H1 count, ToC, heading-level skips) live in
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -30,10 +29,6 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     files = _find_files()
     if not files:
         return 0
-
-    if not shutil.which("markdownlint"):
-        print("FATAL: markdownlint not found on PATH", file=sys.stderr)
-        return 2
 
     cmd: list[str] = ["markdownlint"]
     config = Path(".markdownlint.yaml")

--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -164,11 +163,6 @@ def _ensure_develop_up_to_date() -> None:
         )
 
 
-def _ensure_tool(name: str) -> None:
-    if not shutil.which(name):
-        raise SystemExit(f"Required tool '{name}' not found on PATH.")
-
-
 # -- release steps -----------------------------------------------------------
 
 
@@ -197,7 +191,6 @@ RELEASE_NOTES_DIR = "releases"
 
 
 def _generate_changelog(version: str) -> None:
-    _ensure_tool("git-cliff")
     tag = f"develop-v{version}"
     print(f"Generating changelog with boundary tag: {tag}")
     subprocess.run(("git-cliff", "--tag", tag, "-o", "CHANGELOG.md"), check=True)  # noqa: S603, S607
@@ -289,7 +282,6 @@ def main(argv: list[str] | None = None) -> int:
     _ensure_on_develop()
     _ensure_clean_tree()
     _ensure_develop_up_to_date()
-    _ensure_tool("gh")
 
     ecosystem, version = detect_ecosystem()
     branch = f"release/{version}"

--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import re
 import subprocess
-import sys
 from typing import TYPE_CHECKING
 
 from standard_tooling.lib.config import st_install_tag
@@ -92,9 +91,9 @@ def _build_cached_image(
 ) -> str:
     """Build a cached image with standard-tooling installed."""
     tag = st_install_tag(repo_root)
-    pip_install = f"pip install --quiet 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
+    uv_install = f"uv tool install --quiet 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
     warmup = _WARMUP_COMMANDS.get(lang)
-    setup = f"{pip_install} && {warmup}" if warmup else pip_install
+    setup = f"{uv_install} && {warmup}" if warmup else uv_install
 
     print(f"Building cached image: {target_tag}")
     print(f"  Base:    {base_image}")
@@ -119,11 +118,8 @@ def _build_cached_image(
         text=True,
     )
     if cid_result.returncode != 0:
-        print(
-            f"ERROR: Failed to create container: {cid_result.stderr.strip()}",
-            file=sys.stderr,
-        )
-        return base_image
+        msg = f"Failed to create container: {cid_result.stderr.strip()}"
+        raise RuntimeError(msg)
 
     container_id = cid_result.stdout.strip()
 
@@ -132,11 +128,8 @@ def _build_cached_image(
             ["docker", "start", "-a", container_id],  # noqa: S607
         )
         if run_result.returncode != 0:
-            print(
-                "ERROR: Cache build failed. Falling back to base image.",
-                file=sys.stderr,
-            )
-            return base_image
+            msg = "Cache build failed"
+            raise RuntimeError(msg)
 
         subprocess.run(  # noqa: S603
             ["docker", "commit", container_id, target_tag],  # noqa: S607

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from standard_tooling.lib.docker_cache import (
     _build_cached_image,
     _sanitize_branch,
@@ -292,9 +294,11 @@ def test_build_cached_image_success(tmp_path: Path) -> None:
 def test_build_cached_image_create_fails(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=1, stderr="no space")
-    with patch("standard_tooling.lib.docker_cache.subprocess.run", return_value=create_result):
-        result = _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
-    assert result == "img:1"
+    with (
+        patch("standard_tooling.lib.docker_cache.subprocess.run", return_value=create_result),
+        pytest.raises(RuntimeError, match="Failed to create container"),
+    ):
+        _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
 
 
 def test_build_cached_image_start_fails(tmp_path: Path) -> None:
@@ -303,20 +307,18 @@ def test_build_cached_image_start_fails(tmp_path: Path) -> None:
     start_result = MagicMock(returncode=1)
     rm_result = MagicMock(returncode=0)
 
-    call_count = 0
-
     def mock_run(cmd, **_kwargs):  # noqa: ANN001, ANN003
-        nonlocal call_count
-        call_count += 1
         if cmd[1] == "create":
             return create_result
         if cmd[1] == "start":
             return start_result
         return rm_result
 
-    with patch("standard_tooling.lib.docker_cache.subprocess.run", side_effect=mock_run):
-        result = _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
-    assert result == "img:1"
+    with (
+        patch("standard_tooling.lib.docker_cache.subprocess.run", side_effect=mock_run),
+        pytest.raises(RuntimeError, match="Cache build failed"),
+    ):
+        _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
 
 
 def test_build_cached_image_warmup_printed(
@@ -353,3 +355,22 @@ def test_build_cached_image_no_warmup_for_unknown_lang(
         _build_cached_image(tmp_path, "unknown", "img:1", "img:1--branch--hash")
     out = capsys.readouterr().out
     assert "Warmup:" not in out
+
+
+def test_build_cached_image_uses_uv_tool_install(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    create_result = MagicMock(returncode=0, stdout="abc123\n")
+    ok = MagicMock(returncode=0)
+    create_cmd: list[str] = []
+
+    def mock_run(cmd, **_kwargs):  # noqa: ANN001, ANN003
+        if cmd[1] == "create":
+            create_cmd.extend(cmd)
+            return create_result
+        return ok
+
+    with patch("standard_tooling.lib.docker_cache.subprocess.run", side_effect=mock_run):
+        _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
+    setup_cmd = create_cmd[-1]
+    assert "uv tool install" in setup_cmd
+    assert "pip install" not in setup_cmd

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -21,8 +21,6 @@ from standard_tooling.lib.docker_cache import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 _VALID_TOML = """\
 [project]
 repository-type = "library"

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -79,16 +79,6 @@ def _validation_ok() -> CompletedProcess[bytes]:
     return CompletedProcess(args=("st-validate-local",), returncode=0)
 
 
-def _which_docker_only(name: str) -> str | None:
-    """Simulate st-docker-run on PATH, st-validate-local not."""
-    return "/usr/bin/st-docker-run" if name == "st-docker-run" else None
-
-
-def _which_validator_only(name: str) -> str | None:
-    """Simulate st-validate-local on PATH, st-docker-run not."""
-    return "/usr/bin/st-validate-local" if name == "st-validate-local" else None
-
-
 def test_main_library_release(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
@@ -100,9 +90,9 @@ def test_main_library_release(tmp_path: Path) -> None:
             return_value=["feature/x", "develop"],
         ),
         patch(_MOD + ".git.read_output", return_value=""),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -117,8 +107,8 @@ def test_main_already_on_target(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -146,8 +136,8 @@ def test_main_no_profile(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -173,9 +163,9 @@ def test_main_application_promotion(tmp_path: Path) -> None:
             return_value=["develop", "release", "main", "feature/y"],
         ),
         patch(_MOD + ".git.read_output", return_value=""),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -188,8 +178,8 @@ def test_main_docs_single_branch(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -202,8 +192,8 @@ def test_main_no_deleted_branches(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=["develop"]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -216,43 +206,30 @@ def test_main_validation_fails(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(
             "standard_tooling.bin.finalize_repo.subprocess.run",
             return_value=CompletedProcess(args=("st-validate-local",), returncode=1),
         ),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 1
 
 
-def test_main_validator_not_found(tmp_path: Path) -> None:
+def test_main_calls_docker_run(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (
         patch(_MOD + ".git.repo_root", return_value=tmp_path),
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", return_value=None),
-    ):
-        result = main([])
-    assert result == 1
-
-
-def test_main_prefers_docker_run(tmp_path: Path) -> None:
-    _make_profile(tmp_path, "library-release")
-    with (
-        patch(_MOD + ".git.repo_root", return_value=tmp_path),
-        patch(_MOD + ".git.current_branch", return_value="develop"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_docker_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()) as mock_sub,
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
     cmd = mock_sub.call_args[0][0]
-    assert cmd[0] == "/usr/bin/st-docker-run"
+    assert cmd[0] == "st-docker-run"
     assert cmd[1:] == ("--", "st-validate-local")
 
 
@@ -264,29 +241,13 @@ def test_main_docker_run_uses_uv_for_python(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_docker_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()) as mock_sub,
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
     cmd = mock_sub.call_args[0][0]
-    assert cmd == ("/usr/bin/st-docker-run", "--", "uv", "run", "st-validate-local")
-
-
-def test_main_falls_back_to_direct_validator(tmp_path: Path) -> None:
-    _make_profile(tmp_path, "library-release")
-    with (
-        patch(_MOD + ".git.repo_root", return_value=tmp_path),
-        patch(_MOD + ".git.current_branch", return_value="develop"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
-        patch(_MOD + ".subprocess.run", return_value=_validation_ok()) as mock_sub,
-    ):
-        result = main([])
-    assert result == 0
-    cmd = mock_sub.call_args[0][0]
-    assert cmd == ("/usr/bin/st-validate-local",)
+    assert cmd == ("st-docker-run", "--", "uv", "run", "st-validate-local")
 
 
 # -- _check_docs_workflow_status (issue #303) --------------------------------
@@ -307,63 +268,43 @@ def _gh_run_json(conclusion: str | None) -> str:
     )
 
 
-def test_check_docs_workflow_returns_none_when_gh_missing() -> None:
-    with patch(_MOD + ".shutil.which", return_value=None):
-        assert _check_docs_workflow_status("develop") is None
-
-
 def test_check_docs_workflow_returns_none_when_gh_fails() -> None:
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=1, stdout="", stderr="oops"),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=1, stdout="", stderr="oops"),
     ):
         assert _check_docs_workflow_status("develop") is None
 
 
 def test_check_docs_workflow_returns_none_when_no_runs() -> None:
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout="[]"),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout="[]"),
     ):
         assert _check_docs_workflow_status("develop") is None
 
 
 def test_check_docs_workflow_returns_none_on_success() -> None:
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("success")),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("success")),
     ):
         assert _check_docs_workflow_status("develop") is None
 
 
 def test_check_docs_workflow_returns_none_on_in_progress() -> None:
     # gh reports null conclusion (in_progress / queued).
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json(None)),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json(None)),
     ):
         assert _check_docs_workflow_status("develop") is None
 
 
 def test_check_docs_workflow_returns_message_on_failure() -> None:
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("failure")),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("failure")),
     ):
         msg = _check_docs_workflow_status("develop")
     assert msg is not None
@@ -375,29 +316,23 @@ def test_check_docs_workflow_returns_message_on_failure() -> None:
 
 
 def test_check_docs_workflow_returns_none_on_malformed_json() -> None:
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout="not json"),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout="not json"),
     ):
         assert _check_docs_workflow_status("develop") is None
 
 
 def test_check_docs_workflow_returns_none_on_empty_stdout() -> None:
     # Defensive: stdout missing entirely (None) shouldn't crash.
-    with (
-        patch(_MOD + ".shutil.which", return_value="/usr/bin/gh"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout=None),
-        ),
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout=None),
     ):
         assert _check_docs_workflow_status("develop") is None
 
 
-def test_main_warns_on_docs_failure_but_returns_zero(
+def test_main_returns_one_on_docs_failure(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _make_profile(tmp_path, "library-release")
@@ -406,7 +341,6 @@ def test_main_warns_on_docs_failure_but_returns_zero(
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(
             _MOD + "._check_docs_workflow_status",
@@ -417,11 +351,9 @@ def test_main_warns_on_docs_failure_but_returns_zero(
         ),
     ):
         result = main([])
-    # Soft warning: finalize itself succeeded, so exit 0.
-    assert result == 0
+    assert result == 1
     stderr = capsys.readouterr().err
     assert "Documentation workflow" in stderr
-    assert "Docs publish is async" in stderr
 
 
 def test_main_skips_docs_check_on_dry_run(tmp_path: Path) -> None:
@@ -431,7 +363,6 @@ def test_main_skips_docs_check_on_dry_run(tmp_path: Path) -> None:
         patch(_MOD + ".git.current_branch", return_value="develop"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(
             _MOD + "._check_docs_workflow_status",
             return_value="should not appear",
@@ -530,9 +461,9 @@ def test_main_removes_worktree_before_deleting_branch(tmp_path: Path) -> None:
         patch(_MOD + ".git.run", side_effect=mock_git_run),
         patch(_MOD + ".git.merged_branches", return_value=["feature/99-x"]),
         patch(_MOD + ".git.read_output", return_value=porcelain),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
 
@@ -563,9 +494,9 @@ def test_main_skips_worktree_remove_when_branch_not_in_worktree(tmp_path: Path) 
         patch(_MOD + ".git.run", side_effect=mock_git_run),
         patch(_MOD + ".git.merged_branches", return_value=["feature/99-x"]),
         patch(_MOD + ".git.read_output", return_value=porcelain),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
 
@@ -584,9 +515,9 @@ def test_main_cleans_docker_cache_on_branch_delete(
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=["feature/x"]),
         patch(_MOD + ".git.read_output", return_value=""),
-        patch(_MOD + ".shutil.which", side_effect=_which_validator_only),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=2) as mock_clean,
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0

--- a/tests/standard_tooling/test_markdown_standards.py
+++ b/tests/standard_tooling/test_markdown_standards.py
@@ -47,22 +47,12 @@ def test_main_no_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert main([]) == 0
 
 
-def test_main_markdownlint_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "README.md").write_text("# Hello\n")
-    with patch("standard_tooling.bin.markdown_standards.shutil.which", return_value=None):
-        assert main([]) == 2
-
-
 def test_main_pass(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "README.md").write_text("# Hello\n")
-    with (
-        patch("standard_tooling.bin.markdown_standards.shutil.which", return_value="/usr/bin/ml"),
-        patch(
-            "standard_tooling.bin.markdown_standards.subprocess.run",
-            return_value=subprocess.CompletedProcess(args=[], returncode=0),
-        ),
+    with patch(
+        "standard_tooling.bin.markdown_standards.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=0),
     ):
         assert main([]) == 0
 
@@ -70,12 +60,9 @@ def test_main_pass(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_main_fail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "README.md").write_text("# Hello\n")
-    with (
-        patch("standard_tooling.bin.markdown_standards.shutil.which", return_value="/usr/bin/ml"),
-        patch(
-            "standard_tooling.bin.markdown_standards.subprocess.run",
-            return_value=subprocess.CompletedProcess(args=[], returncode=1),
-        ),
+    with patch(
+        "standard_tooling.bin.markdown_standards.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=1),
     ):
         assert main([]) == 1
 
@@ -90,10 +77,7 @@ def test_main_with_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
         captured_cmd.extend(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0)
 
-    with (
-        patch("standard_tooling.bin.markdown_standards.shutil.which", return_value="/usr/bin/ml"),
-        patch("standard_tooling.bin.markdown_standards.subprocess.run", side_effect=capture_run),
-    ):
+    with patch("standard_tooling.bin.markdown_standards.subprocess.run", side_effect=capture_run):
         main([])
     assert "--config" in captured_cmd
     assert ".markdownlint.yaml" in captured_cmd

--- a/tests/standard_tooling/test_prepare_release.py
+++ b/tests/standard_tooling/test_prepare_release.py
@@ -21,7 +21,6 @@ from standard_tooling.bin.prepare_release import (
     _ensure_clean_tree,
     _ensure_develop_up_to_date,
     _ensure_on_develop,
-    _ensure_tool,
     _generate_release_notes,
     _normalize_trailing_newline,
     detect_ecosystem,
@@ -299,19 +298,6 @@ def test_ensure_develop_up_to_date_diverged() -> None:
         _ensure_develop_up_to_date()
 
 
-def test_ensure_tool_found() -> None:
-    with patch("standard_tooling.bin.prepare_release.shutil.which", return_value="/usr/bin/gh"):
-        _ensure_tool("gh")
-
-
-def test_ensure_tool_not_found() -> None:
-    with (
-        patch("standard_tooling.bin.prepare_release.shutil.which", return_value=None),
-        pytest.raises(SystemExit, match="not found on PATH"),
-    ):
-        _ensure_tool("missing-tool")
-
-
 # -- main flow tests ---
 
 
@@ -366,10 +352,6 @@ def test_main_full_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
         ),
         patch("standard_tooling.bin.prepare_release.git.ref_exists", return_value=False),
         patch(
-            "standard_tooling.bin.prepare_release.shutil.which",
-            return_value="/usr/bin/tool",
-        ),
-        patch(
             "standard_tooling.bin.prepare_release.subprocess.run",
             side_effect=mock_subprocess_run,
         ),
@@ -406,10 +388,6 @@ def test_main_release_branch_already_exists(
             side_effect=mock_read_output,
         ),
         patch("standard_tooling.bin.prepare_release.git.ref_exists", return_value=True),
-        patch(
-            "standard_tooling.bin.prepare_release.shutil.which",
-            return_value="/usr/bin/tool",
-        ),
         pytest.raises(SystemExit, match="already exists"),
     ):
         main(["--issue", "42"])
@@ -444,10 +422,6 @@ def test_main_no_publishable_changes(tmp_path: Path, monkeypatch: pytest.MonkeyP
             side_effect=mock_read_output,
         ),
         patch("standard_tooling.bin.prepare_release.git.ref_exists", return_value=False),
-        patch(
-            "standard_tooling.bin.prepare_release.shutil.which",
-            return_value="/usr/bin/tool",
-        ),
         patch(
             "standard_tooling.bin.prepare_release.subprocess.run",
             side_effect=mock_subprocess_run,
@@ -559,10 +533,6 @@ def test_main_full_flow_with_release_notes(tmp_path: Path, monkeypatch: pytest.M
             side_effect=mock_read_output,
         ),
         patch("standard_tooling.bin.prepare_release.git.ref_exists", return_value=False),
-        patch(
-            "standard_tooling.bin.prepare_release.shutil.which",
-            return_value="/usr/bin/tool",
-        ),
         patch(
             "standard_tooling.bin.prepare_release.subprocess.run",
             side_effect=mock_subprocess_run,


### PR DESCRIPTION
# Pull Request

## Summary

- Replace pip install with uv tool install and remove shutil.which guard patterns

## Issue Linkage

- Ref #429

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

- Replace `pip install` with `uv tool install` in `_build_cached_image` to fix PEP 668 failures on Python 3.13+ containers (issues #427, #429)
- Remove `shutil.which` guard patterns from `finalize_repo.py`, `prepare_release.py`, and `markdown_standards.py` — tools are assumed on PATH per the consumption model
- Make docs workflow failure in `st-finalize-repo` return exit code 1 instead of soft warning (errors are fatal by default)
- Eliminate all `pip install` references from `host-level-tool.md` spec and `releasing.md` guide

## Issue Linkage

- Ref #429
- Ref #427

## Testing

- Full validation via `st-docker-run -- uv run st-validate-local`: 522 tests pass, 100% branch coverage
- Lint, typecheck, shellcheck, markdownlint, yamllint, audit all clean
- Verification greps confirm no `pip install` in source, no `shutil.which` guards outside `validate_local.py`

## Notes

- The `shutil.which` usage in `validate_local.py` is retained — it performs legitimate entry-point discovery, not a guard pattern
- Historical plan/spec documents retain `pip install` references as they describe prior decisions
- Cross-repo cleanup (standard-tooling-docker, standard-actions, standard-tooling-plugin) tracked in separate issues: standard-tooling-docker#103, standard-actions#287, standard-tooling-plugin#218