### PR TITLE
feat(github-config): add CI gates ruleset derivation

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -8,6 +8,10 @@ against the actual GitHub API state to produce audit diffs.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from standard_tooling.lib.config import CiConfig, ProjectConfig
 
 
 @dataclass
@@ -144,5 +148,102 @@ def desired_tag_protection_ruleset() -> DesiredRuleset:
             {"type": "deletion"},
             {"type": "non_fast_forward"},
             {"type": "update"},
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# CI gates ruleset derivation
+# ---------------------------------------------------------------------------
+
+_GITHUB_ACTIONS_INTEGRATION_ID = 15368
+
+_CODEQL_SUPPORTED_LANGUAGES = frozenset(
+    {
+        "python",
+        "go",
+        "java",
+        "ruby",
+        "rust",
+    }
+)
+
+
+def _make_check(context: str) -> dict[str, object]:
+    return {
+        "context": context,
+        "integration_id": _GITHUB_ACTIONS_INTEGRATION_ID,
+    }
+
+
+def _lang_has_check(language: str, check: str) -> bool:
+    """Consult the per-language command registry."""
+    from standard_tooling.lib.validate_commands import CheckKind, language_commands
+
+    kind_map = {
+        "lint": CheckKind.LINT,
+        "typecheck": CheckKind.TYPECHECK,
+        "unit": CheckKind.TEST,
+        "dependencies": CheckKind.AUDIT,
+    }
+    kind = kind_map.get(check)
+    if kind is None:
+        return False
+    return len(language_commands(language, kind)) > 0
+
+
+def desired_ci_gates_ruleset(
+    project: ProjectConfig,
+    ci: CiConfig,
+) -> DesiredRuleset:
+    """Derive the CI gates ruleset from project identity and CI config."""
+    checks: list[dict[str, object]] = []
+    lang = project.primary_language
+
+    # Always present
+    checks.append(_make_check("quality / common"))
+    checks.append(_make_check("security / trivy"))
+    checks.append(_make_check("security / semgrep"))
+    checks.append(_make_check("security / standards"))
+
+    # CodeQL for supported languages
+    if lang in _CODEQL_SUPPORTED_LANGUAGES:
+        checks.append(_make_check("security / codeql"))
+
+    # Versioned checks — only emitted when the language has
+    # a command registry entry for the check
+    for version in ci.versions:
+        if _lang_has_check(lang, "lint"):
+            checks.append(_make_check(f"quality / lint / {version}"))
+        if _lang_has_check(lang, "typecheck"):
+            checks.append(_make_check(f"quality / typecheck / {version}"))
+        if _lang_has_check(lang, "unit"):
+            checks.append(_make_check(f"test / unit / {version}"))
+        if _lang_has_check(lang, "dependencies"):
+            checks.append(_make_check(f"audit / dependencies / {version}"))
+
+    # Integration tests per version (when enabled)
+    if ci.integration_tests:
+        for version in ci.versions:
+            checks.append(_make_check(f"test / integration / {version}"))
+
+    # Release check
+    if project.release_model != "none":
+        checks.append(_make_check("release / version-bump"))
+
+    return DesiredRuleset(
+        name="CI gates",
+        target="branch",
+        enforcement="active",
+        ref_include=["refs/heads/main", "refs/heads/develop"],
+        bypass_actors=[],
+        rules=[
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "strict_required_status_checks_policy": True,
+                    "required_status_checks": checks,
+                },
+            },
         ],
     )

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from standard_tooling.lib.config import CiConfig, ProjectConfig
 from standard_tooling.lib.github_config import (
     desired_actions_permissions,
     desired_branch_protection_ruleset,
+    desired_ci_gates_ruleset,
     desired_repo_settings,
     desired_security_settings,
     desired_tag_protection_ruleset,
@@ -75,3 +77,119 @@ def test_tag_protection_ruleset() -> None:
     assert "deletion" in rule_types
     assert "non_fast_forward" in rule_types
     assert "update" in rule_types
+
+
+# ---------------------------------------------------------------------------
+# CI gates ruleset tests
+# ---------------------------------------------------------------------------
+
+
+def _project(
+    *,
+    language: str = "python",
+    release_model: str = "tagged-release",
+) -> ProjectConfig:
+    return ProjectConfig(
+        repository_type="library",
+        versioning_scheme="semver",
+        branching_model="library-release",
+        release_model=release_model,
+        primary_language=language,
+        co_authors={},
+    )
+
+
+def _ci(
+    *,
+    versions: list[str] | None = None,
+    integration_tests: bool = False,
+) -> CiConfig:
+    return CiConfig(
+        versions=versions or ["3.14"],
+        integration_tests=integration_tests,
+    )
+
+
+def _check_names(ruleset) -> list[str]:  # noqa: ANN001
+    """Extract check context names from a CI gates ruleset."""
+    status_rule = next(rule for rule in ruleset.rules if rule["type"] == "required_status_checks")
+    return [c["context"] for c in status_rule["parameters"]["required_status_checks"]]
+
+
+def test_ci_gates_structure() -> None:
+    r = desired_ci_gates_ruleset(_project(), _ci())
+    assert r.name == "CI gates"
+    assert r.target == "branch"
+    assert r.enforcement == "active"
+    assert r.ref_include == ["refs/heads/main", "refs/heads/develop"]
+    assert r.bypass_actors == []
+
+
+def test_ci_gates_strict_policy() -> None:
+    r = desired_ci_gates_ruleset(_project(), _ci())
+    status_rule = next(rule for rule in r.rules if rule["type"] == "required_status_checks")
+    assert status_rule["parameters"]["strict_required_status_checks_policy"] is True
+
+
+def test_ci_gates_always_includes_common_and_security() -> None:
+    r = desired_ci_gates_ruleset(_project(), _ci())
+    check_names = _check_names(r)
+    assert "quality / common" in check_names
+    assert "security / trivy" in check_names
+    assert "security / semgrep" in check_names
+    assert "security / standards" in check_names
+
+
+def test_ci_gates_codeql_for_supported_language() -> None:
+    r = desired_ci_gates_ruleset(_project(language="python"), _ci())
+    assert "security / codeql" in _check_names(r)
+
+
+def test_ci_gates_no_codeql_for_shell() -> None:
+    r = desired_ci_gates_ruleset(_project(language="shell"), _ci())
+    assert "security / codeql" not in _check_names(r)
+
+
+def test_ci_gates_versioned_checks_per_version() -> None:
+    ci = _ci(versions=["3.12", "3.13", "3.14"])
+    r = desired_ci_gates_ruleset(_project(), ci)
+    names = _check_names(r)
+    assert "quality / lint / 3.12" in names
+    assert "quality / lint / 3.13" in names
+    assert "quality / lint / 3.14" in names
+    assert "quality / typecheck / 3.12" in names
+    assert "test / unit / 3.12" in names
+    assert "audit / dependencies / 3.12" in names
+
+
+def test_ci_gates_integration_tests_when_enabled() -> None:
+    ci = _ci(versions=["3.12", "3.13"], integration_tests=True)
+    r = desired_ci_gates_ruleset(_project(), ci)
+    names = _check_names(r)
+    assert "test / integration / 3.12" in names
+    assert "test / integration / 3.13" in names
+
+
+def test_ci_gates_no_integration_tests_when_disabled() -> None:
+    ci = _ci(versions=["3.12"], integration_tests=False)
+    r = desired_ci_gates_ruleset(_project(), ci)
+    names = _check_names(r)
+    assert not any("test / integration" in n for n in names)
+
+
+def test_ci_gates_release_version_bump_present() -> None:
+    r = desired_ci_gates_ruleset(_project(release_model="tagged-release"), _ci())
+    assert "release / version-bump" in _check_names(r)
+
+
+def test_ci_gates_no_release_when_none() -> None:
+    r = desired_ci_gates_ruleset(_project(release_model="none"), _ci())
+    assert "release / version-bump" not in _check_names(r)
+
+
+def test_ci_gates_shell_has_no_versioned_checks() -> None:
+    r = desired_ci_gates_ruleset(_project(language="shell"), _ci(versions=["latest"]))
+    names = _check_names(r)
+    assert "quality / common" in names
+    assert not any("quality / lint" in n for n in names)
+    assert not any("test / unit" in n for n in names)

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from standard_tooling.lib.config import CiConfig, ProjectConfig
 from standard_tooling.lib.github_config import (
+    _lang_has_check,
     desired_actions_permissions,
     desired_branch_protection_ruleset,
     desired_ci_gates_ruleset,
@@ -193,3 +194,7 @@ def test_ci_gates_shell_has_no_versioned_checks() -> None:
     assert "quality / common" in names
     assert not any("quality / lint" in n for n in names)
     assert not any("test / unit" in n for n in names)
+
+
+def test_lang_has_check_returns_false_for_unknown_check() -> None:
+    assert _lang_has_check("python", "nonexistent") is False


### PR DESCRIPTION
# Pull Request

## Summary

- Adds desired_ci_gates_ruleset() that computes required status checks from project identity and CI config, consulting the per-language command registry for versioned checks.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -