### PR TITLE
CI workflow reset Phase 1: foundations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ st-validate-local-java = "standard_tooling.bin.validate_local_lang:main"
 st-validate-local-common = "standard_tooling.bin.validate_local_common_container:main"
 st-pr-issue-linkage = "standard_tooling.bin.pr_issue_linkage:main"
 st-github-config = "standard_tooling.bin.github_config:main"
+st-validate = "standard_tooling.bin.st_validate:main"
 
 [dependency-groups]
 dev = ["ruff", "mypy", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ st-validate-local-common = "standard_tooling.bin.validate_local_common_container
 st-pr-issue-linkage = "standard_tooling.bin.pr_issue_linkage:main"
 st-github-config = "standard_tooling.bin.github_config:main"
 st-validate = "standard_tooling.bin.st_validate:main"
+st-version = "standard_tooling.bin.version:main"
 
 [dependency-groups]
 dev = ["ruff", "mypy", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]

--- a/src/standard_tooling/bin/finalize_repo.py
+++ b/src/standard_tooling/bin/finalize_repo.py
@@ -239,15 +239,15 @@ def main(argv: list[str] | None = None) -> int:
         print("Running post-finalization validation via st-docker-run...")
         repo_root = Path(git.repo_root())
         if (repo_root / "pyproject.toml").is_file():
-            cmd: tuple[str, ...] = ("st-docker-run", "--", "uv", "run", "st-validate-local")
+            cmd: tuple[str, ...] = ("st-docker-run", "--", "uv", "run", "st-validate")
         else:
-            cmd = ("st-docker-run", "--", "st-validate-local")
+            cmd = ("st-docker-run", "--", "st-validate")
 
         result = subprocess.run(cmd, check=False)  # noqa: S603
         if result.returncode != 0:
             validation_failed = True
     else:
-        print("  [dry-run] st-docker-run -- [uv run] st-validate-local")
+        print("  [dry-run] st-docker-run -- [uv run] st-validate")
 
     # Docs-publish sanity check (issue #303). Runs after validation
     # so a real validation failure stays the headline; a docs failure

--- a/src/standard_tooling/bin/st_validate.py
+++ b/src/standard_tooling/bin/st_validate.py
@@ -111,7 +111,7 @@ def _run_single_check(check: str, language: str, repo_root: Path) -> int:
         return _run_common_checks(repo_root)
 
     kind = _CHECK_KINDS[check]
-    assert kind is not None
+    assert kind is not None  # noqa: S101
     cmds = language_commands(language, kind)
     if not cmds:
         print(f"No {check} commands for language '{language}'")

--- a/src/standard_tooling/bin/st_validate.py
+++ b/src/standard_tooling/bin/st_validate.py
@@ -46,7 +46,7 @@ def _run_commands(cmds: list[str], label: str) -> int:
     return 0
 
 
-def _run_common_checks(repo_root: Path) -> int:
+def _run_common_checks(repo_root: Path) -> int:  # noqa: ARG001
     from standard_tooling.bin.validate_local_common_container import main as common_main
 
     return common_main()
@@ -111,6 +111,7 @@ def _run_single_check(check: str, language: str, repo_root: Path) -> int:
         return _run_common_checks(repo_root)
 
     kind = _CHECK_KINDS[check]
+    assert kind is not None
     cmds = language_commands(language, kind)
     if not cmds:
         print(f"No {check} commands for language '{language}'")

--- a/src/standard_tooling/bin/st_validate.py
+++ b/src/standard_tooling/bin/st_validate.py
@@ -41,7 +41,7 @@ def _run_commands(cmds: list[str], label: str, *, fail_fast: bool = False) -> in
     worst = 0
     for cmd in cmds:
         print(f"Running ({label}): {cmd}")
-        result = subprocess.run(cmd, shell=True, check=False)  # noqa: S602
+        result = subprocess.run(cmd.split(), check=False)  # noqa: S603
         if result.returncode != 0:
             if fail_fast:
                 return result.returncode

--- a/src/standard_tooling/bin/st_validate.py
+++ b/src/standard_tooling/bin/st_validate.py
@@ -37,13 +37,16 @@ def _in_dev_container() -> bool:
     return Path("/.dockerenv").exists() or bool(os.environ.get("ST_IN_DEV_CONTAINER"))
 
 
-def _run_commands(cmds: list[str], label: str) -> int:
+def _run_commands(cmds: list[str], label: str, *, fail_fast: bool = False) -> int:
+    worst = 0
     for cmd in cmds:
         print(f"Running ({label}): {cmd}")
         result = subprocess.run(cmd, shell=True, check=False)  # noqa: S602
         if result.returncode != 0:
-            return result.returncode
-    return 0
+            if fail_fast:
+                return result.returncode
+            worst = result.returncode
+    return worst
 
 
 def _run_common_checks(repo_root: Path) -> int:  # noqa: ARG001
@@ -119,7 +122,7 @@ def _run_single_check(check: str, language: str, repo_root: Path) -> int:
 
     install_cmds = language_commands(language, CheckKind.INSTALL)
     if install_cmds:
-        rc = _run_commands(install_cmds, "install")
+        rc = _run_commands(install_cmds, "install", fail_fast=True)
         if rc != 0:
             return rc
 
@@ -141,7 +144,7 @@ def _run_all_checks(language: str, repo_root: Path) -> int:
         install_cmds = language_commands(language, CheckKind.INSTALL)
         if install_cmds:
             print()
-            rc = _run_commands(install_cmds, "install")
+            rc = _run_commands(install_cmds, "install", fail_fast=True)
             if rc != 0:
                 return rc
 

--- a/src/standard_tooling/bin/st_validate.py
+++ b/src/standard_tooling/bin/st_validate.py
@@ -1,0 +1,170 @@
+"""Unified validation command.
+
+Reads primary_language from standard-tooling.toml, then either runs a
+specific check type (--check) or all checks in sequence:
+  common -> install -> lint -> typecheck -> test -> audit -> custom
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from standard_tooling.lib import config, git
+from standard_tooling.lib.validate_commands import CheckKind, language_commands
+
+_CHECK_KINDS = {
+    "common": None,
+    "lint": CheckKind.LINT,
+    "typecheck": CheckKind.TYPECHECK,
+    "test": CheckKind.TEST,
+    "audit": CheckKind.AUDIT,
+}
+
+_LANGUAGE_CHECK_ORDER = [
+    CheckKind.LINT,
+    CheckKind.TYPECHECK,
+    CheckKind.TEST,
+    CheckKind.AUDIT,
+]
+
+
+def _in_dev_container() -> bool:
+    return Path("/.dockerenv").exists() or bool(os.environ.get("ST_IN_DEV_CONTAINER"))
+
+
+def _run_commands(cmds: list[str], label: str) -> int:
+    for cmd in cmds:
+        print(f"Running ({label}): {cmd}")
+        result = subprocess.run(cmd, shell=True, check=False)  # noqa: S602
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+def _run_common_checks(repo_root: Path) -> int:
+    from standard_tooling.bin.validate_local_common_container import main as common_main
+
+    return common_main()
+
+
+def _find_custom_validator(repo_root: Path) -> str | None:
+    scripts_bin = repo_root / "scripts" / "bin"
+    entry_point = shutil.which("st-validate-local-custom")
+    if entry_point is not None:
+        return entry_point
+    local = scripts_bin / "validate-local-custom"
+    if local.is_file() and os.access(local, os.X_OK):
+        return str(local)
+    return None
+
+
+def _run_custom_validator(path: str) -> int:
+    print(f"Running: {path}")
+    result = subprocess.run((path,), check=False)  # noqa: S603
+    return result.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="st-validate",
+        description="Run validation checks from the command registry.",
+    )
+    parser.add_argument(
+        "--check",
+        choices=list(_CHECK_KINDS.keys()),
+        default=None,
+        help="Run only this check type. Omit to run all.",
+    )
+    args = parser.parse_args(argv)
+
+    if not _in_dev_container():
+        print(
+            "ERROR: st-validate must run inside a dev container.\n"
+            "       Run: st-docker-run -- st-validate",
+            file=sys.stderr,
+        )
+        return 1
+
+    repo_root = git.repo_root()
+
+    try:
+        st_config = config.read_config(repo_root)
+        language = st_config.project.primary_language
+    except FileNotFoundError:
+        language = ""
+    except config.ConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check is not None:
+        return _run_single_check(args.check, language, repo_root)
+    return _run_all_checks(language, repo_root)
+
+
+def _run_single_check(check: str, language: str, repo_root: Path) -> int:
+    if check == "common":
+        return _run_common_checks(repo_root)
+
+    kind = _CHECK_KINDS[check]
+    cmds = language_commands(language, kind)
+    if not cmds:
+        print(f"No {check} commands for language '{language}'")
+        return 0
+
+    install_cmds = language_commands(language, CheckKind.INSTALL)
+    if install_cmds:
+        rc = _run_commands(install_cmds, "install")
+        if rc != 0:
+            return rc
+
+    return _run_commands(cmds, check)
+
+
+def _run_all_checks(language: str, repo_root: Path) -> int:
+    print("=" * 40)
+    print("st-validate")
+    print(f"primary_language: {language or '<not set>'}")
+    print("=" * 40)
+    print()
+
+    rc = _run_common_checks(repo_root)
+    if rc != 0:
+        return rc
+
+    if language and language != "none":
+        install_cmds = language_commands(language, CheckKind.INSTALL)
+        if install_cmds:
+            print()
+            rc = _run_commands(install_cmds, "install")
+            if rc != 0:
+                return rc
+
+        for kind in _LANGUAGE_CHECK_ORDER:
+            cmds = language_commands(language, kind)
+            if cmds:
+                print()
+                rc = _run_commands(cmds, kind.value)
+                if rc != 0:
+                    return rc
+
+    custom = _find_custom_validator(repo_root)
+    if custom is not None:
+        print()
+        rc = _run_custom_validator(custom)
+        if rc != 0:
+            return rc
+
+    print()
+    print("=" * 40)
+    print("st-validate: all checks passed")
+    print("=" * 40)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/standard_tooling/bin/validate_local_common_container.py
+++ b/src/standard_tooling/bin/validate_local_common_container.py
@@ -6,6 +6,8 @@ Runs inside the dev container via ``st-docker-run``:
      the bundled canonical config
   3. shellcheck on all shell scripts under ``scripts/``
   4. yamllint on YAML files under ``.github/`` and ``docs/`` (issue #302)
+  5. hadolint on Dockerfile* files at the repo root
+  6. actionlint on ``.github/workflows/``
 """
 
 from __future__ import annotations
@@ -54,6 +56,15 @@ def _find_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> li
     if readme.is_file():
         found.append(str(readme))
 
+    return sorted(found)
+
+
+def _find_dockerfiles(repo_root: Path) -> list[str]:
+    """Discover Dockerfile* files at the repo root."""
+    found: list[str] = []
+    for path in repo_root.iterdir():
+        if path.is_file() and path.name.startswith("Dockerfile"):
+            found.append(str(path))
     return sorted(found)
 
 
@@ -125,6 +136,26 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         print(f"Running: yamllint ({len(yaml_files)} files)")
         result = subprocess.run(  # noqa: S603
             ["yamllint", *yaml_files],  # noqa: S607
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    dockerfile_files = _find_dockerfiles(repo_root)
+    if dockerfile_files:
+        print(f"Running: hadolint ({len(dockerfile_files)} files)")
+        result = subprocess.run(  # noqa: S603
+            ["hadolint", *dockerfile_files],  # noqa: S607
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    workflows_dir = repo_root / ".github" / "workflows"
+    if workflows_dir.is_dir():
+        print("Running: actionlint")
+        result = subprocess.run(  # noqa: S603
+            ["actionlint"],  # noqa: S607
             check=False,
         )
         if result.returncode != 0:

--- a/src/standard_tooling/bin/version.py
+++ b/src/standard_tooling/bin/version.py
@@ -1,0 +1,47 @@
+"""CLI entry point for st-version."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from standard_tooling.lib.version import bump, show, show_major_minor
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="st-version",
+        description="Version management for standard-tooling repos",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    show_parser = sub.add_parser("show", help="Print current version")
+    show_parser.add_argument(
+        "--major-minor",
+        action="store_true",
+        help="Print major.minor only",
+    )
+    show_parser.add_argument(
+        "--ref",
+        default=None,
+        help="Read version from a git ref (e.g., origin/main) via git show",
+    )
+
+    sub.add_parser("bump", help="Increment patch version")
+
+    args = parser.parse_args()
+    repo_root = Path.cwd()
+
+    if args.command == "show":
+        if args.major_minor:
+            print(show_major_minor(repo_root, ref=args.ref))  # noqa: T201
+        else:
+            print(show(repo_root, ref=args.ref))  # noqa: T201
+    elif args.command == "bump":
+        new_version = bump(repo_root)
+        print(new_version)  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/src/standard_tooling/bin/version.py
+++ b/src/standard_tooling/bin/version.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 
 from standard_tooling.lib.version import bump, show, show_major_minor
@@ -38,7 +37,7 @@ def main() -> None:
             print(show_major_minor(repo_root, ref=args.ref))  # noqa: T201
         else:
             print(show(repo_root, ref=args.ref))  # noqa: T201
-    elif args.command == "bump":
+    else:
         new_version = bump(repo_root)
         print(new_version)  # noqa: T201
 

--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -8,6 +8,7 @@ import subprocess
 from typing import TYPE_CHECKING
 
 from standard_tooling.lib.config import st_install_tag
+from standard_tooling.lib.validate_commands import CheckKind, language_commands
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -25,13 +26,10 @@ _CACHE_FILES: dict[str, list[str]] = {
 }
 _DEFAULT_CACHE_FILES = ["standard-tooling.toml"]
 
-_WARMUP_COMMANDS: dict[str, str] = {
-    "python": "uv sync --group dev",
-    "ruby": "bundle install --jobs 4",
-    "rust": "cargo fetch && cargo build --lib",
-    "go": "go mod download && go build ./...",
-    "java": "./mvnw dependency:resolve",
-}
+
+def _warmup_command(lang: str) -> str:
+    cmds = language_commands(lang, CheckKind.INSTALL)
+    return " && ".join(cmds) if cmds else ""
 
 
 def _is_self_repo(repo_root: Path) -> bool:
@@ -111,7 +109,7 @@ def _build_cached_image(
 ) -> str:
     """Build a cached image with standard-tooling installed."""
     self_repo = _is_self_repo(repo_root)
-    warmup = _WARMUP_COMMANDS.get(lang)
+    warmup = _warmup_command(lang)
 
     if self_repo:
         setup = warmup or "true"

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -1,8 +1,8 @@
 """Per-language validation command registry.
 
-Defines the canonical commands for lint, typecheck, test, and audit
-per supported language. These are not configurable per-repo — the
-standard defines them centrally.
+Defines the canonical commands for install, lint, typecheck, test,
+and audit per supported language. These are not configurable
+per-repo — the standard defines them centrally.
 """
 
 from __future__ import annotations
@@ -11,25 +11,48 @@ from enum import Enum
 
 
 class CheckKind(Enum):
+    INSTALL = "install"
     LINT = "lint"
     TYPECHECK = "typecheck"
     TEST = "test"
     AUDIT = "audit"
 
 
+_PIP_LICENSES_ALLOWLIST = ";".join([
+    "Apache-2.0",
+    "Apache-2.0 AND CNRI-Python",
+    "Apache-2.0 OR BSD-2-Clause",
+    "Apache-2.0 OR BSD-3-Clause",
+    "Apache Software License",
+    "BSD License",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "ISC License (ISCL)",
+    "MIT",
+    "MIT License",
+    "Mozilla Public License 2.0 (MPL 2.0)",
+    "MPL-1.1 OR GPL-2.0-only OR LGPL-2.1-or-later",
+    "PSF-2.0",
+    "Python Software Foundation License",
+])
+
 _REGISTRY: dict[str, dict[CheckKind, list[str]]] = {
     "python": {
-        CheckKind.LINT: ["ruff check", "ruff format --check ."],
-        CheckKind.TYPECHECK: ["mypy src/", "ty check src"],
-        CheckKind.TEST: ["pytest --cov --cov-branch --cov-fail-under=100"],
+        CheckKind.INSTALL: ["uv sync --frozen --group dev"],
+        CheckKind.LINT: ["ruff check src/ tests/", "ruff format --check src/ tests/"],
+        CheckKind.TYPECHECK: ["mypy src/ tests/", "ty check src tests"],
+        CheckKind.TEST: ["pytest --cov=src --cov-branch --cov-fail-under=100"],
         CheckKind.AUDIT: [
             "uv sync --check --frozen --group dev",
             "uv lock --check",
-            "pip-audit -r requirements.txt -r requirements-dev.txt",
-            "pip-licenses --allow-only=<allowlist>",
+            "pip-audit",
+            f"pip-licenses --allow-only={_PIP_LICENSES_ALLOWLIST}",
         ],
     },
     "go": {
+        CheckKind.INSTALL: ["go mod download"],
         CheckKind.LINT: ["golangci-lint run ./...", "gocyclo -over 15 ."],
         CheckKind.TYPECHECK: ["go vet ./..."],
         CheckKind.TEST: [
@@ -39,6 +62,7 @@ _REGISTRY: dict[str, dict[CheckKind, list[str]]] = {
         CheckKind.AUDIT: ["govulncheck ./...", "go-licenses check ./..."],
     },
     "java": {
+        CheckKind.INSTALL: ["./mvnw dependency:resolve -B"],
         CheckKind.LINT: ["./mvnw spotless:check checkstyle:check -B"],
         CheckKind.TYPECHECK: ["./mvnw compile -B"],
         CheckKind.TEST: ["./mvnw verify -B"],
@@ -48,12 +72,14 @@ _REGISTRY: dict[str, dict[CheckKind, list[str]]] = {
         ],
     },
     "ruby": {
+        CheckKind.INSTALL: ["bundle install --jobs 4"],
         CheckKind.LINT: ["bundle exec rubocop"],
         CheckKind.TYPECHECK: ["bundle exec steep check"],
         CheckKind.TEST: ["bundle exec rake"],
         CheckKind.AUDIT: ["bundle exec bundle-audit check --update"],
     },
     "rust": {
+        CheckKind.INSTALL: ["cargo fetch"],
         CheckKind.LINT: ["cargo fmt --all -- --check", "cargo clippy -- -D warnings"],
         CheckKind.TYPECHECK: ["cargo check"],
         CheckKind.TEST: ["cargo llvm-cov --fail-under-lines 100"],

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -18,25 +18,27 @@ class CheckKind(Enum):
     AUDIT = "audit"
 
 
-_PIP_LICENSES_ALLOWLIST = ";".join([
-    "Apache-2.0",
-    "Apache-2.0 AND CNRI-Python",
-    "Apache-2.0 OR BSD-2-Clause",
-    "Apache-2.0 OR BSD-3-Clause",
-    "Apache Software License",
-    "BSD License",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
-    "ISC License (ISCL)",
-    "MIT",
-    "MIT License",
-    "Mozilla Public License 2.0 (MPL 2.0)",
-    "MPL-1.1 OR GPL-2.0-only OR LGPL-2.1-or-later",
-    "PSF-2.0",
-    "Python Software Foundation License",
-])
+_PIP_LICENSES_ALLOWLIST = ";".join(
+    [
+        "Apache-2.0",
+        "Apache-2.0 AND CNRI-Python",
+        "Apache-2.0 OR BSD-2-Clause",
+        "Apache-2.0 OR BSD-3-Clause",
+        "Apache Software License",
+        "BSD License",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "GPL-3.0-only",
+        "GPL-3.0-or-later",
+        "ISC License (ISCL)",
+        "MIT",
+        "MIT License",
+        "Mozilla Public License 2.0 (MPL 2.0)",
+        "MPL-1.1 OR GPL-2.0-only OR LGPL-2.1-or-later",
+        "PSF-2.0",
+        "Python Software Foundation License",
+    ]
+)
 
 _REGISTRY: dict[str, dict[CheckKind, list[str]]] = {
     "python": {

--- a/src/standard_tooling/lib/version.py
+++ b/src/standard_tooling/lib/version.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 import re
 import subprocess
 import tomllib
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from standard_tooling.lib.config import read_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _RUBY_VERSION_RE = re.compile(r"VERSION\s*=\s*'([^']+)'")
 _GO_VERSION_RE = re.compile(r'Version\s*=\s*"([^"]+)"')
@@ -110,8 +113,8 @@ def _version_file_relative(repo_root: Path) -> tuple[str, str]:
 
 
 def _read_version_from_ref(ref: str, relative_path: str, language: str) -> str:
-    result = subprocess.run(  # noqa: S603, S607
-        ["git", "show", f"{ref}:{relative_path}"],
+    result = subprocess.run(  # noqa: S603
+        ["git", "show", f"{ref}:{relative_path}"],  # noqa: S607
         capture_output=True,
         text=True,
         check=True,

--- a/src/standard_tooling/lib/version.py
+++ b/src/standard_tooling/lib/version.py
@@ -1,0 +1,173 @@
+"""Version management for standard-tooling managed repositories.
+
+Discovers, reads, and bumps version strings based on the
+``primary-language`` field in ``standard-tooling.toml``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+from standard_tooling.lib.config import read_config
+
+_RUBY_VERSION_RE = re.compile(r"VERSION\s*=\s*'([^']+)'")
+_GO_VERSION_RE = re.compile(r'Version\s*=\s*"([^"]+)"')
+_JAVA_VERSION_RE = re.compile(r"<version>([^<]+)</version>")
+
+_LOCKFILE_COMMANDS: dict[str, list[str]] = {
+    "python": ["uv", "lock"],
+    "rust": ["cargo", "update", "--workspace"],
+    "ruby": ["bundle", "install"],
+}
+
+_DEFAULT_VERSION_FILES: dict[str, str] = {
+    "python": "pyproject.toml",
+    "rust": "Cargo.toml",
+    "java": "pom.xml",
+    "shell": "VERSION",
+    "none": "VERSION",
+}
+
+
+def _discover_version_file(repo_root: Path, language: str) -> Path:
+    if language in _DEFAULT_VERSION_FILES:
+        return repo_root / _DEFAULT_VERSION_FILES[language]
+
+    if language == "ruby":
+        matches = list(repo_root.glob("lib/**/version.rb"))
+        if not matches:
+            msg = f"No lib/**/version.rb found in {repo_root}"
+            raise FileNotFoundError(msg)
+        return matches[0]
+
+    if language == "go":
+        matches = [m for m in repo_root.glob("**/version.go") if ".git" not in m.parts]
+        if not matches:
+            msg = f"No **/version.go found in {repo_root}"
+            raise FileNotFoundError(msg)
+        return matches[0]
+
+    msg = f"Unsupported language for version discovery: {language}"
+    raise ValueError(msg)
+
+
+def _read_version(text: str, language: str) -> str:
+    if language == "python":
+        data = tomllib.loads(text)
+        return str(data["project"]["version"])
+
+    if language == "rust":
+        data = tomllib.loads(text)
+        return str(data["package"]["version"])
+
+    if language == "ruby":
+        m = _RUBY_VERSION_RE.search(text)
+        if not m:
+            msg = "No VERSION = '...' found"
+            raise ValueError(msg)
+        return m.group(1)
+
+    if language == "go":
+        m = _GO_VERSION_RE.search(text)
+        if not m:
+            msg = 'No Version = "..." found'
+            raise ValueError(msg)
+        return m.group(1)
+
+    if language == "java":
+        m = _JAVA_VERSION_RE.search(text)
+        if not m:
+            msg = "No <version>...</version> found"
+            raise ValueError(msg)
+        return m.group(1)
+
+    return text.strip()
+
+
+def _get_version_file(repo_root: Path) -> tuple[Path, str]:
+    cfg = read_config(repo_root)
+    language = cfg.project.primary_language
+
+    raw_toml = (repo_root / "standard-tooling.toml").read_text()
+    raw = tomllib.loads(raw_toml)
+    override = raw.get("project", {}).get("version-file")
+    if override:
+        return repo_root / override, language
+
+    version_file = _discover_version_file(repo_root, language)
+    if not version_file.is_file():
+        msg = f"Version file not found: {version_file}"
+        raise FileNotFoundError(msg)
+    return version_file, language
+
+
+def _version_file_relative(repo_root: Path) -> tuple[str, str]:
+    version_file, language = _get_version_file(repo_root)
+    return str(version_file.relative_to(repo_root)), language
+
+
+def _read_version_from_ref(ref: str, relative_path: str, language: str) -> str:
+    result = subprocess.run(  # noqa: S603, S607
+        ["git", "show", f"{ref}:{relative_path}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return _read_version(result.stdout, language)
+
+
+def show(repo_root: Path, *, ref: str | None = None) -> str:
+    if ref is not None:
+        rel_path, language = _version_file_relative(repo_root)
+        return _read_version_from_ref(ref, rel_path, language)
+
+    version_file, language = _get_version_file(repo_root)
+    return _read_version(version_file.read_text(), language)
+
+
+def show_major_minor(repo_root: Path, *, ref: str | None = None) -> str:
+    version = show(repo_root, ref=ref)
+    parts = version.split(".")
+    return f"{parts[0]}.{parts[1]}"
+
+
+def _increment_patch(version: str) -> str:
+    parts = version.split(".")
+    parts[2] = str(int(parts[2]) + 1)
+    return ".".join(parts)
+
+
+def _write_version(version_file: Path, language: str, old: str, new: str) -> None:
+    text = version_file.read_text()
+
+    if language in ("python", "rust"):
+        text = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    elif language == "ruby":
+        text = text.replace(f"VERSION = '{old}'", f"VERSION = '{new}'", 1)
+    elif language == "go":
+        text = text.replace(f'Version = "{old}"', f'Version = "{new}"', 1)
+    elif language == "java":
+        text = text.replace(f"<version>{old}</version>", f"<version>{new}</version>", 1)
+    else:
+        text = new + "\n"
+
+    version_file.write_text(text)
+
+
+def _run_lockfile_maintenance(repo_root: Path, language: str) -> None:
+    cmd = _LOCKFILE_COMMANDS.get(language)
+    if cmd is None:
+        return
+    subprocess.run(cmd, cwd=repo_root, check=True)  # noqa: S603
+
+
+def bump(repo_root: Path) -> str:
+    version_file, language = _get_version_file(repo_root)
+    old_version = _read_version(version_file.read_text(), language)
+    new_version = _increment_patch(old_version)
+    _write_version(version_file, language, old_version, new_version)
+    _run_lockfile_maintenance(repo_root, language)
+    return new_version

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -435,7 +435,7 @@ def test_build_cached_image_python_includes_uv_install(tmp_path: Path) -> None:
         _build_cached_image(tmp_path, "python", "img:1", "img:1--branch--hash")
     setup_cmd = create_cmd[-1]
     assert "uv tool install" in setup_cmd
-    assert "uv sync --group dev" in setup_cmd
+    assert "uv sync --frozen --group dev" in setup_cmd
 
 
 def test_ensure_repo_name_included_in_hash(tmp_path: Path) -> None:
@@ -515,4 +515,4 @@ def test_build_cached_image_self_repo_skips_uv_install(tmp_path: Path) -> None:
         _build_cached_image(tmp_path, "python", "img:1", "img:1--branch--hash")
     setup_cmd = create_cmd[-1]
     assert "uv tool install" not in setup_cmd
-    assert "uv sync --group dev" in setup_cmd
+    assert "uv sync --frozen --group dev" in setup_cmd

--- a/tests/standard_tooling/test_finalize_repo.py
+++ b/tests/standard_tooling/test_finalize_repo.py
@@ -87,7 +87,7 @@ def _make_profile(tmp_path: Path, model: str) -> None:
 
 
 def _validation_ok() -> CompletedProcess[bytes]:
-    return CompletedProcess(args=("st-validate-local",), returncode=0)
+    return CompletedProcess(args=("st-validate",), returncode=0)
 
 
 def test_main_library_release(tmp_path: Path) -> None:
@@ -219,7 +219,7 @@ def test_main_validation_fails(tmp_path: Path) -> None:
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(
             "standard_tooling.bin.finalize_repo.subprocess.run",
-            return_value=CompletedProcess(args=("st-validate-local",), returncode=1),
+            return_value=CompletedProcess(args=("st-validate",), returncode=1),
         ),
         patch(_MOD + "._check_docs_workflow_status", return_value=None),
     ):
@@ -241,7 +241,7 @@ def test_main_calls_docker_run(tmp_path: Path) -> None:
     assert result == 0
     cmd = mock_sub.call_args[0][0]
     assert cmd[0] == "st-docker-run"
-    assert cmd[1:] == ("--", "st-validate-local")
+    assert cmd[1:] == ("--", "st-validate")
 
 
 def test_main_docker_run_uses_uv_for_python(tmp_path: Path) -> None:
@@ -258,7 +258,7 @@ def test_main_docker_run_uses_uv_for_python(tmp_path: Path) -> None:
         result = main([])
     assert result == 0
     cmd = mock_sub.call_args[0][0]
-    assert cmd == ("st-docker-run", "--", "uv", "run", "st-validate-local")
+    assert cmd == ("st-docker-run", "--", "uv", "run", "st-validate")
 
 
 # -- _check_docs_workflow_status (issue #303) --------------------------------

--- a/tests/standard_tooling/test_st_validate.py
+++ b/tests/standard_tooling/test_st_validate.py
@@ -184,11 +184,13 @@ def test_run_commands_success() -> None:
 
 
 def test_run_commands_failure_runs_all_by_default() -> None:
-    results = iter([
-        subprocess.CompletedProcess(args=[], returncode=1),
-        subprocess.CompletedProcess(args=[], returncode=0),
-        subprocess.CompletedProcess(args=[], returncode=2),
-    ])
+    results = iter(
+        [
+            subprocess.CompletedProcess(args=[], returncode=1),
+            subprocess.CompletedProcess(args=[], returncode=0),
+            subprocess.CompletedProcess(args=[], returncode=2),
+        ]
+    )
     with patch("standard_tooling.bin.st_validate.subprocess.run", side_effect=results) as mock:
         assert _run_commands(["cmd1", "cmd2", "cmd3"], "test") == 2
     assert mock.call_count == 3

--- a/tests/standard_tooling/test_st_validate.py
+++ b/tests/standard_tooling/test_st_validate.py
@@ -339,7 +339,8 @@ def test_run_all_install_failure_stops(tmp_path: Path) -> None:
 
 def test_run_common_checks_calls_common_main() -> None:
     with patch(
-        "standard_tooling.bin.validate_local_common_container.main", return_value=0,
+        "standard_tooling.bin.validate_local_common_container.main",
+        return_value=0,
     ) as mock:
         result = _run_common_checks(Path("/fake"))
     assert result == 0

--- a/tests/standard_tooling/test_st_validate.py
+++ b/tests/standard_tooling/test_st_validate.py
@@ -62,7 +62,7 @@ def test_check_lint_runs_install_then_lint(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
     calls: list[str] = []
 
-    def mock_run_commands(cmds: list[str], label: str) -> int:
+    def mock_run_commands(cmds: list[str], label: str, **kwargs: bool) -> int:
         calls.extend(cmds)
         return 0
 
@@ -94,7 +94,7 @@ def test_run_all_calls_common_then_language_checks(tmp_path: Path) -> None:
         order.append("common")
         return 0
 
-    def mock_commands(cmds: list[str], label: str) -> int:
+    def mock_commands(cmds: list[str], label: str, **kwargs: bool) -> int:
         order.append(label)
         return 0
 
@@ -183,12 +183,24 @@ def test_run_commands_success() -> None:
         assert _run_commands(["echo hello"], "test") == 0
 
 
-def test_run_commands_failure() -> None:
+def test_run_commands_failure_runs_all_by_default() -> None:
+    results = iter([
+        subprocess.CompletedProcess(args=[], returncode=1),
+        subprocess.CompletedProcess(args=[], returncode=0),
+        subprocess.CompletedProcess(args=[], returncode=2),
+    ])
+    with patch("standard_tooling.bin.st_validate.subprocess.run", side_effect=results) as mock:
+        assert _run_commands(["cmd1", "cmd2", "cmd3"], "test") == 2
+    assert mock.call_count == 3
+
+
+def test_run_commands_fail_fast_stops_on_first() -> None:
     with patch(
         "standard_tooling.bin.st_validate.subprocess.run",
         return_value=subprocess.CompletedProcess(args=[], returncode=1),
-    ):
-        assert _run_commands(["false"], "test") == 1
+    ) as mock:
+        assert _run_commands(["cmd1", "cmd2"], "test", fail_fast=True) == 1
+    assert mock.call_count == 1
 
 
 def test_find_custom_validator_entry_point() -> None:
@@ -259,7 +271,7 @@ def test_check_lint_install_failure_stops(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
     call_count = 0
 
-    def mock_run_commands(cmds: list[str], label: str) -> int:
+    def mock_run_commands(cmds: list[str], label: str, **kwargs: bool) -> int:
         nonlocal call_count
         call_count += 1
         if label == "install":
@@ -281,7 +293,7 @@ def test_check_lint_install_failure_stops(tmp_path: Path) -> None:
 def test_run_all_language_check_failure_stops(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
 
-    def mock_commands(cmds: list[str], label: str) -> int:
+    def mock_commands(cmds: list[str], label: str, **kwargs: bool) -> int:
         if label == "lint":
             return 1
         return 0
@@ -320,7 +332,7 @@ def test_run_all_custom_validator_failure(tmp_path: Path) -> None:
 def test_run_all_install_failure_stops(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
 
-    def mock_commands(cmds: list[str], label: str) -> int:
+    def mock_commands(cmds: list[str], label: str, **kwargs: bool) -> int:
         if label == "install":
             return 1
         return 0

--- a/tests/standard_tooling/test_st_validate.py
+++ b/tests/standard_tooling/test_st_validate.py
@@ -1,0 +1,152 @@
+"""Tests for standard_tooling.bin.st_validate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from standard_tooling.bin.st_validate import main
+
+
+@pytest.fixture(autouse=True)
+def _container_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ST_IN_DEV_CONTAINER", "1")
+
+
+def _write_config(tmp_path: Path, language: str) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(
+        f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
+        f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
+        f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+    )
+
+
+# -- Container guard ----------------------------------------------------------
+
+
+def test_rejects_host_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ST_IN_DEV_CONTAINER", raising=False)
+    with patch("standard_tooling.bin.st_validate._in_dev_container", return_value=False):
+        assert main([]) == 1
+
+
+# -- --check common -----------------------------------------------------------
+
+
+def test_check_common_runs_common_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0) as mock,
+    ):
+        result = main(["--check", "common"])
+    assert result == 0
+    mock.assert_called_once()
+
+
+# -- --check lint (language-specific) -----------------------------------------
+
+
+def test_check_lint_runs_install_then_lint(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    calls: list[str] = []
+
+    def mock_run_commands(cmds: list[str], label: str) -> int:
+        calls.extend(cmds)
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_run_commands),
+    ):
+        result = main(["--check", "lint"])
+    assert result == 0
+    assert "uv sync --frozen --group dev" in calls
+    assert "ruff check src/ tests/" in calls
+
+
+def test_check_lint_no_commands_for_shell(tmp_path: Path) -> None:
+    _write_config(tmp_path, "shell")
+    with patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path):
+        result = main(["--check", "lint"])
+    assert result == 0
+
+
+# -- No --check (run all) ----------------------------------------------------
+
+
+def test_run_all_calls_common_then_language_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    order: list[str] = []
+
+    def mock_common(repo_root: Path) -> int:
+        order.append("common")
+        return 0
+
+    def mock_commands(cmds: list[str], label: str) -> int:
+        order.append(label)
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", side_effect=mock_common),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_commands),
+        patch("standard_tooling.bin.st_validate._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 0
+    assert order[0] == "common"
+    assert "install" in order
+    assert "lint" in order
+    assert "typecheck" in order
+    assert "test" in order
+    assert "audit" in order
+
+
+def test_run_all_stops_on_failure(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    def mock_common(repo_root: Path) -> int:
+        return 1
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", side_effect=mock_common),
+    ):
+        result = main([])
+    assert result == 1
+
+
+def test_run_all_includes_custom_validator(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._run_commands", return_value=0),
+        patch(
+            "standard_tooling.bin.st_validate._find_custom_validator",
+            return_value="/path/to/custom",
+        ),
+        patch(
+            "standard_tooling.bin.st_validate._run_custom_validator",
+            return_value=0,
+        ) as mock_custom,
+    ):
+        result = main([])
+    assert result == 0
+    mock_custom.assert_called_once()
+
+
+def test_run_all_language_none_skips_language_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "none")
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 0

--- a/tests/standard_tooling/test_st_validate.py
+++ b/tests/standard_tooling/test_st_validate.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from standard_tooling.bin.st_validate import main
+from standard_tooling.bin.st_validate import (
+    _find_custom_validator,
+    _in_dev_container,
+    _run_commands,
+    _run_common_checks,
+    _run_custom_validator,
+    main,
+)
+from standard_tooling.lib.validate_commands import CheckKind
 
 
 @pytest.fixture(autouse=True)
@@ -146,6 +155,238 @@ def test_run_all_language_none_skips_language_checks(tmp_path: Path) -> None:
     with (
         patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
         patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 0
+
+
+# -- Unit tests for internal functions ----------------------------------------
+
+
+def test_in_dev_container_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ST_IN_DEV_CONTAINER", "1")
+    assert _in_dev_container() is True
+
+
+def test_in_dev_container_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ST_IN_DEV_CONTAINER", raising=False)
+    with patch("standard_tooling.bin.st_validate.Path.exists", return_value=False):
+        assert _in_dev_container() is False
+
+
+def test_run_commands_success() -> None:
+    with patch(
+        "standard_tooling.bin.st_validate.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=0),
+    ):
+        assert _run_commands(["echo hello"], "test") == 0
+
+
+def test_run_commands_failure() -> None:
+    with patch(
+        "standard_tooling.bin.st_validate.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=1),
+    ):
+        assert _run_commands(["false"], "test") == 1
+
+
+def test_find_custom_validator_entry_point() -> None:
+    with patch("standard_tooling.bin.st_validate.shutil.which", return_value="/usr/bin/custom"):
+        assert _find_custom_validator(Path("/fake")) == "/usr/bin/custom"
+
+
+def test_find_custom_validator_local_script(tmp_path: Path) -> None:
+    scripts_bin = tmp_path / "scripts" / "bin"
+    scripts_bin.mkdir(parents=True)
+    script = scripts_bin / "validate-local-custom"
+    script.write_text("#!/bin/bash\n")
+    script.chmod(0o755)
+    with patch("standard_tooling.bin.st_validate.shutil.which", return_value=None):
+        assert _find_custom_validator(tmp_path) == str(script)
+
+
+def test_find_custom_validator_none(tmp_path: Path) -> None:
+    with patch("standard_tooling.bin.st_validate.shutil.which", return_value=None):
+        assert _find_custom_validator(tmp_path) is None
+
+
+def test_run_custom_validator() -> None:
+    with patch(
+        "standard_tooling.bin.st_validate.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=0),
+    ):
+        assert _run_custom_validator("/path/to/script") == 0
+
+
+def test_run_custom_validator_failure() -> None:
+    with patch(
+        "standard_tooling.bin.st_validate.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=1),
+    ):
+        assert _run_custom_validator("/path/to/script") == 1
+
+
+# -- Config error handling ---------------------------------------------------
+
+
+def test_missing_config_uses_empty_language(tmp_path: Path) -> None:
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+    ):
+        result = main(["--check", "lint"])
+    assert result == 0
+
+
+def test_config_error_returns_1(tmp_path: Path) -> None:
+    from standard_tooling.lib.config import ConfigError
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch(
+            "standard_tooling.bin.st_validate.config.read_config",
+            side_effect=ConfigError("bad config"),
+        ),
+    ):
+        result = main(["--check", "lint"])
+    assert result == 1
+
+
+# -- Install failure stops single check --------------------------------------
+
+
+def test_check_lint_install_failure_stops(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    call_count = 0
+
+    def mock_run_commands(cmds: list[str], label: str) -> int:
+        nonlocal call_count
+        call_count += 1
+        if label == "install":
+            return 1
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_run_commands),
+    ):
+        result = main(["--check", "lint"])
+    assert result == 1
+    assert call_count == 1
+
+
+# -- Run all: language check failure stops -----------------------------------
+
+
+def test_run_all_language_check_failure_stops(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    def mock_commands(cmds: list[str], label: str) -> int:
+        if label == "lint":
+            return 1
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_commands),
+    ):
+        result = main([])
+    assert result == 1
+
+
+# -- Run all: custom validator failure stops ---------------------------------
+
+
+def test_run_all_custom_validator_failure(tmp_path: Path) -> None:
+    _write_config(tmp_path, "none")
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch(
+            "standard_tooling.bin.st_validate._find_custom_validator",
+            return_value="/path/to/custom",
+        ),
+        patch("standard_tooling.bin.st_validate._run_custom_validator", return_value=1),
+    ):
+        result = main([])
+    assert result == 1
+
+
+# -- Run all: install failure stops ------------------------------------------
+
+
+def test_run_all_install_failure_stops(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    def mock_commands(cmds: list[str], label: str) -> int:
+        if label == "install":
+            return 1
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_commands),
+    ):
+        result = main([])
+    assert result == 1
+
+
+# -- _run_common_checks body --------------------------------------------------
+
+
+def test_run_common_checks_calls_common_main() -> None:
+    with patch(
+        "standard_tooling.bin.validate_local_common_container.main", return_value=0,
+    ) as mock:
+        result = _run_common_checks(Path("/fake"))
+    assert result == 0
+    mock.assert_called_once()
+
+
+# -- Branch: no install commands for single check -----------------------------
+
+
+def test_single_check_no_install_commands(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[str]:
+        if kind == CheckKind.INSTALL:
+            return []
+        if kind == CheckKind.LINT:
+            return ["ruff check src/"]
+        return []
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate.language_commands", side_effect=mock_lang_cmds),
+        patch("standard_tooling.bin.st_validate._run_commands", return_value=0) as mock_run,
+    ):
+        result = main(["--check", "lint"])
+    assert result == 0
+    mock_run.assert_called_once_with(["ruff check src/"], "lint")
+
+
+# -- Branch: no install commands in run-all mode ------------------------------
+
+
+def test_run_all_no_install_commands(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[str]:
+        if kind == CheckKind.INSTALL:
+            return []
+        if kind == CheckKind.LINT:
+            return ["ruff check src/"]
+        return []
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate.language_commands", side_effect=mock_lang_cmds),
+        patch("standard_tooling.bin.st_validate._run_commands", return_value=0),
         patch("standard_tooling.bin.st_validate._find_custom_validator", return_value=None),
     ):
         result = main([])

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -10,31 +10,42 @@ from standard_tooling.lib.validate_commands import (
 # -- Python ------------------------------------------------------------------
 
 
+def test_python_install_commands() -> None:
+    cmds = language_commands("python", CheckKind.INSTALL)
+    assert cmds == ["uv sync --frozen --group dev"]
+
+
 def test_python_lint_commands() -> None:
     cmds = language_commands("python", CheckKind.LINT)
-    assert cmds == ["ruff check", "ruff format --check ."]
+    assert cmds == ["ruff check src/ tests/", "ruff format --check src/ tests/"]
 
 
 def test_python_typecheck_commands() -> None:
     cmds = language_commands("python", CheckKind.TYPECHECK)
-    assert "mypy src/" in cmds
-    assert "ty check src" in cmds
+    assert "mypy src/ tests/" in cmds
+    assert "ty check src tests" in cmds
 
 
 def test_python_test_commands() -> None:
     cmds = language_commands("python", CheckKind.TEST)
     assert any("pytest" in c for c in cmds)
+    assert any("--cov=src" in c for c in cmds)
 
 
 def test_python_audit_commands() -> None:
     cmds = language_commands("python", CheckKind.AUDIT)
     assert any("uv sync --check" in c for c in cmds)
     assert any("uv lock --check" in c for c in cmds)
-    assert any("pip-audit" in c for c in cmds)
+    assert "pip-audit" in cmds
     assert any("pip-licenses" in c for c in cmds)
 
 
 # -- Go ----------------------------------------------------------------------
+
+
+def test_go_install_commands() -> None:
+    cmds = language_commands("go", CheckKind.INSTALL)
+    assert cmds == ["go mod download"]
 
 
 def test_go_lint_commands() -> None:
@@ -63,6 +74,11 @@ def test_go_audit_commands() -> None:
 # -- Java ---------------------------------------------------------------------
 
 
+def test_java_install_commands() -> None:
+    cmds = language_commands("java", CheckKind.INSTALL)
+    assert cmds == ["./mvnw dependency:resolve -B"]
+
+
 def test_java_lint_commands() -> None:
     cmds = language_commands("java", CheckKind.LINT)
     assert any("spotless:check" in c for c in cmds)
@@ -88,6 +104,11 @@ def test_java_audit_commands() -> None:
 # -- Ruby ---------------------------------------------------------------------
 
 
+def test_ruby_install_commands() -> None:
+    cmds = language_commands("ruby", CheckKind.INSTALL)
+    assert cmds == ["bundle install --jobs 4"]
+
+
 def test_ruby_lint_commands() -> None:
     cmds = language_commands("ruby", CheckKind.LINT)
     assert any("rubocop" in c for c in cmds)
@@ -109,6 +130,11 @@ def test_ruby_audit_commands() -> None:
 
 
 # -- Rust ---------------------------------------------------------------------
+
+
+def test_rust_install_commands() -> None:
+    cmds = language_commands("rust", CheckKind.INSTALL)
+    assert cmds == ["cargo fetch"]
 
 
 def test_rust_lint_commands() -> None:
@@ -142,6 +168,11 @@ def test_unknown_language_returns_empty() -> None:
 
 def test_shell_language_returns_empty() -> None:
     cmds = language_commands("shell", CheckKind.LINT)
+    assert cmds == []
+
+
+def test_shell_install_commands() -> None:
+    cmds = language_commands("shell", CheckKind.INSTALL)
     assert cmds == []
 
 

--- a/tests/standard_tooling/test_validate_local_common_container.py
+++ b/tests/standard_tooling/test_validate_local_common_container.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from standard_tooling.bin.validate_local_common_container import (
+    _find_dockerfiles,
     _find_markdown_files,
     _find_shell_files,
     _find_yaml_files,
@@ -456,9 +457,8 @@ def test_main_yamllint_runs(tmp_path: Path) -> None:
         ) as mock_run,
     ):
         assert main() == 0
-    mock_run.assert_called_once()
-    call_args = mock_run.call_args[0][0]
-    assert call_args[0] == "yamllint"
+    yamllint_call = mock_run.call_args_list[0][0][0]
+    assert yamllint_call[0] == "yamllint"
 
 
 def test_main_yamllint_fails(tmp_path: Path) -> None:
@@ -479,6 +479,146 @@ def test_main_yamllint_fails(tmp_path: Path) -> None:
         patch(
             "standard_tooling.bin.validate_local_common_container.subprocess.run",
             return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        ),
+    ):
+        assert main() == 1
+
+
+# -- _find_dockerfiles -------------------------------------------------------
+
+
+def test_find_dockerfiles_none(tmp_path: Path) -> None:
+    assert _find_dockerfiles(tmp_path) == []
+
+
+def test_find_dockerfiles_discovers_dockerfile(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+    result = _find_dockerfiles(tmp_path)
+    assert len(result) == 1
+    assert result[0].endswith("Dockerfile")
+
+
+def test_find_dockerfiles_discovers_variants(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+    (tmp_path / "Dockerfile.dev").write_text("FROM python:3.12\n")
+    result = _find_dockerfiles(tmp_path)
+    assert len(result) == 2
+
+
+def test_find_dockerfiles_sorted(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile.dev").write_text("FROM python:3.12\n")
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+    result = _find_dockerfiles(tmp_path)
+    assert result == sorted(result)
+
+
+def test_find_dockerfiles_ignores_non_dockerfile(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("# Project\n")
+    (tmp_path / "Makefile").write_text("build:\n")
+    assert _find_dockerfiles(tmp_path) == []
+
+
+# -- main: hadolint path ----------------------------------------------------
+
+
+def test_main_hadolint_runs(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    hadolint_call = mock_run.call_args_list[0][0][0]
+    assert hadolint_call[0] == "hadolint"
+
+
+def test_main_hadolint_fails(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        ),
+    ):
+        assert main() == 1
+
+
+# -- main: actionlint path --------------------------------------------------
+
+
+def test_main_actionlint_runs(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: CI\n")
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    tool_names = [call[0][0][0] for call in mock_run.call_args_list]
+    assert "actionlint" in tool_names
+
+
+def test_main_actionlint_fails(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_MINIMAL_TOML)
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: CI\n")
+
+    calls = []
+
+    def mock_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(cmd)
+        if cmd[0] == "actionlint":
+            return subprocess.CompletedProcess(args=cmd, returncode=1)
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    with (
+        patch(
+            "standard_tooling.bin.validate_local_common_container.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.repo_profile_cli.main",
+            return_value=0,
+        ),
+        patch(
+            "standard_tooling.bin.validate_local_common_container.subprocess.run",
+            side_effect=mock_run,
         ),
     ):
         assert main() == 1

--- a/tests/standard_tooling/test_version.py
+++ b/tests/standard_tooling/test_version.py
@@ -235,3 +235,67 @@ def test_bump_generic_skips_lockfile(tmp_path: Path) -> None:
     with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
         bump(tmp_path)
         mock_run.assert_not_called()
+
+
+# -- _discover_version_file error paths ----------------------------------------
+
+
+def test_discover_ruby_no_match(tmp_path: Path) -> None:
+    from standard_tooling.lib.version import _discover_version_file
+
+    with pytest.raises(FileNotFoundError, match="No lib"):
+        _discover_version_file(tmp_path, "ruby")
+
+
+def test_discover_go_no_match(tmp_path: Path) -> None:
+    from standard_tooling.lib.version import _discover_version_file
+
+    with pytest.raises(FileNotFoundError, match="No .*/version.go"):
+        _discover_version_file(tmp_path, "go")
+
+
+def test_discover_unsupported_language(tmp_path: Path) -> None:
+    from standard_tooling.lib.version import _discover_version_file
+
+    with pytest.raises(ValueError, match="Unsupported language"):
+        _discover_version_file(tmp_path, "fortran")
+
+
+# -- _read_version error paths -------------------------------------------------
+
+
+def test_read_version_ruby_bad_format() -> None:
+    from standard_tooling.lib.version import _read_version
+
+    with pytest.raises(ValueError, match="No VERSION"):
+        _read_version("no version here", "ruby")
+
+
+def test_read_version_go_bad_format() -> None:
+    from standard_tooling.lib.version import _read_version
+
+    with pytest.raises(ValueError, match="No Version"):
+        _read_version("no version here", "go")
+
+
+def test_read_version_java_bad_format() -> None:
+    from standard_tooling.lib.version import _read_version
+
+    with pytest.raises(ValueError, match="No <version>"):
+        _read_version("no version here", "java")
+
+
+# -- _read_version_from_ref body -----------------------------------------------
+
+
+def test_read_version_from_ref_body(tmp_path: Path) -> None:
+    from standard_tooling.lib.version import _read_version_from_ref
+
+    with patch(
+        "standard_tooling.lib.version.subprocess.run",
+        return_value=__import__("subprocess").CompletedProcess(
+            args=[], returncode=0, stdout="1.2.3\n"
+        ),
+    ):
+        result = _read_version_from_ref("origin/main", "VERSION", "shell")
+    assert result == "1.2.3"

--- a/tests/standard_tooling/test_version.py
+++ b/tests/standard_tooling/test_version.py
@@ -29,9 +29,7 @@ def _write_toml(tmp_path: Path, language: str) -> None:
 
 def test_show_python(tmp_path: Path) -> None:
     _write_toml(tmp_path, "python")
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nname = "example"\nversion = "1.2.3"\n'
-    )
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\nversion = "1.2.3"\n')
     assert show(tmp_path) == "1.2.3"
 
 
@@ -43,9 +41,7 @@ def test_show_generic_version_file(tmp_path: Path) -> None:
 
 def test_show_rust(tmp_path: Path) -> None:
     _write_toml(tmp_path, "rust")
-    (tmp_path / "Cargo.toml").write_text(
-        '[package]\nname = "example"\nversion = "0.3.7"\n'
-    )
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "example"\nversion = "0.3.7"\n')
     assert show(tmp_path) == "0.3.7"
 
 
@@ -67,9 +63,7 @@ def test_show_go(tmp_path: Path) -> None:
 
 def test_show_java(tmp_path: Path) -> None:
     _write_toml(tmp_path, "java")
-    (tmp_path / "pom.xml").write_text(
-        "<project>\n  <version>3.2.1</version>\n</project>\n"
-    )
+    (tmp_path / "pom.xml").write_text("<project>\n  <version>3.2.1</version>\n</project>\n")
     assert show(tmp_path) == "3.2.1"
 
 
@@ -134,9 +128,7 @@ def test_bump_generic(tmp_path: Path) -> None:
 
 def test_bump_python(tmp_path: Path) -> None:
     _write_toml(tmp_path, "python")
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nname = "example"\nversion = "2.0.0"\n'
-    )
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\nversion = "2.0.0"\n')
     with patch("standard_tooling.lib.version.subprocess.run"):
         result = bump(tmp_path)
     assert result == "2.0.1"
@@ -146,9 +138,7 @@ def test_bump_python(tmp_path: Path) -> None:
 
 def test_bump_rust(tmp_path: Path) -> None:
     _write_toml(tmp_path, "rust")
-    (tmp_path / "Cargo.toml").write_text(
-        '[package]\nname = "example"\nversion = "0.3.7"\n'
-    )
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "example"\nversion = "0.3.7"\n')
     with patch("standard_tooling.lib.version.subprocess.run"):
         result = bump(tmp_path)
     assert result == "0.3.8"
@@ -181,9 +171,7 @@ def test_bump_go(tmp_path: Path) -> None:
 
 def test_bump_java(tmp_path: Path) -> None:
     _write_toml(tmp_path, "java")
-    (tmp_path / "pom.xml").write_text(
-        "<project>\n  <version>3.2.1</version>\n</project>\n"
-    )
+    (tmp_path / "pom.xml").write_text("<project>\n  <version>3.2.1</version>\n</project>\n")
     result = bump(tmp_path)
     assert result == "3.2.2"
     text = (tmp_path / "pom.xml").read_text()
@@ -195,25 +183,25 @@ def test_bump_java(tmp_path: Path) -> None:
 
 def test_bump_python_runs_uv_lock(tmp_path: Path) -> None:
     _write_toml(tmp_path, "python")
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nname = "example"\nversion = "1.0.0"\n'
-    )
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\nversion = "1.0.0"\n')
     with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
         bump(tmp_path)
         mock_run.assert_called_once_with(
-            ["uv", "lock"], cwd=tmp_path, check=True,
+            ["uv", "lock"],
+            cwd=tmp_path,
+            check=True,
         )
 
 
 def test_bump_rust_runs_cargo_update(tmp_path: Path) -> None:
     _write_toml(tmp_path, "rust")
-    (tmp_path / "Cargo.toml").write_text(
-        '[package]\nname = "example"\nversion = "0.1.0"\n'
-    )
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "example"\nversion = "0.1.0"\n')
     with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
         bump(tmp_path)
         mock_run.assert_called_once_with(
-            ["cargo", "update", "--workspace"], cwd=tmp_path, check=True,
+            ["cargo", "update", "--workspace"],
+            cwd=tmp_path,
+            check=True,
         )
 
 
@@ -225,7 +213,9 @@ def test_bump_ruby_runs_bundle_install(tmp_path: Path) -> None:
     with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
         bump(tmp_path)
         mock_run.assert_called_once_with(
-            ["bundle", "install"], cwd=tmp_path, check=True,
+            ["bundle", "install"],
+            cwd=tmp_path,
+            check=True,
         )
 
 

--- a/tests/standard_tooling/test_version.py
+++ b/tests/standard_tooling/test_version.py
@@ -1,0 +1,237 @@
+"""Tests for standard_tooling.lib.version."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from standard_tooling.lib.version import bump, show, show_major_minor
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# -- Fixture helpers ----------------------------------------------------------
+
+
+def _write_toml(tmp_path: Path, language: str) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(
+        f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
+        f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
+        f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+    )
+
+
+# -- show() tests ------------------------------------------------------------
+
+
+def test_show_python(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "python")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "1.2.3"\n'
+    )
+    assert show(tmp_path) == "1.2.3"
+
+
+def test_show_generic_version_file(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "shell")
+    (tmp_path / "VERSION").write_text("2.0.1\n")
+    assert show(tmp_path) == "2.0.1"
+
+
+def test_show_rust(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "rust")
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "example"\nversion = "0.3.7"\n'
+    )
+    assert show(tmp_path) == "0.3.7"
+
+
+def test_show_ruby(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "ruby")
+    version_dir = tmp_path / "lib" / "mq" / "rest" / "admin"
+    version_dir.mkdir(parents=True)
+    (version_dir / "version.rb").write_text("  VERSION = '4.1.0'\n")
+    assert show(tmp_path) == "4.1.0"
+
+
+def test_show_go(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "go")
+    pkg_dir = tmp_path / "mqrestadmin"
+    pkg_dir.mkdir()
+    (pkg_dir / "version.go").write_text('package mqrestadmin\n\nVersion = "1.0.5"\n')
+    assert show(tmp_path) == "1.0.5"
+
+
+def test_show_java(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "java")
+    (tmp_path / "pom.xml").write_text(
+        "<project>\n  <version>3.2.1</version>\n</project>\n"
+    )
+    assert show(tmp_path) == "3.2.1"
+
+
+# -- show_major_minor() tests ------------------------------------------------
+
+
+def test_show_major_minor(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "shell")
+    (tmp_path / "VERSION").write_text("1.5.2\n")
+    assert show_major_minor(tmp_path) == "1.5"
+
+
+# -- version_file override ---------------------------------------------------
+
+
+def test_show_with_version_file_override(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(
+        '[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
+        'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
+        'primary-language = "shell"\nversion-file = "custom/VERSION"\n\n'
+        '[dependencies]\nstandard-tooling = "v1.4"\n'
+    )
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    (custom_dir / "VERSION").write_text("9.8.7\n")
+    assert show(tmp_path) == "9.8.7"
+
+
+# -- error cases --------------------------------------------------------------
+
+
+def test_show_missing_version_file(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "shell")
+    with pytest.raises(FileNotFoundError):
+        show(tmp_path)
+
+
+# -- show_ref() tests --------------------------------------------------------
+
+
+def test_show_ref_reads_via_git(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "shell")
+    (tmp_path / "VERSION").write_text("3.0.0\n")
+
+    with patch("standard_tooling.lib.version._read_version_from_ref") as mock:
+        mock.return_value = "2.9.0"
+        result = show(tmp_path, ref="origin/main")
+    assert result == "2.9.0"
+    mock.assert_called_once()
+
+
+# -- bump() tests ------------------------------------------------------------
+
+
+def test_bump_generic(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "shell")
+    (tmp_path / "VERSION").write_text("1.2.3\n")
+    result = bump(tmp_path)
+    assert result == "1.2.4"
+    assert (tmp_path / "VERSION").read_text().strip() == "1.2.4"
+
+
+def test_bump_python(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "python")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "2.0.0"\n'
+    )
+    with patch("standard_tooling.lib.version.subprocess.run"):
+        result = bump(tmp_path)
+    assert result == "2.0.1"
+    text = (tmp_path / "pyproject.toml").read_text()
+    assert 'version = "2.0.1"' in text
+
+
+def test_bump_rust(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "rust")
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "example"\nversion = "0.3.7"\n'
+    )
+    with patch("standard_tooling.lib.version.subprocess.run"):
+        result = bump(tmp_path)
+    assert result == "0.3.8"
+    text = (tmp_path / "Cargo.toml").read_text()
+    assert 'version = "0.3.8"' in text
+
+
+def test_bump_ruby(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "ruby")
+    version_dir = tmp_path / "lib" / "mq"
+    version_dir.mkdir(parents=True)
+    (version_dir / "version.rb").write_text("  VERSION = '1.0.0'\n")
+    with patch("standard_tooling.lib.version.subprocess.run"):
+        result = bump(tmp_path)
+    assert result == "1.0.1"
+    text = (version_dir / "version.rb").read_text()
+    assert "VERSION = '1.0.1'" in text
+
+
+def test_bump_go(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "go")
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "version.go").write_text('package pkg\n\nVersion = "1.0.5"\n')
+    result = bump(tmp_path)
+    assert result == "1.0.6"
+    text = (pkg_dir / "version.go").read_text()
+    assert 'Version = "1.0.6"' in text
+
+
+def test_bump_java(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "java")
+    (tmp_path / "pom.xml").write_text(
+        "<project>\n  <version>3.2.1</version>\n</project>\n"
+    )
+    result = bump(tmp_path)
+    assert result == "3.2.2"
+    text = (tmp_path / "pom.xml").read_text()
+    assert "<version>3.2.2</version>" in text
+
+
+# -- lockfile maintenance tests -----------------------------------------------
+
+
+def test_bump_python_runs_uv_lock(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "python")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "1.0.0"\n'
+    )
+    with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
+        bump(tmp_path)
+        mock_run.assert_called_once_with(
+            ["uv", "lock"], cwd=tmp_path, check=True,
+        )
+
+
+def test_bump_rust_runs_cargo_update(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "rust")
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "example"\nversion = "0.1.0"\n'
+    )
+    with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
+        bump(tmp_path)
+        mock_run.assert_called_once_with(
+            ["cargo", "update", "--workspace"], cwd=tmp_path, check=True,
+        )
+
+
+def test_bump_ruby_runs_bundle_install(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "ruby")
+    version_dir = tmp_path / "lib" / "mq"
+    version_dir.mkdir(parents=True)
+    (version_dir / "version.rb").write_text("  VERSION = '1.0.0'\n")
+    with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
+        bump(tmp_path)
+        mock_run.assert_called_once_with(
+            ["bundle", "install"], cwd=tmp_path, check=True,
+        )
+
+
+def test_bump_generic_skips_lockfile(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "shell")
+    (tmp_path / "VERSION").write_text("1.0.0\n")
+    with patch("standard_tooling.lib.version.subprocess.run") as mock_run:
+        bump(tmp_path)
+        mock_run.assert_not_called()

--- a/tests/standard_tooling/test_version_cli.py
+++ b/tests/standard_tooling/test_version_cli.py
@@ -1,0 +1,57 @@
+"""Tests for st-version CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from standard_tooling.bin.version import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_toml(tmp_path: Path, language: str = "shell") -> None:
+    (tmp_path / "standard-tooling.toml").write_text(
+        f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
+        f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
+        f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+    )
+
+
+def test_show(tmp_path: Path, capsys: object) -> None:
+    _write_toml(tmp_path)
+    (tmp_path / "VERSION").write_text("1.2.3\n")
+    with patch("standard_tooling.bin.version.Path.cwd", return_value=tmp_path):
+        main.__wrapped__() if hasattr(main, "__wrapped__") else None  # noqa: B018
+    # Use direct function approach instead
+    from standard_tooling.lib.version import show
+
+    assert show(tmp_path) == "1.2.3"
+
+
+def test_show_major_minor(tmp_path: Path) -> None:
+    _write_toml(tmp_path)
+    (tmp_path / "VERSION").write_text("1.2.3\n")
+    from standard_tooling.lib.version import show_major_minor
+
+    assert show_major_minor(tmp_path) == "1.2"
+
+
+def test_show_ref(tmp_path: Path) -> None:
+    _write_toml(tmp_path)
+    (tmp_path / "VERSION").write_text("1.2.3\n")
+    with patch("standard_tooling.lib.version._read_version_from_ref", return_value="1.1.0"):
+        from standard_tooling.lib.version import show
+
+        assert show(tmp_path, ref="HEAD") == "1.1.0"
+
+
+def test_bump(tmp_path: Path) -> None:
+    _write_toml(tmp_path)
+    (tmp_path / "VERSION").write_text("1.2.3\n")
+    from standard_tooling.lib.version import bump
+
+    result = bump(tmp_path)
+    assert result == "1.2.4"
+    assert (tmp_path / "VERSION").read_text().strip() == "1.2.4"

--- a/tests/standard_tooling/test_version_cli.py
+++ b/tests/standard_tooling/test_version_cli.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+if TYPE_CHECKING:
+    import pytest
+
 from standard_tooling.bin.version import main
 
 if TYPE_CHECKING:
@@ -19,39 +22,52 @@ def _write_toml(tmp_path: Path, language: str = "shell") -> None:
     )
 
 
-def test_show(tmp_path: Path, capsys: object) -> None:
+def test_show(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _write_toml(tmp_path)
     (tmp_path / "VERSION").write_text("1.2.3\n")
-    with patch("standard_tooling.bin.version.Path.cwd", return_value=tmp_path):
-        main.__wrapped__() if hasattr(main, "__wrapped__") else None  # noqa: B018
-    # Use direct function approach instead
-    from standard_tooling.lib.version import show
+    with (
+        patch("standard_tooling.bin.version.Path.cwd", return_value=tmp_path),
+        patch("sys.argv", ["st-version", "show"]),
+    ):
+        main()
+    assert capsys.readouterr().out.strip() == "1.2.3"
 
-    assert show(tmp_path) == "1.2.3"
 
-
-def test_show_major_minor(tmp_path: Path) -> None:
+def test_show_major_minor(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     _write_toml(tmp_path)
     (tmp_path / "VERSION").write_text("1.2.3\n")
-    from standard_tooling.lib.version import show_major_minor
+    with (
+        patch("standard_tooling.bin.version.Path.cwd", return_value=tmp_path),
+        patch("sys.argv", ["st-version", "show", "--major-minor"]),
+    ):
+        main()
+    assert capsys.readouterr().out.strip() == "1.2"
 
-    assert show_major_minor(tmp_path) == "1.2"
 
-
-def test_show_ref(tmp_path: Path) -> None:
+def test_show_ref(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _write_toml(tmp_path)
     (tmp_path / "VERSION").write_text("1.2.3\n")
-    with patch("standard_tooling.lib.version._read_version_from_ref", return_value="1.1.0"):
-        from standard_tooling.lib.version import show
+    with (
+        patch("standard_tooling.bin.version.Path.cwd", return_value=tmp_path),
+        patch(
+            "standard_tooling.lib.version._read_version_from_ref",
+            return_value="1.1.0",
+        ),
+        patch("sys.argv", ["st-version", "show", "--ref", "origin/main"]),
+    ):
+        main()
+    assert capsys.readouterr().out.strip() == "1.1.0"
 
-        assert show(tmp_path, ref="HEAD") == "1.1.0"
 
-
-def test_bump(tmp_path: Path) -> None:
+def test_bump(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _write_toml(tmp_path)
     (tmp_path / "VERSION").write_text("1.2.3\n")
-    from standard_tooling.lib.version import bump
-
-    result = bump(tmp_path)
-    assert result == "1.2.4"
+    with (
+        patch("standard_tooling.bin.version.Path.cwd", return_value=tmp_path),
+        patch("sys.argv", ["st-version", "bump"]),
+    ):
+        main()
+    assert capsys.readouterr().out.strip() == "1.2.4"
     assert (tmp_path / "VERSION").read_text().strip() == "1.2.4"

--- a/tests/standard_tooling/test_version_cli.py
+++ b/tests/standard_tooling/test_version_cli.py
@@ -33,9 +33,7 @@ def test_show(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert capsys.readouterr().out.strip() == "1.2.3"
 
 
-def test_show_major_minor(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_show_major_minor(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _write_toml(tmp_path)
     (tmp_path / "VERSION").write_text("1.2.3\n")
     with (


### PR DESCRIPTION
# Pull Request

## Summary

- Command registry fixes, st-validate, st-version, common check enhancements

## Issue Linkage

- Ref #544

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Phase 1 of the CI workflow reset: foundations in the standard-tooling repo.

### Command registry updates
- Fix Python commands to target src/ tests/ instead of bare module names
- Add INSTALL check kind with per-language install commands (python, rust, ruby, go, java)
- Embed pip-licenses allowlist sourced from ai-research-methodology
- Simplify pip-audit to plain pip-audit (no -r flags)

### New: st-validate unified CLI
- Reads primary-language from standard-tooling.toml
- Supports --check {common,lint,typecheck,test,audit} for single checks
- Run-all mode: common -> install -> lint -> typecheck -> test -> audit -> custom
- Container guard (ST_IN_DEV_CONTAINER or /.dockerenv)
- Custom validator discovery (entry point or scripts/bin/validate-local-custom)

### New: st-version library and CLI
- Per-language version discovery (python/pyproject.toml, rust/Cargo.toml, ruby/version.rb, go/version.go, java/pom.xml, shell/VERSION)
- show, show --major-minor, show --ref, bump subcommands
- version-file override via standard-tooling.toml
- Lockfile maintenance after bump (uv lock, cargo update, bundle install)

### Common validation enhancements
- Add hadolint (Dockerfile linting) after yamllint
- Add actionlint (GitHub Actions workflow linting) after hadolint

### Refactors
- docker_cache.py: replace hardcoded _WARMUP_COMMANDS with registry-driven install lookup
- finalize_repo.py: call st-validate instead of st-validate-local

### Quality
- 751 tests, 100% branch coverage
- All lint, format, typecheck, and audit checks pass