### PR TITLE
feat(github-config): add fetch_actual_state() for GitHub API reads

### DIFF
--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 
@@ -24,6 +25,13 @@ def read_output(*args: str) -> str:
         capture_output=True,
     )
     return result.stdout.strip()
+
+
+def read_json(*args: str) -> dict[str, object] | list[object]:
+    """Run a gh command and return parsed JSON from stdout."""
+    raw = read_output(*args)
+    result: dict[str, object] | list[object] = json.loads(raw)
+    return result
 
 
 def create_pr(*, base: str, title: str, body_file: str) -> str:

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -1,0 +1,194 @@
+"""GitHub configuration derivation engine.
+
+Computes the desired GitHub configuration for a repository from its
+``standard-tooling.toml`` identity.  The desired state can be compared
+against the actual GitHub API state to produce audit diffs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+from standard_tooling.lib import github
+
+
+@dataclass
+class DesiredRepoSettings:
+    default_branch: str
+    allow_auto_merge: bool
+    delete_branch_on_merge: bool
+    allow_merge_commit: bool
+    allow_squash_merge: bool
+    allow_rebase_merge: bool
+    has_issues: bool
+    has_projects: bool
+    has_wiki: bool
+
+
+@dataclass
+class DesiredSecuritySettings:
+    secret_scanning: str
+    secret_scanning_push_protection: str
+    vulnerability_alerts: bool
+    dependabot_security_updates: str
+
+
+@dataclass
+class DesiredActionsPermissions:
+    default_workflow_permissions: str
+    can_approve_pull_request_reviews: bool
+    allowed_actions: str
+    patterns_allowed: list[str]
+
+
+@dataclass
+class DesiredRuleset:
+    name: str
+    target: str
+    enforcement: str
+    ref_include: list[str]
+    bypass_actors: list[dict[str, object]]
+    rules: list[dict[str, object]]
+
+
+@dataclass
+class DesiredState:
+    repo_settings: DesiredRepoSettings
+    security: DesiredSecuritySettings
+    actions_permissions: DesiredActionsPermissions
+    rulesets: list[DesiredRuleset]
+
+
+def desired_repo_settings() -> DesiredRepoSettings:
+    return DesiredRepoSettings(
+        default_branch="develop",
+        allow_auto_merge=False,
+        delete_branch_on_merge=True,
+        allow_merge_commit=True,
+        allow_squash_merge=True,
+        allow_rebase_merge=True,
+        has_issues=True,
+        has_projects=True,
+        has_wiki=True,
+    )
+
+
+def _fetch_vulnerability_alerts(repo: str) -> bool:
+    """Check if vulnerability alerts are enabled (204 = enabled, 404 = disabled)."""
+    result = subprocess.run(  # noqa: S603
+        ("gh", "api", f"repos/{repo}/vulnerability-alerts", "-i"),  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return "204" in result.stdout.split("\n")[0]
+
+
+def fetch_actual_state(repo: str) -> DesiredState:
+    """Fetch the current GitHub configuration for a repo via gh api."""
+    repo_data = github.read_json("api", f"repos/{repo}")
+
+    sa_raw = repo_data.get("security_and_analysis", {}) if isinstance(repo_data, dict) else {}
+    sa: dict[str, object] = sa_raw if isinstance(sa_raw, dict) else {}
+
+    repo_settings = DesiredRepoSettings(
+        default_branch=str(repo_data.get("default_branch", ""))
+        if isinstance(repo_data, dict)
+        else "",
+        allow_auto_merge=bool(repo_data.get("allow_auto_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        delete_branch_on_merge=bool(repo_data.get("delete_branch_on_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_merge_commit=bool(repo_data.get("allow_merge_commit", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_squash_merge=bool(repo_data.get("allow_squash_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_rebase_merge=bool(repo_data.get("allow_rebase_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_issues=bool(repo_data.get("has_issues", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_projects=bool(repo_data.get("has_projects", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_wiki=bool(repo_data.get("has_wiki", False)) if isinstance(repo_data, dict) else False,
+    )
+
+    def _sa_status(key: str) -> str:
+        val = sa.get(key, {})
+        if isinstance(val, dict):
+            return str(val.get("status", "disabled"))
+        return "disabled"
+
+    security = DesiredSecuritySettings(
+        secret_scanning=_sa_status("secret_scanning"),
+        secret_scanning_push_protection=_sa_status("secret_scanning_push_protection"),
+        vulnerability_alerts=_fetch_vulnerability_alerts(repo),
+        dependabot_security_updates=_sa_status("dependabot_security_updates"),
+    )
+
+    actions_perm = github.read_json("api", f"repos/{repo}/actions/permissions")
+    actions_workflow = github.read_json("api", f"repos/{repo}/actions/permissions/workflow")
+
+    patterns: list[str] = []
+    allowed_actions_val = (
+        actions_perm.get("allowed_actions", "") if isinstance(actions_perm, dict) else ""
+    )
+    if allowed_actions_val == "selected":
+        selected = github.read_json("api", f"repos/{repo}/actions/permissions/selected-actions")
+        if isinstance(selected, dict):
+            raw_patterns = selected.get("patterns_allowed", [])
+            patterns = list(raw_patterns) if isinstance(raw_patterns, list) else []
+
+    actions_permissions = DesiredActionsPermissions(
+        default_workflow_permissions=str(
+            actions_workflow.get("default_workflow_permissions", "")
+            if isinstance(actions_workflow, dict)
+            else ""
+        ),
+        can_approve_pull_request_reviews=bool(
+            actions_workflow.get("can_approve_pull_request_reviews", False)
+            if isinstance(actions_workflow, dict)
+            else False
+        ),
+        allowed_actions=str(allowed_actions_val),
+        patterns_allowed=sorted(str(p) for p in patterns),
+    )
+
+    raw_rulesets = github.read_json("api", f"repos/{repo}/rulesets")
+    rulesets: list[DesiredRuleset] = []
+    if isinstance(raw_rulesets, list):
+        for rs_summary in raw_rulesets:
+            if not isinstance(rs_summary, dict):
+                continue
+            rs_detail = github.read_json("api", f"repos/{repo}/rulesets/{rs_summary['id']}")
+            if not isinstance(rs_detail, dict):
+                continue
+            conditions = rs_detail.get("conditions", {})
+            ref_name = conditions.get("ref_name", {}) if isinstance(conditions, dict) else {}
+            ref_include_raw = ref_name.get("include", []) if isinstance(ref_name, dict) else []
+            bypass_raw = rs_detail.get("bypass_actors", [])
+            rules_raw = rs_detail.get("rules", [])
+            rulesets.append(
+                DesiredRuleset(
+                    name=str(rs_detail.get("name", "")),
+                    target=str(rs_detail.get("target", "")),
+                    enforcement=str(rs_detail.get("enforcement", "")),
+                    ref_include=list(ref_include_raw) if isinstance(ref_include_raw, list) else [],
+                    bypass_actors=list(bypass_raw) if isinstance(bypass_raw, list) else [],
+                    rules=list(rules_raw) if isinstance(rules_raw, list) else [],
+                )
+            )
+
+    return DesiredState(
+        repo_settings=repo_settings,
+        security=security,
+        actions_permissions=actions_permissions,
+        rulesets=rulesets,
+    )

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -30,6 +30,18 @@ def test_read_output_returns_stripped_stdout() -> None:
     )
 
 
+def test_read_json_parses_dict() -> None:
+    with patch("standard_tooling.lib.github.read_output", return_value='{"key": "value"}'):
+        result = github.read_json("api", "repos/o/r")
+    assert result == {"key": "value"}
+
+
+def test_read_json_parses_list() -> None:
+    with patch("standard_tooling.lib.github.read_output", return_value='[{"id": 1}]'):
+        result = github.read_json("api", "repos/o/r/rulesets")
+    assert result == [{"id": 1}]
+
+
 def test_create_pr_returns_url() -> None:
     with patch("standard_tooling.lib.github.read_output", return_value="https://github.com/pr/1"):
         url = github.create_pr(base="main", title="title", body_file="body.md")

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -1,0 +1,376 @@
+"""Tests for standard_tooling.lib.github_config."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from standard_tooling.lib.github_config import (
+    _fetch_vulnerability_alerts,
+    desired_repo_settings,
+    fetch_actual_state,
+)
+
+
+def test_desired_repo_settings_are_fixed() -> None:
+    s = desired_repo_settings()
+    assert s.default_branch == "develop"
+    assert s.allow_auto_merge is False
+    assert s.delete_branch_on_merge is True
+    assert s.allow_merge_commit is True
+    assert s.allow_squash_merge is True
+    assert s.allow_rebase_merge is True
+    assert s.has_issues is True
+    assert s.has_projects is True
+    assert s.has_wiki is True
+
+
+# ---------------------------------------------------------------------------
+# fetch_actual_state tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_actual_state_repo_settings() -> None:
+    repo_json = {
+        "default_branch": "develop",
+        "allow_auto_merge": False,
+        "delete_branch_on_merge": True,
+        "allow_merge_commit": True,
+        "allow_squash_merge": True,
+        "allow_rebase_merge": True,
+        "has_issues": True,
+        "has_projects": True,
+        "has_wiki": True,
+        "security_and_analysis": {
+            "secret_scanning": {"status": "enabled"},
+            "secret_scanning_push_protection": {"status": "enabled"},
+            "dependabot_security_updates": {"status": "disabled"},
+        },
+    }
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"enabled": True, "allowed_actions": "selected"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        if endpoint == "repos/o/r/actions/permissions/selected-actions":
+            return {"patterns_allowed": ["actions/*", "wphillipmoore/*"]}
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.repo_settings.default_branch == "develop"
+    assert actual.repo_settings.delete_branch_on_merge is True
+    assert actual.security.secret_scanning == "enabled"  # noqa: S105
+    assert actual.security.vulnerability_alerts is False
+    assert actual.actions_permissions.default_workflow_permissions == "read"
+    assert actual.actions_permissions.patterns_allowed == [
+        "actions/*",
+        "wphillipmoore/*",
+    ]
+    assert actual.rulesets == []
+
+
+def test_fetch_actual_state_with_rulesets() -> None:
+    repo_json: dict = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+    ruleset_summary: list = [{"id": 42}]
+    ruleset_detail: dict = {
+        "name": "Branch protection",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["refs/heads/main"]}},
+        "bypass_actors": [],
+        "rules": [{"type": "deletion"}],
+    }
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return ruleset_summary
+        if endpoint == "repos/o/r/rulesets/42":
+            return ruleset_detail
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert len(actual.rulesets) == 1
+    assert actual.rulesets[0].name == "Branch protection"
+    assert actual.rulesets[0].ref_include == ["refs/heads/main"]
+    assert actual.rulesets[0].rules == [{"type": "deletion"}]
+
+
+def test_fetch_actual_state_no_selected_actions_skips_patterns() -> None:
+    """When allowed_actions != 'selected', don't fetch patterns endpoint."""
+    repo_json: dict = {"default_branch": "develop", "security_and_analysis": {}}
+
+    call_log: list[str] = []
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        call_log.append(endpoint)
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "write",
+                "can_approve_pull_request_reviews": True,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert "repos/o/r/actions/permissions/selected-actions" not in call_log
+    assert actual.actions_permissions.patterns_allowed == []
+
+
+def test_fetch_actual_state_sa_non_dict_value() -> None:
+    """When security_and_analysis contains a non-dict value, _sa_status returns 'disabled'."""
+    repo_json: dict = {
+        "default_branch": "develop",
+        "security_and_analysis": {
+            "secret_scanning": "not-a-dict",
+            "secret_scanning_push_protection": None,
+            "dependabot_security_updates": 42,
+        },
+    }
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.security.secret_scanning == "disabled"  # noqa: S105
+    assert actual.security.secret_scanning_push_protection == "disabled"  # noqa: S105
+    assert actual.security.dependabot_security_updates == "disabled"
+
+
+def test_fetch_actual_state_selected_actions_returns_list() -> None:
+    """When selected-actions endpoint returns a list instead of dict, patterns stay empty."""
+    repo_json: dict = {"default_branch": "develop", "security_and_analysis": {}}
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "selected"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        if endpoint == "repos/o/r/actions/permissions/selected-actions":
+            return []  # list, not dict
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.actions_permissions.patterns_allowed == []
+
+
+def test_fetch_actual_state_rulesets_not_a_list() -> None:
+    """When rulesets endpoint returns a dict (unexpected), rulesets stays empty."""
+    repo_json: dict = {"default_branch": "develop", "security_and_analysis": {}}
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return {"error": "unexpected"}  # dict, not list
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.rulesets == []
+
+
+def test_fetch_actual_state_ruleset_summary_not_dict() -> None:
+    """When a ruleset summary entry is not a dict, it's skipped."""
+    repo_json: dict = {"default_branch": "develop", "security_and_analysis": {}}
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return ["not-a-dict", 123]  # non-dict entries
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.rulesets == []
+
+
+def test_fetch_actual_state_ruleset_detail_not_dict() -> None:
+    """When a ruleset detail response is not a dict, it's skipped."""
+    repo_json: dict = {"default_branch": "develop", "security_and_analysis": {}}
+
+    def mock_read_json(*args: str) -> dict | list:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return [{"id": 99}]
+        if endpoint == "repos/o/r/rulesets/99":
+            return []  # list, not dict
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.rulesets == []
+
+
+def test_fetch_vulnerability_alerts_enabled() -> None:
+    cp = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="HTTP/2.0 204 No Content\n", stderr=""
+    )
+    with patch("standard_tooling.lib.github_config.subprocess.run", return_value=cp):
+        assert _fetch_vulnerability_alerts("o/r") is True
+
+
+def test_fetch_vulnerability_alerts_disabled() -> None:
+    cp = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="HTTP/2.0 404 Not Found\n", stderr=""
+    )
+    with patch("standard_tooling.lib.github_config.subprocess.run", return_value=cp):
+        assert _fetch_vulnerability_alerts("o/r") is False


### PR DESCRIPTION
# Pull Request

## Summary

- Adds fetch_actual_state() that fetches repo settings, security settings, Actions permissions, and rulesets via gh api and returns a DesiredState for comparison. Also adds read_json() to github.py and full test coverage.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -