### PR TITLE
feat(github-config): add diff computation engine

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -8,7 +8,7 @@ against the actual GitHub API state to produce audit diffs.
 from __future__ import annotations
 
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -405,3 +405,90 @@ def fetch_actual_state(repo: str) -> DesiredState:
         actions_permissions=actions_permissions,
         rulesets=rulesets,
     )
+
+
+# ---------------------------------------------------------------------------
+# Diff computation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiffItem:
+    field: str
+    expected: object
+    actual: object
+
+
+@dataclass
+class ConfigDiff:
+    items: list[DiffItem] = field(default_factory=list)
+
+    def is_compliant(self) -> bool:
+        return len(self.items) == 0
+
+
+def _diff_dataclass(
+    prefix: str,
+    desired: object,
+    actual: object,
+    items: list[DiffItem],
+) -> None:
+    if not hasattr(desired, "__dataclass_fields__"):
+        if desired != actual:
+            items.append(DiffItem(field=prefix, expected=desired, actual=actual))
+        return
+    for field_name in desired.__dataclass_fields__:
+        d_val = getattr(desired, field_name)
+        a_val = getattr(actual, field_name)
+        _diff_dataclass(f"{prefix}.{field_name}", d_val, a_val, items)
+
+
+def _diff_rulesets(
+    desired: list[DesiredRuleset],
+    actual: list[DesiredRuleset],
+    items: list[DiffItem],
+) -> None:
+    desired_by_name = {r.name: r for r in desired}
+    actual_by_name = {r.name: r for r in actual}
+
+    for name in desired_by_name:
+        if name not in actual_by_name:
+            items.append(
+                DiffItem(
+                    field=f"rulesets.{name}",
+                    expected="present",
+                    actual="missing",
+                )
+            )
+        else:
+            _diff_dataclass(
+                f"rulesets.{name}",
+                desired_by_name[name],
+                actual_by_name[name],
+                items,
+            )
+
+    for name in actual_by_name:
+        if name not in desired_by_name:
+            items.append(
+                DiffItem(
+                    field=f"rulesets.{name}",
+                    expected="absent",
+                    actual="present",
+                )
+            )
+
+
+def compute_diff(*, desired: DesiredState, actual: DesiredState) -> ConfigDiff:
+    """Compare desired vs actual state and return structured diff."""
+    items: list[DiffItem] = []
+    _diff_dataclass("repo_settings", desired.repo_settings, actual.repo_settings, items)
+    _diff_dataclass("security", desired.security, actual.security, items)
+    _diff_dataclass(
+        "actions_permissions",
+        desired.actions_permissions,
+        actual.actions_permissions,
+        items,
+    )
+    _diff_rulesets(desired.rulesets, actual.rulesets, items)
+    return ConfigDiff(items=items)

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -13,9 +13,11 @@ from standard_tooling.lib.config import (
     StConfig,
 )
 from standard_tooling.lib.github_config import (
+    DesiredRuleset,
     _fetch_vulnerability_alerts,
     _lang_has_check,
     compute_desired_state,
+    compute_diff,
     desired_actions_permissions,
     desired_branch_protection_ruleset,
     desired_ci_gates_ruleset,
@@ -640,3 +642,69 @@ def test_fetch_vulnerability_alerts_disabled() -> None:
     )
     with patch("standard_tooling.lib.github_config.subprocess.run", return_value=cp):
         assert _fetch_vulnerability_alerts("o/r") is False
+
+
+# ---------------------------------------------------------------------------
+# Diff computation tests
+# ---------------------------------------------------------------------------
+
+
+def test_diff_identical_states_is_empty() -> None:
+    state = compute_desired_state(_st_config())
+    diff = compute_diff(desired=state, actual=state)
+    assert diff.is_compliant()
+    assert diff.items == []
+
+
+def test_diff_detects_repo_setting_mismatch() -> None:
+    desired = compute_desired_state(_st_config())
+    actual = compute_desired_state(_st_config())
+    actual.repo_settings.allow_auto_merge = True
+    diff = compute_diff(desired=desired, actual=actual)
+    assert not diff.is_compliant()
+    assert any(d.field == "repo_settings.allow_auto_merge" for d in diff.items)
+
+
+def test_diff_detects_missing_ruleset() -> None:
+    desired = compute_desired_state(_st_config())
+    actual = compute_desired_state(_st_config())
+    actual.rulesets = []
+    diff = compute_diff(desired=desired, actual=actual)
+    assert not diff.is_compliant()
+    assert any(d.field.startswith("rulesets.") for d in diff.items)
+
+
+def test_diff_detects_extra_ruleset() -> None:
+    desired = compute_desired_state(_st_config())
+    actual = compute_desired_state(_st_config())
+    actual.rulesets.append(
+        DesiredRuleset(
+            name="Extra",
+            target="branch",
+            enforcement="active",
+            ref_include=[],
+            bypass_actors=[],
+            rules=[],
+        )
+    )
+    diff = compute_diff(desired=desired, actual=actual)
+    assert not diff.is_compliant()
+    assert any(d.field == "rulesets.Extra" and d.expected == "absent" for d in diff.items)
+
+
+def test_diff_detects_actions_permission_mismatch() -> None:
+    desired = compute_desired_state(_st_config())
+    actual = compute_desired_state(_st_config())
+    actual.actions_permissions.default_workflow_permissions = "write"
+    diff = compute_diff(desired=desired, actual=actual)
+    assert not diff.is_compliant()
+    assert any(d.field == "actions_permissions.default_workflow_permissions" for d in diff.items)
+
+
+def test_diff_detects_security_mismatch() -> None:
+    desired = compute_desired_state(_st_config())
+    actual = compute_desired_state(_st_config())
+    actual.security.vulnerability_alerts = True
+    diff = compute_diff(desired=desired, actual=actual)
+    assert not diff.is_compliant()
+    assert any(d.field == "security.vulnerability_alerts" for d in diff.items)


### PR DESCRIPTION
# Pull Request

## Summary

- Add DiffItem, ConfigDiff, and compute_diff() for comparing desired vs actual DesiredState objects field-by-field, with ruleset-level comparison by name

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -