### PR TITLE
docs: markdownlint standardization spec, plan, and reviews (#476)

### DIFF
--- a/docs/plans/2026-05-03-markdownlint-standardization.md
+++ b/docs/plans/2026-05-03-markdownlint-standardization.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Standardize markdownlint configuration
+
+Spec: `docs/specs/2026-05-03-markdownlint-standardization-design.md`
+Issue: https://github.com/wphillipmoore/standard-tooling/issues/476
+
+## Phase 1: Validator changes (standard-tooling)
+
+All work in the `issue-476-markdownlint-standardization` worktree.
+
+### Step 1: Create the configs package
+
+Create `src/standard_tooling/configs/` as a Python package with the
+bundled config files:
+
+- `src/standard_tooling/configs/__init__.py` (empty)
+- `src/standard_tooling/configs/markdownlint.yaml` (canonical config)
+- `src/standard_tooling/configs/markdownlintignore` (vendored paths)
+
+Ensure `pyproject.toml` includes the configs directory in package data
+(verify `[tool.setuptools.package-data]` or equivalent for the build
+backend).
+
+### Step 2: Update `validate_local_common_container.py`
+
+Replace the markdownlint section:
+
+1. Remove `_find_markdown_files()` helper.
+2. Replace the markdownlint invocation block with:
+   - Resolve bundled config and ignore paths via `importlib.resources`.
+   - Run `markdownlint --config <config> -p <ignore> .` from repo root.
+3. Keep shellcheck and yamllint sections unchanged.
+
+### Step 3: Remove `st-markdown-standards`
+
+1. Delete `src/standard_tooling/bin/markdown_standards.py`.
+2. Remove the `st-markdown-standards` entry from
+   `pyproject.toml` `[project.scripts]`.
+3. Delete `tests/standard_tooling/test_markdown_standards.py`.
+
+### Step 4: Update tests for the common container validator
+
+1. Remove `_find_markdown_files` from test imports.
+2. Remove `test_find_markdown_files_*` test functions.
+3. Add tests for the new markdownlint invocation:
+   - Verify the command includes `--config` pointing to bundled config.
+   - Verify the command includes `-p` pointing to bundled ignore file.
+   - Verify the command runs against `.` (whole repo).
+   - Verify non-zero return code propagates.
+
+### Step 5: Fix lint violations in standard-tooling itself
+
+Run the new validator against this repo's markdown. Fix any violations
+surfaced by linting all `.md` files (previously only `docs/site/` +
+`README.md` was checked). Delete the repo-local `.markdownlint.yaml`
+and `.markdownlintignore`.
+
+### Step 6: Validate
+
+Run `st-docker-run -- uv run st-validate-local` to confirm all checks
+pass. Iterate on violations until green.
+
+### Step 7: Submit PR
+
+Submit via `st-submit-pr`, wait for CI green.
+
+## Phase 2: Release
+
+After the PR merges:
+
+1. Run `st-prepare-release` to cut a new patch release.
+2. Follow the standard release workflow through to publish.
+
+## Phase 3: Fleet sweep
+
+After the release ships, sweep each repo that has a local markdownlint
+config. Order from least to most markdown-heavy to surface issues
+incrementally.
+
+**Per repo:**
+
+1. Update `standard-tooling` dependency pin in
+   `standard-tooling.toml` (and `pyproject.toml` if Python).
+2. Delete `.markdownlint.yaml` / `.markdownlint.json`.
+3. Delete `.markdownlintignore`.
+4. Delete `releases/.markdownlint.json` if present.
+5. Run validation; fix any violations.
+6. Submit PR via `st-submit-pr`.
+
+**Suggested sweep order:**
+
+1. standard-tooling-plugin (small, YAML config)
+2. standard-actions (small, JSON config)
+3. standards-and-conventions (YAML config)
+4. standard-tooling-docker (YAML config + standalone CI job removal)
+5. ai-research-methodology (YAML config with custom rules)
+6. mq-rest-admin-template (JSON, minimal content)
+7. mq-rest-admin-dev-environment (JSON)
+8. mq-rest-admin-common (JSON + ignore)
+9. mq-rest-admin-go (JSON)
+10. mq-rest-admin-java (JSON)
+11. mq-rest-admin-python (JSON)
+12. mq-rest-admin-ruby (JSON + HTML element override)
+13. mq-rest-admin-rust (JSON)
+
+Repos with no existing config (career-strategy, laptop-upgrade,
+mnemosys-core, mnemosys-operations, the-infrastructure-mindset) gain
+coverage automatically when they next update their standard-tooling
+pin — no dedicated sweep PR needed unless violations already exist.
+
+## Out of scope
+
+- Implementing Approach B (repo-local override fallback). Only added
+  if a repo proves non-conformable during the sweep.
+- Fixing the changelog generator if it produces non-compliant output.
+  That would be a separate issue if discovered.

--- a/docs/plans/2026-05-03-markdownlint-standardization.md
+++ b/docs/plans/2026-05-03-markdownlint-standardization.md
@@ -16,19 +16,23 @@ bundled config files:
 - `src/standard_tooling/configs/markdownlint.yaml` (canonical config)
 - `src/standard_tooling/configs/markdownlintignore` (vendored paths)
 
-Ensure `pyproject.toml` includes the configs directory in package data
-(verify `[tool.setuptools.package-data]` or equivalent for the build
-backend).
+Update `[tool.setuptools.package-data]` in `pyproject.toml` to include
+the new config files. The current glob (`data/*.json`) does not match
+`.yaml` or extensionless files. Add `configs/*` to the list so that
+`importlib.resources` can resolve the bundled files at runtime.
 
 ### Step 2: Update `validate_local_common_container.py`
 
 Replace the markdownlint section:
 
-1. Remove `_find_markdown_files()` helper.
-2. Replace the markdownlint invocation block with:
+1. Update the module docstring to reflect the new scope (all
+   repo-owned markdown via bundled config, not just `docs/site/`
+   + `README.md`).
+2. Remove `_find_markdown_files()` helper.
+3. Replace the markdownlint invocation block with:
    - Resolve bundled config and ignore paths via `importlib.resources`.
    - Run `markdownlint --config <config> -p <ignore> .` from repo root.
-3. Keep shellcheck and yamllint sections unchanged.
+4. Keep shellcheck and yamllint sections unchanged.
 
 ### Step 3: Remove `st-markdown-standards`
 
@@ -111,5 +115,3 @@ pin — no dedicated sweep PR needed unless violations already exist.
 
 - Implementing Approach B (repo-local override fallback). Only added
   if a repo proves non-conformable during the sweep.
-- Fixing the changelog generator if it produces non-compliant output.
-  That would be a separate issue if discovered.

--- a/docs/specs/2026-05-03-markdownlint-standardization-design.md
+++ b/docs/specs/2026-05-03-markdownlint-standardization-design.md
@@ -1,0 +1,142 @@
+# Standardize markdownlint configuration across the fleet
+
+Ref: https://github.com/wphillipmoore/standard-tooling/issues/476
+
+## Problem
+
+Each repo maintains its own markdownlint config with varying formats
+(`.yaml` vs `.json`), rule sets, ignore patterns, and lint scopes.
+Identical content passes in one repo and fails in another. Fleet-wide
+changes require per-repo lint debugging.
+
+Root cause of the triggering incident (standard-tooling-docker PR #122):
+that repo runs `markdownlint .` as a standalone CI job against the
+entire repo, while all other repos scope to `docs/site/**/*.md` +
+`README.md` via `st-validate-local-common`.
+
+## Decision
+
+**Approach A: validator-owns-everything.**
+
+The `st-validate-local-common` validator bundles the canonical config
+as package data. It runs `markdownlint .` against the whole repo using
+only the bundled config. Repos delete their local markdownlint configs
+entirely.
+
+If a repo genuinely cannot conform, we fall back to Approach B
+(repo-local override) for that repo only, with documented justification.
+
+## Canonical Config
+
+Bundled at `src/standard_tooling/configs/markdownlint.yaml`:
+
+```yaml
+default: true
+no-duplicate-heading:
+  siblings_only: true
+MD013:
+  line_length: 100
+  tables: false
+  code_blocks: false
+MD060: false
+```
+
+Bundled at `src/standard_tooling/configs/markdownlintignore`:
+
+```
+# Empty — lint everything. Add entries here only with documented justification.
+```
+
+### Rule Rationale
+
+- `default: true` — enforce all rules unless explicitly disabled.
+- `no-duplicate-heading: siblings_only` — changelogs and multi-section
+  docs legitimately reuse heading text across sections.
+- `MD013: line_length: 100` — matches the project's ruff line-length
+  setting for consistency. Tables and code blocks are exempt because
+  they commonly exceed prose width.
+- `MD060: false` — enforcing visual table column alignment adds
+  maintenance burden with no reader benefit.
+
+## Validator Changes
+
+File: `src/standard_tooling/bin/validate_local_common_container.py`
+
+1. **Scope**: Replace `_find_markdown_files()` (which scopes to
+   `docs/site/**/*.md` + `README.md`) with `markdownlint .` — lint
+   the entire repo.
+2. **Config resolution**: Use `importlib.resources` to resolve the
+   bundled config and ignore file paths.
+3. **No repo-local fallback**: Always use bundled config. Ignore any
+   repo-local `.markdownlint.yaml` or `.markdownlintignore`.
+4. **Remove `st-markdown-standards`**: The standalone
+   `markdown_standards.py` entry point is redundant — remove the
+   console script and module. This is an internal tool (not consumed
+   by other repos), so no deprecation cycle is needed.
+5. **Other validators unchanged**: shellcheck and yamllint invocations
+   in the same file remain as-is. Only the markdownlint section
+   changes.
+
+Invocation:
+
+```python
+from importlib.resources import files
+
+config = files("standard_tooling.configs") / "markdownlint.yaml"
+ignore = files("standard_tooling.configs") / "markdownlintignore"
+cmd = ["markdownlint", "--config", str(config), "-p", str(ignore), "."]
+```
+
+## Fleet Cleanup
+
+Order of operations:
+
+1. Ship the validator change in a standard-tooling release.
+2. Sweep the fleet — each repo updates its `standard-tooling` pin,
+   deletes local markdownlint configs, and fixes any violations
+   surfaced by the new config.
+3. Remove the standalone `markdownlint .` CI job from
+   `standard-tooling-docker`'s `ci.yml`.
+
+Per-repo cleanup:
+- Delete `.markdownlint.yaml` / `.markdownlint.json`
+- Delete `.markdownlintignore`
+- Fix lint violations (use `markdownlint --fix .` where possible,
+  manual fixes for the rest)
+
+## Fallback Path (Approach B)
+
+Not implemented unless forced. If a repo proves it cannot conform:
+
+1. The validator gains a check: if a repo-local `.markdownlint.yaml`
+   exists, use it instead of the bundled config. Same for
+   `.markdownlintignore`.
+2. The repo-local config must include a comment explaining why the
+   override is necessary.
+3. This escape hatch is documented but not shipped until needed.
+
+## Affected Repos
+
+All 19 repos with `standard-tooling.toml`:
+
+| Repo | Current config | Action |
+|------|---------------|--------|
+| standard-tooling | .markdownlint.yaml | Delete |
+| standard-tooling-docker | .markdownlint.yaml + standalone CI job | Delete config, remove CI job |
+| standard-tooling-plugin | .markdownlint.yaml | Delete |
+| standard-actions | .markdownlint.json | Delete |
+| standards-and-conventions | .markdownlint.yaml | Delete |
+| ai-research-methodology | .markdownlint.yaml | Delete |
+| mq-rest-admin-common | .markdownlint.json | Delete |
+| mq-rest-admin-dev-environment | .markdownlint.json | Delete |
+| mq-rest-admin-go | .markdownlint.json | Delete |
+| mq-rest-admin-java | .markdownlint.json | Delete |
+| mq-rest-admin-python | .markdownlint.json | Delete |
+| mq-rest-admin-ruby | .markdownlint.json | Delete |
+| mq-rest-admin-rust | .markdownlint.json | Delete |
+| mq-rest-admin-template | .markdownlint.json | Delete |
+| career-strategy | (none) | No action |
+| laptop-upgrade | (none) | No action |
+| mnemosys-core | (none) | No action |
+| mnemosys-operations | (none) | No action |
+| the-infrastructure-mindset | (none) | No action |

--- a/docs/specs/2026-05-03-markdownlint-standardization-design.md
+++ b/docs/specs/2026-05-03-markdownlint-standardization-design.md
@@ -44,8 +44,21 @@ MD060: false
 Bundled at `src/standard_tooling/configs/markdownlintignore`:
 
 ```
-# Empty — lint everything. Add entries here only with documented justification.
+# Vendored / build / duplicate paths — these contain third-party or
+# duplicated markdown that cannot conform and is not repo-owned content.
+.venv/
+.venv-host/
+node_modules/
+.worktrees/
 ```
+
+**Philosophy: global by default, shrink back as needed.** The ignore
+file excludes only paths that are structurally non-repo-owned (vendored
+dependencies, build artifacts, worktree duplicates). Generated content
+like `CHANGELOG.md` and `releases/` stays in scope — if the generators
+produce non-compliant markdown, fix the generators. Exceptions are
+added only when a specific path proves non-conformable after reasonable
+effort.
 
 ### Rule Rationale
 
@@ -89,6 +102,17 @@ cmd = ["markdownlint", "--config", str(config), "-p", str(ignore), "."]
 
 ## Fleet Cleanup
 
+**Blast radius note.** Switching from `docs/site/**/*.md` + `README.md`
+to `markdownlint .` is a fundamental change in lint scope. Every `.md`
+file in every repo — specs, plans, design docs, `CLAUDE.md`, etc. —
+will now be linted for the first time. The cleanup effort is
+proportional to how much unlinted markdown exists across the fleet,
+not just config file deletion.
+
+Order the sweep from least to most markdown-heavy repos to surface
+issues incrementally and refine the bundled config before hitting the
+repos with the most content.
+
 Order of operations:
 
 1. Ship the validator change in a standard-tooling release.
@@ -101,6 +125,7 @@ Order of operations:
 Per-repo cleanup:
 - Delete `.markdownlint.yaml` / `.markdownlint.json`
 - Delete `.markdownlintignore`
+- Delete `releases/.markdownlint.json` (directory-level override)
 - Fix lint violations (use `markdownlint --fix .` where possible,
   manual fixes for the rest)
 

--- a/paad/alignment-reviews/2026-05-03-markdownlint-standardization-alignment.md
+++ b/paad/alignment-reviews/2026-05-03-markdownlint-standardization-alignment.md
@@ -1,0 +1,61 @@
+# Alignment Review: Standardize markdownlint configuration
+
+**Date:** 2026-05-03
+**Commit:** ff993c74da2728372164ef4eb9a0c41450064b55
+
+## Documents Reviewed
+
+- **Intent:** docs/specs/2026-05-03-markdownlint-standardization-design.md
+- **Action:** docs/plans/2026-05-03-markdownlint-standardization.md
+- **Design:** none (spec serves as both requirements and design)
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes (covered in pushback review).
+
+## Issues Reviewed
+
+### [1] Plan "Out of scope" contradicts spec's "global by default" philosophy
+
+- **Category:** missing coverage
+- **Severity:** important
+- **Documents:** Plan "Out of scope" vs spec "Canonical Config" philosophy
+- **Issue:** The plan declared changelog generator fixes out of scope,
+  but the spec (updated during pushback) says generated content stays
+  in lint scope and generators should be fixed. This created a
+  contradictory decision path for Step 5 / Phase 3 when generated
+  files fail linting.
+- **Resolution:** Removed the out-of-scope line about generators.
+  The spec's "global by default, shrink back as needed" philosophy
+  already covers the decision path — fix generators if possible,
+  add to ignore file only after reasonable effort fails.
+
+### [2] Package data config insufficient for new config files
+
+- **Category:** missing coverage
+- **Severity:** important
+- **Documents:** Plan Step 1 vs pyproject.toml
+- **Issue:** The plan said "verify [tool.setuptools.package-data]"
+  but didn't flag that the current config (`data/*.json`) specifically
+  cannot match `.yaml` or extensionless files in the new `configs/`
+  directory. Missing this would cause `importlib.resources` to fail
+  at runtime — a "works in dev, broken in install" bug.
+- **Resolution:** Made the pyproject.toml update an explicit sub-step
+  in Step 1 with the specific glob needed (`configs/*`).
+
+### [3] Validator module docstring describes old behavior
+
+- **Category:** missing coverage
+- **Severity:** minor
+- **Documents:** Plan Step 2 vs validate_local_common_container.py
+- **Issue:** The module docstring says "markdownlint on published
+  markdown (docs/site/, README.md)" which would be wrong after the
+  change. The plan didn't mention updating it.
+- **Resolution:** Added a note to Step 2 to update the docstring.
+
+## Alignment Summary
+
+- **Requirements:** 12 traced, 12 covered after fixes, 0 gaps
+- **Tasks:** 10 total (7 phase-1 steps + release + fleet sweep + out
+  of scope), 10 in scope, 0 orphaned
+- **Status:** aligned (plan and spec updated)

--- a/paad/pushback-reviews/2026-05-03-markdownlint-standardization-pushback.md
+++ b/paad/pushback-reviews/2026-05-03-markdownlint-standardization-pushback.md
@@ -1,0 +1,95 @@
+# Pushback Review: Standardize markdownlint configuration across the fleet
+
+**Date:** 2026-05-03
+**Spec:** docs/specs/2026-05-03-markdownlint-standardization-design.md
+**Commit:** ff993c74da2728372164ef4eb9a0c41450064b55
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. The spec accurately describes
+the current state of `validate_local_common_container.py` and the
+`st-markdown-standards` entry point. Recent commit `c1133c4` (remove
+markdownlint shutil.which guard) is consistent with the spec's direction.
+
+## Scope Shape
+
+Single cohesive initiative, no split needed. In-repo code change is
+small; fleet sweep is mechanical. Reasonable as one spec.
+
+## Issues Reviewed
+
+### [1] Empty ignore file will lint vendored and generated content
+
+- **Category:** omission
+- **Severity:** critical
+- **Issue:** `markdownlint` does not respect `.gitignore`. The spec
+  bundled an empty `.markdownlintignore` and runs `markdownlint .`,
+  which would lint `.venv/`, `.venv-host/`, `node_modules/`,
+  `.worktrees/`, `CHANGELOG.md`, and `releases/`. The current
+  `releases/.markdownlint.json` disables 8 rules, confirming that
+  content cannot pass the standard config. The current
+  `.markdownlintignore` excludes `CHANGELOG.md` and `releases/`,
+  but those exemptions may have been agent drift rather than
+  deliberate decisions.
+- **Resolution:** Populate the bundled ignore file with
+  vendored/build/duplicate paths (`.venv/`, `.venv-host/`,
+  `node_modules/`, `.worktrees/`). Generated content (`CHANGELOG.md`,
+  `releases/`) stays in scope — fix the generators rather than
+  permanently exempting output. Philosophy is "global by default,
+  shrink back as needed": exceptions added only when a path proves
+  non-conformable after reasonable effort. Spec updated.
+
+### [2] Scope expansion blast radius unacknowledged
+
+- **Category:** scope imbalance
+- **Severity:** serious
+- **Issue:** The switch from `docs/site/**/*.md` + `README.md` to
+  `markdownlint .` is a fundamental change in lint philosophy, but
+  the spec treated it as a one-liner. Every `.md` file in every
+  repo — specs, plans, design docs, `CLAUDE.md`, AI-generated
+  review outputs — would be linted for the first time. The fleet
+  cleanup section said "fix lint violations" without estimating
+  the blast radius.
+- **Resolution:** Spec updated to acknowledge the blast radius and
+  recommend ordering the fleet sweep from least to most
+  markdown-heavy repos to surface issues incrementally. Universal
+  scope stays — the cleanup is finite.
+
+### [3] `releases/.markdownlint.json` directory-level override
+
+- **Category:** feasibility
+- **Severity:** moderate
+- **Issue:** The spec said "delete local markdownlint configs" but
+  didn't address the `releases/.markdownlint.json` directory-level
+  override. This override disables 8 rules because release notes
+  (sourced from GitHub Releases API data) don't conform. With
+  `--config` pointing at the bundled config, markdownlint-cli
+  ignores directory-level overrides, so strict rules would apply
+  to `releases/` content.
+- **Resolution:** Consistent with issue 1: try global scope first.
+  If release note generators can produce compliant output, the
+  override was unnecessary. If not, `releases/` gets added to the
+  bundled ignore file after the attempt. Per-repo cleanup updated
+  to include deleting `releases/.markdownlint.json`. Spec updated.
+
+### [4] `st-markdown-standards` removal ordering (withdrawn)
+
+- **Category:** feasibility
+- **Severity:** minor
+- **Issue:** Initially flagged a potential ordering concern between
+  removing `st-markdown-standards` and updating consuming repos.
+  On closer inspection, the ordering holds: `st-markdown-standards`
+  is genuinely internal, and `standard-tooling-docker`'s standalone
+  CI job is in its own CI pipeline, not in consuming repos.
+- **Resolution:** Withdrawn — non-issue. Additionally noted: this
+  is a scale-of-one project with no external users. The spec
+  designs for proper staged deployment (so the patterns are ready
+  when users arrive) but execution can skip deprecation cycles and
+  transition windows in the interest of moving fast.
+
+## Summary
+
+- **Issues found:** 4
+- **Issues resolved:** 4 (1 withdrawn)
+- **Unresolved:** 0
+- **Spec status:** ready for implementation (spec updated with resolutions)


### PR DESCRIPTION
# Pull Request

## Summary

- Design spec, implementation plan, and review artifacts for standardizing markdownlint configuration across the fleet. Docs-only PR �� no code changes. Implementation follows after merge.

## Issue Linkage

- Ref #476

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -