### PR TITLE
fix(github-config): normalize audit comparison for patterns and rule defaults

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -298,9 +298,7 @@ def _normalize_rules(rules: list[object]) -> list[dict[str, object]]:
             continue
         params = rule.get("parameters")
         if isinstance(params, dict):
-            cleaned_params = {
-                k: v for k, v in params.items() if k not in _STRIP_RULE_PARAMS
-            }
+            cleaned_params = {k: v for k, v in params.items() if k not in _STRIP_RULE_PARAMS}
             normalized.append({**rule, "parameters": cleaned_params})
         else:
             normalized.append(dict(rule))
@@ -406,9 +404,7 @@ def fetch_actual_state(repo: str) -> DesiredState:
             bypass_raw = rs_detail.get("bypass_actors")
             bypass = bypass_raw if isinstance(bypass_raw, list) else []
             rules_raw = rs_detail.get("rules")
-            rules = _normalize_rules(
-                rules_raw if isinstance(rules_raw, list) else []
-            )
+            rules = _normalize_rules(rules_raw if isinstance(rules_raw, list) else [])
 
             rulesets.append(
                 DesiredRuleset(

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -65,8 +65,8 @@ class DesiredState:
 
 
 _ALLOWED_ACTION_PATTERNS = [
-    "actions/*",
     "actions-rust-lang/*",
+    "actions/*",
     "astral-sh/*",
     "docker/*",
     "github/*",
@@ -287,6 +287,26 @@ def _fetch_vulnerability_alerts(repo: str) -> bool:
     return "204" in result.stdout.split("\n")[0]
 
 
+_STRIP_RULE_PARAMS = frozenset({"do_not_enforce_on_create"})
+
+
+def _normalize_rules(rules: list[object]) -> list[dict[str, object]]:
+    """Strip API-default fields from rule parameters for clean comparison."""
+    normalized: list[dict[str, object]] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        params = rule.get("parameters")
+        if isinstance(params, dict):
+            cleaned_params = {
+                k: v for k, v in params.items() if k not in _STRIP_RULE_PARAMS
+            }
+            normalized.append({**rule, "parameters": cleaned_params})
+        else:
+            normalized.append(dict(rule))
+    return normalized
+
+
 def fetch_actual_state(repo: str) -> DesiredState:
     """Fetch the current GitHub configuration for a repo via gh api."""
     repo_data = github.read_json("api", f"repos/{repo}")
@@ -386,7 +406,9 @@ def fetch_actual_state(repo: str) -> DesiredState:
             bypass_raw = rs_detail.get("bypass_actors")
             bypass = bypass_raw if isinstance(bypass_raw, list) else []
             rules_raw = rs_detail.get("rules")
-            rules = rules_raw if isinstance(rules_raw, list) else []
+            rules = _normalize_rules(
+                rules_raw if isinstance(rules_raw, list) else []
+            )
 
             rulesets.append(
                 DesiredRuleset(

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -21,6 +21,7 @@ from standard_tooling.lib.github_config import (
     _cleanup_classic_branch_protection,
     _fetch_vulnerability_alerts,
     _lang_has_check,
+    _normalize_rules,
     _ruleset_body,
     apply_desired_state,
     compute_desired_state,
@@ -1004,3 +1005,30 @@ def test_cleanup_deduplicates_branches_across_rulesets() -> None:
     # Should only call once per unique branch
     assert mock_del.call_count == 2
     assert sorted(removed) == ["develop", "main"]
+
+
+def test_normalize_rules_strips_default_params() -> None:
+    rules: list[object] = [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "do_not_enforce_on_create": False,
+                "required_status_checks": [],
+            },
+        },
+    ]
+    result = _normalize_rules(rules)
+    assert len(result) == 1
+    assert "do_not_enforce_on_create" not in result[0]["parameters"]
+    assert result[0]["parameters"]["strict_required_status_checks_policy"] is True
+
+
+def test_normalize_rules_skips_non_dict_entries() -> None:
+    rules: list[object] = [
+        "not-a-dict",
+        {"type": "deletion"},
+    ]
+    result = _normalize_rules(rules)
+    assert len(result) == 1
+    assert result[0] == {"type": "deletion"}


### PR DESCRIPTION
# Pull Request

## Summary

- Fix two false-positive audit diffs: sort patterns_allowed to match GitHub's alphabetical return order, and strip do_not_enforce_on_create from fetched ruleset rules since it's an API-default field not part of our desired state.

## Issue Linkage

- Ref #173

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -