### PR TITLE
feat(github): add read_json() helper for gh api calls

### DIFF
--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -27,10 +27,11 @@ def read_output(*args: str) -> str:
     return result.stdout.strip()
 
 
-def read_json(*args: str) -> dict | list:
+def read_json(*args: str) -> dict[str, object] | list[object]:
     """Run a gh command and return parsed JSON from stdout."""
     raw = read_output(*args)
-    return json.loads(raw)
+    result: dict[str, object] | list[object] = json.loads(raw)
+    return result
 
 
 def create_pr(*, base: str, title: str, body_file: str) -> str:

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 
@@ -24,6 +25,12 @@ def read_output(*args: str) -> str:
         capture_output=True,
     )
     return result.stdout.strip()
+
+
+def read_json(*args: str) -> dict | list:
+    """Run a gh command and return parsed JSON from stdout."""
+    raw = read_output(*args)
+    return json.loads(raw)
 
 
 def create_pr(*, base: str, title: str, body_file: str) -> str:

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from unittest.mock import patch
 
@@ -124,6 +125,22 @@ def test_list_project_repos_empty() -> None:
         return_value="",
     ):
         assert github.list_project_repos("acme", "5") == []
+
+
+def test_read_json_returns_parsed_dict() -> None:
+    payload = {"name": "test", "value": 42}
+    cp = _completed(stdout=json.dumps(payload) + "\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        result = github.read_json("api", "repos/o/r")
+    assert result == payload
+
+
+def test_read_json_returns_parsed_list() -> None:
+    payload = [{"id": 1}, {"id": 2}]
+    cp = _completed(stdout=json.dumps(payload) + "\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        result = github.read_json("api", "repos/o/r/rulesets")
+    assert result == payload
 
 
 def test_checks_registered_returns_false_when_phrase_in_stdout() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Adds read_json() helper that wraps read_output() with JSON parsing for use by the upcoming st-github-config tool.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -