### PR TITLE
feat(github-config): implement apply mode for st-github-config CLI

### DIFF
--- a/src/standard_tooling/bin/github_config.py
+++ b/src/standard_tooling/bin/github_config.py
@@ -109,9 +109,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "diff":
         return 0
 
-    non_compliant = [
-        r for r in repos if not _audit_repo(r, _fetch_remote_config(r)).is_compliant()
-    ]
+    non_compliant = [r for r in repos if not _audit_repo(r, _fetch_remote_config(r)).is_compliant()]
     if not non_compliant:
         print("All repos compliant, nothing to apply.")
         return 0

--- a/src/standard_tooling/bin/github_config.py
+++ b/src/standard_tooling/bin/github_config.py
@@ -11,6 +11,7 @@ from standard_tooling.lib import github
 from standard_tooling.lib.config import StConfig, _parse_raw_config
 from standard_tooling.lib.github_config import (
     ConfigDiff,
+    apply_desired_state,
     compute_desired_state,
     compute_diff,
     fetch_actual_state,
@@ -85,6 +86,12 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
         print(f"    {item.field}: expected={item.expected!r}, actual={item.actual!r}")
 
 
+def _apply_repo(repo: str, config: StConfig) -> None:
+    """Apply desired state to a repo."""
+    desired = compute_desired_state(config)
+    apply_desired_state(repo, desired)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repos = _resolve_repos(args)
@@ -102,7 +109,28 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "diff":
         return 0
 
-    # apply mode — not yet implemented
+    non_compliant = [
+        r for r in repos if not _audit_repo(r, _fetch_remote_config(r)).is_compliant()
+    ]
+    if not non_compliant:
+        print("All repos compliant, nothing to apply.")
+        return 0
+
+    if not args.yes:
+        print(f"\nAbout to apply changes to {len(non_compliant)} repo(s):")
+        for repo in non_compliant:
+            print(f"  - {repo}")
+        answer = input("\nProceed? [y/N] ")
+        if answer.lower() != "y":
+            print("Aborted.")
+            return 1
+
+    for repo in non_compliant:
+        config = _fetch_remote_config(repo)
+        print(f"  Applying to {repo}...")
+        _apply_repo(repo, config)
+        print(f"  {repo}: applied")
+
     return 0
 
 

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -34,6 +34,27 @@ def read_json(*args: str) -> dict[str, object] | list[object]:
     return result
 
 
+def write_json(method: str, endpoint: str, body: dict[str, object]) -> None:
+    """Call gh api with a JSON body via stdin."""
+    subprocess.run(  # noqa: S603
+        ("gh", "api", endpoint, "-X", method, "--input", "-"),  # noqa: S607
+        input=json.dumps(body),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def delete(endpoint: str) -> None:
+    """Call gh api with DELETE method."""
+    subprocess.run(  # noqa: S603
+        ("gh", "api", endpoint, "-X", "DELETE"),  # noqa: S607
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
 def create_pr(*, base: str, title: str, body_file: str) -> str:
     """Create a pull request and return its URL."""
     return read_output("pr", "create", "--base", base, "--title", title, "--body-file", body_file)

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -492,3 +492,123 @@ def compute_diff(*, desired: DesiredState, actual: DesiredState) -> ConfigDiff:
     )
     _diff_rulesets(desired.rulesets, actual.rulesets, items)
     return ConfigDiff(items=items)
+
+
+# ---------------------------------------------------------------------------
+# Apply desired state via GitHub API
+# ---------------------------------------------------------------------------
+
+
+def _apply_repo_settings(repo: str, settings: DesiredRepoSettings) -> None:
+    github.write_json(
+        "PATCH",
+        f"repos/{repo}",
+        {
+            "default_branch": settings.default_branch,
+            "allow_auto_merge": settings.allow_auto_merge,
+            "delete_branch_on_merge": settings.delete_branch_on_merge,
+            "allow_merge_commit": settings.allow_merge_commit,
+            "allow_squash_merge": settings.allow_squash_merge,
+            "allow_rebase_merge": settings.allow_rebase_merge,
+            "has_issues": settings.has_issues,
+            "has_projects": settings.has_projects,
+            "has_wiki": settings.has_wiki,
+        },
+    )
+
+
+def _apply_security_settings(repo: str, security: DesiredSecuritySettings) -> None:
+    github.write_json(
+        "PATCH",
+        f"repos/{repo}",
+        {
+            "security_and_analysis": {
+                "secret_scanning": {"status": security.secret_scanning},
+                "secret_scanning_push_protection": {
+                    "status": security.secret_scanning_push_protection,
+                },
+                "dependabot_security_updates": {
+                    "status": security.dependabot_security_updates,
+                },
+            },
+        },
+    )
+    if security.vulnerability_alerts:
+        github.write_json("PUT", f"repos/{repo}/vulnerability-alerts", {})
+    else:
+        github.delete(f"repos/{repo}/vulnerability-alerts")
+
+
+def _apply_actions_permissions(repo: str, perms: DesiredActionsPermissions) -> None:
+    github.write_json(
+        "PUT",
+        f"repos/{repo}/actions/permissions",
+        {"allowed_actions": perms.allowed_actions},
+    )
+    github.write_json(
+        "PUT",
+        f"repos/{repo}/actions/permissions/workflow",
+        {
+            "default_workflow_permissions": perms.default_workflow_permissions,
+            "can_approve_pull_request_reviews": perms.can_approve_pull_request_reviews,
+        },
+    )
+    if perms.allowed_actions == "selected":
+        github.write_json(
+            "PUT",
+            f"repos/{repo}/actions/permissions/selected-actions",
+            {"patterns_allowed": perms.patterns_allowed},
+        )
+
+
+def _ruleset_body(ruleset: DesiredRuleset) -> dict[str, object]:
+    return {
+        "name": ruleset.name,
+        "target": ruleset.target,
+        "enforcement": ruleset.enforcement,
+        "conditions": {
+            "ref_name": {
+                "include": ruleset.ref_include,
+                "exclude": [],
+            },
+        },
+        "bypass_actors": ruleset.bypass_actors,
+        "rules": ruleset.rules,
+    }
+
+
+def _apply_rulesets(repo: str, desired: list[DesiredRuleset]) -> None:
+    raw_rulesets = github.read_json("api", f"repos/{repo}/rulesets")
+    existing: dict[str, int] = {}
+    if isinstance(raw_rulesets, list):
+        for rs in raw_rulesets:
+            if isinstance(rs, dict):
+                name = rs.get("name")
+                rs_id = rs.get("id")
+                if isinstance(name, str) and isinstance(rs_id, int):
+                    existing[name] = rs_id
+
+    desired_names = {r.name for r in desired}
+
+    for ruleset in desired:
+        body = _ruleset_body(ruleset)
+        if ruleset.name in existing:
+            github.write_json(
+                "PUT",
+                f"repos/{repo}/rulesets/{existing[ruleset.name]}",
+                body,
+            )
+        else:
+            github.write_json("POST", f"repos/{repo}/rulesets", body)
+
+    for name, rs_id in existing.items():
+        if name not in desired_names:
+            github.delete(f"repos/{repo}/rulesets/{rs_id}")
+
+
+def apply_desired_state(repo: str, desired: DesiredState) -> None:
+    """Apply the desired configuration to a GitHub repo via the API."""
+    _apply_repo_settings(repo, desired.repo_settings)
+    _apply_security_settings(repo, desired.security)
+    _apply_actions_permissions(repo, desired.actions_permissions)
+    _apply_rulesets(repo, desired.rulesets)

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -179,9 +179,7 @@ def test_write_json_put_method() -> None:
         mock_run.return_value = _completed()
         github.write_json("PUT", "repos/o/r/actions/permissions", {"allowed_actions": "all"})
     call_args = mock_run.call_args
-    expected_cmd = (
-        "gh", "api", "repos/o/r/actions/permissions", "-X", "PUT", "--input", "-"
-    )
+    expected_cmd = ("gh", "api", "repos/o/r/actions/permissions", "-X", "PUT", "--input", "-")
     assert call_args[0][0] == expected_cmd
     assert json.loads(call_args[1]["input"]) == {"allowed_actions": "all"}
 

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -159,3 +159,40 @@ def test_checks_registered_returns_true_when_checks_exist() -> None:
     cp = _completed(stdout="ci/tests\tpass\nhttps://example.com\n")
     with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
         assert github._checks_registered("https://github.com/pr/1") is True
+
+
+def test_write_json_sends_body_via_stdin() -> None:
+    with patch("standard_tooling.lib.github.subprocess.run") as mock_run:
+        mock_run.return_value = _completed()
+        github.write_json("PATCH", "repos/o/r", {"key": "value"})
+    mock_run.assert_called_once_with(
+        ("gh", "api", "repos/o/r", "-X", "PATCH", "--input", "-"),
+        input='{"key": "value"}',
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_write_json_put_method() -> None:
+    with patch("standard_tooling.lib.github.subprocess.run") as mock_run:
+        mock_run.return_value = _completed()
+        github.write_json("PUT", "repos/o/r/actions/permissions", {"allowed_actions": "all"})
+    call_args = mock_run.call_args
+    expected_cmd = (
+        "gh", "api", "repos/o/r/actions/permissions", "-X", "PUT", "--input", "-"
+    )
+    assert call_args[0][0] == expected_cmd
+    assert json.loads(call_args[1]["input"]) == {"allowed_actions": "all"}
+
+
+def test_delete_calls_gh_api() -> None:
+    with patch("standard_tooling.lib.github.subprocess.run") as mock_run:
+        mock_run.return_value = _completed()
+        github.delete("repos/o/r/vulnerability-alerts")
+    mock_run.assert_called_once_with(
+        ("gh", "api", "repos/o/r/vulnerability-alerts", "-X", "DELETE"),
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/tests/standard_tooling/test_github_config_cli.py
+++ b/tests/standard_tooling/test_github_config_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from standard_tooling.bin.github_config import (
+    _apply_repo,
     _audit_repo,
     _fetch_remote_config,
     _resolve_repos,
@@ -246,3 +247,112 @@ def test_audit_repo_calls_compute_and_diff() -> None:
     mock_fetch.assert_called_once_with("o/r")
     mock_diff.assert_called_once()
     assert result.is_compliant()
+
+
+# -- _apply_repo ---------------------------------------------------------------
+
+
+def test_apply_repo_calls_apply_desired_state() -> None:
+    cfg = _make_config()
+    with (
+        patch("standard_tooling.bin.github_config.compute_desired_state") as mock_desired,
+        patch("standard_tooling.bin.github_config.apply_desired_state") as mock_apply,
+    ):
+        _apply_repo("o/r", cfg)
+    mock_desired.assert_called_once_with(cfg)
+    mock_apply.assert_called_once_with("o/r", mock_desired.return_value)
+
+
+# -- apply mode integration ----------------------------------------------------
+
+
+def test_apply_all_compliant_does_nothing() -> None:
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_compliant(),
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+        patch("standard_tooling.bin.github_config._apply_repo") as mock_apply,
+    ):
+        result = main(["apply", "--repo", "o/r", "--yes"])
+    assert result == 0
+    mock_apply.assert_not_called()
+
+
+def test_apply_with_yes_applies_noncompliant() -> None:
+    call_count = [0]
+
+    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
+        call_count[0] += 1
+        return _mock_noncompliant()
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            side_effect=audit_side_effect,
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+        patch("standard_tooling.bin.github_config._apply_repo") as mock_apply,
+    ):
+        result = main(["apply", "--repo", "o/r", "--yes"])
+    assert result == 0
+    mock_apply.assert_called_once()
+
+
+def test_apply_without_yes_prompts_and_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    call_count = [0]
+
+    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
+        call_count[0] += 1
+        return _mock_noncompliant()
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            side_effect=audit_side_effect,
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+        patch("standard_tooling.bin.github_config._apply_repo") as mock_apply,
+    ):
+        result = main(["apply", "--repo", "o/r"])
+    assert result == 1
+    mock_apply.assert_not_called()
+
+
+def test_apply_without_yes_prompts_and_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    call_count = [0]
+
+    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
+        call_count[0] += 1
+        return _mock_noncompliant()
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            side_effect=audit_side_effect,
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+        patch("standard_tooling.bin.github_config._apply_repo") as mock_apply,
+    ):
+        result = main(["apply", "--repo", "o/r"])
+    assert result == 0
+    mock_apply.assert_called_once()

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -906,9 +906,7 @@ def test_apply_desired_state_orchestrates_all() -> None:
     with (
         patch("standard_tooling.lib.github_config._apply_repo_settings") as mock_repo,
         patch("standard_tooling.lib.github_config._apply_security_settings") as mock_sec,
-        patch(
-            "standard_tooling.lib.github_config._apply_actions_permissions"
-        ) as mock_actions,
+        patch("standard_tooling.lib.github_config._apply_actions_permissions") as mock_actions,
         patch("standard_tooling.lib.github_config._apply_rulesets") as mock_rulesets,
     ):
         apply_desired_state("o/r", state)

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -14,8 +14,14 @@ from standard_tooling.lib.config import (
 )
 from standard_tooling.lib.github_config import (
     DesiredRuleset,
+    _apply_actions_permissions,
+    _apply_repo_settings,
+    _apply_rulesets,
+    _apply_security_settings,
     _fetch_vulnerability_alerts,
     _lang_has_check,
+    _ruleset_body,
+    apply_desired_state,
     compute_desired_state,
     compute_diff,
     desired_actions_permissions,
@@ -708,3 +714,205 @@ def test_diff_detects_security_mismatch() -> None:
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
     assert any(d.field == "security.vulnerability_alerts" for d in diff.items)
+
+
+# ---------------------------------------------------------------------------
+# Apply tests
+# ---------------------------------------------------------------------------
+
+
+def test_apply_repo_settings_calls_write_json() -> None:
+    settings = desired_repo_settings()
+    with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_repo_settings("o/r", settings)
+    mock_write.assert_called_once()
+    call_args = mock_write.call_args
+    assert call_args[0][0] == "PATCH"
+    assert call_args[0][1] == "repos/o/r"
+    body = call_args[0][2]
+    assert body["default_branch"] == "develop"
+    assert body["delete_branch_on_merge"] is True
+
+
+def test_apply_security_settings_enables_vuln_alerts() -> None:
+    from standard_tooling.lib.github_config import DesiredSecuritySettings
+
+    sec = DesiredSecuritySettings(
+        secret_scanning="enabled",  # noqa: S106
+        secret_scanning_push_protection="enabled",  # noqa: S106
+        vulnerability_alerts=True,
+        dependabot_security_updates="disabled",
+    )
+    with (
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete") as mock_del,
+    ):
+        _apply_security_settings("o/r", sec)
+    assert mock_write.call_count == 2
+    # First call is PATCH repos/o/r with security_and_analysis
+    assert mock_write.call_args_list[0][0][0] == "PATCH"
+    # Second call is PUT vulnerability-alerts
+    assert mock_write.call_args_list[1][0][0] == "PUT"
+    assert "vulnerability-alerts" in mock_write.call_args_list[1][0][1]
+    mock_del.assert_not_called()
+
+
+def test_apply_security_settings_disables_vuln_alerts() -> None:
+    from standard_tooling.lib.github_config import DesiredSecuritySettings
+
+    sec = DesiredSecuritySettings(
+        secret_scanning="enabled",  # noqa: S106
+        secret_scanning_push_protection="enabled",  # noqa: S106
+        vulnerability_alerts=False,
+        dependabot_security_updates="disabled",
+    )
+    with (
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete") as mock_del,
+    ):
+        _apply_security_settings("o/r", sec)
+    assert mock_write.call_count == 1
+    mock_del.assert_called_once_with("repos/o/r/vulnerability-alerts")
+
+
+def test_apply_actions_permissions_selected() -> None:
+    perms = desired_actions_permissions()
+    with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_actions_permissions("o/r", perms)
+    assert mock_write.call_count == 3
+    endpoints = [c[0][1] for c in mock_write.call_args_list]
+    assert "repos/o/r/actions/permissions" in endpoints
+    assert "repos/o/r/actions/permissions/workflow" in endpoints
+    assert "repos/o/r/actions/permissions/selected-actions" in endpoints
+
+
+def test_apply_actions_permissions_not_selected_skips_patterns() -> None:
+    from standard_tooling.lib.github_config import DesiredActionsPermissions
+
+    perms = DesiredActionsPermissions(
+        default_workflow_permissions="read",
+        can_approve_pull_request_reviews=False,
+        allowed_actions="all",
+        patterns_allowed=[],
+    )
+    with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_actions_permissions("o/r", perms)
+    assert mock_write.call_count == 2
+    endpoints = [c[0][1] for c in mock_write.call_args_list]
+    assert "repos/o/r/actions/permissions/selected-actions" not in endpoints
+
+
+def test_apply_rulesets_creates_new() -> None:
+    ruleset = desired_branch_protection_ruleset()
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            return_value=[],
+        ),
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete") as mock_del,
+    ):
+        _apply_rulesets("o/r", [ruleset])
+    mock_write.assert_called_once()
+    assert mock_write.call_args[0][0] == "POST"
+    assert mock_write.call_args[0][1] == "repos/o/r/rulesets"
+    mock_del.assert_not_called()
+
+
+def test_apply_rulesets_updates_existing() -> None:
+    ruleset = desired_branch_protection_ruleset()
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            return_value=[{"name": "Branch protection", "id": 42}],
+        ),
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete") as mock_del,
+    ):
+        _apply_rulesets("o/r", [ruleset])
+    mock_write.assert_called_once()
+    assert mock_write.call_args[0][0] == "PUT"
+    assert mock_write.call_args[0][1] == "repos/o/r/rulesets/42"
+    mock_del.assert_not_called()
+
+
+def test_apply_rulesets_deletes_extra() -> None:
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            return_value=[{"name": "Old rule", "id": 99}],
+        ),
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete") as mock_del,
+    ):
+        _apply_rulesets("o/r", [])
+    mock_write.assert_not_called()
+    mock_del.assert_called_once_with("repos/o/r/rulesets/99")
+
+
+def test_apply_rulesets_skips_invalid_entries() -> None:
+    ruleset = desired_branch_protection_ruleset()
+    # Mix of invalid entries: non-dict, missing name, missing id
+    existing: list[object] = [
+        "not-a-dict",
+        {"name": 123, "id": 1},  # name not str
+        {"name": "Valid", "id": "not-int"},  # id not int
+        {"name": "Branch protection", "id": 7},
+    ]
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            return_value=existing,
+        ),
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete"),
+    ):
+        _apply_rulesets("o/r", [ruleset])
+    assert mock_write.call_args[0][0] == "PUT"
+    assert mock_write.call_args[0][1] == "repos/o/r/rulesets/7"
+
+
+def test_apply_rulesets_non_list_response_creates_all() -> None:
+    ruleset = desired_branch_protection_ruleset()
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            return_value={"error": "unexpected"},
+        ),
+        patch("standard_tooling.lib.github_config.github.write_json") as mock_write,
+        patch("standard_tooling.lib.github_config.github.delete") as mock_del,
+    ):
+        _apply_rulesets("o/r", [ruleset])
+    mock_write.assert_called_once()
+    assert mock_write.call_args[0][0] == "POST"
+    mock_del.assert_not_called()
+
+
+def test_ruleset_body_structure() -> None:
+    ruleset = desired_tag_protection_ruleset()
+    body = _ruleset_body(ruleset)
+    assert body["name"] == "Tag protection"
+    assert body["target"] == "tag"
+    assert body["enforcement"] == "active"
+    assert body["conditions"] == {
+        "ref_name": {"include": ["refs/tags/v*.*.*"], "exclude": []},
+    }
+    assert body["bypass_actors"] == ruleset.bypass_actors
+    assert body["rules"] == ruleset.rules
+
+
+def test_apply_desired_state_orchestrates_all() -> None:
+    state = compute_desired_state(_st_config())
+    with (
+        patch("standard_tooling.lib.github_config._apply_repo_settings") as mock_repo,
+        patch("standard_tooling.lib.github_config._apply_security_settings") as mock_sec,
+        patch(
+            "standard_tooling.lib.github_config._apply_actions_permissions"
+        ) as mock_actions,
+        patch("standard_tooling.lib.github_config._apply_rulesets") as mock_rulesets,
+    ):
+        apply_desired_state("o/r", state)
+    mock_repo.assert_called_once_with("o/r", state.repo_settings)
+    mock_sec.assert_called_once_with("o/r", state.security)
+    mock_actions.assert_called_once_with("o/r", state.actions_permissions)
+    mock_rulesets.assert_called_once_with("o/r", state.rulesets)


### PR DESCRIPTION
# Pull Request

## Summary

- Adds apply subcommand to st-github-config: repo settings, security, actions permissions, and ruleset CRUD via GitHub API

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- 662 tests, 100% branch coverage, confirmation prompt with --yes override