### PR TITLE
feat(github-config): add --config flag to override remote config source

### DIFF
--- a/src/standard_tooling/bin/github_config.py
+++ b/src/standard_tooling/bin/github_config.py
@@ -6,6 +6,7 @@ import argparse
 import base64
 import sys
 import tomllib
+from pathlib import Path
 
 from standard_tooling.lib import github
 from standard_tooling.lib.config import StConfig, _parse_raw_config
@@ -29,6 +30,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         sp.add_argument("--repo", help="Single repo (OWNER/REPO)")
         sp.add_argument("--owner", help="GitHub owner (project mode)")
         sp.add_argument("--project", help="GitHub Project number")
+        sp.add_argument(
+            "--config",
+            help="Local path to standard-tooling.toml (overrides remote fetch)",
+        )
         if name == "apply":
             sp.add_argument(
                 "--yes",
@@ -49,6 +54,13 @@ def _resolve_repos(args: argparse.Namespace) -> list[str]:
     if args.repo:
         return [args.repo]
     return github.list_project_repos(args.owner, args.project)
+
+
+def _load_local_config(path: str) -> StConfig:
+    """Load and parse standard-tooling.toml from a local file path."""
+    with Path(path).open("rb") as f:
+        raw = tomllib.load(f)
+    return _parse_raw_config(raw)
 
 
 def _fetch_remote_config(repo: str) -> StConfig:
@@ -97,8 +109,13 @@ def main(argv: list[str] | None = None) -> int:
     repos = _resolve_repos(args)
     all_compliant = True
 
+    local_config = _load_local_config(args.config) if args.config else None
+
+    def get_config(repo: str) -> StConfig:
+        return local_config if local_config is not None else _fetch_remote_config(repo)
+
     for repo in repos:
-        config = _fetch_remote_config(repo)
+        config = get_config(repo)
         diff = _audit_repo(repo, config)
         _print_diff(repo, diff)
         if not diff.is_compliant():
@@ -109,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "diff":
         return 0
 
-    non_compliant = [r for r in repos if not _audit_repo(r, _fetch_remote_config(r)).is_compliant()]
+    non_compliant = [r for r in repos if not _audit_repo(r, get_config(r)).is_compliant()]
     if not non_compliant:
         print("All repos compliant, nothing to apply.")
         return 0
@@ -124,7 +141,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     for repo in non_compliant:
-        config = _fetch_remote_config(repo)
+        config = get_config(repo)
         print(f"  Applying to {repo}...")
         removed = _apply_repo(repo, config)
         if removed:

--- a/tests/standard_tooling/test_github_config_cli.py
+++ b/tests/standard_tooling/test_github_config_cli.py
@@ -12,6 +12,7 @@ from standard_tooling.bin.github_config import (
     _apply_repo,
     _audit_repo,
     _fetch_remote_config,
+    _load_local_config,
     _resolve_repos,
     main,
     parse_args,
@@ -58,6 +59,26 @@ def test_parse_project_mode() -> None:
 def test_parse_no_target_fails() -> None:
     with pytest.raises(SystemExit):
         parse_args(["audit"])
+
+
+def test_parse_config_flag_audit() -> None:
+    args = parse_args(["audit", "--repo", "o/r", "--config", "local/st.toml"])
+    assert args.config == "local/st.toml"
+
+
+def test_parse_config_flag_diff() -> None:
+    args = parse_args(["diff", "--repo", "o/r", "--config", "./st.toml"])
+    assert args.config == "./st.toml"
+
+
+def test_parse_config_flag_apply() -> None:
+    args = parse_args(["apply", "--repo", "o/r", "--config", "st.toml"])
+    assert args.config == "st.toml"
+
+
+def test_parse_config_flag_absent() -> None:
+    args = parse_args(["audit", "--repo", "o/r"])
+    assert args.config is None
 
 
 def test_parse_no_command_fails() -> None:
@@ -206,6 +227,24 @@ def test_fetch_remote_config_no_content_field() -> None:
         pytest.raises(RuntimeError, match="No content field"),
     ):
         _fetch_remote_config("o/r")
+
+
+# -- _load_local_config --------------------------------------------------------
+
+
+def test_load_local_config_success(tmp_path: object) -> None:
+    from pathlib import Path
+
+    p = Path(str(tmp_path)) / "standard-tooling.toml"
+    p.write_bytes(_VALID_TOML)
+    cfg = _load_local_config(str(p))
+    assert cfg.project.primary_language == "python"
+    assert cfg.project.versioning_scheme == "semver"
+
+
+def test_load_local_config_file_not_found() -> None:
+    with pytest.raises(FileNotFoundError):
+        _load_local_config("/nonexistent/path/standard-tooling.toml")
 
 
 # -- _audit_repo ---------------------------------------------------------------
@@ -384,3 +423,85 @@ def test_apply_reports_legacy_protection_removed(monkeypatch: pytest.MonkeyPatch
     assert result == 0
     output = " ".join(str(c) for c in mock_print.call_args_list)
     assert "legacy protection removed" in output
+
+
+# -- --config flag integration -------------------------------------------------
+
+
+def test_config_flag_bypasses_remote_fetch(tmp_path: object) -> None:
+    from pathlib import Path
+
+    p = Path(str(tmp_path)) / "standard-tooling.toml"
+    p.write_bytes(_VALID_TOML)
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_compliant(),
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch(
+            "standard_tooling.bin.github_config._fetch_remote_config",
+        ) as mock_remote,
+    ):
+        result = main(["audit", "--repo", "o/r", "--config", str(p)])
+    assert result == 0
+    mock_remote.assert_not_called()
+
+
+def test_config_flag_passes_parsed_config_to_audit(tmp_path: object) -> None:
+    from pathlib import Path
+
+    p = Path(str(tmp_path)) / "standard-tooling.toml"
+    p.write_bytes(_VALID_TOML)
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            return_value=_mock_compliant(),
+        ) as mock_audit,
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+    ):
+        main(["audit", "--repo", "o/r", "--config", str(p)])
+    cfg = mock_audit.call_args[0][1]
+    assert cfg.project.primary_language == "python"
+
+
+def test_config_flag_apply_uses_local_config(tmp_path: object) -> None:
+    from pathlib import Path
+
+    p = Path(str(tmp_path)) / "standard-tooling.toml"
+    p.write_bytes(_VALID_TOML)
+
+    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
+        return _mock_noncompliant()
+
+    with (
+        patch(
+            "standard_tooling.bin.github_config._audit_repo",
+            side_effect=audit_side_effect,
+        ),
+        patch(
+            "standard_tooling.bin.github_config._resolve_repos",
+            return_value=["o/r"],
+        ),
+        patch(
+            "standard_tooling.bin.github_config._fetch_remote_config",
+        ) as mock_remote,
+        patch(
+            "standard_tooling.bin.github_config._apply_repo",
+            return_value=[],
+        ) as mock_apply,
+    ):
+        result = main(["apply", "--repo", "o/r", "--yes", "--config", str(p)])
+    assert result == 0
+    mock_remote.assert_not_called()
+    mock_apply.assert_called_once()
+    cfg = mock_apply.call_args[0][1]
+    assert cfg.project.primary_language == "python"


