### PR TITLE
fix: retry when no checks registered in st-wait-until-green

### DIFF
--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import subprocess
+import time
+
+_NO_CHECKS_PHRASE = "no checks reported"
+_POLL_INTERVAL_SECS = 5
+_POLL_TIMEOUT_SECS = 60
 
 
 def run(*args: str) -> None:
@@ -26,13 +31,38 @@ def create_pr(*, base: str, title: str, body_file: str) -> str:
     return read_output("pr", "create", "--base", base, "--title", title, "--body-file", body_file)
 
 
-def wait_for_checks(pr: str) -> None:
+def _checks_registered(pr: str) -> bool:
+    """Return True if at least one check is registered on ``pr``."""
+    result = subprocess.run(  # noqa: S603
+        ("gh", "pr", "checks", pr),  # noqa: S607
+        capture_output=True,
+        text=True,
+    )
+    return _NO_CHECKS_PHRASE not in (result.stdout + result.stderr)
+
+
+def wait_for_checks(
+    pr: str,
+    *,
+    poll_interval: int = _POLL_INTERVAL_SECS,
+    poll_timeout: int = _POLL_TIMEOUT_SECS,
+) -> None:
     """Block until all required checks on ``pr`` complete; fail fast on the first red.
+
+    Polls internally when no checks have registered yet (the window between
+    git push and GitHub registering the checks run). Polls every
+    ``poll_interval`` seconds for up to ``poll_timeout`` seconds before
+    falling through to the blocking watch.
 
     Surfaces the failure via ``subprocess.CalledProcessError`` — callers are
     responsible for deciding how to react (the release-workflow convention is
     to stop and surface; do not retry).
     """
+    deadline = time.monotonic() + poll_timeout
+    while not _checks_registered(pr):
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval)
     run("pr", "checks", pr, "--watch", "--fail-fast")
 
 

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -38,12 +38,65 @@ def test_create_pr_returns_url() -> None:
     assert url == "https://github.com/pr/1"
 
 
-def test_wait_for_checks_passes_pr_ref() -> None:
-    with patch("standard_tooling.lib.github.run") as mock_run:
+def test_wait_for_checks_skips_poll_when_already_registered() -> None:
+    with (
+        patch("standard_tooling.lib.github._checks_registered", return_value=True),
+        patch("standard_tooling.lib.github.run") as mock_run,
+    ):
         github.wait_for_checks("https://github.com/pr/1")
     mock_run.assert_called_once_with(
         "pr", "checks", "https://github.com/pr/1", "--watch", "--fail-fast"
     )
+
+
+def test_wait_for_checks_polls_until_registered() -> None:
+    with (
+        patch(
+            "standard_tooling.lib.github._checks_registered",
+            side_effect=[False, False, True],
+        ),
+        patch("standard_tooling.lib.github.time.sleep") as mock_sleep,
+        patch("standard_tooling.lib.github.run") as mock_run,
+    ):
+        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
+
+    assert mock_sleep.call_count == 2
+    mock_sleep.assert_called_with(5)
+    mock_run.assert_called_once_with(
+        "pr", "checks", "https://github.com/pr/1", "--watch", "--fail-fast"
+    )
+
+
+def test_wait_for_checks_proceeds_after_timeout() -> None:
+    # monotonic: [initial (deadline), loop iter1 check, loop iter2 check (expired)]
+    with (
+        patch("standard_tooling.lib.github._checks_registered", return_value=False),
+        patch(
+            "standard_tooling.lib.github.time.monotonic",
+            side_effect=[0.0, 0.0, 61.0],
+        ),
+        patch("standard_tooling.lib.github.time.sleep"),
+        patch("standard_tooling.lib.github.run") as mock_run,
+    ):
+        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
+
+    mock_run.assert_called_once_with(
+        "pr", "checks", "https://github.com/pr/1", "--watch", "--fail-fast"
+    )
+
+
+def test_wait_for_checks_uses_poll_interval_for_sleep() -> None:
+    with (
+        patch(
+            "standard_tooling.lib.github._checks_registered",
+            side_effect=[False, True],
+        ),
+        patch("standard_tooling.lib.github.time.sleep") as mock_sleep,
+        patch("standard_tooling.lib.github.run"),
+    ):
+        github.wait_for_checks("https://github.com/pr/1", poll_interval=10, poll_timeout=60)
+
+    mock_sleep.assert_called_once_with(10)
 
 
 def test_merge_delegates_to_gh() -> None:

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -8,8 +8,12 @@ from unittest.mock import patch
 from standard_tooling.lib import github
 
 
-def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 def test_run_delegates_to_subprocess() -> None:
@@ -69,3 +73,21 @@ def test_list_project_repos_empty() -> None:
         return_value="",
     ):
         assert github.list_project_repos("acme", "5") == []
+
+
+def test_checks_registered_returns_false_when_phrase_in_stdout() -> None:
+    cp = _completed(returncode=1, stdout="no checks reported on the 'main' branch\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        assert github._checks_registered("https://github.com/pr/1") is False
+
+
+def test_checks_registered_returns_false_when_phrase_in_stderr() -> None:
+    cp = _completed(returncode=1, stderr="no checks reported on the 'main' branch\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        assert github._checks_registered("https://github.com/pr/1") is False
+
+
+def test_checks_registered_returns_true_when_checks_exist() -> None:
+    cp = _completed(stdout="ci/tests\tpass\nhttps://example.com\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        assert github._checks_registered("https://github.com/pr/1") is True

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -11,9 +11,7 @@ from standard_tooling.lib import github
 def _completed(
     returncode: int = 0, stdout: str = "", stderr: str = ""
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(
-        args=[], returncode=returncode, stdout=stdout, stderr=stderr
-    )
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 def test_run_delegates_to_subprocess() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a polling loop to wait_for_checks that retries every 5 seconds for up to 60 seconds when no checks are registered yet, eliminating the race between git push and GitHub registering CI checks.

## Issue Linkage

- Ref #462

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -