### PR TITLE
feat(finalize-repo): fail on dirty working tree after cleanup

### DIFF
--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -211,6 +211,23 @@ def main(argv: list[str] | None = None) -> int:
     else:
         git.run("remote", "prune", "origin")
 
+    # -- working-tree cleanliness gate (issue #472) ----------------------------
+    if not args.dry_run:
+        dirty = git.working_tree_status()
+        if dirty:
+            print()
+            print(
+                f"ERROR: {args.target_branch} working tree is not clean.",
+                file=sys.stderr,
+            )
+            for line in dirty.splitlines():
+                print(f"  {line}", file=sys.stderr)
+            print(
+                "\n  Clean up these files before starting the next issue.",
+                file=sys.stderr,
+            )
+            return 1
+
     # -- post-finalization validation ------------------------------------------
     # Run canonical validation to catch problems on the target branch before
     # the next PR is created.  Failures are reported as warnings — the

--- a/src/standard_tooling/lib/git.py
+++ b/src/standard_tooling/lib/git.py
@@ -93,3 +93,8 @@ def merged_branches(target: str) -> list[str]:
     if not output:
         return []
     return output.splitlines()
+
+
+def working_tree_status() -> str:
+    """Return ``git status --porcelain`` output (empty string when clean)."""
+    return read_output("status", "--porcelain")

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -36,6 +36,17 @@ def _main_worktree() -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _clean_working_tree() -> Iterator[None]:
+    """Default every test to a clean working tree.
+
+    Individual tests can override by patching working_tree_status
+    directly — the innermost patch wins.
+    """
+    with patch(_MOD + ".git.working_tree_status", return_value=""):
+        yield
+
+
 def test_parse_args_defaults() -> None:
     args = parse_args([])
     assert args.target_branch == "develop"

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -534,3 +534,30 @@ def test_main_cleans_docker_cache_on_branch_delete(
     assert result == 0
     mock_clean.assert_called_once_with("feature/x")
     assert "Cleaned 2 cached Docker image(s)" in capsys.readouterr().out
+
+
+# -- working-tree cleanliness gate (issue #472) -------------------------------
+
+
+def test_main_fails_on_dirty_working_tree(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #472: after cleanup, develop must be clean — any dirty state
+    is a hard error so orphaned files don't silently accumulate.
+    """
+    _make_profile(tmp_path, "library-release")
+    dirty_status = "?? orphan-spec.md\n?? stale-plan.md"
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".git.working_tree_status", return_value=dirty_status),
+    ):
+        result = main([])
+
+    assert result == 1
+    stderr = capsys.readouterr().err
+    assert "working tree is not clean" in stderr
+    assert "orphan-spec.md" in stderr
+    assert "stale-plan.md" in stderr

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -561,3 +561,16 @@ def test_main_fails_on_dirty_working_tree(
     assert "working tree is not clean" in stderr
     assert "orphan-spec.md" in stderr
     assert "stale-plan.md" in stderr
+
+
+def test_main_skips_dirty_check_on_dry_run(tmp_path: Path) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".git.working_tree_status", return_value="?? should-not-fail.md"),
+    ):
+        result = main(["--dry-run"])
+    assert result == 0

--- a/tests/standard_tooling/test_git.py
+++ b/tests/standard_tooling/test_git.py
@@ -152,3 +152,15 @@ def test_merged_branches_empty() -> None:
     with patch("standard_tooling.lib.git.read_output", return_value=""):
         result = git.merged_branches("develop")
     assert result == []
+
+
+def test_working_tree_status_returns_porcelain_output() -> None:
+    with patch("standard_tooling.lib.git.read_output", return_value="?? orphan.md") as mock:
+        result = git.working_tree_status()
+    assert result == "?? orphan.md"
+    mock.assert_called_once_with("status", "--porcelain")
+
+
+def test_working_tree_status_returns_empty_when_clean() -> None:
+    with patch("standard_tooling.lib.git.read_output", return_value=""):
+        assert git.working_tree_status() == ""


### PR DESCRIPTION
# Pull Request

## Summary

- st-finalize-repo fails on dirty working tree after cleanup

## Issue Linkage

- Ref #472

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

- Add a working-tree cleanliness gate to `st-finalize-repo` that runs `git status --porcelain` after branch deletion and ref pruning, failing with a hard error if any dirty state is found (untracked files, unstaged changes, staged changes).
- Add `working_tree_status()` helper to `git.py` as a dedicated mock target that avoids collisions with the existing `read_output` mock used for worktree detection.
- Skip the check in `--dry-run` mode, consistent with validation being skipped.

## Testing

- `test_main_fails_on_dirty_working_tree` — verifies return code 1 and stderr listing of dirty files
- `test_main_skips_dirty_check_on_dry_run` — verifies the check is skipped when `--dry-run` is passed
- `test_working_tree_status_returns_porcelain_output` / `test_working_tree_status_returns_empty_when_clean` — unit tests for the new `git.py` helper
- Autouse fixture `_clean_working_tree` added to default all existing finalize-repo tests to a clean working tree
- Full `st-validate-local` green: 547 tests, 100% coverage, lint/typecheck/audit pass

## Notes

- The check is placed after ref-pruning and before post-finalization validation — dirty state makes validation unreliable, so it catches the problem early.
- Motivated by orphaned planning docs left on `develop` from a completed issue (#228 / PR #237 in standard-tooling-plugin), where an agent wrote spec files on `develop` before being redirected to a worktree.