### PR TITLE
Add retry with exponential backoff to GitHub API calls

### DIFF
--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -1,24 +1,70 @@
-"""GitHub CLI (``gh``) subprocess wrappers."""
+"""GitHub CLI (``gh``) subprocess wrappers.
+
+All functions that use ``check=True`` retry transparently on transient
+GitHub API errors (HTTP 502, 503, 504, 429 and network-level timeouts)
+with exponential backoff.
+"""
 
 from __future__ import annotations
 
 import json
+import logging
+import random
 import subprocess
 import time
+from typing import Any
+
+log = logging.getLogger(__name__)
 
 _NO_CHECKS_PHRASE = "no checks reported"
 _POLL_INTERVAL_SECS = 5
 _POLL_TIMEOUT_SECS = 60
 
+_MAX_RETRIES = 4
+_BASE_DELAY_SECS = 2.0
+_MAX_DELAY_SECS = 60.0
+_RETRYABLE_PATTERNS = (
+    "http 502",
+    "http 503",
+    "http 504",
+    "http 429",
+    "timed out",
+    "connection reset",
+)
+
+
+def _is_retryable(exc: subprocess.CalledProcessError) -> bool:
+    detail = ((exc.stderr or "") + (exc.stdout or "")).lower()
+    return any(p in detail for p in _RETRYABLE_PATTERNS)
+
+
+def _run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            return subprocess.run(*args, **kwargs)  # noqa: S603
+        except subprocess.CalledProcessError as exc:
+            if attempt == _MAX_RETRIES or not _is_retryable(exc):
+                raise
+            delay = min(_BASE_DELAY_SECS * (2**attempt), _MAX_DELAY_SECS)
+            delay *= 0.5 + random.random()  # noqa: S311
+            log.warning(
+                "GitHub API error (attempt %d/%d), retrying in %.1fs",
+                attempt + 1,
+                _MAX_RETRIES + 1,
+                delay,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
+
 
 def run(*args: str) -> None:
     """Run a gh command and raise on failure."""
-    subprocess.run(("gh", *args), check=True)  # noqa: S603, S607
+    _run_with_retry(("gh", *args), check=True)  # noqa: S607
 
 
 def read_output(*args: str) -> str:
     """Run a gh command and return stripped stdout."""
-    result = subprocess.run(  # noqa: S603
+    result = _run_with_retry(
         ("gh", *args),  # noqa: S607
         check=True,
         text=True,
@@ -36,7 +82,7 @@ def read_json(*args: str) -> dict[str, object] | list[object]:
 
 def write_json(method: str, endpoint: str, body: dict[str, object]) -> None:
     """Call gh api with a JSON body via stdin."""
-    subprocess.run(  # noqa: S603
+    _run_with_retry(
         ("gh", "api", endpoint, "-X", method, "--input", "-"),  # noqa: S607
         input=json.dumps(body),
         check=True,
@@ -47,7 +93,7 @@ def write_json(method: str, endpoint: str, body: dict[str, object]) -> None:
 
 def delete(endpoint: str) -> None:
     """Call gh api with DELETE method."""
-    subprocess.run(  # noqa: S603
+    _run_with_retry(
         ("gh", "api", endpoint, "-X", "DELETE"),  # noqa: S607
         check=True,
         text=True,
@@ -95,9 +141,9 @@ def wait_for_checks(
     ``poll_interval`` seconds for up to ``poll_timeout`` seconds before
     falling through to the blocking watch.
 
-    Surfaces the failure via ``subprocess.CalledProcessError`` — callers are
-    responsible for deciding how to react (the release-workflow convention is
-    to stop and surface; do not retry).
+    Transient GitHub API errors (502/503/504/429) are retried automatically
+    via the library-level retry wrapper.  Persistent failures surface as
+    ``subprocess.CalledProcessError``.
     """
     deadline = time.monotonic() + poll_timeout
     while not _checks_registered(pr):

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -6,6 +6,8 @@ import json
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from standard_tooling.lib import github
 
 
@@ -212,3 +214,155 @@ def test_delete_if_exists_returns_true_on_empty_stdout() -> None:
     cp = _completed(stdout="")
     with patch("standard_tooling.lib.github.subprocess.run", return_value=cp):
         assert github.delete_if_exists("repos/o/r/branches/main/protection") is True
+
+
+# --- Retry logic ---
+
+
+def _api_error(
+    returncode: int = 1, stderr: str = "", stdout: str = ""
+) -> subprocess.CalledProcessError:
+    exc = subprocess.CalledProcessError(returncode=returncode, cmd=["gh"])
+    exc.stderr = stderr
+    exc.stdout = stdout
+    return exc
+
+
+class TestIsRetryable:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "HTTP 502 Bad Gateway",
+            "HTTP 503 Service Unavailable",
+            "HTTP 504 Gateway Timeout",
+            "HTTP 429 rate limit exceeded",
+            "request timed out",
+            "connection reset by peer",
+        ],
+    )
+    def test_retryable_errors(self, stderr: str) -> None:
+        assert github._is_retryable(_api_error(stderr=stderr)) is True
+
+    def test_retryable_error_in_stdout(self) -> None:
+        assert github._is_retryable(_api_error(stdout="HTTP 504")) is True
+
+    def test_non_retryable_error(self) -> None:
+        assert github._is_retryable(_api_error(stderr="HTTP 404 Not Found")) is False
+
+    def test_empty_output(self) -> None:
+        assert github._is_retryable(_api_error()) is False
+
+
+class TestRunWithRetry:
+    def test_succeeds_on_first_attempt(self) -> None:
+        with patch("standard_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="ok")
+            result = github._run_with_retry(("gh", "pr", "view"), check=True)
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 1
+
+    def test_retries_on_504_then_succeeds(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=[err, err, _completed(stdout="ok")],
+            ) as mock_run,
+            patch("standard_tooling.lib.github.time.sleep") as mock_sleep,
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+        ):
+            result = github._run_with_retry(("gh", "pr", "view"), check=True)
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_raises_after_max_retries(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=err,
+            ),
+            patch("standard_tooling.lib.github.time.sleep"),
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            github._run_with_retry(("gh", "pr", "view"), check=True)
+
+    def test_raises_immediately_on_non_retryable_error(self) -> None:
+        err = _api_error(stderr="HTTP 404 Not Found")
+        with (
+            patch("standard_tooling.lib.github.subprocess.run", side_effect=err),
+            patch("standard_tooling.lib.github.time.sleep") as mock_sleep,
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            github._run_with_retry(("gh", "pr", "view"), check=True)
+        mock_sleep.assert_not_called()
+
+    def test_backoff_delay_increases(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=[err, err, err, _completed()],
+            ),
+            patch("standard_tooling.lib.github.time.sleep") as mock_sleep,
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+        ):
+            github._run_with_retry(("gh", "pr", "view"), check=True)
+        delays = [c.args[0] for c in mock_sleep.call_args_list]
+        assert delays[0] < delays[1] < delays[2]
+
+
+class TestRetryIntegration:
+    def test_run_retries_on_504(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=[err, _completed()],
+            ) as mock_run,
+            patch("standard_tooling.lib.github.time.sleep"),
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+        ):
+            github.run("pr", "list")
+        assert mock_run.call_count == 2
+
+    def test_read_output_retries_on_502(self) -> None:
+        err = _api_error(stderr="HTTP 502 Bad Gateway")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=[err, _completed(stdout="result\n")],
+            ) as mock_run,
+            patch("standard_tooling.lib.github.time.sleep"),
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+        ):
+            assert github.read_output("pr", "view") == "result"
+        assert mock_run.call_count == 2
+
+    def test_write_json_retries_on_503(self) -> None:
+        err = _api_error(stderr="HTTP 503 Service Unavailable")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=[err, _completed()],
+            ) as mock_run,
+            patch("standard_tooling.lib.github.time.sleep"),
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+        ):
+            github.write_json("PATCH", "repos/o/r", {"key": "val"})
+        assert mock_run.call_count == 2
+
+    def test_delete_retries_on_429(self) -> None:
+        err = _api_error(stderr="HTTP 429 rate limit exceeded")
+        with (
+            patch(
+                "standard_tooling.lib.github.subprocess.run",
+                side_effect=[err, _completed()],
+            ) as mock_run,
+            patch("standard_tooling.lib.github.time.sleep"),
+            patch("standard_tooling.lib.github.random.random", return_value=0.5),
+        ):
+            github.delete("repos/o/r/vulnerability-alerts")
+        assert mock_run.call_count == 2


### PR DESCRIPTION
# Pull Request

## Summary

- Add retry with exponential backoff to all GitHub API calls

## Issue Linkage

- Ref #555

## Testing

- markdownlint
- ci: shellcheck

## Notes

- GitHub API 504 errors have been causing `st-merge-when-green` (and by
extension the release workflow) to fail with unrecoverable exceptions.
During the standard-actions v1.5.9 release, HTTP 504 errors hit on two
separate occasions — once during the release PR merge and again during
the bump PR merge — both requiring manual workarounds.

### Changes

**`src/standard_tooling/lib/github.py`**

- Added `_is_retryable()` — inspects `CalledProcessError` stderr/stdout
  for transient HTTP status codes (502, 503, 504, 429) and network-level
  errors (timeouts, connection resets).
- Added `_run_with_retry()` — wraps `subprocess.run` with up to 4 retries,
  exponential backoff (2 s base, 60 s cap), and jitter.
- `run()`, `read_output()`, `write_json()`, and `delete()` now use
  `_run_with_retry()` instead of calling `subprocess.run` directly.
- All consumers (`st-merge-when-green`, `st-wait-until-green`,
  `st-prepare-release`, `github-config`, etc.) get retry protection
  automatically with zero code changes.
- Updated `wait_for_checks` docstring to reflect the new retry behavior.

**`tests/standard_tooling/test_github.py`**

- 17 new tests covering `_is_retryable` classification, `_run_with_retry`
  behavior (first-attempt success, retry-then-succeed, max-retries
  exhaustion, immediate raise on non-retryable, increasing backoff
  delays), and integration tests for `run()`, `read_output()`,
  `write_json()`, and `delete()`.
- 100% code coverage maintained.