### PR TITLE
feat(github-config): add fetch_actual_state() for GitHub API reads

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -7,11 +7,14 @@ against the actual GitHub API state to produce audit diffs.
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from standard_tooling.lib.config import CiConfig, ProjectConfig, StConfig
+
+from standard_tooling.lib import github
 
 
 @dataclass
@@ -264,5 +267,141 @@ def compute_desired_state(config: StConfig) -> DesiredState:
         repo_settings=desired_repo_settings(),
         security=desired_security_settings(),
         actions_permissions=desired_actions_permissions(),
+        rulesets=rulesets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fetch actual state from GitHub API
+# ---------------------------------------------------------------------------
+
+
+def _fetch_vulnerability_alerts(repo: str) -> bool:
+    """Check if vulnerability alerts are enabled (204 = enabled, 404 = disabled)."""
+    result = subprocess.run(  # noqa: S603
+        ("gh", "api", f"repos/{repo}/vulnerability-alerts", "-i"),  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return "204" in result.stdout.split("\n")[0]
+
+
+def fetch_actual_state(repo: str) -> DesiredState:
+    """Fetch the current GitHub configuration for a repo via gh api."""
+    repo_data = github.read_json("api", f"repos/{repo}")
+
+    sa = repo_data.get("security_and_analysis") if isinstance(repo_data, dict) else None
+    if not isinstance(sa, dict):
+        sa = {}
+
+    repo_settings = DesiredRepoSettings(
+        default_branch=str(repo_data.get("default_branch", ""))
+        if isinstance(repo_data, dict)
+        else "",
+        allow_auto_merge=bool(repo_data.get("allow_auto_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        delete_branch_on_merge=bool(repo_data.get("delete_branch_on_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_merge_commit=bool(repo_data.get("allow_merge_commit", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_squash_merge=bool(repo_data.get("allow_squash_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_rebase_merge=bool(repo_data.get("allow_rebase_merge", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_issues=bool(repo_data.get("has_issues", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_projects=bool(repo_data.get("has_projects", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_wiki=bool(repo_data.get("has_wiki", False)) if isinstance(repo_data, dict) else False,
+    )
+
+    ss = sa.get("secret_scanning")
+    ss_status = ss.get("status", "disabled") if isinstance(ss, dict) else "disabled"
+    sspp = sa.get("secret_scanning_push_protection")
+    sspp_status = sspp.get("status", "disabled") if isinstance(sspp, dict) else "disabled"
+    dsu = sa.get("dependabot_security_updates")
+    dsu_status = dsu.get("status", "disabled") if isinstance(dsu, dict) else "disabled"
+
+    security = DesiredSecuritySettings(
+        secret_scanning=ss_status,
+        secret_scanning_push_protection=sspp_status,
+        vulnerability_alerts=_fetch_vulnerability_alerts(repo),
+        dependabot_security_updates=dsu_status,
+    )
+
+    actions_perm = github.read_json("api", f"repos/{repo}/actions/permissions")
+    actions_workflow = github.read_json("api", f"repos/{repo}/actions/permissions/workflow")
+
+    patterns: list[str] = []
+    allowed_actions = (
+        actions_perm.get("allowed_actions") if isinstance(actions_perm, dict) else None
+    )
+    if allowed_actions == "selected":
+        selected = github.read_json("api", f"repos/{repo}/actions/permissions/selected-actions")
+        if isinstance(selected, dict):
+            raw_patterns = selected.get("patterns_allowed")
+            if isinstance(raw_patterns, list):
+                patterns = [str(p) for p in raw_patterns]
+
+    actions_permissions = DesiredActionsPermissions(
+        default_workflow_permissions=str(actions_workflow.get("default_workflow_permissions", ""))
+        if isinstance(actions_workflow, dict)
+        else "",
+        can_approve_pull_request_reviews=bool(
+            actions_workflow.get("can_approve_pull_request_reviews", False)
+        )
+        if isinstance(actions_workflow, dict)
+        else False,
+        allowed_actions=str(allowed_actions) if allowed_actions else "",
+        patterns_allowed=sorted(patterns),
+    )
+
+    raw_rulesets = github.read_json("api", f"repos/{repo}/rulesets")
+    rulesets: list[DesiredRuleset] = []
+    if isinstance(raw_rulesets, list):
+        for rs_summary in raw_rulesets:
+            if not isinstance(rs_summary, dict):
+                continue
+            rs_id = rs_summary.get("id")
+            if rs_id is None:
+                continue
+            rs_detail = github.read_json("api", f"repos/{repo}/rulesets/{rs_id}")
+            if not isinstance(rs_detail, dict):
+                continue
+            conditions = rs_detail.get("conditions")
+            conditions = conditions if isinstance(conditions, dict) else {}
+            ref_name = conditions.get("ref_name")
+            ref_name = ref_name if isinstance(ref_name, dict) else {}
+            include = ref_name.get("include")
+            include = include if isinstance(include, list) else []
+
+            bypass_raw = rs_detail.get("bypass_actors")
+            bypass = bypass_raw if isinstance(bypass_raw, list) else []
+            rules_raw = rs_detail.get("rules")
+            rules = rules_raw if isinstance(rules_raw, list) else []
+
+            rulesets.append(
+                DesiredRuleset(
+                    name=str(rs_detail.get("name", "")),
+                    target=str(rs_detail.get("target", "")),
+                    enforcement=str(rs_detail.get("enforcement", "")),
+                    ref_include=[str(r) for r in include],
+                    bypass_actors=bypass,
+                    rules=rules,
+                )
+            )
+
+    return DesiredState(
+        repo_settings=repo_settings,
+        security=security,
+        actions_permissions=actions_permissions,
         rulesets=rulesets,
     )

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+from unittest.mock import patch
+
 from standard_tooling.lib.config import (
     CiConfig,
     GithubOverrides,
@@ -10,6 +13,7 @@ from standard_tooling.lib.config import (
     StConfig,
 )
 from standard_tooling.lib.github_config import (
+    _fetch_vulnerability_alerts,
     _lang_has_check,
     compute_desired_state,
     desired_actions_permissions,
@@ -18,6 +22,7 @@ from standard_tooling.lib.github_config import (
     desired_repo_settings,
     desired_security_settings,
     desired_tag_protection_ruleset,
+    fetch_actual_state,
 )
 
 
@@ -265,3 +270,373 @@ def test_compute_desired_state_includes_security() -> None:
 def test_compute_desired_state_includes_actions() -> None:
     state = compute_desired_state(_st_config())
     assert state.actions_permissions.allowed_actions == "selected"
+
+
+# ---------------------------------------------------------------------------
+# fetch_actual_state tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_actual_state_repo_settings() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "allow_auto_merge": False,
+        "delete_branch_on_merge": True,
+        "allow_merge_commit": True,
+        "allow_squash_merge": True,
+        "allow_rebase_merge": True,
+        "has_issues": True,
+        "has_projects": True,
+        "has_wiki": True,
+        "security_and_analysis": {
+            "secret_scanning": {"status": "enabled"},
+            "secret_scanning_push_protection": {"status": "enabled"},
+            "dependabot_security_updates": {"status": "disabled"},
+        },
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"enabled": True, "allowed_actions": "selected"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        if endpoint == "repos/o/r/actions/permissions/selected-actions":
+            return {"patterns_allowed": ["actions/*", "wphillipmoore/*"]}
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.repo_settings.default_branch == "develop"
+    assert actual.repo_settings.delete_branch_on_merge is True
+    assert actual.security.secret_scanning == "enabled"  # noqa: S105
+    assert actual.security.vulnerability_alerts is False
+    assert actual.actions_permissions.default_workflow_permissions == "read"
+    assert actual.actions_permissions.patterns_allowed == [
+        "actions/*",
+        "wphillipmoore/*",
+    ]
+    assert actual.rulesets == []
+
+
+def test_fetch_actual_state_with_rulesets() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+    ruleset_summary: list[object] = [{"id": 42}]
+    ruleset_detail: dict[str, object] = {
+        "name": "Branch protection",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["refs/heads/main"]}},
+        "bypass_actors": [],
+        "rules": [{"type": "deletion"}],
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return ruleset_summary
+        if endpoint == "repos/o/r/rulesets/42":
+            return ruleset_detail
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert len(actual.rulesets) == 1
+    assert actual.rulesets[0].name == "Branch protection"
+    assert actual.rulesets[0].ref_include == ["refs/heads/main"]
+
+
+def test_fetch_actual_state_no_selected_actions_skips_patterns() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+    call_log: list[str] = []
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        call_log.append(endpoint)
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "write",
+                "can_approve_pull_request_reviews": True,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert "repos/o/r/actions/permissions/selected-actions" not in call_log
+    assert actual.actions_permissions.patterns_allowed == []
+
+
+def test_fetch_actual_state_missing_security_and_analysis() -> None:
+    """Cover branch where security_and_analysis is None/missing."""
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        # no security_and_analysis key at all
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.security.secret_scanning == "disabled"  # noqa: S105
+    assert actual.security.secret_scanning_push_protection == "disabled"  # noqa: S105
+    assert actual.security.dependabot_security_updates == "disabled"
+
+
+def test_fetch_actual_state_rulesets_edge_cases() -> None:
+    """Cover branches: non-dict summary, missing id, non-dict detail, non-list rulesets."""
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+    # Include: a non-dict entry, a dict without id, and a valid one
+    ruleset_summary: list[object] = [
+        "not-a-dict",
+        {"name": "no id here"},
+        {"id": 99},
+    ]
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return ruleset_summary
+        if endpoint == "repos/o/r/rulesets/99":
+            # Return a list instead of dict to trigger non-dict detail branch
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    # All invalid rulesets should be skipped
+    assert actual.rulesets == []
+
+
+def test_fetch_actual_state_rulesets_not_a_list() -> None:
+    """Cover branch where raw_rulesets is a dict (not a list)."""
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return {"error": "unexpected format"}
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.rulesets == []
+
+
+def test_fetch_actual_state_selected_actions_non_dict_response() -> None:
+    """Cover branches where selected-actions response is non-dict or patterns is non-list."""
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "selected"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        if endpoint == "repos/o/r/actions/permissions/selected-actions":
+            # Return a list instead of dict to trigger non-dict branch
+            return []
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.actions_permissions.patterns_allowed == []
+
+
+def test_fetch_actual_state_selected_actions_non_list_patterns() -> None:
+    """Cover branch where patterns_allowed is not a list."""
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "selected"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        if endpoint == "repos/o/r/actions/permissions/selected-actions":
+            return {"patterns_allowed": "not-a-list"}
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        actual = fetch_actual_state("o/r")
+
+    assert actual.actions_permissions.patterns_allowed == []
+
+
+def test_fetch_vulnerability_alerts_enabled() -> None:
+    cp = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="HTTP/2.0 204 No Content\n", stderr=""
+    )
+    with patch("standard_tooling.lib.github_config.subprocess.run", return_value=cp):
+        assert _fetch_vulnerability_alerts("o/r") is True
+
+
+def test_fetch_vulnerability_alerts_disabled() -> None:
+    cp = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="HTTP/2.0 404 Not Found\n", stderr=""
+    )
+    with patch("standard_tooling.lib.github_config.subprocess.run", return_value=cp):
+        assert _fetch_vulnerability_alerts("o/r") is False


### PR DESCRIPTION
# Pull Request

## Summary

- Add fetch_actual_state() and _fetch_vulnerability_alerts() to github_config.py for fetching current GitHub repo configuration via gh api

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -