### PR TITLE
feat(wait-until-green): detect branch-behind state and auto-update

### DIFF
--- a/src/standard_tooling/bin/wait_until_green.py
+++ b/src/standard_tooling/bin/wait_until_green.py
@@ -1,8 +1,9 @@
-"""Block until a PR's required checks pass.
+"""Block until a PR's required checks pass and the branch is up to date.
 
-Thin wrapper around ``gh pr checks --watch --fail-fast`` so agents have a
-single command instead of inlining gh flags. Surfaces any check failure
-with a non-zero exit code.
+Wraps ``gh pr checks --watch --fail-fast`` with an outer loop that detects
+when the PR branch is behind its base. When the branch is behind,
+auto-updates it (fast-forward merge from base) and re-polls CI so the caller
+only sees success when the PR is both green and mergeable.
 """
 
 from __future__ import annotations
@@ -11,6 +12,8 @@ import argparse
 import sys
 
 from standard_tooling.lib import github
+
+_MAX_BRANCH_UPDATES = 5
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -24,8 +27,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    print(f"Waiting for checks to pass on {args.pr}...")
-    github.wait_for_checks(args.pr)
+    updates = 0
+    while True:
+        print(f"Waiting for checks to pass on {args.pr}...")
+        github.wait_for_checks(args.pr)
+        if github.merge_state_status(args.pr) != "BEHIND":
+            break
+        updates += 1
+        if updates > _MAX_BRANCH_UPDATES:
+            print(
+                "Branch still behind after multiple updates — giving up.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Branch is behind base — updating and re-checking...")
+        github.update_branch(args.pr)
     print("All checks passed.")
     return 0
 

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -153,6 +153,31 @@ def wait_for_checks(
     run("pr", "checks", pr, "--watch", "--fail-fast")
 
 
+def merge_state_status(pr: str) -> str:
+    """Return the PR's mergeStateStatus (e.g. ``CLEAN``, ``BEHIND``, ``DIRTY``)."""
+    return read_output(
+        "pr",
+        "view",
+        pr,
+        "--json",
+        "mergeStateStatus",
+        "--jq",
+        ".mergeStateStatus",
+    )
+
+
+def update_branch(pr: str) -> None:
+    """Fast-forward merge the base branch into the PR branch.
+
+    Uses the GitHub REST API ``PUT /repos/{owner}/{repo}/pulls/{number}/update-branch``.
+    Only appropriate when the branch is behind the base — not when there are
+    merge conflicts.
+    """
+    number = read_output("pr", "view", pr, "--json", "number", "--jq", ".number")
+    repo = read_output("repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+    read_output("api", f"repos/{repo}/pulls/{number}/update-branch", "-X", "PUT")
+
+
 def merge(pr: str, *, strategy: str) -> None:
     """Merge a PR synchronously (without ``--auto``).
 

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -100,6 +100,48 @@ def test_wait_for_checks_uses_poll_interval_for_sleep() -> None:
     mock_sleep.assert_called_once_with(10)
 
 
+def test_merge_state_status_returns_clean() -> None:
+    with patch("standard_tooling.lib.github.read_output", return_value="CLEAN"):
+        assert github.merge_state_status("https://github.com/pr/1") == "CLEAN"
+
+
+def test_merge_state_status_returns_behind() -> None:
+    with patch("standard_tooling.lib.github.read_output", return_value="BEHIND"):
+        assert github.merge_state_status("https://github.com/pr/1") == "BEHIND"
+
+
+def test_update_branch_calls_api() -> None:
+    with patch(
+        "standard_tooling.lib.github.read_output",
+        side_effect=["42", "acme/repo", ""],
+    ) as mock_read:
+        github.update_branch("https://github.com/pr/1")
+    calls = mock_read.call_args_list
+    assert calls[0].args == (
+        "pr",
+        "view",
+        "https://github.com/pr/1",
+        "--json",
+        "number",
+        "--jq",
+        ".number",
+    )
+    assert calls[1].args == (
+        "repo",
+        "view",
+        "--json",
+        "nameWithOwner",
+        "--jq",
+        ".nameWithOwner",
+    )
+    assert calls[2].args == (
+        "api",
+        "repos/acme/repo/pulls/42/update-branch",
+        "-X",
+        "PUT",
+    )
+
+
 def test_merge_delegates_to_gh() -> None:
     with patch("standard_tooling.lib.github.run") as mock_run:
         github.merge("https://github.com/pr/1", strategy="merge")

--- a/tests/standard_tooling/test_wait_until_green.py
+++ b/tests/standard_tooling/test_wait_until_green.py
@@ -3,25 +3,29 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
 from standard_tooling.bin.wait_until_green import main, parse_args
 
 _MOD = "standard_tooling.bin.wait_until_green"
+_PR = "https://github.com/pr/1"
 
 
 def test_parse_args() -> None:
-    args = parse_args(["https://github.com/pr/1"])
-    assert args.pr == "https://github.com/pr/1"
+    args = parse_args([_PR])
+    assert args.pr == _PR
 
 
-def test_main_happy_path() -> None:
-    with patch(f"{_MOD}.github.wait_for_checks") as mock_wait:
-        result = main(["https://github.com/pr/1"])
+def test_main_happy_path_not_behind() -> None:
+    with (
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
+    ):
+        result = main([_PR])
     assert result == 0
-    mock_wait.assert_called_once_with("https://github.com/pr/1")
+    mock_wait.assert_called_once_with(_PR)
 
 
 def test_main_surfaces_check_failure() -> None:
@@ -30,4 +34,57 @@ def test_main_surfaces_check_failure() -> None:
         patch(f"{_MOD}.github.wait_for_checks", side_effect=err),
         pytest.raises(subprocess.CalledProcessError),
     ):
-        main(["https://github.com/pr/1"])
+        main([_PR])
+
+
+def test_main_updates_branch_when_behind() -> None:
+    with (
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(
+            f"{_MOD}.github.merge_state_status",
+            side_effect=["BEHIND", "CLEAN"],
+        ),
+        patch(f"{_MOD}.github.update_branch") as mock_update,
+    ):
+        result = main([_PR])
+    assert result == 0
+    assert mock_wait.call_count == 2
+    mock_update.assert_called_once_with(_PR)
+
+
+def test_main_updates_branch_multiple_times() -> None:
+    with (
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(
+            f"{_MOD}.github.merge_state_status",
+            side_effect=["BEHIND", "BEHIND", "CLEAN"],
+        ),
+        patch(f"{_MOD}.github.update_branch") as mock_update,
+    ):
+        result = main([_PR])
+    assert result == 0
+    assert mock_wait.call_count == 3
+    assert mock_update.call_count == 2
+    mock_update.assert_has_calls([call(_PR), call(_PR)])
+
+
+def test_main_gives_up_after_max_updates() -> None:
+    with (
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BEHIND"),
+        patch(f"{_MOD}.github.update_branch"),
+    ):
+        result = main([_PR])
+    assert result == 1
+
+
+def test_main_succeeds_for_non_behind_states() -> None:
+    for status in ("CLEAN", "DIRTY", "BLOCKED", "UNSTABLE", "UNKNOWN"):
+        with (
+            patch(f"{_MOD}.github.wait_for_checks"),
+            patch(f"{_MOD}.github.merge_state_status", return_value=status),
+            patch(f"{_MOD}.github.update_branch") as mock_update,
+        ):
+            result = main([_PR])
+        assert result == 0, f"Expected success for status {status}"
+        mock_update.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- detect branch-behind state and auto-update before reporting success

## Issue Linkage

- Ref #577

## Testing

- markdownlint
- ci: shellcheck

## Notes

- After `st-wait-until-green` reports all checks passed, the PR may still
be blocked from merging because the branch is behind the base branch
(requires up-to-date branches before merging). This causes a false
hand-off: the agent stops polling, but the human returns to find the
PR needs a branch update, which retriggers CI.

### Changes

**`lib/github.py`** — two new functions:
- `merge_state_status(pr)` — queries the PR's `mergeStateStatus` via
  `gh pr view`
- `update_branch(pr)` — triggers a fast-forward update via the GitHub
  REST API `PUT .../pulls/{number}/update-branch`

**`bin/wait_until_green.py`** — outer loop after checks pass: if
`mergeStateStatus` is `BEHIND`, auto-updates the branch and re-polls
CI. Caps at 5 update attempts to prevent infinite loops when the base
branch keeps moving. Only targets the `BEHIND` case — conflicts and
other states pass through unchanged.

**Tests** — covers: not-behind happy path, single and multiple updates,
max-retry bailout, and all non-BEHIND merge states.