### PR TITLE
feat(commit): reject GitHub auto-close keywords in commit bodies and PR bodies

### DIFF
--- a/docs/git-hooks-and-validation.md
+++ b/docs/git-hooks-and-validation.md
@@ -158,9 +158,11 @@ issue linkage.
 **Requires**: `GITHUB_EVENT_PATH` environment variable
 pointing to the GitHub Actions event payload JSON.
 
-**Accepted linkage keywords**: `Fixes`, `Closes`,
-`Resolves`, `Ref` — followed by `#123` or a cross-repo
-reference like `owner/repo#123`.
+**Accepted linkage keyword**: `Ref` — followed by `#123`
+or a cross-repo reference like `owner/repo#123`. Auto-close
+keywords (`Fixes`, `Closes`, `Resolves` and variants) are
+rejected to keep issues open until post-merge workflows
+succeed.
 
 The keyword may optionally include a colon and may appear
 as a list item.
@@ -275,10 +277,14 @@ markdown files were discovered. Ensure docs exist under
 **`"ERROR: pull request body is empty"`** — The PR has
 no body text. Add issue linkage to the PR description.
 
+**`"ERROR: pull request body contains a GitHub auto-close
+keyword"`** — The PR body uses `Fixes`, `Closes`, `Resolves`
+or a variant. Replace with `Ref #N`. Issues must remain open
+until post-merge workflows succeed.
+
 **`"ERROR: pull request body must include primary issue
-linkage"`** — The PR body does not contain a recognized
-linkage keyword (`Fixes`, `Closes`, `Resolves`, or `Ref`)
-followed by an issue reference.
+linkage"`** — The PR body does not contain `Ref` followed by
+an issue reference.
 
 **`"ERROR: repository profile not found"`** — The file
 `docs/repository-standards.md` does not exist. Create it

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -62,7 +62,8 @@ st-submit-pr \
 
 - `--issue` (required): GitHub issue number (just the number)
 - `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
+- `--linkage` (optional, default: `Ref`): `Ref` (only `Ref` is accepted;
+  auto-close keywords are rejected)
 - `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
 - `--dry-run` (optional): print generated PR without executing

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -269,8 +269,9 @@ jobs:
 What the composite action runs inside the `dev-base` container:
 
 - `st-repo-profile` — validates `docs/repository-standards.md`
-- `st-pr-issue-linkage` — validates PR body has an issue linkage
-  keyword (`Fixes`, `Closes`, `Resolves`, `Ref`)
+- `st-pr-issue-linkage` — validates PR body uses `Ref` for issue
+  linkage and rejects auto-close keywords (`Fixes`, `Closes`,
+  `Resolves`)
 
 The `dev-base` container already has standard-tooling on PATH, so
 no further setup is needed in the workflow.

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -142,7 +142,8 @@ st-submit-pr \
 
 - Pushes the current branch to `origin`.
 - Constructs a standards-compliant PR body with issue linkage
-  (`Fixes #42`, `Closes`, `Resolves`, or `Ref`).
+  (`Ref #42`). Auto-close keywords (`Fixes`, `Closes`,
+  `Resolves`) are not accepted.
 - Creates the PR via `gh pr create` under the hood.
 
 !!! note "Auto-merge is disabled"

--- a/docs/site/docs/guides/validation-matrix.md
+++ b/docs/site/docs/guides/validation-matrix.md
@@ -48,8 +48,10 @@ reference for config details and file scope.
 
 **Trigger:** PR opened or updated
 
-Validates the PR body contains `Fixes #N`, `Closes #N`,
-`Resolves #N`, or `Ref #N`.
+Validates the PR body uses `Ref #N` for issue linkage.
+Rejects auto-close keywords (`Fixes`, `Closes`, `Resolves`
+and variants) to keep issues open until post-merge workflows
+succeed.
 
 ## Exit Code Reference
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -202,16 +202,18 @@ placeholder values.
 
 ### st-pr-issue-linkage
 
-Check that a pull request body includes primary issue linkage.
-Reads the GitHub event payload from `GITHUB_EVENT_PATH`.
+Check that a pull request body uses `Ref` for issue linkage and
+does not contain auto-close keywords (`Fixes`, `Closes`, `Resolves`
+and variants). Reads the GitHub event payload from
+`GITHUB_EVENT_PATH`.
 
 | Attribute | Value |
 |---|---|
 | Source | `standard_tooling.bin.pr_issue_linkage` |
 | Args | None |
 | Preconditions | `GITHUB_EVENT_PATH` set and pointing to a valid JSON file |
-| Failure mode | Exit 2 for missing env var or file; exit 1 for missing linkage |
-| Exit codes | 0 valid, 1 missing linkage, 2 infrastructure error |
+| Failure mode | Exit 2 for missing env var or file; exit 1 for auto-close keyword or missing linkage |
+| Exit codes | 0 valid, 1 rejected linkage or missing linkage, 2 infrastructure error |
 | Status | Active |
 
 ## Removed in this audit

--- a/docs/site/docs/reference/lint/pr-issue-linkage.md
+++ b/docs/site/docs/reference/lint/pr-issue-linkage.md
@@ -2,8 +2,9 @@
 
 **Installed as:** `st-pr-issue-linkage` (Python console script)
 
-Validates that a pull request body contains issue linkage. Runs in
-CI using the GitHub event payload.
+Validates that a pull request body uses `Ref` for issue linkage
+and rejects auto-close keywords. Runs in CI using the GitHub event
+payload.
 
 ## Usage
 
@@ -15,20 +16,18 @@ reads the PR body from `$GITHUB_EVENT_PATH`.
 The PR body must contain at least one line matching:
 
 ```text
-Fixes #123
-Closes #123
-Resolves #123
 Ref #123
-```
-
-Cross-repository references are also accepted:
-
-```text
-Fixes owner/repo#123
+Ref owner/repo#123
 ```
 
 The pattern allows optional leading whitespace, list markers
 (`-` or `*`), and an optional colon after the keyword.
+
+Auto-close keywords (`Fixes`, `Closes`, `Resolves` and all
+variants like `Fix`, `Fixed`, `Close`, `Closed`, `Resolve`,
+`Resolved`) are rejected. Issues must remain open until
+post-merge workflows succeed; premature closure loses tracking
+for multi-PR and multi-repo work.
 
 ## Environment
 
@@ -40,6 +39,6 @@ The pattern allows optional leading whitespace, list markers
 
 | Code | Meaning |
 | ---- | ------- |
-| 0 | Valid issue linkage found |
-| 1 | No issue linkage or empty PR body |
+| 0 | Valid `Ref` linkage found |
+| 1 | Auto-close keyword used, no linkage, or empty PR body |
 | 2 | `GITHUB_EVENT_PATH` not set or file not found |

--- a/src/standard_tooling/bin/commit.py
+++ b/src/standard_tooling/bin/commit.py
@@ -42,6 +42,12 @@ _ISSUE_FORMAT_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a
 _WORKTREE_SCOPED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _WORKTREES_DIRNAME = ".worktrees"
 
+_AUTOCLOSE_RE = re.compile(
+    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+    r":?\s+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
+    re.IGNORECASE,
+)
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -162,6 +168,13 @@ def main(argv: list[str] | None = None) -> int:
     rc = _validate_commit_context(root, branching_model)
     if rc != 0:
         return rc
+
+    if args.body and _AUTOCLOSE_RE.search(args.body):
+        return _reject(
+            "ERROR: commit body contains a GitHub auto-close keyword "
+            "(close/fix/resolve). Use 'Ref #N' instead.",
+            "Issues must remain open until post-merge workflows succeed.",
+        )
 
     if st_config is None or args.agent not in st_config.project.co_authors:
         print(

--- a/src/standard_tooling/bin/pr_issue_linkage.py
+++ b/src/standard_tooling/bin/pr_issue_linkage.py
@@ -1,8 +1,9 @@
 """Check that a pull request body includes primary issue linkage.
 
 Reads the GitHub event payload from ``GITHUB_EVENT_PATH`` and validates
-that the PR body contains a linkage keyword (Fixes, Closes, Resolves,
-or Ref) followed by an issue reference.
+that the PR body contains ``Ref`` followed by an issue reference.
+Auto-close keywords (Fixes, Closes, Resolves and variants) are
+rejected — issues must remain open until post-merge workflows succeed.
 """
 
 from __future__ import annotations
@@ -14,9 +15,15 @@ import sys
 from pathlib import Path
 
 _LINKAGE_RE = re.compile(
-    r"^\s*[-*]?\s*(Fixes|Closes|Resolves|Ref):?\s+"
+    r"^\s*[-*]?\s*Ref:?\s+"
     r"([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
     re.MULTILINE,
+)
+
+_AUTOCLOSE_RE = re.compile(
+    r"^\s*[-*]?\s*(close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+"
+    r"([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
+    re.MULTILINE | re.IGNORECASE,
 )
 
 
@@ -44,11 +51,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         )
         return 1
 
+    if _AUTOCLOSE_RE.search(pr_body):
+        print(
+            "ERROR: pull request body contains a GitHub auto-close keyword "
+            "(close/fix/resolve). Use 'Ref #N' instead. "
+            "Issues must remain open until post-merge workflows succeed.",
+            file=sys.stderr,
+        )
+        return 1
+
     if not _LINKAGE_RE.search(pr_body):
         print(
             "ERROR: pull request body must include primary issue linkage "
-            "(Fixes #123, Closes #123, Resolves #123, or Ref #123). "
-            "Cross-repo references (owner/repo#123) are also accepted.",
+            "(Ref #123). Cross-repo references (Ref owner/repo#123) are "
+            "also accepted.",
             file=sys.stderr,
         )
         return 1

--- a/tests/standard_tooling/test_commit.py
+++ b/tests/standard_tooling/test_commit.py
@@ -363,6 +363,54 @@ def test_validate_admits_main_worktree_feature_commit_without_worktrees_dir(
 
 
 # --------------------------------------------------------------------------
+# Check 6: auto-close keywords in commit body
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #42",
+        "closes #42",
+        "CLOSES #42",
+        "Close #42",
+        "Closed #42",
+        "Fixes #42",
+        "fixes #42",
+        "Fix #42",
+        "Fixed #42",
+        "Resolves #42",
+        "resolves #42",
+        "Resolve #42",
+        "Resolved #42",
+        "Fixes: #42",
+        "Closes owner/repo#42",
+        "Some context.\n\nCloses #99",
+    ],
+)
+def test_validate_rejects_autoclose_keywords_in_body(tmp_path: Path, body: str) -> None:
+    with _commit_environment(tmp_path):
+        result = main(["--type", "feat", "--message", "test", "--body", body, "--agent", "claude"])
+    assert result == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Ref #42",
+        "This closes the loop on the design.",
+        "Fixed the edge case for empty input.",
+        "Resolves a long-standing performance issue.",
+        "",
+    ],
+)
+def test_validate_admits_safe_body_content(tmp_path: Path, body: str) -> None:
+    with _commit_environment(tmp_path):
+        result = main(["--type", "feat", "--message", "test", "--body", body, "--agent", "claude"])
+    assert result == 0
+
+
+# --------------------------------------------------------------------------
 # Task 1.2 — `git.run` is responsible for setting ST_COMMIT_CONTEXT=1
 # (issue #295 moved the contract from commit.py to lib/git.py). The
 # pinning test for that contract lives in tests/standard_tooling/test_git.py;

--- a/tests/standard_tooling/test_pr_issue_linkage.py
+++ b/tests/standard_tooling/test_pr_issue_linkage.py
@@ -6,6 +6,8 @@ import json
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import pytest
+
 from standard_tooling.bin.pr_issue_linkage import main
 
 if TYPE_CHECKING:
@@ -48,58 +50,67 @@ def test_no_linkage(tmp_path: Path) -> None:
         assert main() == 1
 
 
-def test_fixes_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "## Summary\n\nFixes #42\n")
-    with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
-
-
-def test_closes_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "Closes #99\n")
-    with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
-
-
-def test_resolves_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "Resolves #7\n")
-    with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
-
-
 def test_ref_linkage(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "Ref #123\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 0
 
 
-def test_cross_repo_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "Fixes owner/repo#123\n")
+def test_ref_cross_repo_linkage(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "Ref owner/repo#123\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 0
 
 
-def test_bullet_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "- Fixes #42\n")
+def test_ref_bullet_linkage(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "- Ref #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 0
 
 
-def test_star_bullet_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "* Fixes #42\n")
+def test_ref_star_bullet_linkage(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "* Ref #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 0
 
 
-def test_linkage_with_colon(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "Fixes: #42\n")
+def test_ref_with_colon(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "Ref: #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 0
 
 
-def test_indented_linkage(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "  Fixes #42\n")
+def test_ref_indented(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "  Ref #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 0
+
+
+# -- auto-close keyword rejection -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Fixes #42",
+        "Closes #99",
+        "Resolves #7",
+        "closes #42",
+        "FIXES #42",
+        "Fixed #42",
+        "Close #42",
+        "Resolved #42",
+        "- Fixes #42",
+        "* Closes #42",
+        "  Resolves #42",
+        "Fixes: #42",
+        "Fixes owner/repo#123",
+    ],
+)
+def test_rejects_autoclose_keywords(tmp_path: Path, body: str) -> None:
+    event_path = _write_event(tmp_path, body)
+    with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
+        assert main() == 1
 
 
 def test_no_pull_request_key(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Close the enforcement gap that allowed Closes/Fixes/Resolves keywords to slip through in commit bodies and PR bodies, bypassing the Ref-only policy.

## Issue Linkage

- Ref #594

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Changes

### Layer 1: `st-commit` — commit body validation
- Added `_AUTOCLOSE_RE` regex matching all 9 GitHub auto-close keyword
  variants (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved)
  followed by `#N` or `owner/repo#N`, case-insensitive.
- Rejects `--body` content containing these patterns before building the
  commit message.
- Prose usage of these words without an issue reference (e.g., "Fixed the
  edge case") is not affected.

### Layer 2: `st-pr-issue-linkage` — PR body validation (CI)
- Changed `_LINKAGE_RE` to only accept `Ref` (was `Fixes|Closes|Resolves|Ref`).
- Added `_AUTOCLOSE_RE` check that runs before the linkage check, giving a
  specific error message when auto-close keywords are found.

### Documentation
Updated 7 docs files to reflect `Ref`-only policy:
- `docs/git-hooks-and-validation.md`
- `docs/repository-standards.md`
- `docs/site/docs/guides/consuming-repo-setup.md`
- `docs/site/docs/guides/git-workflow.md`
- `docs/site/docs/guides/validation-matrix.md`
- `docs/site/docs/reference/cli-tools-overview.md`
- `docs/site/docs/reference/lint/pr-issue-linkage.md`

### Follow-up
The `standard-tooling:pr-workflow` skill references a `block-autoclose-linkage`
hook that never existed. That skill text needs updating to reflect that
enforcement lives in `st-commit` and `st-pr-issue-linkage`. Tracked in
issue #594 comment.

## Testing

- 800 tests pass (769 baseline + 31 new), 100% branch coverage.
- Parametrized tests cover all 9 keyword variants, case variations,
  cross-repo references, bullet/colon/indented forms, and safe prose
  that should not trigger rejection.