### PR TITLE
feat(validate): add per-language command registry

### DIFF
--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -1,0 +1,66 @@
+"""Per-language validation command registry.
+
+Defines the canonical commands for lint, typecheck, test, and audit
+per supported language. These are not configurable per-repo — the
+standard defines them centrally.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CheckKind(Enum):
+    LINT = "lint"
+    TYPECHECK = "typecheck"
+    TEST = "test"
+    AUDIT = "audit"
+
+
+_REGISTRY: dict[str, dict[CheckKind, list[str]]] = {
+    "python": {
+        CheckKind.LINT: ["ruff check", "ruff format --check ."],
+        CheckKind.TYPECHECK: ["mypy src/"],
+        CheckKind.TEST: ["pytest --cov --cov-branch --cov-fail-under=100"],
+        CheckKind.AUDIT: [
+            "uv sync --check --frozen --group dev",
+            "uv lock --check",
+        ],
+    },
+    "go": {
+        CheckKind.LINT: ["golangci-lint run", "gocyclo -over 15 ."],
+        CheckKind.TYPECHECK: [],
+        CheckKind.TEST: ["go test -coverprofile=coverage.out ./..."],
+        CheckKind.AUDIT: ["govulncheck ./..."],
+    },
+    "java": {
+        CheckKind.LINT: ["./mvnw spotless:check checkstyle:check"],
+        CheckKind.TYPECHECK: [],
+        CheckKind.TEST: ["./mvnw verify"],
+        CheckKind.AUDIT: [],
+    },
+    "ruby": {
+        CheckKind.LINT: ["rubocop"],
+        CheckKind.TYPECHECK: [],
+        CheckKind.TEST: ["rake"],
+        CheckKind.AUDIT: [],
+    },
+    "rust": {
+        CheckKind.LINT: ["cargo fmt --check", "cargo clippy"],
+        CheckKind.TYPECHECK: [],
+        CheckKind.TEST: ["cargo llvm-cov --fail-under-lines 100"],
+        CheckKind.AUDIT: ["cargo audit"],
+    },
+}
+
+
+def language_commands(language: str, kind: CheckKind) -> list[str]:
+    """Return the canonical commands for a language and check kind.
+
+    Returns an empty list if the language is unknown or has no commands
+    for the given kind.
+    """
+    lang_entry = _REGISTRY.get(language)
+    if lang_entry is None:
+        return []
+    return list(lang_entry.get(kind, []))

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -1,0 +1,54 @@
+"""Tests for standard_tooling.lib.validate_commands."""
+
+from __future__ import annotations
+
+from standard_tooling.lib.validate_commands import (
+    CheckKind,
+    language_commands,
+)
+
+
+def test_python_lint_commands() -> None:
+    cmds = language_commands("python", CheckKind.LINT)
+    assert cmds == ["ruff check", "ruff format --check ."]
+
+
+def test_python_typecheck_commands() -> None:
+    cmds = language_commands("python", CheckKind.TYPECHECK)
+    assert cmds == ["mypy src/"]
+
+
+def test_python_test_commands() -> None:
+    cmds = language_commands("python", CheckKind.TEST)
+    assert cmds == ["pytest --cov --cov-branch --cov-fail-under=100"]
+
+
+def test_python_audit_commands() -> None:
+    cmds = language_commands("python", CheckKind.AUDIT)
+    assert cmds == ["uv sync --check --frozen --group dev", "uv lock --check"]
+
+
+def test_go_lint_commands() -> None:
+    cmds = language_commands("go", CheckKind.LINT)
+    assert "golangci-lint run" in cmds
+
+
+def test_go_test_commands() -> None:
+    cmds = language_commands("go", CheckKind.TEST)
+    assert any("go test" in c for c in cmds)
+
+
+def test_rust_lint_commands() -> None:
+    cmds = language_commands("rust", CheckKind.LINT)
+    assert "cargo fmt --check" in cmds
+    assert "cargo clippy" in cmds
+
+
+def test_unknown_language_returns_empty() -> None:
+    cmds = language_commands("unknown", CheckKind.LINT)
+    assert cmds == []
+
+
+def test_language_with_no_typecheck() -> None:
+    cmds = language_commands("go", CheckKind.TYPECHECK)
+    assert cmds == []


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a per-language validation command registry that centrally defines lint/typecheck/test/audit commands for Python, Go, Java, Ruby, and Rust. Provides CheckKind enum and language_commands() lookup. Pulled forward because CI gates derivation depends on it.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -