### PR TITLE
fix(docs): remove stale validate-local references from mkdocs nav and reference index

### DIFF
--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -29,12 +29,7 @@ Run inside dev containers launched by `st-docker-run`.
 
 | Tool | Purpose |
 | ---- | ------- |
-| [st-validate-local](dev/validate-local.md) | Local validation driver |
-| `st-validate-local-common` | Shared checks (repo profile, markdown, shellcheck, yamllint) |
-| `st-validate-local-python` | Python-specific validation (lint, typecheck, test, audit) |
-| `st-validate-local-rust` | Rust-specific validation |
-| `st-validate-local-go` | Go-specific validation |
-| `st-validate-local-java` | Java-specific validation |
+| [st-validate](cli-tools-overview.md#st-validate) | Unified validation driver (common + language-specific checks) |
 | [st-repo-profile](lint/repo-profile.md) | Repository profile attribute validation |
 | [Markdown validation](lint/markdown-standards.md) | Markdownlint with bundled canonical config |
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -74,7 +74,6 @@ nav:
           - st-submit-pr: reference/dev/submit-pr.md
           - st-prepare-release: reference/dev/prepare-release.md
           - st-finalize-repo: reference/dev/finalize-repo.md
-          - st-validate-local: reference/dev/validate-local.md
   - Guides:
       - Git Workflow: guides/git-workflow.md
       - Consuming Repo Setup: guides/consuming-repo-setup.md


### PR DESCRIPTION
# Pull Request

## Summary

- remove stale validate-local references from mkdocs nav and reference index

## Issue Linkage

- Ref #575

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Removes stale references to the decommissioned `validate-local.md` page that were missed in PR #571.

## Changes

- `docs/site/mkdocs.yml`: remove nav entry for `reference/dev/validate-local.md`
- `docs/site/docs/reference/index.md`: replace decommissioned `st-validate-local-*` tools with `st-validate` in the Container tools table

These broken references caused `docs.yml` to abort in mkdocs strict mode, blocking docs deployment for v1.4.22.

Ref #575