### PR TITLE
Replace blanket chore skip with targeted mechanical-commit filters

### DIFF
--- a/cliff-release-notes.toml
+++ b/cliff-release-notes.toml
@@ -30,7 +30,11 @@ commit_parsers = [
   { message = "^style", group = "Styling" },
   { message = "^test", group = "Testing" },
   { message = "^ci", group = "CI" },
-  { message = "^chore", skip = true },
+  { message = "^chore: bump version to", skip = true },
+  { message = "^chore\\(version\\):", skip = true },
+  { message = "^chore: prepare release", skip = true },
+  { message = "^chore: merge .* into release/", skip = true },
+  { message = "^chore", group = "Chores" },
 ]
 protect_breaking_commits = false
 filter_commits = false

--- a/cliff.toml
+++ b/cliff.toml
@@ -36,7 +36,11 @@ commit_parsers = [
   { message = "^style", group = "Styling" },
   { message = "^test", group = "Testing" },
   { message = "^ci", group = "CI" },
-  { message = "^chore", skip = true },
+  { message = "^chore: bump version to", skip = true },
+  { message = "^chore\\(version\\):", skip = true },
+  { message = "^chore: prepare release", skip = true },
+  { message = "^chore: merge .* into release/", skip = true },
+  { message = "^chore", group = "Chores" },
 ]
 protect_breaking_commits = false
 filter_commits = false


### PR DESCRIPTION
# Pull Request

## Summary

- Narrow cliff.toml skip rules from all chores to four mechanical release patterns; surface meaningful chore commits in a new Chores changelog group

## Issue Linkage

- Ref #445

## Testing

- markdownlint
- ci: shellcheck

## Notes

- The blanket `^chore` skip rule in `cliff.toml` and `cliff-release-notes.toml` was dropping 115 commits, including dependency updates, CI migrations, tooling cleanup, and CI retriggers — real work that belongs in the changelog.

This PR replaces the single `{ message = "^chore", skip = true }` rule with four targeted skip patterns for purely mechanical release-pipeline commits:

- `chore: bump version to` — automated version bumps
- `chore(version):` — scoped version commits
- `chore: prepare release` — release preparation
- `chore: merge .* into release/` — release branch merges

All other chore commits now route to a new "Chores" changelog group. Skipped count drops from 115 to 60; the 55 newly-visible commits are all meaningful work.

Applied identically to both `cliff.toml` (full changelog) and `cliff-release-notes.toml` (per-release notes).