### PR TITLE
feat(github-config): add classic branch protection cleanup during apply

### DIFF
--- a/src/standard_tooling/bin/github_config.py
+++ b/src/standard_tooling/bin/github_config.py
@@ -86,10 +86,10 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
         print(f"    {item.field}: expected={item.expected!r}, actual={item.actual!r}")
 
 
-def _apply_repo(repo: str, config: StConfig) -> None:
-    """Apply desired state to a repo."""
+def _apply_repo(repo: str, config: StConfig) -> list[str]:
+    """Apply desired state to a repo. Returns branches with legacy protection removed."""
     desired = compute_desired_state(config)
-    apply_desired_state(repo, desired)
+    return apply_desired_state(repo, desired)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -126,8 +126,11 @@ def main(argv: list[str] | None = None) -> int:
     for repo in non_compliant:
         config = _fetch_remote_config(repo)
         print(f"  Applying to {repo}...")
-        _apply_repo(repo, config)
-        print(f"  {repo}: applied")
+        removed = _apply_repo(repo, config)
+        if removed:
+            print(f"  {repo}: applied (legacy protection removed: {', '.join(removed)})")
+        else:
+            print(f"  {repo}: applied")
 
     return 0
 

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -55,6 +55,18 @@ def delete(endpoint: str) -> None:
     )
 
 
+def delete_if_exists(endpoint: str) -> bool:
+    """Call gh api DELETE; return True if deleted (2xx), False if 404."""
+    result = subprocess.run(  # noqa: S603
+        ("gh", "api", endpoint, "-X", "DELETE", "-i"),  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    first_line = result.stdout.split("\n")[0] if result.stdout else ""
+    return "404" not in first_line
+
+
 def create_pr(*, base: str, title: str, body_file: str) -> str:
     """Create a pull request and return its URL."""
     return read_output("pr", "create", "--base", base, "--title", title, "--body-file", body_file)

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -606,9 +606,34 @@ def _apply_rulesets(repo: str, desired: list[DesiredRuleset]) -> None:
             github.delete(f"repos/{repo}/rulesets/{rs_id}")
 
 
-def apply_desired_state(repo: str, desired: DesiredState) -> None:
-    """Apply the desired configuration to a GitHub repo via the API."""
+def _cleanup_classic_branch_protection(repo: str, rulesets: list[DesiredRuleset]) -> list[str]:
+    """Remove legacy branch protection for branches covered by rulesets.
+
+    Returns list of branches where legacy protection was removed.
+    """
+    branches: set[str] = set()
+    for ruleset in rulesets:
+        if ruleset.target != "branch":
+            continue
+        for ref in ruleset.ref_include:
+            if ref.startswith("refs/heads/"):
+                branches.add(ref.removeprefix("refs/heads/"))
+
+    removed: list[str] = []
+    for branch in sorted(branches):
+        endpoint = f"repos/{repo}/branches/{branch}/protection"
+        if github.delete_if_exists(endpoint):
+            removed.append(branch)
+    return removed
+
+
+def apply_desired_state(repo: str, desired: DesiredState) -> list[str]:
+    """Apply the desired configuration to a GitHub repo via the API.
+
+    Returns list of branches where legacy branch protection was removed.
+    """
     _apply_repo_settings(repo, desired.repo_settings)
     _apply_security_settings(repo, desired.security)
     _apply_actions_permissions(repo, desired.actions_permissions)
     _apply_rulesets(repo, desired.rulesets)
+    return _cleanup_classic_branch_protection(repo, desired.rulesets)

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -194,3 +194,21 @@ def test_delete_calls_gh_api() -> None:
         text=True,
         capture_output=True,
     )
+
+
+def test_delete_if_exists_returns_true_on_success() -> None:
+    cp = _completed(stdout="HTTP/2.0 204 No Content\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        assert github.delete_if_exists("repos/o/r/branches/main/protection") is True
+
+
+def test_delete_if_exists_returns_false_on_404() -> None:
+    cp = _completed(returncode=1, stdout="HTTP/2.0 404 Not Found\n")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        assert github.delete_if_exists("repos/o/r/branches/main/protection") is False
+
+
+def test_delete_if_exists_returns_true_on_empty_stdout() -> None:
+    cp = _completed(stdout="")
+    with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
+        assert github.delete_if_exists("repos/o/r/branches/main/protection") is True

--- a/tests/standard_tooling/test_github_config_cli.py
+++ b/tests/standard_tooling/test_github_config_cli.py
@@ -301,7 +301,7 @@ def test_apply_with_yes_applies_noncompliant() -> None:
             return_value=["o/r"],
         ),
         patch("standard_tooling.bin.github_config._fetch_remote_config"),
-        patch("standard_tooling.bin.github_config._apply_repo") as mock_apply,
+        patch("standard_tooling.bin.github_config._apply_repo", return_value=[]) as mock_apply,
     ):
         result = main(["apply", "--repo", "o/r", "--yes"])
     assert result == 0
@@ -351,8 +351,36 @@ def test_apply_without_yes_prompts_and_proceeds(monkeypatch: pytest.MonkeyPatch)
             return_value=["o/r"],
         ),
         patch("standard_tooling.bin.github_config._fetch_remote_config"),
