### PR TITLE
fix: make --title required in st-submit-pr

### DIFF
--- a/src/standard_tooling/bin/submit_pr.py
+++ b/src/standard_tooling/bin/submit_pr.py
@@ -29,7 +29,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--linkage", default="Ref", choices=ALLOWED_LINKAGES, help="Issue linkage keyword"
     )
     parser.add_argument("--notes", default="", help="Additional notes")
-    parser.add_argument("--title", default="", help="PR title (default: latest commit subject)")
+    parser.add_argument("--title", required=True, help="PR title")
     parser.add_argument("--dry-run", action="store_true", help="Print without executing")
     return parser.parse_args(argv)
 
@@ -70,7 +70,7 @@ def main(argv: list[str] | None = None) -> int:
 
     target_branch = "main" if branch.startswith("release/") else "develop"
 
-    title = args.title or git.read_output("log", "-1", "--pretty=%s")
+    title = args.title
 
     testing_section = _extract_testing_section(root)
 

--- a/tests/standard_tooling/test_submit_pr.py
+++ b/tests/standard_tooling/test_submit_pr.py
@@ -132,9 +132,12 @@ def test_main_dry_run_release_branch(tmp_path: Path) -> None:
     ):
         result = main(
             [
-                "--issue", "42",
-                "--summary", "Release 1.0.0",
-                "--title", "release: 1.0.0",
+                "--issue",
+                "42",
+                "--summary",
+                "Release 1.0.0",
+                "--title",
+                "release: 1.0.0",
                 "--dry-run",
             ]
         )

--- a/tests/standard_tooling/test_submit_pr.py
+++ b/tests/standard_tooling/test_submit_pr.py
@@ -37,11 +37,17 @@ def test_resolve_zero() -> None:
 
 
 def test_parse_args_required() -> None:
-    args = parse_args(["--issue", "42", "--summary", "Fix bug"])
+    args = parse_args(["--issue", "42", "--summary", "Fix bug", "--title", "fix: bug"])
     assert args.issue == "42"
     assert args.summary == "Fix bug"
+    assert args.title == "fix: bug"
     assert args.linkage == "Ref"
     assert args.dry_run is False
+
+
+def test_parse_args_title_is_required() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--issue", "42", "--summary", "Fix bug"])
 
 
 def test_parse_args_all_options() -> None:
@@ -92,9 +98,8 @@ def test_main_dry_run(tmp_path: Path) -> None:
     with (
         patch("standard_tooling.bin.submit_pr.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.submit_pr.git.current_branch", return_value="feature/x"),
-        patch("standard_tooling.bin.submit_pr.git.read_output", return_value="feat: add thing"),
     ):
-        result = main(["--issue", "42", "--summary", "Fix bug", "--dry-run"])
+        result = main(["--issue", "42", "--summary", "Fix bug", "--title", "fix: bug", "--dry-run"])
     assert result == 0
 
 
@@ -124,9 +129,10 @@ def test_main_dry_run_release_branch(tmp_path: Path) -> None:
             "standard_tooling.bin.submit_pr.git.current_branch",
             return_value="release/1.0.0",
         ),
-        patch("standard_tooling.bin.submit_pr.git.read_output", return_value="release: 1.0.0"),
     ):
-        result = main(["--issue", "42", "--summary", "Release 1.0.0", "--dry-run"])
+        result = main(
+            ["--issue", "42", "--summary", "Release 1.0.0", "--title", "release: 1.0.0", "--dry-run"]
+        )
     assert result == 0
 
 
@@ -134,14 +140,13 @@ def test_main_submits_pr(tmp_path: Path) -> None:
     with (
         patch("standard_tooling.bin.submit_pr.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.submit_pr.git.current_branch", return_value="feature/x"),
-        patch("standard_tooling.bin.submit_pr.git.read_output", return_value="feat: thing"),
         patch("standard_tooling.bin.submit_pr.git.run") as mock_git_run,
         patch(
             "standard_tooling.bin.submit_pr.github.create_pr",
             return_value="https://github.com/pr/1",
         ) as mock_create_pr,
     ):
-        result = main(["--issue", "42", "--summary", "Fix bug"])
+        result = main(["--issue", "42", "--summary", "Fix bug", "--title", "fix: bug"])
     assert result == 0
     mock_git_run.assert_called_once_with("push", "-u", "origin", "feature/x")
     mock_create_pr.assert_called_once()
@@ -151,7 +156,6 @@ def test_main_submits_pr_with_notes(tmp_path: Path) -> None:
     with (
         patch("standard_tooling.bin.submit_pr.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.submit_pr.git.current_branch", return_value="feature/x"),
-        patch("standard_tooling.bin.submit_pr.git.read_output", return_value="feat: thing"),
         patch("standard_tooling.bin.submit_pr.git.run"),
         patch(
             "standard_tooling.bin.submit_pr.github.create_pr",
@@ -164,6 +168,8 @@ def test_main_submits_pr_with_notes(tmp_path: Path) -> None:
                 "42",
                 "--summary",
                 "Fix bug",
+                "--title",
+                "fix: bug",
                 "--notes",
                 "Tested on macOS",
             ]

--- a/tests/standard_tooling/test_submit_pr.py
+++ b/tests/standard_tooling/test_submit_pr.py
@@ -131,7 +131,12 @@ def test_main_dry_run_release_branch(tmp_path: Path) -> None:
         ),
     ):
         result = main(
-            ["--issue", "42", "--summary", "Release 1.0.0", "--title", "release: 1.0.0", "--dry-run"]
+            [
+                "--issue", "42",
+                "--summary", "Release 1.0.0",
+                "--title", "release: 1.0.0",
+                "--dry-run",
+            ]
         )
     assert result == 0
 


### PR DESCRIPTION
# Pull Request

## Summary

- Removes the silent fallback to the latest commit subject when --title is omitted; callers must now always provide an explicit PR title.

## Issue Linkage

- Ref #464

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -