### PR TITLE
feat(validate-local): add container guard to st-validate-local

### DIFF
--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -70,8 +70,8 @@ Environment overrides:
     Build the dev images locally before first use:
     `cd ../standard-tooling-docker && docker/build.sh`
 
-The `.githooks` pre-commit gate runs `st-validate-local` on every commit,
-which dispatches to the per-language scripts above. Hook bypass
+The `.githooks` pre-commit gate runs `st-docker-run -- uv run st-validate-local`
+on every commit, which dispatches to the per-language scripts above. Hook bypass
 (`--no-verify`) is disallowed by policy.
 
 ## Tier 2: PR CI

--- a/docs/site/docs/reference/dev/validate-local.md
+++ b/docs/site/docs/reference/dev/validate-local.md
@@ -10,10 +10,12 @@ and language-specific validation based on the repository profile.
 ## Usage
 
 ```bash
-st-validate-local
+st-docker-run -- uv run st-validate-local
 ```
 
-Run from the repository root. No arguments required.
+Must run inside a dev container via `st-docker-run`. Running
+`st-validate-local` directly on the host is not supported and will
+exit with an error.
 
 ## Behavior
 

--- a/src/standard_tooling/bin/validate_local.py
+++ b/src/standard_tooling/bin/validate_local.py
@@ -12,12 +12,9 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from standard_tooling.lib import config, git
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _find_validator(name: str, scripts_bin: Path) -> str | None:
@@ -46,11 +43,18 @@ def _run_validator(name: str, scripts_bin: Path) -> bool:
     return result.returncode == 0
 
 
+def _in_dev_container() -> bool:
+    return Path("/.dockerenv").exists() or bool(os.environ.get("ST_IN_DEV_CONTAINER"))
+
+
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    # st-validate-local is designed to run inside a dev container
-    # (launched by `st-docker-run`).  No host-level docker check is
-    # appropriate — if a caller runs this on the host, the inner scripts
-    # will surface missing tooling (uv, ruff, etc.) with their own errors.
+    if not _in_dev_container():
+        print(
+            "ERROR: st-validate-local must run inside a dev container.\n"
+            "       Run: st-docker-run -- uv run st-validate-local",
+            file=sys.stderr,
+        )
+        return 1
 
     root = git.repo_root()
     scripts_bin = root / "scripts" / "bin"

--- a/tests/standard_tooling/test_validate_local.py
+++ b/tests/standard_tooling/test_validate_local.py
@@ -6,7 +6,19 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from standard_tooling.bin.validate_local import _find_validator, _run_validator, main
+import pytest
+
+from standard_tooling.bin.validate_local import (
+    _find_validator,
+    _in_dev_container,
+    _run_validator,
+    main,
+)
+
+
+@pytest.fixture(autouse=True)
+def _container_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ST_IN_DEV_CONTAINER", "1")
 
 
 def test_find_validator_entry_point() -> None:
@@ -228,3 +240,37 @@ def test_main_custom_validator_fails(tmp_path: Path) -> None:
     ):
         result = main([])
     assert result == 1
+
+
+# --- Container guard tests ---
+
+
+def test_in_dev_container_true_when_dockerenv_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ST_IN_DEV_CONTAINER", raising=False)
+    with patch("standard_tooling.bin.validate_local.Path.exists", return_value=True):
+        assert _in_dev_container() is True
+
+
+def test_in_dev_container_true_when_env_var_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ST_IN_DEV_CONTAINER", "1")
+    with patch("standard_tooling.bin.validate_local.Path.exists", return_value=False):
+        assert _in_dev_container() is True
+
+
+def test_in_dev_container_false_when_neither(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ST_IN_DEV_CONTAINER", raising=False)
+    with patch("standard_tooling.bin.validate_local.Path.exists", return_value=False):
+        assert _in_dev_container() is False
+
+
+def test_main_rejects_host_execution(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ST_IN_DEV_CONTAINER", raising=False)
+    with patch("standard_tooling.bin.validate_local._in_dev_container", return_value=False):
+        result = main([])
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "st-validate-local" in captured.err
+    assert "st-docker-run" in captured.err


### PR DESCRIPTION
# Pull Request

## Summary

- st-validate-local now detects host execution and exits with a clear error directing the user to run via st-docker-run, instead of crashing with an unhandled FileNotFoundError

## Issue Linkage

- Ref #432

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Guard checks Path('/.dockerenv').exists() with ST_IN_DEV_CONTAINER env var as escape hatch. Docs updated in validate-local reference page and ci-architecture guide.