-        patch("standard_tooling.bin.github_config._apply_repo") as mock_apply,
+        patch("standard_tooling.bin.github_config._apply_repo", return_value=[]) as mock_apply,
     ):
         result = main(["apply", "--repo", "o/r"])
     assert result == 0
     mock_apply.assert_called_once()
+
+
+def test_apply_reports_legacy_protection_removed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
+        return _mock_noncompliant()
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            side_effect=audit_side_effect,
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch("standard_tooling.bin.github_config._fetch_remote_config"),
+        patch(
+            "standard_tooling.bin.github_config._apply_repo",
+            return_value=["main", "develop"],
+        ),
+        patch("builtins.print") as mock_print,
+    ):
+        result = main(["apply", "--repo", "o/r"])
+    assert result == 0
+    output = " ".join(str(c) for c in mock_print.call_args_list)
+    assert "legacy protection removed" in output

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -18,6 +18,7 @@ from standard_tooling.lib.github_config import (
     _apply_repo_settings,
     _apply_rulesets,
     _apply_security_settings,
+    _cleanup_classic_branch_protection,
     _fetch_vulnerability_alerts,
     _lang_has_check,
     _ruleset_body,
@@ -908,9 +909,98 @@ def test_apply_desired_state_orchestrates_all() -> None:
         patch("standard_tooling.lib.github_config._apply_security_settings") as mock_sec,
         patch("standard_tooling.lib.github_config._apply_actions_permissions") as mock_actions,
         patch("standard_tooling.lib.github_config._apply_rulesets") as mock_rulesets,
+        patch(
+            "standard_tooling.lib.github_config._cleanup_classic_branch_protection",
+            return_value=[],
+        ) as mock_cleanup,
     ):
-        apply_desired_state("o/r", state)
+        result = apply_desired_state("o/r", state)
     mock_repo.assert_called_once_with("o/r", state.repo_settings)
     mock_sec.assert_called_once_with("o/r", state.security)
     mock_actions.assert_called_once_with("o/r", state.actions_permissions)
     mock_rulesets.assert_called_once_with("o/r", state.rulesets)
+    mock_cleanup.assert_called_once_with("o/r", state.rulesets)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Classic branch protection cleanup tests
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_removes_legacy_protection_for_covered_branches() -> None:
+    rulesets = [desired_branch_protection_ruleset()]
+    with patch(
+        "standard_tooling.lib.github_config.github.delete_if_exists",
+        return_value=True,
+    ) as mock_del:
+        removed = _cleanup_classic_branch_protection("o/r", rulesets)
+    assert sorted(removed) == ["develop", "main"]
+    assert mock_del.call_count == 2
+    endpoints = sorted(c[0][0] for c in mock_del.call_args_list)
+    assert endpoints == [
+        "repos/o/r/branches/develop/protection",
+        "repos/o/r/branches/main/protection",
+    ]
+
+
+def test_cleanup_returns_empty_when_no_legacy_protection() -> None:
+    rulesets = [desired_branch_protection_ruleset()]
+    with patch(
+        "standard_tooling.lib.github_config.github.delete_if_exists",
+        return_value=False,
+    ):
+        removed = _cleanup_classic_branch_protection("o/r", rulesets)
+    assert removed == []
+
+
+def test_cleanup_skips_tag_rulesets() -> None:
+    rulesets = [desired_tag_protection_ruleset()]
+    with patch(
+        "standard_tooling.lib.github_config.github.delete_if_exists",
+    ) as mock_del:
+        removed = _cleanup_classic_branch_protection("o/r", rulesets)
+    mock_del.assert_not_called()
+    assert removed == []
+
+
+def test_cleanup_ignores_non_heads_refs() -> None:
+    rulesets = [
+        DesiredRuleset(
+            name="Mixed refs",
+            target="branch",
+            enforcement="active",
+            ref_include=["refs/heads/main", "refs/tags/v*"],
+            bypass_actors=[],
+            rules=[],
+        ),
+    ]
+    with patch(
+        "standard_tooling.lib.github_config.github.delete_if_exists",
+        return_value=True,
+    ) as mock_del:
+        removed = _cleanup_classic_branch_protection("o/r", rulesets)
+    mock_del.assert_called_once_with("repos/o/r/branches/main/protection")
+    assert removed == ["main"]
+
+
+def test_cleanup_deduplicates_branches_across_rulesets() -> None:
+    rulesets = [
+        desired_branch_protection_ruleset(),
+        DesiredRuleset(
+            name="CI gates",
+            target="branch",
+            enforcement="active",
+            ref_include=["refs/heads/main", "refs/heads/develop"],
+            bypass_actors=[],
+            rules=[],
+        ),
+    ]
+    with patch(
+        "standard_tooling.lib.github_config.github.delete_if_exists",
+        return_value=True,
+    ) as mock_del:
+        removed = _cleanup_classic_branch_protection("o/r", rulesets)
+    # Should only call once per unique branch
+    assert mock_del.call_count == 2
+    assert sorted(removed) == ["develop", "main"]


### PR DESCRIPTION
# Pull Request

## Summary

- Removes legacy branch protection rules for branches covered by rulesets during apply

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- 671 tests, 100% branch coverage. apply_desired_state now returns removed branches.