### PR TITLE
feat(github-config): add st-github-config CLI with audit and diff modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ st-validate-local-go = "standard_tooling.bin.validate_local_lang:main"
 st-validate-local-java = "standard_tooling.bin.validate_local_lang:main"
 st-validate-local-common = "standard_tooling.bin.validate_local_common_container:main"
 st-pr-issue-linkage = "standard_tooling.bin.pr_issue_linkage:main"
+st-github-config = "standard_tooling.bin.github_config:main"
 
 [dependency-groups]
 dev = ["ruff", "mypy", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]

--- a/src/standard_tooling/bin/github_config.py
+++ b/src/standard_tooling/bin/github_config.py
@@ -1,0 +1,110 @@
+"""Audit, diff, and apply GitHub configuration for managed repos."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import tomllib
+
+from standard_tooling.lib import github
+from standard_tooling.lib.config import StConfig, _parse_raw_config
+from standard_tooling.lib.github_config import (
+    ConfigDiff,
+    compute_desired_state,
+    compute_diff,
+    fetch_actual_state,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Enforce canonical GitHub configuration.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    for name in ("audit", "diff", "apply"):
+        sp = sub.add_parser(name)
+        sp.add_argument("--repo", help="Single repo (OWNER/REPO)")
+        sp.add_argument("--owner", help="GitHub owner (project mode)")
+        sp.add_argument("--project", help="GitHub Project number")
+        if name == "apply":
+            sp.add_argument(
+                "--yes",
+                action="store_true",
+                help="Skip confirmation prompt",
+            )
+
+    args = parser.parse_args(argv)
+
+    if not args.repo and not (getattr(args, "owner", None) and getattr(args, "project", None)):
+        parser.error("--repo or --owner/--project required")
+
+    return args
+
+
+def _resolve_repos(args: argparse.Namespace) -> list[str]:
+    """Return list of repos to operate on."""
+    if args.repo:
+        return [args.repo]
+    return github.list_project_repos(args.owner, args.project)
+
+
+def _fetch_remote_config(repo: str) -> StConfig:
+    """Fetch and parse standard-tooling.toml from a remote repo."""
+    content_data = github.read_json(
+        "api",
+        f"repos/{repo}/contents/standard-tooling.toml",
+    )
+    if not isinstance(content_data, dict):
+        msg = f"Unexpected response fetching config from {repo}"
+        raise RuntimeError(msg)
+    content = content_data.get("content")
+    if not isinstance(content, str):
+        msg = f"No content field in config response from {repo}"
+        raise RuntimeError(msg)
+    raw_bytes = base64.b64decode(content)
+    raw = tomllib.loads(raw_bytes.decode())
+    return _parse_raw_config(raw)
+
+
+def _audit_repo(repo: str, config: StConfig) -> ConfigDiff:
+    """Compute diff between desired and actual state for a repo."""
+    desired = compute_desired_state(config)
+    actual = fetch_actual_state(repo)
+    return compute_diff(desired=desired, actual=actual)
+
+
+def _print_diff(repo: str, diff: ConfigDiff) -> None:
+    """Print diff results for a repo."""
+    if diff.is_compliant():
+        print(f"  {repo}: compliant")
+        return
+    print(f"  {repo}: NON-COMPLIANT ({len(diff.items)} issues)")
+    for item in diff.items:
+        print(f"    {item.field}: expected={item.expected!r}, actual={item.actual!r}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repos = _resolve_repos(args)
+    all_compliant = True
+
+    for repo in repos:
+        config = _fetch_remote_config(repo)
+        diff = _audit_repo(repo, config)
+        _print_diff(repo, diff)
+        if not diff.is_compliant():
+            all_compliant = False
+
+    if args.command == "audit":
+        return 0 if all_compliant else 1
+    if args.command == "diff":
+        return 0
+
+    # apply mode — not yet implemented
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -6,7 +6,7 @@ import os
 import re
 import tomllib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -71,20 +71,8 @@ class StConfig:
     github: GithubOverrides
 
 
-def read_config(repo_root: Path) -> StConfig:
-    """Parse, validate, and return ``standard-tooling.toml``."""
-    config_path = repo_root / CONFIG_FILE
-    if not config_path.is_file():
-        msg = f"{CONFIG_FILE} not found at {repo_root}"
-        raise FileNotFoundError(msg)
-
-    try:
-        with config_path.open("rb") as f:
-            raw = tomllib.load(f)
-    except tomllib.TOMLDecodeError as exc:
-        msg = f"{CONFIG_FILE} is not valid TOML: {exc}"
-        raise ConfigError(msg) from exc
-
+def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
+    """Parse and validate a raw TOML dict into StConfig."""
     project_raw = raw.get("project", {})
 
     for field in _PROJECT_FIELDS:
@@ -157,6 +145,23 @@ def read_config(repo_root: Path) -> StConfig:
         ci=ci,
         github=github_overrides,
     )
+
+
+def read_config(repo_root: Path) -> StConfig:
+    """Parse, validate, and return ``standard-tooling.toml``."""
+    config_path = repo_root / CONFIG_FILE
+    if not config_path.is_file():
+        msg = f"{CONFIG_FILE} not found at {repo_root}"
+        raise FileNotFoundError(msg)
+
+    try:
+        with config_path.open("rb") as f:
+            raw = tomllib.load(f)
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"{CONFIG_FILE} is not valid TOML: {exc}"
+        raise ConfigError(msg) from exc
+
+    return _parse_raw_config(raw)
 
 
 def st_install_tag(repo_root: Path) -> str:

--- a/tests/standard_tooling/test_github_config_cli.py
+++ b/tests/standard_tooling/test_github_config_cli.py
@@ -1,0 +1,248 @@
+"""Tests for standard_tooling.bin.github_config."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from unittest.mock import patch
+
+import pytest
+
+from standard_tooling.bin.github_config import (
+    _audit_repo,
+    _fetch_remote_config,
+    _resolve_repos,
+    main,
+    parse_args,
+)
+from standard_tooling.lib.config import (
+    GithubOverrides,
+    MarkdownlintConfig,
+    ProjectConfig,
+    StConfig,
+)
+from standard_tooling.lib.github_config import ConfigDiff, DiffItem
+
+# -- Argument parsing ---------------------------------------------------------
+
+
+def test_parse_audit_single_repo() -> None:
+    args = parse_args(["audit", "--repo", "o/r"])
+    assert args.command == "audit"
+    assert args.repo == "o/r"
+
+
+def test_parse_diff_single_repo() -> None:
+    args = parse_args(["diff", "--repo", "o/r"])
+    assert args.command == "diff"
+
+
+def test_parse_apply_single_repo() -> None:
+    args = parse_args(["apply", "--repo", "o/r"])
+    assert args.command == "apply"
+    assert args.yes is False
+
+
+def test_parse_apply_with_yes() -> None:
+    args = parse_args(["apply", "--repo", "o/r", "--yes"])
+    assert args.yes is True
+
+
+def test_parse_project_mode() -> None:
+    args = parse_args(["audit", "--owner", "acme", "--project", "3"])
+    assert args.owner == "acme"
+    assert args.project == "3"
+
+
+def test_parse_no_target_fails() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["audit"])
+
+
+def test_parse_no_command_fails() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--repo", "o/r"])
+
+
+# -- Audit mode ---------------------------------------------------------------
+
+
+def _mock_compliant() -> ConfigDiff:
+    return ConfigDiff(items=[])
+
+
+def _mock_noncompliant() -> ConfigDiff:
+    return ConfigDiff(
+        items=[
+            DiffItem(
+                field="repo_settings.allow_auto_merge",
+                expected=False,
+                actual=True,
+            ),
+        ]
+    )
+
+
+def test_audit_compliant_returns_zero() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_compliant(),
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+    ):
+        assert main(["audit", "--repo", "o/r"]) == 0
+
+
+def test_audit_noncompliant_returns_one() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_noncompliant(),
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+    ):
+        assert main(["audit", "--repo", "o/r"]) == 1
+
+
+def test_diff_always_returns_zero() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_noncompliant(),
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+    ):
+        assert main(["diff", "--repo", "o/r"]) == 0
+
+
+def test_apply_returns_zero() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_compliant(),
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+    ):
+        assert main(["apply", "--repo", "o/r"]) == 0
+
+
+# -- _resolve_repos -----------------------------------------------------------
+
+
+def test_resolve_repos_single_repo() -> None:
+    args = argparse.Namespace(repo="o/r", owner=None, project=None)
+    assert _resolve_repos(args) == ["o/r"]
+
+
+def test_resolve_repos_project_mode() -> None:
+    args = argparse.Namespace(repo=None, owner="acme", project="3")
+    with patch(
+        "standard_tooling.bin.github_config.github.list_project_repos",
+        return_value=["acme/a", "acme/b"],
+    ):
+        assert _resolve_repos(args) == ["acme/a", "acme/b"]
+
+
+# -- _fetch_remote_config -----------------------------------------------------
+
+_VALID_TOML = b"""\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+"""
+
+
+def test_fetch_remote_config_success() -> None:
+    encoded = base64.b64encode(_VALID_TOML).decode()
+    with patch(
+        "standard_tooling.bin.github_config.github.read_json",
+        return_value={"content": encoded},
+    ):
+        cfg = _fetch_remote_config("o/r")
+    assert cfg.project.primary_language == "python"
+
+
+def test_fetch_remote_config_non_dict_response() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config.github.read_json",
+            return_value=[],
+        ),
+        pytest.raises(RuntimeError, match="Unexpected response"),
+    ):
+        _fetch_remote_config("o/r")
+
+
+def test_fetch_remote_config_no_content_field() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config.github.read_json",
+            return_value={"encoding": "base64"},
+        ),
+        pytest.raises(RuntimeError, match="No content field"),
+    ):
+        _fetch_remote_config("o/r")
+
+
+# -- _audit_repo ---------------------------------------------------------------
+
+
+def _make_config() -> StConfig:
+    return StConfig(
+        project=ProjectConfig(
+            repository_type="library",
+            versioning_scheme="semver",
+            branching_model="library-release",
+            release_model="tagged-release",
+            primary_language="python",
+            co_authors={},
+        ),
+        dependencies={"standard-tooling": "v1.4"},
+        markdownlint=MarkdownlintConfig(ignore=[]),
+        ci=None,
+        github=GithubOverrides(skip_rulesets=True),
+    )
+
+
+def test_audit_repo_calls_compute_and_diff() -> None:
+    cfg = _make_config()
+    with (
+        patch(
+            "standard_tooling.bin.github_config.fetch_actual_state",
+        ) as mock_fetch,
+        patch(
+            "standard_tooling.bin.github_config.compute_desired_state",
+        ) as mock_desired,
+        patch(
+            "standard_tooling.bin.github_config.compute_diff",
+            return_value=ConfigDiff(items=[]),
+        ) as mock_diff,
+    ):
+        result = _audit_repo("o/r", cfg)
+    mock_desired.assert_called_once_with(cfg)
+    mock_fetch.assert_called_once_with("o/r")
+    mock_diff.assert_called_once()
+    assert result.is_compliant()


### PR DESCRIPTION
# Pull Request

## Summary

- Adds st-github-config CLI entry point with audit/diff/apply subcommands, extracts _parse_raw_config() for remote config parsing

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -