### PR TITLE
feat(config): add [ci] section to standard-tooling.toml schema

### DIFF
--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -52,10 +52,17 @@ class MarkdownlintConfig:
 
 
 @dataclass
+class CiConfig:
+    versions: list[str]
+    integration_tests: bool
+
+
+@dataclass
 class StConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
+    ci: CiConfig | None
 
 
 def read_config(repo_root: Path) -> StConfig:
@@ -106,6 +113,24 @@ def read_config(repo_root: Path) -> StConfig:
         raise ConfigError(msg)
     markdownlint = MarkdownlintConfig(ignore=ml_ignore)
 
+    ci_raw = raw.get("ci")
+    ci: CiConfig | None = None
+    if ci_raw is not None:
+        versions = ci_raw.get("versions")
+        if versions is None:
+            msg = f"{CONFIG_FILE}: [ci] missing required field 'versions'"
+            raise ConfigError(msg)
+        if not isinstance(versions, list) or not versions:
+            msg = f"{CONFIG_FILE}: [ci].versions must be a list with at least one entry"
+            raise ConfigError(msg)
+        if not all(isinstance(v, str) for v in versions):
+            msg = f"{CONFIG_FILE}: [ci].versions entries must be strings"
+            raise ConfigError(msg)
+        ci = CiConfig(
+            versions=versions,
+            integration_tests=bool(ci_raw.get("integration-tests", False)),
+        )
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -114,7 +139,7 @@ def read_config(repo_root: Path) -> StConfig:
         primary_language=project_raw["primary-language"],
         co_authors=co_authors,
     )
-    return StConfig(project=project, dependencies=dict(deps), markdownlint=markdownlint)
+    return StConfig(project=project, dependencies=dict(deps), markdownlint=markdownlint, ci=ci)
 
 
 def st_install_tag(repo_root: Path) -> str:

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -219,7 +219,7 @@ def test_read_config_ci_section(tmp_path: Path) -> None:
 
 
 def test_read_config_ci_no_integration_tests(tmp_path: Path) -> None:
-    toml = _VALID_TOML + "[ci]\nversions = [\"3.14\"]\n"
+    toml = _VALID_TOML + '[ci]\nversions = ["3.14"]\n'
     (tmp_path / "standard-tooling.toml").write_text(toml)
     cfg = read_config(tmp_path)
     assert cfg.ci is not None

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from standard_tooling.lib.config import (
+    CiConfig,
     ConfigError,
     MarkdownlintConfig,
     read_config,
@@ -197,3 +198,56 @@ def test_read_config_markdownlint_ignore_not_a_list(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(toml)
     with pytest.raises(ConfigError, match=r"\[markdownlint\]\.ignore must be a list"):
         read_config(tmp_path)
+
+
+# -- [ci] section --------------------------------------------------------------
+
+_CI_TOML = (
+    _VALID_TOML
+    + """
+[ci]
+versions = ["3.12", "3.13", "3.14"]
+integration-tests = true
+"""
+)
+
+
+def test_read_config_ci_section(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_CI_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.ci == CiConfig(versions=["3.12", "3.13", "3.14"], integration_tests=True)
+
+
+def test_read_config_ci_no_integration_tests(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[ci]\nversions = [\"3.14\"]\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.ci is not None
+    assert cfg.ci.integration_tests is False
+
+
+def test_read_config_ci_missing_versions(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[ci]\nintegration-tests = true\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    with pytest.raises(ConfigError, match="versions"):
+        read_config(tmp_path)
+
+
+def test_read_config_ci_empty_versions(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[ci]\nversions = []\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    with pytest.raises(ConfigError, match="versions.*at least one"):
+        read_config(tmp_path)
+
+
+def test_read_config_ci_versions_not_strings(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[ci]\nversions = [3.12, 3.13]\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    with pytest.raises(ConfigError, match="versions.*strings"):
+        read_config(tmp_path)
+
+
+def test_read_config_no_ci_section(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.ci is None


### PR DESCRIPTION
# Pull Request

## Summary

- Adds CiConfig dataclass with versions (required list) and integration-tests (optional bool) to the config module, with full validation and tests.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -