### PR TITLE
docs: narrow markdownlint standardization to published docs scope (#476)

### DIFF
--- a/docs/plans/2026-05-03-markdownlint-standardization.md
+++ b/docs/plans/2026-05-03-markdownlint-standardization.md
@@ -10,28 +10,29 @@ All work in the `issue-476-markdownlint-standardization` worktree.
 ### Step 1: Create the configs package
 
 Create `src/standard_tooling/configs/` as a Python package with the
-bundled config files:
+bundled config:
 
 - `src/standard_tooling/configs/__init__.py` (empty)
 - `src/standard_tooling/configs/markdownlint.yaml` (canonical config)
-- `src/standard_tooling/configs/markdownlintignore` (vendored paths)
+
+No ignore file is needed — the scoped file discovery
+(`docs/site/**/*.md` + `README.md`) avoids vendored and internal
+content by construction.
 
 Update `[tool.setuptools.package-data]` in `pyproject.toml` to include
 the new config files. The current glob (`data/*.json`) does not match
-`.yaml` or extensionless files. Add `configs/*` to the list so that
-`importlib.resources` can resolve the bundled files at runtime.
+`.yaml` files. Add `configs/*` to the list so that
+`importlib.resources` can resolve the bundled config at runtime.
 
 ### Step 2: Update `validate_local_common_container.py`
 
-Replace the markdownlint section:
+Replace the markdownlint config resolution:
 
-1. Update the module docstring to reflect the new scope (all
-   repo-owned markdown via bundled config, not just `docs/site/`
-   + `README.md`).
-2. Remove `_find_markdown_files()` helper.
-3. Replace the markdownlint invocation block with:
-   - Resolve bundled config and ignore paths via `importlib.resources`.
-   - Run `markdownlint --config <config> -p <ignore> .` from repo root.
+1. Update the module docstring to note that markdownlint now uses
+   the bundled canonical config (scope is unchanged).
+2. Replace the repo-local `.markdownlint.yaml` check with
+   `importlib.resources` resolution of the bundled config.
+3. Keep `_find_markdown_files()` and the existing scope unchanged.
 4. Keep shellcheck and yamllint sections unchanged.
 
 ### Step 3: Remove `st-markdown-standards`
@@ -43,20 +44,21 @@ Replace the markdownlint section:
 
 ### Step 4: Update tests for the common container validator
 
-1. Remove `_find_markdown_files` from test imports.
-2. Remove `test_find_markdown_files_*` test functions.
-3. Add tests for the new markdownlint invocation:
-   - Verify the command includes `--config` pointing to bundled config.
-   - Verify the command includes `-p` pointing to bundled ignore file.
-   - Verify the command runs against `.` (whole repo).
-   - Verify non-zero return code propagates.
+1. Update `test_main_markdownlint_with_config` — it currently creates
+   a repo-local `.markdownlint.yaml` and checks for `--config`. Change
+   it to verify the bundled config is always used regardless of whether
+   a repo-local config exists.
+2. Add a test verifying that `--config` points to the bundled config
+   path (via `importlib.resources`).
+3. Keep `_find_markdown_files` tests and existing scope tests unchanged.
 
-### Step 5: Fix lint violations in standard-tooling itself
+### Step 5: Clean up standard-tooling itself
 
-Run the new validator against this repo's markdown. Fix any violations
-surfaced by linting all `.md` files (previously only `docs/site/` +
-`README.md` was checked). Delete the repo-local `.markdownlint.yaml`
-and `.markdownlintignore`.
+1. Delete the repo-local `.markdownlint.yaml` and `.markdownlintignore`.
+2. Delete `releases/.markdownlint.json` (stale directory-level override
+   for content outside the lint scope).
+3. Run the validator — fix any violations in `docs/site/` + `README.md`
+   surfaced by the new canonical rules.
 
 ### Step 6: Validate
 
@@ -77,8 +79,9 @@ After the PR merges:
 ## Phase 3: Fleet sweep
 
 After the release ships, sweep each repo that has a local markdownlint
-config. Order from least to most markdown-heavy to surface issues
-incrementally.
+config. The effort is modest — only published documentation
+(`docs/site/` + `README.md`) is linted, so violation fixes are limited
+to that scope. The main work is deleting stale configs.
 
 **Per repo:**
 
@@ -86,8 +89,8 @@ incrementally.
    `standard-tooling.toml` (and `pyproject.toml` if Python).
 2. Delete `.markdownlint.yaml` / `.markdownlint.json`.
 3. Delete `.markdownlintignore`.
-4. Delete `releases/.markdownlint.json` if present.
-5. Run validation; fix any violations.
+4. Delete `releases/.markdownlint.json` if present (stale override).
+5. Run validation; fix any violations in `docs/site/` + `README.md`.
 6. Submit PR via `st-submit-pr`.
 
 **Suggested sweep order:**

--- a/docs/plans/2026-05-03-markdownlint-standardization.md
+++ b/docs/plans/2026-05-03-markdownlint-standardization.md
@@ -116,5 +116,6 @@ pin — no dedicated sweep PR needed unless violations already exist.
 
 ## Out of scope
 
-- Implementing Approach B (repo-local override fallback). Only added
-  if a repo proves non-conformable during the sweep.
+- Repo-local config overrides. The lint scope covers only content we
+  fully own (`docs/site/` + `README.md`), so there is no legitimate
+  need for per-repo exceptions.

--- a/docs/specs/2026-05-03-markdownlint-standardization-design.md
+++ b/docs/specs/2026-05-03-markdownlint-standardization-design.md
@@ -16,15 +16,20 @@ entire repo, while all other repos scope to `docs/site/**/*.md` +
 
 ## Decision
 
-**Approach A: validator-owns-everything.**
+**Validator-owns-config, scope unchanged.**
 
 The `st-validate-local-common` validator bundles the canonical config
-as package data. It runs `markdownlint .` against the whole repo using
-only the bundled config. Repos delete their local markdownlint configs
-entirely.
+as package data and uses it for all repos. The lint scope stays at
+`docs/site/**/*.md` + `README.md` — published, user-facing
+documentation. Repos delete their local markdownlint configs entirely.
 
-If a repo genuinely cannot conform, we fall back to Approach B
-(repo-local override) for that repo only, with documented justification.
+Rejected alternative: running `markdownlint .` against the entire repo.
+This was explored and rejected during pushback review — it introduces
+vendored-path exclusions, generator-compliance questions, and
+fleet-wide violation cleanup for internal working documents (specs,
+plans, design docs) with no user-facing benefit. The config
+standardization delivers the real value; the scope expansion is where
+the cost lives.
 
 ## Canonical Config
 
@@ -41,24 +46,9 @@ MD013:
 MD060: false
 ```
 
-Bundled at `src/standard_tooling/configs/markdownlintignore`:
-
-```
-# Vendored / build / duplicate paths — these contain third-party or
-# duplicated markdown that cannot conform and is not repo-owned content.
-.venv/
-.venv-host/
-node_modules/
-.worktrees/
-```
-
-**Philosophy: global by default, shrink back as needed.** The ignore
-file excludes only paths that are structurally non-repo-owned (vendored
-dependencies, build artifacts, worktree duplicates). Generated content
-like `CHANGELOG.md` and `releases/` stays in scope — if the generators
-produce non-compliant markdown, fix the generators. Exceptions are
-added only when a specific path proves non-conformable after reasonable
-effort.
+No ignore file is bundled. The scoped file discovery
+(`docs/site/**/*.md` + `README.md`) avoids vendored, generated, and
+internal content by construction.
 
 ### Rule Rationale
 
@@ -75,20 +65,19 @@ effort.
 
 File: `src/standard_tooling/bin/validate_local_common_container.py`
 
-1. **Scope**: Replace `_find_markdown_files()` (which scopes to
-   `docs/site/**/*.md` + `README.md`) with `markdownlint .` — lint
-   the entire repo.
+1. **Scope unchanged**: Keep `_find_markdown_files()` — it discovers
+   `docs/site/**/*.md` + `README.md`, which is the correct scope.
 2. **Config resolution**: Use `importlib.resources` to resolve the
-   bundled config and ignore file paths.
-3. **No repo-local fallback**: Always use bundled config. Ignore any
-   repo-local `.markdownlint.yaml` or `.markdownlintignore`.
-4. **Remove `st-markdown-standards`**: The standalone
+   bundled config path. Replace the repo-local `.markdownlint.yaml`
+   check with the bundled config — always use it, ignore any
+   repo-local config.
+3. **Remove `st-markdown-standards`**: The standalone
    `markdown_standards.py` entry point is redundant — remove the
    console script and module. This is an internal tool (not consumed
    by other repos), so no deprecation cycle is needed.
-5. **Other validators unchanged**: shellcheck and yamllint invocations
-   in the same file remain as-is. Only the markdownlint section
-   changes.
+4. **Other validators unchanged**: shellcheck and yamllint invocations
+   in the same file remain as-is. Only the markdownlint config
+   resolution changes.
 
 Invocation:
 
@@ -96,49 +85,36 @@ Invocation:
 from importlib.resources import files
 
 config = files("standard_tooling.configs") / "markdownlint.yaml"
-ignore = files("standard_tooling.configs") / "markdownlintignore"
-cmd = ["markdownlint", "--config", str(config), "-p", str(ignore), "."]
+md_files = _find_markdown_files(repo_root)
+cmd = ["markdownlint", "--config", str(config), *md_files]
 ```
 
 ## Fleet Cleanup
 
-**Blast radius note.** Switching from `docs/site/**/*.md` + `README.md`
-to `markdownlint .` is a fundamental change in lint scope. Every `.md`
-file in every repo — specs, plans, design docs, `CLAUDE.md`, etc. —
-will now be linted for the first time. The cleanup effort is
-proportional to how much unlinted markdown exists across the fleet,
-not just config file deletion.
+Since the lint scope is unchanged (`docs/site/**/*.md` + `README.md`),
+the cleanup effort is modest — the new bundled config may surface
+violations where per-repo configs were more permissive, but only in
+published documentation that was already being linted.
 
-Order the sweep from least to most markdown-heavy repos to surface
-issues incrementally and refine the bundled config before hitting the
-repos with the most content.
+The main work is hygiene: deleting stale per-repo markdownlint configs
+that are no longer consulted, including directory-level overrides that
+applied to content outside the lint scope.
 
 Order of operations:
 
 1. Ship the validator change in a standard-tooling release.
 2. Sweep the fleet — each repo updates its `standard-tooling` pin,
-   deletes local markdownlint configs, and fixes any violations
-   surfaced by the new config.
+   deletes all local markdownlint configs, and fixes any violations
+   surfaced by the new canonical rules.
 3. Remove the standalone `markdownlint .` CI job from
    `standard-tooling-docker`'s `ci.yml`.
 
 Per-repo cleanup:
 - Delete `.markdownlint.yaml` / `.markdownlint.json`
 - Delete `.markdownlintignore`
-- Delete `releases/.markdownlint.json` (directory-level override)
-- Fix lint violations (use `markdownlint --fix .` where possible,
-  manual fixes for the rest)
-
-## Fallback Path (Approach B)
-
-Not implemented unless forced. If a repo proves it cannot conform:
-
-1. The validator gains a check: if a repo-local `.markdownlint.yaml`
-   exists, use it instead of the bundled config. Same for
-   `.markdownlintignore`.
-2. The repo-local config must include a comment explaining why the
-   override is necessary.
-3. This escape hatch is documented but not shipped until needed.
+- Delete `releases/.markdownlint.json` (stale directory-level override)
+- Fix lint violations in `docs/site/` + `README.md` (use
+  `markdownlint --fix` where possible, manual fixes for the rest)
 
 ## Affected Repos
 

--- a/docs/specs/2026-05-03-markdownlint-standardization-design.md
+++ b/docs/specs/2026-05-03-markdownlint-standardization-design.md
@@ -23,6 +23,11 @@ as package data and uses it for all repos. The lint scope stays at
 `docs/site/**/*.md` + `README.md` — published, user-facing
 documentation. Repos delete their local markdownlint configs entirely.
 
+No repo-local config overrides are supported. The lint scope covers
+only `docs/site/**/*.md` + `README.md` — content we fully own and
+control. There is no scenario where a repo legitimately cannot conform
+to the canonical rules for its own published documentation.
+
 Rejected alternative: running `markdownlint .` against the entire repo.
 This was explored and rejected during pushback review — it introduces
 vendored-path exclusions, generator-compliance questions, and
@@ -68,9 +73,8 @@ File: `src/standard_tooling/bin/validate_local_common_container.py`
 1. **Scope unchanged**: Keep `_find_markdown_files()` — it discovers
    `docs/site/**/*.md` + `README.md`, which is the correct scope.
 2. **Config resolution**: Use `importlib.resources` to resolve the
-   bundled config path. Replace the repo-local `.markdownlint.yaml`
-   check with the bundled config — always use it, ignore any
-   repo-local config.
+   bundled config path. Remove the repo-local `.markdownlint.yaml`
+   check entirely — the bundled config is the only config.
 3. **Remove `st-markdown-standards`**: The standalone
    `markdown_standards.py` entry point is redundant — remove the
    console script and module. This is an internal tool (not consumed

--- a/paad/pushback-reviews/2026-05-03-markdownlint-standardization-pushback.md
+++ b/paad/pushback-reviews/2026-05-03-markdownlint-standardization-pushback.md
@@ -87,9 +87,30 @@ small; fleet sweep is mechanical. Reasonable as one spec.
   when users arrive) but execution can skip deprecation cycles and
   transition windows in the interest of moving fast.
 
+### [5] Global linting scope is not worth the complexity (post-merge re-evaluation)
+
+- **Category:** scope imbalance
+- **Severity:** serious
+- **Issue:** After merging the initial spec, the author questioned
+  whether linting all markdown files delivers any real return on
+  investment. The config standardization (bundled canonical rules,
+  delete per-repo configs) solves the original problem — config drift
+  causing identical content to pass in one repo and fail in another.
+  The scope expansion from `docs/site/ + README.md` to `markdownlint .`
+  was responsible for nearly every complication addressed in issues
+  1-3: vendored-path exclusions, generator compliance, blast radius,
+  directory-level override migration. Internal working documents
+  (specs, plans, design docs) are not user-facing and gain no value
+  from markdownlint enforcement.
+- **Resolution:** Reverted scope to the original `docs/site/**/*.md`
+  + `README.md`. The ignore file, "global by default" philosophy,
+  blast radius note, and generator compliance concerns were all
+  removed. Config standardization and stale config hygiene remain.
+  Spec and plan updated.
+
 ## Summary
 
-- **Issues found:** 4
-- **Issues resolved:** 4 (1 withdrawn)
+- **Issues found:** 5
+- **Issues resolved:** 5 (1 withdrawn)
 - **Unresolved:** 0
-- **Spec status:** ready for implementation (spec updated with resolutions)
+- **Spec status:** ready for implementation (scope narrowed, spec and plan updated)


### PR DESCRIPTION
# Pull Request

## Summary

- Restrict lint scope to docs/site plus README.md with bundled canonical config. Remove global linting, vendored-path exclusions, generator compliance concerns, and repo-local config fallback. Config standardization and stale config hygiene remain.

## Issue Linkage

- Ref #476

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -