### PR TITLE
fix(github-config): include enabled field in actions/permissions PUT

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -543,7 +543,7 @@ def _apply_actions_permissions(repo: str, perms: DesiredActionsPermissions) -> N
     github.write_json(
         "PUT",
         f"repos/{repo}/actions/permissions",
-        {"allowed_actions": perms.allowed_actions},
+        {"enabled": True, "allowed_actions": perms.allowed_actions},
     )
     github.write_json(
         "PUT",


### PR DESCRIPTION
# Pull Request

## Summary

- The GitHub API PUT repos/{owner}/{repo}/actions/permissions endpoint requires the enabled field alongside allowed_actions. Without it the call returns a 422, crashing st-github-config apply.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -