### PR TITLE
fix(docker): Fix --pull=always breaking cached image lookup; route Python through cache

### DIFF
--- a/src/standard_tooling/bin/docker_run.py
+++ b/src/standard_tooling/bin/docker_run.py
@@ -79,9 +79,6 @@ def main(argv: list[str] | None = None) -> int:
     if env_image:
         image = env_image
         image_source = "env"
-    elif lang == "python":
-        image = default_image(lang, fallback=True)
-        image_source = "default"
     else:
         base = default_image(lang, fallback=True)
         image = ensure_cached_image(repo_root, lang, base)
@@ -100,7 +97,8 @@ def main(argv: list[str] | None = None) -> int:
 
     assert_docker_available()
 
-    docker_args = build_docker_args(repo_root, image, command)
+    pull_policy = "never" if image_source == "cached" else "always"
+    docker_args = build_docker_args(repo_root, image, command, pull_policy=pull_policy)
     os.execvp("docker", docker_args)  # noqa: S606, S607
     return 0  # pragma: no cover
 

--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -96,12 +96,14 @@ def build_docker_args(
     docker_args = ["docker", "run", "--rm"]
     if pull_policy != "never":
         docker_args.append("--pull=always")
-    docker_args.extend([
-        "-v",
-        f"{repo_root}:/workspace",
-        "-w",
-        "/workspace",
-    ])
+    docker_args.extend(
+        [
+            "-v",
+            f"{repo_root}:/workspace",
+            "-w",
+            "/workspace",
+        ]
+    )
 
     # When repo_root is a git worktree, the worktree's `.git` is a file
     # pointing at <parent>/.git/worktrees/<name>. Mount the parent .git

--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -87,20 +87,21 @@ def build_docker_args(
     repo_root: Path,
     image: str,
     command: list[str],
+    *,
+    pull_policy: str = "always",
 ) -> list[str]:
     """Build the ``docker run`` argument list."""
     network = os.environ.get("DOCKER_NETWORK", "")
 
-    docker_args = [
-        "docker",
-        "run",
-        "--rm",
-        "--pull=always",
+    docker_args = ["docker", "run", "--rm"]
+    if pull_policy != "never":
+        docker_args.append("--pull=always")
+    docker_args.extend([
         "-v",
         f"{repo_root}:/workspace",
         "-w",
         "/workspace",
-    ]
+    ])
 
     # When repo_root is a git worktree, the worktree's `.git` is a file
     # pointing at <parent>/.git/worktrees/<name>. Mount the parent .git

--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -38,11 +38,13 @@ def cache_sensitive_files(repo_root: Path, lang: str) -> list[Path]:
     return [repo_root / n for n in names if (repo_root / n).is_file()]
 
 
-def compute_cache_hash(files: list[Path]) -> str:
-    """SHA-256 over sorted file contents, first 8 hex chars."""
+def compute_cache_hash(files: list[Path], *, salt: str = "") -> str:
+    """SHA-256 over sorted file contents plus optional salt, first 8 hex chars."""
     h = hashlib.sha256()
     for f in sorted(files):
         h.update(f.read_bytes())
+    if salt:
+        h.update(salt.encode())
     return h.hexdigest()[:8]
 
 
@@ -93,7 +95,12 @@ def _build_cached_image(
     tag = st_install_tag(repo_root)
     uv_install = f"uv tool install --quiet 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
     warmup = _WARMUP_COMMANDS.get(lang)
-    setup = f"{uv_install} && {warmup}" if warmup else uv_install
+    if lang == "python":
+        setup = warmup or ""
+    elif warmup:
+        setup = f"{uv_install} && {warmup}"
+    else:
+        setup = uv_install
 
     print(f"Building cached image: {target_tag}")
     print(f"  Base:    {base_image}")
@@ -153,20 +160,16 @@ def ensure_cached_image(
 ) -> str:
     """Return a cached image tag, building one if needed.
 
-    Returns *base_image* unchanged for Python repos (they use dev deps)
-    or if the cache build fails.
+    Returns *base_image* unchanged if no cache-sensitive files are found.
     """
-    if lang == "python":
+    files = cache_sensitive_files(repo_root, lang)
+    if not files:
         return base_image
 
     from standard_tooling.lib import git as _git
 
     branch = _git.current_branch()
-    files = cache_sensitive_files(repo_root, lang)
-    if not files:
-        return base_image
-
-    current_hash = compute_cache_hash(files)
+    current_hash = compute_cache_hash(files, salt=repo_root.name)
     existing = find_cached_image(base_image, branch)
 
     if existing is not None:

--- a/tests/standard_tooling/test_docker.py
+++ b/tests/standard_tooling/test_docker.py
@@ -311,3 +311,19 @@ def test_build_docker_args_no_extra_mount_for_main_worktree(tmp_path: Path) -> N
     v_indices = [i for i, a in enumerate(args) if a == "-v"]
     assert len(v_indices) == 1
     assert args[v_indices[0] + 1] == f"{tmp_path}:/workspace"
+
+
+# -- pull policy --------------------------------------------------------------
+
+
+def test_build_docker_args_pull_always_by_default(tmp_path: Path) -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_docker_args(tmp_path, "img:1", ["cmd"])
+    assert "--pull=always" in args
+
+
+def test_build_docker_args_pull_never_omits_pull_flag(tmp_path: Path) -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_docker_args(tmp_path, "img:1", ["cmd"], pull_policy="never")
+    assert "--pull=always" not in args
+    assert not any(a.startswith("--pull=") for a in args)

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -163,7 +163,7 @@ def test_ensure_returns_existing_cache_on_hash_match(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     cached_tag = "ghcr.io/r/dev-go:1.26--feature-42--"
     files = cache_sensitive_files(tmp_path, "go")
-    expected_hash = compute_cache_hash(files)
+    expected_hash = compute_cache_hash(files, salt=tmp_path.name)
     full_tag = cached_tag + expected_hash
 
     with (
@@ -372,3 +372,92 @@ def test_build_cached_image_uses_uv_tool_install(tmp_path: Path) -> None:
     setup_cmd = create_cmd[-1]
     assert "uv tool install" in setup_cmd
     assert "pip install" not in setup_cmd
+
+
+# -- compute_cache_hash salt --------------------------------------------------
+
+
+def test_compute_cache_hash_differs_with_different_salt(tmp_path: Path) -> None:
+    (tmp_path / "f.toml").write_text("same content")
+    h1 = compute_cache_hash([tmp_path / "f.toml"], salt="repo-a")
+    h2 = compute_cache_hash([tmp_path / "f.toml"], salt="repo-b")
+    assert h1 != h2
+
+
+def test_compute_cache_hash_same_salt_is_stable(tmp_path: Path) -> None:
+    (tmp_path / "f.toml").write_text("content")
+    h1 = compute_cache_hash([tmp_path / "f.toml"], salt="my-repo")
+    h2 = compute_cache_hash([tmp_path / "f.toml"], salt="my-repo")
+    assert h1 == h2
+
+
+def test_compute_cache_hash_no_salt_matches_empty_salt(tmp_path: Path) -> None:
+    (tmp_path / "f.toml").write_text("content")
+    assert compute_cache_hash([tmp_path / "f.toml"]) == compute_cache_hash(
+        [tmp_path / "f.toml"], salt=""
+    )
+
+
+# -- Python caching -----------------------------------------------------------
+
+
+def test_ensure_python_builds_cached_image(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("lock\n")
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+
+    with (
+        patch("standard_tooling.lib.git.current_branch", return_value="develop"),
+        patch("standard_tooling.lib.docker_cache.find_cached_image", return_value=None),
+        patch(
+            "standard_tooling.lib.docker_cache._build_cached_image",
+            return_value="img:1--develop--hash",
+        ) as mock_build,
+    ):
+        result = ensure_cached_image(tmp_path, "python", "img:1")
+    mock_build.assert_called_once()
+    assert result != "img:1"
+
+
+def test_build_cached_image_python_skips_uv_install(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    create_result = MagicMock(returncode=0, stdout="abc123\n")
+    ok = MagicMock(returncode=0)
+    create_cmd: list[str] = []
+
+    def mock_run(cmd, **_kwargs):  # noqa: ANN001, ANN003
+        if cmd[1] == "create":
+            create_cmd.extend(cmd)
+            return create_result
+        return ok
+
+    with patch("standard_tooling.lib.docker_cache.subprocess.run", side_effect=mock_run):
+        _build_cached_image(tmp_path, "python", "img:1", "img:1--branch--hash")
+    setup_cmd = create_cmd[-1]
+    assert "uv tool install" not in setup_cmd
+    assert "uv sync" in setup_cmd
+
+
+def test_ensure_repo_name_included_in_hash(tmp_path: Path) -> None:
+    repo_a = tmp_path / "repo-alpha"
+    repo_b = tmp_path / "repo-beta"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    (repo_a / "standard-tooling.toml").write_text(_VALID_TOML)
+    (repo_b / "standard-tooling.toml").write_text(_VALID_TOML)
+
+    built_tags: list[str] = []
+
+    def capture_build(repo_root, lang, base_image, target_tag) -> str:  # noqa: ANN001
+        built_tags.append(target_tag)
+        return target_tag
+
+    with (
+        patch("standard_tooling.lib.git.current_branch", return_value="develop"),
+        patch("standard_tooling.lib.docker_cache.find_cached_image", return_value=None),
+        patch("standard_tooling.lib.docker_cache._build_cached_image", side_effect=capture_build),
+    ):
+        ensure_cached_image(repo_a, "go", "img:1")
+        ensure_cached_image(repo_b, "go", "img:1")
+
+    assert len(built_tags) == 2
+    assert built_tags[0] != built_tags[1], "repos with identical files must get distinct image tags"

--- a/tests/standard_tooling/test_docker_run.py
+++ b/tests/standard_tooling/test_docker_run.py
@@ -247,21 +247,6 @@ def test_non_python_command_not_wrapped(tmp_path: Path) -> None:
     assert args[-2:] == ["echo", "hi"]
 
 
-def test_python_skips_cache(tmp_path: Path) -> None:
-    (tmp_path / "pyproject.toml").write_text("[project]\n")
-    env = {"GH_TOKEN": "tok"}
-    with (
-        patch("standard_tooling.bin.docker_run.git.repo_root", return_value=tmp_path),
-        patch("standard_tooling.bin.docker_run.assert_docker_available"),
-        patch("standard_tooling.bin.docker_run.ensure_cached_image") as mock_cache,
-        patch("standard_tooling.bin.docker_run.os.execvp") as mock_exec,
-        patch.dict("os.environ", env, clear=True),
-    ):
-        main(["--", "uv", "run", "pytest"])
-    mock_cache.assert_not_called()
-    args = mock_exec.call_args[0][1]
-    assert args[-3:] == ["uv", "run", "pytest"]
-
 
 def test_cached_image_diagnostic(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     (tmp_path / "go.mod").write_text("module example\n")
@@ -277,3 +262,53 @@ def test_cached_image_diagnostic(tmp_path: Path, capsys: pytest.CaptureFixture[s
         main(["--", "cmd"])
     out = capsys.readouterr().out
     assert "(cached)" in out
+
+
+# -- pull policy integration --------------------------------------------------
+
+
+def test_cached_image_uses_pull_never(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example\n")
+    cached = "ghcr.io/wphillipmoore/dev-go:1.26--feature-42--abcd1234"
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("standard_tooling.bin.docker_run.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_run.assert_docker_available"),
+        patch("standard_tooling.bin.docker_run.ensure_cached_image", return_value=cached),
+        patch("standard_tooling.bin.docker_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "cmd"])
+    args = mock_exec.call_args[0][1]
+    assert "--pull=always" not in args
+
+
+def test_registry_image_uses_pull_always(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example\n")
+    base = "ghcr.io/wphillipmoore/dev-go:1.26"
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("standard_tooling.bin.docker_run.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_run.assert_docker_available"),
+        patch("standard_tooling.bin.docker_run.ensure_cached_image", return_value=base),
+        patch("standard_tooling.bin.docker_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "cmd"])
+    args = mock_exec.call_args[0][1]
+    assert "--pull=always" in args
+
+
+def test_python_routes_through_cache(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("standard_tooling.bin.docker_run.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.docker_run.assert_docker_available"),
+        patch("standard_tooling.bin.docker_run.ensure_cached_image") as mock_cache,
+        patch("standard_tooling.bin.docker_run.os.execvp"),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        mock_cache.return_value = "ghcr.io/wphillipmoore/dev-python:3.14--develop--aabbccdd"
+        main(["--", "uv", "run", "pytest"])
+    mock_cache.assert_called_once()

--- a/tests/standard_tooling/test_docker_run.py
+++ b/tests/standard_tooling/test_docker_run.py
@@ -247,7 +247,6 @@ def test_non_python_command_not_wrapped(tmp_path: Path) -> None:
     assert args[-2:] == ["echo", "hi"]
 
 
-
 def test_cached_image_diagnostic(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     (tmp_path / "go.mod").write_text("module example\n")
     cached = "ghcr.io/wphillipmoore/dev-go:1.26--feature-42--abcd1234"


### PR DESCRIPTION
# Pull Request

## Summary

- Fixes the two root causes identified in the fleet-wide st-finalize-repo audit:

1. --pull=always on locally-cached images: add a pull_policy parameter to build_docker_args (default "always"). docker_run passes pull_policy="never" when image_source=="cached", preventing registry lookup for locally-built cache tags.

2. Python repos bypassing cache entirely: remove the Python early-return from ensure_cached_image so all languages use per-branch caching. _build_cached_image skips uv tool install for Python (uses uv sync --group dev only, since standard-tooling is already a dev dep in Python repos).

3. Hash collisions across repos: salt compute_cache_hash with repo_root.name so repos sharing identical standard-tooling.toml content get distinct image tags.

## Issue Linkage

- Ref #453

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -