### PR TITLE
chore(deps): post-1.4.14 dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4.7
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
     with:
       language: python
       run-standards: ${{ inputs.run-release-gates || 'true' }}


### PR DESCRIPTION
# Pull Request

## Summary

- Fix ci-security.yml patch-level pin and confirm all deps at latest

## Issue Linkage

- Ref #492

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Post-1.4.14 dependency sweep as part of the release cycle.

### CI action pins
- **Fix:** `ci-security.yml` pin reverted from `@v1.4.7` (patch-level) to `@v1.4` (floating major.minor). Filed wphillipmoore/standard-actions#308 for a fleet-wide audit of similar stale patch pins.

### Python dependencies
- `uv lock --upgrade` found no updates — all dependencies at latest compatible versions.

### Anchored dependencies
- No anchor records to review.

### Toolchain versions confirmed current
- ruff 0.15.12, mypy 1.20.2, pytest 9.0.3
- setup-uv v8.1.0, actions/checkout v6, actions/setup-python v6