### PR TITLE
feat(config): add [github] override section to TOML schema

### DIFF
--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -58,11 +58,17 @@ class CiConfig:
 
 
 @dataclass
+class GithubOverrides:
+    skip_rulesets: bool
+
+
+@dataclass
 class StConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
     ci: CiConfig | None
+    github: GithubOverrides
 
 
 def read_config(repo_root: Path) -> StConfig:
@@ -131,6 +137,11 @@ def read_config(repo_root: Path) -> StConfig:
             integration_tests=bool(ci_raw.get("integration-tests", False)),
         )
 
+    github_raw = raw.get("github", {})
+    github_overrides = GithubOverrides(
+        skip_rulesets=bool(github_raw.get("skip-rulesets", False)),
+    )
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -139,7 +150,13 @@ def read_config(repo_root: Path) -> StConfig:
         primary_language=project_raw["primary-language"],
         co_authors=co_authors,
     )
-    return StConfig(project=project, dependencies=dict(deps), markdownlint=markdownlint, ci=ci)
+    return StConfig(
+        project=project,
+        dependencies=dict(deps),
+        markdownlint=markdownlint,
+        ci=ci,
+        github=github_overrides,
+    )
 
 
 def st_install_tag(repo_root: Path) -> str:

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -10,6 +10,7 @@ import pytest
 from standard_tooling.lib.config import (
     CiConfig,
     ConfigError,
+    GithubOverrides,
     MarkdownlintConfig,
     read_config,
     st_install_tag,
@@ -251,3 +252,26 @@ def test_read_config_no_ci_section(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     cfg = read_config(tmp_path)
     assert cfg.ci is None
+
+
+# -- [github] section ---------------------------------------------------------
+
+_GITHUB_OVERRIDE_TOML = (
+    _VALID_TOML
+    + """
+[github]
+skip-rulesets = true
+"""
+)
+
+
+def test_read_config_github_overrides(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_GITHUB_OVERRIDE_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.github == GithubOverrides(skip_rulesets=True)
+
+
+def test_read_config_no_github_section(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.github == GithubOverrides(skip_rulesets=False)


### PR DESCRIPTION
# Pull Request

## Summary

- Adds GithubOverrides dataclass with skip-rulesets flag for repos that intentionally deviate from the standard ruleset configuration

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Part of the GitHub configuration enforcement feature. Adds parsing of optional [github] section from standard-tooling.toml with a default of skip-rulesets=false.