### PR TITLE
feat(markdownlint): repo-specific ignore paths in standard-tooling.toml

### DIFF
--- a/docs/specs/standard-tooling-toml.md
+++ b/docs/specs/standard-tooling-toml.md
@@ -35,6 +35,9 @@ primary-language = "python"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[markdownlint]
+ignore = ["docs/site/docs/research"]
+
 [dependencies]
 standard-tooling = "v1.4"
 ```
@@ -76,6 +79,21 @@ Repos with no AI agent workflow may omit this table entirely.
 Expected value format: `Co-Authored-By: <name> <<email>>` — a
 standard git trailer. The validator checks for the `Co-Authored-By:`
 prefix and the presence of angle-bracketed email.
+
+### `[markdownlint]` table
+
+Optional. Controls markdownlint behavior for `st-validate-local-common`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `ignore` | array of strings | `[]` | Relative paths (from repo root) to exclude from markdown file discovery |
+
+Files under any ignored path are skipped during `_find_markdown_files()`
+discovery. This is useful for repos with large auto-generated markdown
+trees (e.g., research output) that should not be linted.
+
+Repos without this section get default behavior — all files under
+`docs/site/` and `README.md` are linted.
 
 ### `[dependencies]` table
 

--- a/src/standard_tooling/bin/validate_local_common_container.py
+++ b/src/standard_tooling/bin/validate_local_common_container.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from standard_tooling.bin import repo_profile_cli
 from standard_tooling.lib import git
+from standard_tooling.lib.config import read_config
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,13 +38,18 @@ def _find_shell_files(repo_root: Path) -> list[str]:
     return sorted(found)
 
 
-def _find_markdown_files(repo_root: Path) -> list[str]:
+def _find_markdown_files(
+    repo_root: Path, ignore: list[str] | None = None
+) -> list[str]:
     """Discover published markdown files: docs/site/**/*.md and README.md."""
     found: list[str] = []
+    ignore_paths = [repo_root / p for p in (ignore or [])]
 
     site_dir = repo_root / "docs" / "site"
     if site_dir.is_dir():
         for path in site_dir.rglob("*.md"):
+            if any(path.is_relative_to(ip) for ip in ignore_paths):
+                continue
             found.append(str(path))
 
     readme = repo_root / "README.md"
@@ -96,7 +102,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     if rc != 0:
         return rc
 
-    md_files = _find_markdown_files(repo_root)
+    cfg = read_config(repo_root)
+    md_files = _find_markdown_files(repo_root, ignore=cfg.markdownlint.ignore)
     if md_files:
         print(f"Running: markdownlint ({len(md_files)} files)")
         config = files("standard_tooling.configs") / "markdownlint.yaml"

--- a/src/standard_tooling/bin/validate_local_common_container.py
+++ b/src/standard_tooling/bin/validate_local_common_container.py
@@ -38,9 +38,7 @@ def _find_shell_files(repo_root: Path) -> list[str]:
     return sorted(found)
 
 
-def _find_markdown_files(
-    repo_root: Path, ignore: list[str] | None = None
-) -> list[str]:
+def _find_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> list[str]:
     """Discover published markdown files: docs/site/**/*.md and README.md."""
     found: list[str] = []
     ignore_paths = [repo_root / p for p in (ignore or [])]

--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -47,9 +47,15 @@ class ProjectConfig:
 
 
 @dataclass
+class MarkdownlintConfig:
+    ignore: list[str]
+
+
+@dataclass
 class StConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
+    markdownlint: MarkdownlintConfig
 
 
 def read_config(repo_root: Path) -> StConfig:
@@ -93,6 +99,13 @@ def read_config(repo_root: Path) -> StConfig:
         msg = f"{CONFIG_FILE}: [dependencies] must contain 'standard-tooling'"
         raise ConfigError(msg)
 
+    ml_raw = raw.get("markdownlint", {})
+    ml_ignore = ml_raw.get("ignore", [])
+    if not isinstance(ml_ignore, list) or not all(isinstance(p, str) for p in ml_ignore):
+        msg = f"{CONFIG_FILE}: [markdownlint].ignore must be a list of strings"
+        raise ConfigError(msg)
+    markdownlint = MarkdownlintConfig(ignore=ml_ignore)
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -101,7 +114,7 @@ def read_config(repo_root: Path) -> StConfig:
         primary_language=project_raw["primary-language"],
         co_authors=co_authors,
     )
-    return StConfig(project=project, dependencies=dict(deps))
+    return StConfig(project=project, dependencies=dict(deps), markdownlint=markdownlint)
 
 
 def st_install_tag(repo_root: Path) -> str:

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import pytest
 
-from standard_tooling.lib.config import ConfigError, read_config, st_install_tag
+from standard_tooling.lib.config import (
+    ConfigError,
+    MarkdownlintConfig,
+    read_config,
+    st_install_tag,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -135,3 +140,53 @@ def test_read_config_no_co_authors(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text("".join(lines))
     cfg = read_config(tmp_path)
     assert cfg.project.co_authors == {}
+
+
+# -- [markdownlint] section ---------------------------------------------------
+
+_ML_IGNORE_TOML = (
+    _VALID_TOML
+    + """
+[markdownlint]
+ignore = ["docs/site/docs/research"]
+"""
+)
+
+
+def test_read_config_markdownlint_ignore(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_ML_IGNORE_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.markdownlint == MarkdownlintConfig(ignore=["docs/site/docs/research"])
+
+
+def test_read_config_markdownlint_multiple_ignores(tmp_path: Path) -> None:
+    toml = (
+        _VALID_TOML
+        + '[markdownlint]\nignore = ["docs/site/docs/research", "docs/site/docs/archive"]\n'
+    )
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.markdownlint.ignore == [
+        "docs/site/docs/research",
+        "docs/site/docs/archive",
+    ]
+
+
+def test_read_config_no_markdownlint_section(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.markdownlint == MarkdownlintConfig(ignore=[])
+
+
+def test_read_config_markdownlint_empty_ignore(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[markdownlint]\nignore = []\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.markdownlint.ignore == []
+
+
+def test_read_config_markdownlint_no_ignore_key(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[markdownlint]\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.markdownlint.ignore == []

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -190,3 +190,10 @@ def test_read_config_markdownlint_no_ignore_key(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(toml)
     cfg = read_config(tmp_path)
     assert cfg.markdownlint.ignore == []
+
+
+def test_read_config_markdownlint_ignore_not_a_list(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '[markdownlint]\nignore = "not-a-list"\n'
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[markdownlint\]\.ignore must be a list"):
+        read_config(tmp_path)

--- a/tests/standard_tooling/test_validate_local_common_container.py
+++ b/tests/standard_tooling/test_validate_local_common_container.py
@@ -16,6 +16,18 @@ from standard_tooling.bin.validate_local_common_container import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+_MINIMAL_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+"""
+
 
 # -- _find_shell_files --------------------------------------------------------
 
@@ -109,10 +121,65 @@ def test_find_markdown_files_sorted(tmp_path: Path) -> None:
     assert result == sorted(result)
 
 
+def test_find_markdown_files_ignore_directory(tmp_path: Path) -> None:
+    site = tmp_path / "docs" / "site"
+    research = site / "docs" / "research"
+    research.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    (research / "report.md").write_text("# Report\n")
+    result = _find_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
+    assert len(result) == 1
+    assert result[0].endswith("index.md")
+
+
+def test_find_markdown_files_ignore_nested(tmp_path: Path) -> None:
+    site = tmp_path / "docs" / "site"
+    deep = site / "docs" / "research" / "2026" / "output"
+    deep.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    (deep / "report.md").write_text("# Report\n")
+    result = _find_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
+    assert len(result) == 1
+    assert result[0].endswith("index.md")
+
+
+def test_find_markdown_files_ignore_multiple(tmp_path: Path) -> None:
+    site = tmp_path / "docs" / "site"
+    research = site / "docs" / "research"
+    archive = site / "docs" / "archive"
+    research.mkdir(parents=True)
+    archive.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    (research / "report.md").write_text("# Report\n")
+    (archive / "old.md").write_text("# Old\n")
+    result = _find_markdown_files(
+        tmp_path,
+        ignore=["docs/site/docs/research", "docs/site/docs/archive"],
+    )
+    assert len(result) == 1
+    assert result[0].endswith("index.md")
+
+
+def test_find_markdown_files_ignore_does_not_affect_readme(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Hello\n")
+    result = _find_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
+    assert len(result) == 1
+    assert result[0].endswith("README.md")
+
+
+def test_find_markdown_files_ignore_empty_list(tmp_path: Path) -> None:
+    site = tmp_path / "docs" / "site"
+    site.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    result = _find_markdown_files(tmp_path, ignore=[])
+    assert len(result) == 1
+
+
 # -- main --------------------------------------------------------------------
 
 
 def test_main_all_pass(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     with (
         patch(
             "standard_tooling.bin.validate_local_common_container.git.repo_root",
@@ -141,6 +208,7 @@ def test_main_repo_profile_fails(tmp_path: Path) -> None:
 
 
 def test_main_markdownlint_uses_bundled_config(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
@@ -169,6 +237,7 @@ def test_main_markdownlint_uses_bundled_config(tmp_path: Path) -> None:
 
 
 def test_main_markdownlint_ignores_repo_local_config(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
@@ -197,6 +266,7 @@ def test_main_markdownlint_ignores_repo_local_config(tmp_path: Path) -> None:
 
 
 def test_main_markdownlint_fails(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     (tmp_path / "README.md").write_text("# Hello\n")
 
     with (
@@ -216,7 +286,40 @@ def test_main_markdownlint_fails(tmp_path: Path) -> None:
         assert main() == 1
 
 
+def test_main_markdownlint_honors_ignore(tmp_path: Path) -> None:
+    toml = _MINIMAL_TOML + '\n[markdownlint]\nignore = ["docs/site/docs/research"]\n'
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    site = tmp_path / "docs" / "site"
+    research = site / "docs" / "research"
+    research.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    (research / "report.md").write_text("# Report\n")
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    ml_call = mock_run.call_args_list[0][0][0]
+    assert ml_call[0] == "markdownlint"
+    md_args = ml_call[3:]
+    assert len(md_args) == 1
+    assert md_args[0].endswith("index.md")
+    assert not any("research" in a for a in md_args)
+
+
 def test_main_shellcheck_runs(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     scripts = tmp_path / "scripts" / "dev"
     scripts.mkdir(parents=True)
     (scripts / "lint.sh").write_text("#!/bin/bash\n")
@@ -242,6 +345,7 @@ def test_main_shellcheck_runs(tmp_path: Path) -> None:
 
 
 def test_main_shellcheck_fails(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     scripts = tmp_path / "scripts" / "dev"
     scripts.mkdir(parents=True)
     (scripts / "lint.sh").write_text("#!/bin/bash\n")
@@ -332,6 +436,7 @@ def test_find_yaml_files_sorted_and_deduped(tmp_path: Path) -> None:
 
 
 def test_main_yamllint_runs(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     (workflows / "ci.yml").write_text("name: CI\n")
@@ -357,6 +462,7 @@ def test_main_yamllint_runs(tmp_path: Path) -> None:
 
 
 def test_main_yamllint_fails(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     (workflows / "ci.yml").write_text("name: CI\n")


### PR DESCRIPTION
# Pull Request

## Summary

- Add optional [markdownlint].ignore config to standard-tooling.toml so repos with large auto-generated markdown trees can exclude paths from lint discovery

## Issue Linkage

- Ref #489

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Adds a `[markdownlint]` section to `standard-tooling.toml` with an `ignore` list of relative paths to exclude from markdown file discovery. This solves the ARG_MAX failure in `the-infrastructure-mindset` (wphillipmoore/the-infrastructure-mindset#177) where ~16,950 research markdown files were being passed as CLI arguments to markdownlint.

### Changes

- **`config.py`**: `MarkdownlintConfig` dataclass with `ignore: list[str]`, added to `StConfig`, parsed from the optional `[markdownlint]` section with type validation
- **`validate_local_common_container.py`**: `_find_markdown_files()` now accepts an `ignore` parameter and skips files under ignored paths via `Path.is_relative_to()`; `main()` reads the config and passes the ignore list
- **`standard-tooling-toml.md`**: Schema docs updated with the new `[markdownlint]` section
- **Tests**: 12 new tests covering config parsing (with/without section, multiple ignores, empty, invalid type) and file discovery (directory exclusion, nested, multiple, README unaffected); existing `main()` tests updated for the new `read_config()` call

### Consumer usage

```toml
[markdownlint]
ignore = ["docs/site/docs/research"]
```

Repos without this section get unchanged behavior — all files under `docs/site/` and `README.md` are linted.

### Follow-on

- Update `the-infrastructure-mindset` `standard-tooling.toml` to add the ignore entry (separate PR in that repo once this lands)