### PR TITLE
fix(docker): pass --platform for correct arch selection

### DIFF
--- a/src/standard_tooling/bin/docker_docs.py
+++ b/src/standard_tooling/bin/docker_docs.py
@@ -11,6 +11,7 @@ import os
 import sys
 
 from standard_tooling.lib import git
+from standard_tooling.lib.docker import docker_platform
 
 
 def _usage(port: str) -> None:
@@ -62,6 +63,7 @@ def main(argv: list[str] | None = None) -> int:
         "docker",
         "run",
         "--rm",
+        f"--platform={docker_platform()}",
         "-v",
         f"{repo_root}:/workspace",
         "-w",

--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -26,6 +27,18 @@ _DEFAULT_TEST_COMMANDS: dict[str, str] = {
 }
 
 _FALLBACK_IMAGE = f"{_GHCR}/dev-base:latest"
+
+_MACHINE_TO_PLATFORM: dict[str, str] = {
+    "arm64": "linux/arm64",
+    "aarch64": "linux/arm64",
+    "x86_64": "linux/amd64",
+    "AMD64": "linux/amd64",
+}
+
+
+def docker_platform() -> str:
+    """Return the Docker ``--platform`` value for the host architecture."""
+    return _MACHINE_TO_PLATFORM.get(platform.machine(), "linux/amd64")
 
 
 def detect_language(repo_root: Path) -> str:
@@ -93,7 +106,7 @@ def build_docker_args(
     """Build the ``docker run`` argument list."""
     network = os.environ.get("DOCKER_NETWORK", "")
 
-    docker_args = ["docker", "run", "--rm"]
+    docker_args = ["docker", "run", "--rm", f"--platform={docker_platform()}"]
     if pull_policy != "never":
         docker_args.append("--pull=always")
     docker_args.extend(

--- a/src/standard_tooling/lib/docker_cache.py
+++ b/src/standard_tooling/lib/docker_cache.py
@@ -8,6 +8,7 @@ import subprocess
 from typing import TYPE_CHECKING
 
 from standard_tooling.lib.config import st_install_tag
+from standard_tooling.lib.docker import docker_platform
 from standard_tooling.lib.validate_commands import CheckKind, language_commands
 
 if TYPE_CHECKING:
@@ -131,6 +132,7 @@ def _build_cached_image(
         [  # noqa: S607
             "docker",
             "create",
+            f"--platform={docker_platform()}",
             "-v",
             f"{repo_root}:/workspace",
             "-w",

--- a/tests/standard_tooling/test_docker.py
+++ b/tests/standard_tooling/test_docker.py
@@ -14,6 +14,7 @@ from standard_tooling.lib.docker import (
     build_docker_args,
     default_image,
     detect_language,
+    docker_platform,
     worktree_parent_gitdir,
 )
 
@@ -83,13 +84,37 @@ def test_default_image_empty_with_fallback() -> None:
     assert default_image("", fallback=True) == _FALLBACK_IMAGE
 
 
+# -- docker_platform ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("machine", "expected"),
+    [
+        ("arm64", "linux/arm64"),
+        ("aarch64", "linux/arm64"),
+        ("x86_64", "linux/amd64"),
+        ("AMD64", "linux/amd64"),
+    ],
+)
+def test_docker_platform_known(machine: str, expected: str) -> None:
+    with patch("standard_tooling.lib.docker.platform.machine", return_value=machine):
+        assert docker_platform() == expected
+
+
+def test_docker_platform_unknown_defaults_to_amd64() -> None:
+    with patch("standard_tooling.lib.docker.platform.machine", return_value="riscv64"):
+        assert docker_platform() == "linux/amd64"
+
+
 # -- build_docker_args --------------------------------------------------------
 
 
 def test_build_docker_args_basic(tmp_path: Path) -> None:
     with patch.dict("os.environ", {}, clear=True):
         args = build_docker_args(tmp_path, "img:1", ["echo", "hello"])
-    assert args[:4] == ["docker", "run", "--rm", "--pull=always"]
+    assert args[0:3] == ["docker", "run", "--rm"]
+    assert any(a.startswith("--platform=linux/") for a in args)
+    assert "--pull=always" in args
     assert f"{tmp_path}:/workspace" in args
     assert "img:1" in args
     assert args[-2:] == ["echo", "hello"]

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -290,6 +290,23 @@ def test_build_cached_image_success(tmp_path: Path) -> None:
     assert result == "img:1--branch--hash"
 
 
+def test_build_cached_image_includes_platform(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    create_result = MagicMock(returncode=0, stdout="abc123\n")
+    ok = MagicMock(returncode=0)
+    create_cmd: list[str] = []
+
+    def mock_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[1] == "create":
+            create_cmd.extend(cmd)
+            return create_result
+        return ok
+
+    with patch("standard_tooling.lib.docker_cache.subprocess.run", side_effect=mock_run):
+        _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash")
+    assert any(a.startswith("--platform=linux/") for a in create_cmd)
+
+
 def test_build_cached_image_create_fails(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=1, stderr="no space")

--- a/tests/standard_tooling/test_docker_docs.py
+++ b/tests/standard_tooling/test_docker_docs.py
@@ -26,6 +26,7 @@ def test_serve_execvp(tmp_path: Path) -> None:
         main(["serve"])
     mock_exec.assert_called_once()
     args = mock_exec.call_args[0][1]
+    assert any(a.startswith("--platform=linux/") for a in args)
     assert "-p" in args
     assert "8000:8000" in args
     assert "mkdocs serve" in args[-1]


### PR DESCRIPTION
# Pull Request

## Summary

- Pass --platform to docker run and docker create for correct arch selection on Apple Silicon

## Issue Linkage

- Ref #583

## Testing

- markdownlint
- ci: shellcheck

## Notes

- On Apple Silicon Macs, Docker may pull or run the wrong architecture image without an explicit `--platform` flag, causing Rosetta errors:

```
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
```

This PR adds a `docker_platform()` helper to `docker.py` that maps `platform.machine()` to Docker platform strings (`arm64`/`aarch64` to `linux/arm64`, `x86_64`/`AMD64` to `linux/amd64`), and passes `--platform` in all three Docker invocation paths:

- `build_docker_args()` in `docker.py` (`docker run`)
- `_build_cached_image()` in `docker_cache.py` (`docker create`)
- Inline `docker run` in `docker_docs.py`