### PR TITLE
feat(github-config): add GHAS check runs to CI gates required checks

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -162,6 +162,7 @@ def desired_tag_protection_ruleset() -> DesiredRuleset:
 # ---------------------------------------------------------------------------
 
 _GITHUB_ACTIONS_INTEGRATION_ID = 15368
+_GHAS_INTEGRATION_ID = 57789
 
 _CODEQL_SUPPORTED_LANGUAGES = frozenset(
     {
@@ -178,6 +179,13 @@ def _make_check(context: str) -> dict[str, object]:
     return {
         "context": context,
         "integration_id": _GITHUB_ACTIONS_INTEGRATION_ID,
+    }
+
+
+def _make_ghas_check(context: str) -> dict[str, object]:
+    return {
+        "context": context,
+        "integration_id": _GHAS_INTEGRATION_ID,
     }
 
 
@@ -210,6 +218,12 @@ def desired_ci_gates_ruleset(
     checks.append(_make_check("security / trivy"))
     checks.append(_make_check("security / semgrep"))
     checks.append(_make_check("security / standards"))
+
+    # GHAS check runs — created by GitHub Advanced Security (app 57789)
+    # when workflows upload SARIF via codeql-action/upload-sarif.  These
+    # gate on whether the PR introduces new alerts in changed lines.
+    checks.append(_make_ghas_check("Trivy"))
+    checks.append(_make_ghas_check("Semgrep OSS"))
 
     # CodeQL for supported languages
     if lang in _CODEQL_SUPPORTED_LANGUAGES:

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -136,9 +136,14 @@ def _ci(
 
 def _check_names(ruleset: DesiredRuleset) -> list[str]:
     """Extract check context names from a CI gates ruleset."""
+    return [c["context"] for c in _checks(ruleset)]
+
+
+def _checks(ruleset: DesiredRuleset) -> list[dict[str, object]]:
+    """Extract all check dicts from a CI gates ruleset."""
     status_rule = next(rule for rule in ruleset.rules if rule["type"] == "required_status_checks")
-    params = cast("dict[str, list[dict[str, str]]]", status_rule["parameters"])
-    return [c["context"] for c in params["required_status_checks"]]
+    params = cast("dict[str, list[dict[str, object]]]", status_rule["parameters"])
+    return params["required_status_checks"]
 
 
 def test_ci_gates_structure() -> None:
@@ -164,6 +169,16 @@ def test_ci_gates_always_includes_common_and_security() -> None:
     assert "security / trivy" in check_names
     assert "security / semgrep" in check_names
     assert "security / standards" in check_names
+    assert "Trivy" in check_names
+    assert "Semgrep OSS" in check_names
+
+
+def test_ci_gates_ghas_checks_use_ghas_integration_id() -> None:
+    r = desired_ci_gates_ruleset(_project(), _ci())
+    checks = _checks(r)
+    ghas_names = ("Trivy", "Semgrep OSS")
+    ghas_checks = {c["context"]: c["integration_id"] for c in checks if c["context"] in ghas_names}
+    assert ghas_checks == {"Trivy": 57789, "Semgrep OSS": 57789}
 
 
 def test_ci_gates_codeql_for_supported_language() -> None:

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -136,7 +136,7 @@ def _ci(
 
 def _check_names(ruleset: DesiredRuleset) -> list[str]:
     """Extract check context names from a CI gates ruleset."""
-    return [c["context"] for c in _checks(ruleset)]
+    return [str(c["context"]) for c in _checks(ruleset)]
 
 
 def _checks(ruleset: DesiredRuleset) -> list[dict[str, object]]:


### PR DESCRIPTION
# Pull Request

## Summary

- Add Semgrep OSS and Trivy GHAS check runs (integration_id 57789) to the CI gates ruleset required checks, so PRs cannot merge while GHAS is still processing uploaded SARIF.

## Issue Linkage

- Ref #553

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Adds two new required checks to the CI gates ruleset derived by st-github-config:

- **Trivy** (integration_id 57789) — gates on whether GHAS found new Trivy alerts in PR changed lines
- **Semgrep OSS** (integration_id 57789) — gates on whether GHAS found new Semgrep alerts in PR changed lines

These are distinct from the existing workflow checks (security / trivy, security / semgrep) which only verify the scan completed successfully. The GHAS checks are created by GitHub Advanced Security (app 57789) when workflows upload SARIF via codeql-action/upload-sarif.

Changes:
- Added _GHAS_INTEGRATION_ID constant and _make_ghas_check() helper
- Added Trivy and Semgrep OSS checks to desired_ci_gates_ruleset()
- Added _checks() test helper for full check dict extraction
- Added test for GHAS check presence and integration_id verification