### PR TITLE
docs(markdownlint): update published docs for bundled config

### DIFF
--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -135,8 +135,8 @@ If all three behave as expected, you're wired up correctly.
 ## Next steps
 
 - **[Consuming Repo Setup](guides/consuming-repo-setup.md)** —
-  detailed walkthrough including CI workflow, markdownlint config,
-  plugin nuances, and troubleshooting.
+  detailed walkthrough including CI workflow, plugin nuances, and
+  troubleshooting.
 - **[Git Workflow](guides/git-workflow.md)** — branching, commit /
   PR / finalize cycle, two-layer enforcement, worktrees in practice.
 - **[Worktree convention spec][worktree-spec]**

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -238,38 +238,7 @@ plugin's commit-block hook activates against the presence of
 For how to actually use worktrees during development, see
 [Git Workflow → Parallel work with worktrees](git-workflow.md#parallel-work-with-worktrees).
 
-## Step 7: Markdownlint configuration
-
-Create `.markdownlint.yaml` at your repo root:
-
-```yaml
-default: true
-no-duplicate-heading:
-  siblings_only: true
-# Exempt tables and code blocks from the 80-char line-length check.
-# Wide reference tables and pasted commands legitimately exceed it.
-MD013:
-  line_length: 80
-  tables: false
-  code_blocks: false
-# Disable the table-column-style rule. Tables render correctly
-# regardless of strict pipe alignment; enforcing it adds maintenance
-# burden for no reader benefit.
-MD060: false
-```
-
-The base rule set (`default: true`) plus the three customizations
-above match what standard-tooling itself uses, so markdown files
-that pass locally will pass in CI.
-
-Optional: add `.markdownlintignore` to skip generated files:
-
-```text
-CHANGELOG.md
-releases/
-```
-
-## Step 8: CI workflow
+## Step 7: CI workflow
 
 Use the `standards-compliance` composite action from
 `wphillipmoore/standard-actions`. Minimal workflow
@@ -300,7 +269,6 @@ jobs:
 What the composite action runs inside the `dev-base` container:
 
 - `st-repo-profile` — validates `docs/repository-standards.md`
-- `st-markdown-standards` — markdownlint + structural checks
 - `st-pr-issue-linkage` — validates PR body has an issue linkage
   keyword (`Fixes`, `Closes`, `Resolves`, `Ref`)
 
@@ -310,7 +278,7 @@ no further setup is needed in the workflow.
 See the [CI Architecture](ci-architecture.md) guide if you also want
 per-language test/lint/audit tiers.
 
-## Step 9: Verify end-to-end
+## Step 8: Verify end-to-end
 
 Once the above is in place, sanity-check each layer:
 

--- a/docs/site/docs/guides/validation-matrix.md
+++ b/docs/site/docs/guides/validation-matrix.md
@@ -9,7 +9,7 @@ and its exit codes.
 | ----- | ---- | -- | ------ |
 | Branch naming | Yes | -- | `pre-commit` |
 | Repository profile | -- | Yes | `st-repo-profile` |
-| Markdown standards | -- | Yes | `st-markdown-standards` |
+| Markdown standards | -- | Yes | `st-validate-local-common` |
 | PR issue linkage | -- | Yes | `st-pr-issue-linkage` |
 | Shellcheck | -- | Yes | CI workflow step |
 
@@ -35,13 +35,14 @@ and its exit codes.
 Validates `docs/repository-standards.md` has all six required
 attributes.
 
-### st-markdown-standards
+### Markdown validation (st-validate-local-common)
 
 **Trigger:** PR opened or updated
 
-Runs markdownlint on all markdown files. Structural checks (single
-H1, TOC, heading hierarchy) apply to standard docs only -- not
-doc-site pages or CHANGELOG.md.
+Runs markdownlint on published markdown (`docs/site/**/*.md` and
+`README.md`) using the canonical config bundled in standard-tooling.
+See the [Markdown Validation](../reference/lint/markdown-standards.md)
+reference for config details and file scope.
 
 ### st-pr-issue-linkage
 

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -12,8 +12,7 @@ commits, PRs, releases, and validation alongside bash validators and git hooks
 `st-finalize-repo`, `st-validate-local`
 
 **Lint tools** (installed as `st-*`):
-`st-repo-profile`, `st-markdown-standards`,
-`st-pr-issue-linkage`, validation drivers
+`st-repo-profile`, `st-pr-issue-linkage`, validation drivers
 
 **Git hooks** (`.githooks/`):
 Env-var gate that admits `st-commit` and blocks raw `git commit`

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -185,8 +185,9 @@ from the repository profile, then dispatches to
 ### st-validate-local-common
 
 Shared validation checks for all repos: repository profile
-validation, markdown standards, shellcheck on `scripts/`, and
-yamllint on `.github/` and `docs/` YAML files.
+validation, markdownlint on published markdown (`docs/site/**/*.md`
+and `README.md`) using the bundled canonical config, shellcheck on
+`scripts/`, and yamllint on `.github/` and `docs/` YAML files.
 
 | Attribute | Value |
 |---|---|
@@ -225,21 +226,6 @@ placeholder values.
 | Preconditions | `docs/repository-standards.md` exists |
 | Failure mode | Exit 2 if profile file not found; exit 1 for missing or placeholder attributes |
 | Exit codes | 0 valid, 1 invalid, 2 file not found |
-| Status | Active |
-
-### st-markdown-standards
-
-Validate published documentation against markdown standards.
-Runs markdownlint on `docs/site/**/*.md` and structural checks
-(H1 count, ToC heading, heading-level skips) on `README.md`.
-
-| Attribute | Value |
-|---|---|
-| Source | `standard_tooling.bin.markdown_standards` |
-| Args | `[file...]` (optional; defaults to docs/site + README.md) |
-| Preconditions | `markdownlint` on PATH |
-| Failure mode | Exit 2 if markdownlint not found |
-| Exit codes | 0 passed, 1 violations found, 2 tool missing |
 | Status | Active |
 
 ## CI-only tools

--- a/docs/site/docs/reference/dev/prepare-release.md
+++ b/docs/site/docs/reference/dev/prepare-release.md
@@ -25,7 +25,7 @@ st-prepare-release --issue 42
 - Must be on the `develop` branch
 - Working tree must be clean
 - Local `develop` must match `origin/develop`
-- Required tools: `gh`, `git-cliff`, `markdownlint`
+- Required tools: `gh`, `git-cliff`
 
 ## Ecosystem Detection
 
@@ -47,7 +47,7 @@ The tool auto-detects the project ecosystem to find the version:
 3. **Merge main** -- incorporates prior release history to prevent
    changelog conflicts. Uses `-X ours` for auto-resolution.
 4. **Generate changelog** -- runs `git-cliff` with a boundary tag,
-   validates with markdownlint.
+   validates the generated output.
 5. **Push branch** -- pushes `release/{version}` to origin.
 6. **Create PR** -- creates a PR targeting `main` with
    `Ref #{issue}` linkage.

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -36,7 +36,7 @@ Run inside dev containers launched by `st-docker-run`.
 | `st-validate-local-go` | Go-specific validation |
 | `st-validate-local-java` | Java-specific validation |
 | [st-repo-profile](lint/repo-profile.md) | Repository profile attribute validation |
-| [st-markdown-standards](lint/markdown-standards.md) | Markdown linting and structural checks |
+| [Markdown validation](lint/markdown-standards.md) | Markdownlint with bundled canonical config |
 
 ## CI-only tools
 

--- a/docs/site/docs/reference/lint/markdown-standards.md
+++ b/docs/site/docs/reference/lint/markdown-standards.md
@@ -1,60 +1,63 @@
-# st-markdown-standards
+# Markdown Validation
 
-**Installed as:** `st-markdown-standards` (Python console script)
+Markdown validation is handled by `st-validate-local-common` as part
+of the standard validation pipeline. It runs `markdownlint` against
+published documentation using a canonical config bundled in
+standard-tooling.
 
-Validates markdown files using markdownlint and structural checks.
-Applies different levels of validation depending on file location.
+## Scope
 
-## Usage
+Validation targets published markdown only:
 
-```bash
-st-markdown-standards
-```
+| Source | Pattern |
+| ------ | ------- |
+| Documentation site | `docs/site/**/*.md` |
+| Project README | `README.md` |
 
-Run from the repository root. No arguments required.
-
-## File Discovery
-
-The script collects files from three sources:
-
-### Standard Docs (markdownlint + structural checks)
-
-Files found in `docs/` (excluding `docs/sphinx/`, `docs/site/`, and
-`docs/announcements/`), plus `README.md` if it exists.
-
-### Doc-Site Files (markdownlint only)
-
-Files under `docs/sphinx/` and `docs/site/`. These are exempt from
-structural checks because documentation site generators (MkDocs,
-Sphinx) handle structure.
-
-### CHANGELOG.md (markdownlint only)
-
-`CHANGELOG.md` gets markdownlint but no structural checks because
-changelog files have different heading conventions.
-
-## Structural Checks
-
-Applied only to standard docs, these checks enforce:
-
-| Check | Rule |
-| ----- | ---- |
-| **Single H1** | Exactly one `#` heading per file |
-| **Table of Contents** | A `## Table of Contents` section must exist |
-| **Heading Hierarchy** | No skipped heading levels |
-
-Code blocks (fenced with `` ``` `` or `~~~`) are excluded from
-structural analysis.
+Other markdown files (changelogs, release notes, internal docs) are
+not validated by this check.
 
 ## Configuration
 
-Markdownlint uses `.markdownlint.yaml` at the repository root if
-present. Otherwise it runs with default rules.
+The canonical config is bundled at
+`src/standard_tooling/configs/markdownlint.yaml` and resolved at
+runtime via `importlib.resources`. Consuming repos do not need a
+local `.markdownlint.yaml` -- the bundled config applies everywhere.
+
+```yaml
+default: true
+no-duplicate-heading:
+  siblings_only: true
+MD013:
+  line_length: 100
+  tables: false
+  code_blocks: false
+MD060: false
+```
+
+Key rules:
+
+| Rule | Setting | Rationale |
+| ---- | ------- | --------- |
+| Line length (MD013) | 100 chars | Matches ruff `line-length` setting |
+| Tables | Exempt from line length | Wide reference tables are legitimate |
+| Code blocks | Exempt from line length | Pasted commands and snippets exceed it |
+| Duplicate headings | Siblings only | Same heading text is fine across sections |
+| Table column style (MD060) | Disabled | No reader benefit for strict pipe alignment |
+
+## How it runs
+
+`st-validate-local` dispatches to `st-validate-local-common`, which:
+
+1. Discovers markdown files matching the scope above.
+2. Resolves the bundled `markdownlint.yaml` config.
+3. Invokes `markdownlint --config <bundled-config> <files...>`.
+
+This runs inside the dev container where `markdownlint` is on PATH.
 
 ## Exit Codes
 
 | Code | Meaning |
 | ---- | ------- |
 | 0 | All files pass |
-| 1 | One or more validation failures |
-| 2 | No markdown files found, or markdownlint not installed |
+| Non-zero | One or more validation failures |

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -67,7 +67,7 @@ nav:
           - pre-commit: reference/hooks/pre-commit.md
       - Validators:
           - repo-profile: reference/lint/repo-profile.md
-          - markdown-standards: reference/lint/markdown-standards.md
+          - markdown-validation: reference/lint/markdown-standards.md
           - pr-issue-linkage: reference/lint/pr-issue-linkage.md
       - CLI Tools:
           - st-commit: reference/dev/commit.md


### PR DESCRIPTION
# Pull Request

## Summary

- Update published docs for bundled markdownlint config

## Issue Linkage

- Ref #476

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

Update all published documentation under `docs/site/` to reflect the
markdownlint standardization shipped in #476 / v1.4.13:

- Remove `st-markdown-standards` references throughout (tool removed)
- Rewrite `reference/lint/markdown-standards.md` as "Markdown Validation"
  documenting the bundled canonical config, file scope, and rule rationale
- Remove Step 7 (local `.markdownlint.yaml` creation) from consuming-repo-setup
  and renumber subsequent steps
- Update validation matrix, CLI tools overview, index pages, getting-started,
  prepare-release prerequisites, and mkdocs nav entry

Ref #476

## Test plan

- [ ] `st-validate-local` green (540 tests, 100% coverage, markdownlint
  passes on all 19 published markdown files)
- [ ] Verify no remaining `st-markdown-standards` references in docs/site