### PR TITLE
chore: next-cycle dependency updates for v1.4.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4.6
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4.7
     with:
       language: python
       run-standards: ${{ inputs.run-release-gates || 'true' }}


### PR DESCRIPTION
# Pull Request

## Summary

- Bump standard-actions CI pin from v1.4.6 to v1.4.7

## Issue Linkage

- Ref #467

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -