### PR TITLE
feat(release): centralize git-cliff configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = ["ruff", "mypy", "ty", "pytest", "pytest-cov", "pip-audit", "pip-licenses"
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-standard_tooling = ["data/*.json", "configs/*.yaml"]
+standard_tooling = ["data/*.json", "configs/*.yaml", "configs/*.toml"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/standard_tooling/bin/commit.py
+++ b/src/standard_tooling/bin/commit.py
@@ -61,7 +61,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="commit_type",
         help="Conventional commit type",
     )
-    parser.add_argument("--scope", default="", help="Conventional commit scope")
+    parser.add_argument("--scope", required=True, help="Conventional commit scope")
     parser.add_argument("--message", required=True, help="Commit description")
     parser.add_argument("--body", default="", help="Detailed commit body")
     parser.add_argument("--agent", required=True, help="AI tool identity (e.g. claude, codex)")
@@ -191,10 +191,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    subject = args.commit_type
-    if args.scope:
-        subject = f"{subject}({args.scope})"
-    subject = f"{subject}: {args.message}"
+    subject = f"{args.commit_type}({args.scope}): {args.message}"
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
         f.write(f"{subject}\n")

--- a/src/standard_tooling/bin/prepare_release.py
+++ b/src/standard_tooling/bin/prepare_release.py
@@ -23,6 +23,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Callable
+from importlib.resources import files
 from pathlib import Path
 
 from standard_tooling.lib import git, github
@@ -182,18 +183,21 @@ def _merge_main(version: str) -> None:
         "-X",
         "ours",
         "-m",
-        f"chore: merge main into release/{version}",
+        f"chore(release): merge main into release/{version}",
     )
 
 
-RELEASE_NOTES_CONFIG = "cliff-release-notes.toml"
 RELEASE_NOTES_DIR = "releases"
 
 
 def _generate_changelog(version: str) -> None:
     tag = f"develop-v{version}"
     print(f"Generating changelog with boundary tag: {tag}")
-    subprocess.run(("git-cliff", "--tag", tag, "-o", "CHANGELOG.md"), check=True)  # noqa: S603, S607
+    config = files("standard_tooling.configs") / "cliff.toml"
+    subprocess.run(  # noqa: S603
+        ("git-cliff", "--config", str(config), "--tag", tag, "-o", "CHANGELOG.md"),  # noqa: S607
+        check=True,
+    )
     _normalize_trailing_newline(Path("CHANGELOG.md"))
     git.run("add", "CHANGELOG.md")
     _generate_release_notes(version, tag)
@@ -204,23 +208,15 @@ def _generate_changelog(version: str) -> None:
             f"All commits after develop-v{version} are filtered by git-cliff.\n"
             f"Aborting release preparation."
         )
-    git.run("commit", "-m", f"chore: prepare release {version}")
+    git.run("commit", "-m", f"chore(release): prepare {version}")
 
 
 def _generate_release_notes(version: str, tag: str) -> None:
-    config = Path(RELEASE_NOTES_CONFIG)
-    if not config.is_file():
-        return
+    config = files("standard_tooling.configs") / "cliff-release-notes.toml"
     releases_dir = Path(RELEASE_NOTES_DIR)
     releases_dir.mkdir(exist_ok=True)
     output_file = releases_dir / f"v{version}.md"
     print(f"Generating release notes: {output_file}")
-    # `--unreleased` (not `--latest`) — at release-prep time the target
-    # boundary tag (`develop-v{version}`) does not yet exist in git, so
-    # `--latest` falls back to the previous existing tag and renders
-    # the wrong section into the file. `--unreleased` correctly scopes
-    # to commits that are not yet under any tag, which under
-    # `--tag <name>` get grouped under that label. Issue #298.
     subprocess.run(  # noqa: S603
         (  # noqa: S607
             "git-cliff",

--- a/src/standard_tooling/configs/cliff-release-notes.toml
+++ b/src/standard_tooling/configs/cliff-release-notes.toml
@@ -30,10 +30,7 @@ commit_parsers = [
   { message = "^style", group = "Styling" },
   { message = "^test", group = "Testing" },
   { message = "^ci", group = "CI" },
-  { message = "^chore: bump version to", skip = true },
-  { message = "^chore\\(version\\):", skip = true },
-  { message = "^chore: prepare release", skip = true },
-  { message = "^chore: merge .* into release/", skip = true },
+  { message = "^chore\\(release\\):", skip = true },
   { message = "^chore", group = "Chores" },
 ]
 protect_breaking_commits = false

--- a/src/standard_tooling/configs/cliff.toml
+++ b/src/standard_tooling/configs/cliff.toml
@@ -36,10 +36,7 @@ commit_parsers = [
   { message = "^style", group = "Styling" },
   { message = "^test", group = "Testing" },
   { message = "^ci", group = "CI" },
-  { message = "^chore: bump version to", skip = true },
-  { message = "^chore\\(version\\):", skip = true },
-  { message = "^chore: prepare release", skip = true },
-  { message = "^chore: merge .* into release/", skip = true },
+  { message = "^chore\\(release\\):", skip = true },
   { message = "^chore", group = "Chores" },
 ]
 protect_breaking_commits = false

--- a/tests/standard_tooling/test_commit.py
+++ b/tests/standard_tooling/test_commit.py
@@ -73,11 +73,13 @@ def _commit_environment(
 
 
 def test_parse_args_required() -> None:
-    args = parse_args(["--type", "feat", "--message", "add thing", "--agent", "claude"])
+    args = parse_args(
+        ["--type", "feat", "--scope", "core", "--message", "add thing", "--agent", "claude"]
+    )
     assert args.commit_type == "feat"
+    assert args.scope == "core"
     assert args.message == "add thing"
     assert args.agent == "claude"
-    assert args.scope == ""
     assert args.body == ""
 
 
@@ -103,16 +105,18 @@ def test_parse_args_with_scope_and_body() -> None:
 
 def test_parse_args_invalid_type() -> None:
     with pytest.raises(SystemExit):
-        parse_args(["--type", "invalid", "--message", "x", "--agent", "claude"])
+        parse_args(["--type", "invalid", "--scope", "core", "--message", "x", "--agent", "claude"])
 
 
 def test_main_no_staged_changes(tmp_path: Path) -> None:
     with _commit_environment(tmp_path, has_staged=False):
-        result = main(["--type", "feat", "--message", "test", "--agent", "claude"])
+        result = main(
+            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "claude"]
+        )
     assert result == 1
 
 
-def test_main_with_staged_changes_no_scope(tmp_path: Path) -> None:
+def test_main_with_staged_changes(tmp_path: Path) -> None:
     commit_file_content = ""
 
     def capture_run(*args: str) -> None:
@@ -124,9 +128,11 @@ def test_main_with_staged_changes_no_scope(tmp_path: Path) -> None:
         _commit_environment(tmp_path),
         patch("standard_tooling.bin.commit.git.run", side_effect=capture_run),
     ):
-        result = main(["--type", "feat", "--message", "add feature", "--agent", "claude"])
+        result = main(
+            ["--type", "feat", "--scope", "core", "--message", "add feature", "--agent", "claude"]
+        )
     assert result == 0
-    assert commit_file_content.startswith("feat: add feature\n")
+    assert commit_file_content.startswith("feat(core): add feature\n")
     assert "Co-Authored-By: test <test@test.com>" in commit_file_content
 
 
@@ -190,7 +196,9 @@ def test_main_missing_config(tmp_path: Path) -> None:
 
 def test_main_unknown_agent(tmp_path: Path) -> None:
     with _commit_environment(tmp_path):
-        result = main(["--type", "feat", "--message", "test", "--agent", "nonexistent"])
+        result = main(
+            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "nonexistent"]
+        )
     assert result == 1
 
 
@@ -203,7 +211,7 @@ def test_main_unknown_agent(tmp_path: Path) -> None:
 # Reference: docs/specs/host-level-tool.md "Migration / standard-tooling
 # itself" step 1; docs/plans/host-level-tool-plan.md Task 1.1.
 
-_DEFAULT_ARGS = ["--type", "feat", "--message", "test", "--agent", "claude"]
+_DEFAULT_ARGS = ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "claude"]
 
 
 # Check 1: detached HEAD
@@ -390,7 +398,20 @@ def test_validate_admits_main_worktree_feature_commit_without_worktrees_dir(
 )
 def test_validate_rejects_autoclose_keywords_in_body(tmp_path: Path, body: str) -> None:
     with _commit_environment(tmp_path):
-        result = main(["--type", "feat", "--message", "test", "--body", body, "--agent", "claude"])
+        result = main(
+            [
+                "--type",
+                "feat",
+                "--scope",
+                "core",
+                "--message",
+                "test",
+                "--body",
+                body,
+                "--agent",
+                "claude",
+            ]
+        )
     assert result == 1
 
 
@@ -406,7 +427,20 @@ def test_validate_rejects_autoclose_keywords_in_body(tmp_path: Path, body: str) 
 )
 def test_validate_admits_safe_body_content(tmp_path: Path, body: str) -> None:
     with _commit_environment(tmp_path):
-        result = main(["--type", "feat", "--message", "test", "--body", body, "--agent", "claude"])
+        result = main(
+            [
+                "--type",
+                "feat",
+                "--scope",
+                "core",
+                "--message",
+                "test",
+                "--body",
+                body,
+                "--agent",
+                "claude",
+            ]
+        )
     assert result == 0
 
 

--- a/tests/standard_tooling/test_prepare_release.py
+++ b/tests/standard_tooling/test_prepare_release.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import pytest
 
 from standard_tooling.bin.prepare_release import (
-    RELEASE_NOTES_CONFIG,
     RELEASE_NOTES_DIR,
     _detect_cargo,
     _detect_claude_plugin,
@@ -336,8 +335,11 @@ def test_main_full_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     def mock_subprocess_run(
         cmd: tuple[str, ...], **kwargs: object
     ) -> subprocess.CompletedProcess[str]:
-        if "git-cliff" in cmd:
-            (tmp_path / "CHANGELOG.md").write_text("# Changelog\n")
+        if "git-cliff" in cmd and "-o" in cmd:
+            output_idx = list(cmd).index("-o") + 1
+            output_path = Path(cmd[output_idx])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("# Content\n")
         return subprocess.CompletedProcess(args=list(cmd), returncode=0, stdout="", stderr="")
 
     with (
@@ -407,8 +409,11 @@ def test_main_no_publishable_changes(tmp_path: Path, monkeypatch: pytest.MonkeyP
     def mock_subprocess_run(
         cmd: tuple[str, ...], **kwargs: object
     ) -> subprocess.CompletedProcess[str]:
-        if "git-cliff" in cmd:
-            (tmp_path / "CHANGELOG.md").write_text("# Changelog\n")
+        if "git-cliff" in cmd and "-o" in cmd:
+            output_idx = list(cmd).index("-o") + 1
+            output_path = Path(cmd[output_idx])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("# Content\n")
         return subprocess.CompletedProcess(args=list(cmd), returncode=0, stdout="", stderr="")
 
     with (
@@ -451,17 +456,10 @@ def test_normalize_trailing_newline_no_newline(tmp_path: Path) -> None:
 # -- release notes tests ---
 
 
-def test_generate_release_notes_no_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    _generate_release_notes("1.0.0", "develop-v1.0.0")
-    assert not (tmp_path / RELEASE_NOTES_DIR).exists()
-
-
 def test_generate_release_notes_creates_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    (tmp_path / RELEASE_NOTES_CONFIG).write_text("[changelog]\nbody = ''\n")
 
     captured_cmds: list[tuple[str, ...]] = []
 
@@ -486,18 +484,15 @@ def test_generate_release_notes_creates_file(
     assert (tmp_path / RELEASE_NOTES_DIR / "v1.0.0.md").is_file()
     assert (tmp_path / RELEASE_NOTES_DIR / "v1.0.0.md").read_text() == "# Release 1.0.0\n"
 
-    # Pin the --unreleased flag (issue #298). At release-prep time the
-    # target boundary tag does not yet exist in git, so `--latest`
-    # would render the previous tag's section instead of the new one.
     cliff_cmd = next(c for c in captured_cmds if "git-cliff" in c)
     assert "--unreleased" in cliff_cmd
     assert "--latest" not in cliff_cmd
+    assert "--config" in cliff_cmd
 
 
 def test_main_full_flow_with_release_notes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "pyproject.toml").write_text('version = "1.0.0"\n')
-    (tmp_path / RELEASE_NOTES_CONFIG).write_text("[changelog]\nbody = ''\n")
 
     status_calls = 0
 


### PR DESCRIPTION
# Pull Request

## Summary

- Centralize git-cliff configs as bundled package data

## Issue Linkage

- Ref #592

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Centralizes the two git-cliff config files (`cliff.toml`, `cliff-release-notes.toml`) as
bundled package data in `src/standard_tooling/configs/`, following the same pattern used
for markdownlint and yamllint configs. This eliminates per-repo config drift across the
fleet — consuming repos will no longer need their own copies.

Key changes:

- **Bundled canonical cliff configs** — `cliff.toml` and `cliff-release-notes.toml` are
  now shipped as package data and loaded at runtime via `importlib.resources`.
- **`chore(release):` scope** — release-workflow commits (`merge main into release/X`,
  `prepare X`) now use `chore(release):` instead of plain `chore:`. Only release-automation
  chores are filtered from changelogs; all other chore commits remain visible.
- **`--scope` required in `st-commit`** — agents must always provide a scope, enforcing
  consistent conventional-commit structure.
- **Deleted repo-local cliff configs** — `cliff.toml` and `cliff-release-notes.toml`
  removed from the repo root.

Fleet cleanup (removing cliff configs from consuming repos) is tracked separately.
Plugin repo issue for updating the publish skill: wphillipmoore/standard-tooling-claude-plugin#277.