### PR DESCRIPTION
# Pull Request

## Summary

- Add --config flag to st-github-config audit/diff/apply subcommands to read config from a local file instead of fetching from the remote default branch

## Issue Linkage

- Ref #556

## Testing

- markdownlint
- ci: shellcheck

## Notes

- When `st-github-config` computes desired state, it always fetches
`standard-tooling.toml` from the remote default branch. This means
a PR that changes `ci.versions` can't update rulesets ahead of
merge — the tool sees the old config and reports "compliant" while
the new CI checks don't match.

The `--config` flag accepts a local file path and overrides the
remote fetch. Workflow:

1. Edit `standard-tooling.toml` on a feature branch
2. `st-github-config apply --repo owner/repo --config ./standard-tooling.toml`
3. Submit the PR — required checks now match what CI will produce

When `--config` is omitted, existing behavior is preserved.

### Changes

- `parse_args()`: added `--config` to all three subcommands
- `_load_local_config(path)`: new function — reads and parses a
  local TOML file via `Path.open()` + `tomllib`
- `main()`: preloads local config when `--config` is provided;
  uses `get_config(repo)` helper that returns local config or
  falls back to `_fetch_remote_config(repo)`
- 9 new tests: arg parsing (4), `_load_local_config` unit (2),
  integration (3 — verifies remote fetch is bypassed, parsed
  config reaches audit/apply)