### PR TITLE
fix(docker-cache): skip self-install in standard-tooling repo

### DIFF
--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -44,7 +44,8 @@ def _is_self_repo(repo_root: Path) -> bool:
 
         with pyproject.open("rb") as f:
             data = tomllib.load(f)
-        return data.get("project", {}).get("name") == _SELF_PROJECT_NAME
+        name: object = data.get("project", {}).get("name")
+        return name == _SELF_PROJECT_NAME
     except (OSError, tomllib.TOMLDecodeError, KeyError):
         return False
 

--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -12,6 +12,8 @@ from standard_tooling.lib.config import st_install_tag
 if TYPE_CHECKING:
     from pathlib import Path
 
+_SELF_PROJECT_NAME = "standard-tooling"
+
 _ST_GIT_URL = "https://github.com/wphillipmoore/standard-tooling"
 
 _CACHE_FILES: dict[str, list[str]] = {
@@ -30,6 +32,21 @@ _WARMUP_COMMANDS: dict[str, str] = {
     "go": "go mod download && go build ./...",
     "java": "./mvnw dependency:resolve",
 }
+
+
+def _is_self_repo(repo_root: Path) -> bool:
+    """Return True when *repo_root* is the standard-tooling project itself."""
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+    try:
+        import tomllib
+
+        with pyproject.open("rb") as f:
+            data = tomllib.load(f)
+        return data.get("project", {}).get("name") == _SELF_PROJECT_NAME
+    except (OSError, tomllib.TOMLDecodeError, KeyError):
+        return False
 
 
 def cache_sensitive_files(repo_root: Path, lang: str) -> list[Path]:
@@ -92,14 +109,22 @@ def _build_cached_image(
     target_tag: str,
 ) -> str:
     """Build a cached image with standard-tooling installed."""
-    tag = st_install_tag(repo_root)
-    uv_install = f"uv tool install --quiet 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
+    self_repo = _is_self_repo(repo_root)
     warmup = _WARMUP_COMMANDS.get(lang)
-    setup = f"{uv_install} && {warmup}" if warmup else uv_install
+
+    if self_repo:
+        setup = warmup or "true"
+    else:
+        tag = st_install_tag(repo_root)
+        uv_install = f"uv tool install --quiet 'standard-tooling @ git+{_ST_GIT_URL}@{tag}'"
+        setup = f"{uv_install} && {warmup}" if warmup else uv_install
 
     print(f"Building cached image: {target_tag}")
     print(f"  Base:    {base_image}")
-    print(f"  Install: standard-tooling@{tag}")
+    if self_repo:
+        print("  Install: skipped (self-repo uses local dev version)")
+    else:
+        print(f"  Install: standard-tooling@{tag}")
     if warmup:
         print(f"  Warmup:  {warmup}")
 

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -9,6 +9,7 @@ import pytest
 
 from standard_tooling.lib.docker_cache import (
     _build_cached_image,
+    _is_self_repo,
     _sanitize_branch,
     cache_image_tag,
     cache_sensitive_files,
@@ -461,3 +462,57 @@ def test_ensure_repo_name_included_in_hash(tmp_path: Path) -> None:
 
     assert len(built_tags) == 2
     assert built_tags[0] != built_tags[1], "repos with identical files must get distinct image tags"
+
+
+# -- _is_self_repo ------------------------------------------------------------
+
+
+def test_is_self_repo_true(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "standard-tooling"\n')
+    assert _is_self_repo(tmp_path) is True
+
+
+def test_is_self_repo_false_different_name(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "my-app"\n')
+    assert _is_self_repo(tmp_path) is False
+
+
+def test_is_self_repo_false_no_pyproject(tmp_path: Path) -> None:
+    assert _is_self_repo(tmp_path) is False
+
+
+def test_is_self_repo_false_no_project_table(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.ruff]\nline-length = 100\n')
+    assert _is_self_repo(tmp_path) is False
+
+
+def test_is_self_repo_false_invalid_toml(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("not valid [[[toml content")
+    assert _is_self_repo(tmp_path) is False
+
+
+# -- _build_cached_image self-repo skip ----------------------------------------
+
+
+def test_build_cached_image_self_repo_skips_uv_install(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "standard-tooling"\n')
+    create_result = MagicMock(returncode=0, stdout="abc123\n")
+    ok = MagicMock(returncode=0)
+    create_cmd: list[str] = []
+
+    def mock_run(cmd, **_kwargs):  # noqa: ANN001, ANN003
+        if cmd[1] == "create":
+            create_cmd.extend(cmd)
+            return create_result
+        return ok
+
+    with patch("standard_tooling.lib.docker_cache.subprocess.run", side_effect=mock_run):
+        _build_cached_image(tmp_path, "python", "img:1", "img:1--branch--hash")
+    setup_cmd = create_cmd[-1]
+    assert "uv tool install" not in setup_cmd
+    assert "uv sync --group dev" in setup_cmd

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -485,7 +485,7 @@ def test_is_self_repo_false_no_pyproject(tmp_path: Path) -> None:
 
 def test_is_self_repo_false_no_project_table(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[tool.ruff]\nline-length = 100\n')
+    pyproject.write_text("[tool.ruff]\nline-length = 100\n")
     assert _is_self_repo(tmp_path) is False
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Skip uv tool install when building cache for standard-tooling itself

## Issue Linkage

- Ref #537

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

When building a cached Docker image for the standard-tooling repository itself,
`uv tool install standard-tooling@<tag>` installed a released version over the
local development version. This wasted work and created a confusing two-copy
state inside the container.

The fix detects when the repo is standard-tooling (via `pyproject.toml` name
field) and skips the `uv tool install` step. The warmup (`uv sync --group dev`)
still runs, providing the local dev version on PATH.

Ref #537