### PR TITLE
fix(commit): tighten cliff regexes, fix doc to docs, add build and revert types

### DIFF
--- a/docs/plans/2026-05-08-commit-type-cleanup.md
+++ b/docs/plans/2026-05-08-commit-type-cleanup.md
@@ -1,0 +1,184 @@
+# Commit Type Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten git-cliff commit parser regexes for precision, fix `doc`→`docs`, add `build`/`revert` types, and add `revert` to st-commit's `ALLOWED_TYPES`.
+
+**Architecture:** Four files modified — two cliff TOML configs (identical parser changes), one Python source file (one-line tuple change), one Markdown doc (one-line type list update). No new files, no new dependencies.
+
+**Tech Stack:** TOML (git-cliff config), Python, Markdown
+
+**Spec:** `docs/specs/2026-05-08-commitlint-and-cliff-cleanup-design.md`
+
+---
+
+### Task 1: Update cliff.toml commit parsers
+
+**Files:**
+- Modify: `src/standard_tooling/configs/cliff.toml:30-41`
+
+- [ ] **Step 1: Update the commit_parsers block**
+
+Replace the `commit_parsers` array (lines 30–41) with precision regexes. Every type pattern gets `[(:!]` appended. `^doc` becomes `^docs[(:!]`. New entries for `build` and `revert` are added. The chore skip rules that use literal strings (e.g., `^chore: bump version to`) are already precise and stay unchanged.
+
+```toml
+commit_parsers = [
+  { message = "^feat[(:!]", group = "Features" },
+  { message = "^fix[(:!]", group = "Bug fixes" },
+  { message = "^docs[(:!]", group = "Documentation" },
+  { message = "^perf[(:!]", group = "Performance" },
+  { message = "^refactor[(:!]", group = "Refactoring" },
+  { message = "^style[(:!]", group = "Styling" },
+  { message = "^test[(:!]", group = "Testing" },
+  { message = "^build[(:!]", group = "Build" },
+  { message = "^ci[(:!]", group = "CI" },
+  { message = "^revert[(:!]", group = "Reverts" },
+  { message = "^chore\\(release\\):", skip = true },
+  { message = "^chore: bump version to", skip = true },
+  { message = "^chore\\(version\\):", skip = true },
+  { message = "^chore: prepare release", skip = true },
+  { message = "^chore: merge .* into release/", skip = true },
+  { message = "^chore[(:!]", group = "Chores" },
+]
+```
+
+- [ ] **Step 2: Verify the file looks correct**
+
+Run: `cat src/standard_tooling/configs/cliff.toml`
+
+Expected: the `commit_parsers` block matches step 1 exactly, and the rest of the file is unchanged.
+
+---
+
+### Task 2: Update cliff-release-notes.toml commit parsers
+
+**Files:**
+- Modify: `src/standard_tooling/configs/cliff-release-notes.toml:24-35`
+
+- [ ] **Step 1: Update the commit_parsers block**
+
+Replace the `commit_parsers` array (lines 24–35) with the same precision regexes. This file has fewer chore skip rules — only `^chore(release):`.
+
+```toml
+commit_parsers = [
+  { message = "^feat[(:!]", group = "Features" },
+  { message = "^fix[(:!]", group = "Bug fixes" },
+  { message = "^docs[(:!]", group = "Documentation" },
+  { message = "^perf[(:!]", group = "Performance" },
+  { message = "^refactor[(:!]", group = "Refactoring" },
+  { message = "^style[(:!]", group = "Styling" },
+  { message = "^test[(:!]", group = "Testing" },
+  { message = "^build[(:!]", group = "Build" },
+  { message = "^ci[(:!]", group = "CI" },
+  { message = "^revert[(:!]", group = "Reverts" },
+  { message = "^chore\\(release\\):", skip = true },
+  { message = "^chore[(:!]", group = "Chores" },
+]
+```
+
+- [ ] **Step 2: Verify the file looks correct**
+
+Run: `cat src/standard_tooling/configs/cliff-release-notes.toml`
+
+Expected: the `commit_parsers` block matches step 1 exactly, and the rest of the file is unchanged.
+
+---
+
+### Task 3: Add `revert` to st-commit ALLOWED_TYPES
+
+**Files:**
+- Modify: `src/standard_tooling/bin/commit.py:21`
+- Test: `tests/standard_tooling/test_commit.py`
+
+- [ ] **Step 1: Write a test that `revert` is accepted as a commit type**
+
+Add a test to `tests/standard_tooling/test_commit.py` that parses args with `--type revert` and asserts success. Place it after the existing `test_parse_args_with_scope_and_body` test (after line 103).
+
+```python
+def test_parse_args_revert_type() -> None:
+    args = parse_args(
+        ["--type", "revert", "--scope", "auth", "--message", "undo token change", "--agent", "claude"]
+    )
+    assert args.commit_type == "revert"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `st-docker-run -- uv run pytest tests/standard_tooling/test_commit.py::test_parse_args_revert_type -v`
+
+Expected: FAIL — `argparse` rejects `revert` because it's not in the `choices` tuple.
+
+- [ ] **Step 3: Add `revert` to `ALLOWED_TYPES`**
+
+In `src/standard_tooling/bin/commit.py` line 21, change:
+
+```python
+ALLOWED_TYPES = ("feat", "fix", "docs", "style", "refactor", "test", "chore", "ci", "build")
+```
+
+to:
+
+```python
+ALLOWED_TYPES = ("feat", "fix", "docs", "style", "refactor", "test", "chore", "ci", "build", "revert")
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `st-docker-run -- uv run pytest tests/standard_tooling/test_commit.py::test_parse_args_revert_type -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Run the full commit test suite**
+
+Run: `st-docker-run -- uv run pytest tests/standard_tooling/test_commit.py -v`
+
+Expected: all tests pass (the existing `test_parse_args_invalid_type` test uses `"invalid"` which is still rejected).
+
+---
+
+### Task 4: Update documentation
+
+**Files:**
+- Modify: `docs/repository-standards.md:45`
+
+- [ ] **Step 1: Update the type list**
+
+Change line 45 from:
+
+```markdown
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
+```
+
+to:
+
+```markdown
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build|revert`
+```
+
+---
+
+### Task 5: Run full validation and commit
+
+- [ ] **Step 1: Run st-validate**
+
+Run: `st-docker-run -- uv run st-validate`
+
+Expected: all checks pass.
+
+- [ ] **Step 2: Commit all changes**
+
+```bash
+git add \
+  src/standard_tooling/configs/cliff.toml \
+  src/standard_tooling/configs/cliff-release-notes.toml \
+  src/standard_tooling/bin/commit.py \
+  tests/standard_tooling/test_commit.py \
+  docs/repository-standards.md \
+  docs/specs/2026-05-08-commitlint-and-cliff-cleanup-design.md \
+  docs/plans/2026-05-08-commit-type-cleanup.md
+st-commit \
+  --type fix --scope commit \
+  --message "tighten cliff regexes, fix doc to docs, add build/revert types" \
+  --body "Ref #598" \
+  --agent claude
+```

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -42,7 +42,7 @@ st-commit \
   [--scope SCOPE] [--body BODY]
 ```
 
-- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build|revert`
 - `--message` (required): commit description
 - `--agent` (required): `claude` or `codex`
 - `--scope` (optional): conventional commit scope

--- a/docs/specs/2026-05-08-commitlint-and-cliff-cleanup-design.md
+++ b/docs/specs/2026-05-08-commitlint-and-cliff-cleanup-design.md
@@ -1,0 +1,93 @@
+# Commit type cleanup: cliff regex precision, `doc`->`docs`, add `build`/`revert`
+
+**Issue:** [#598](https://github.com/wphillipmoore/standard-tooling/issues/598)
+**Date:** 2026-05-08
+
+## Background
+
+An audit of commit type handling revealed three problems:
+
+1. **Imprecise cliff regexes.** All `commit_parsers` patterns use bare
+   prefixes (`^feat`, `^fix`, etc.) without a delimiter. This means
+   `^doc` accidentally matches `docs:` (which happens to be correct
+   behavior by luck) and every pattern would false-match a hypothetical
+   type that shares a prefix (e.g., `^fix` matching `fixed:`).
+
+2. **`doc` vs `docs` inconsistency.** `st-commit` uses `docs` (the
+   Conventional Commits standard). The cliff configs use `^doc`. The
+   match works by accident because `^doc` is a prefix of `docs`, but
+   the intent is wrong.
+
+3. **Missing types.** `build` has a `commit_parsers` entry in neither
+   cliff config despite being in `st-commit`'s `ALLOWED_TYPES`.
+   `revert` is absent from both cliff configs and `ALLOWED_TYPES`.
+
+## Scope
+
+Commitlint (the Node.js tool proposed in the issue) is out of scope.
+`st-commit` already enforces type validation at commit creation time,
+making a second validator redundant. Adding a Node.js dependency to a
+Python-only toolchain is not justified.
+
+## Changes
+
+### 1. Tighten all `commit_parsers` regexes (both cliff configs)
+
+Replace bare prefix patterns with delimiter-aware patterns using
+`[(:!]` after the type name. This matches the three valid
+conventional-commit continuations:
+
+- `:` — `type: description`
+- `(` — `type(scope): description`
+- `!` — `type!: description` (breaking change)
+
+The `chore(release):` skip rule already uses a precise literal match
+and does not need changes.
+
+### 2. Fix `^doc` to `^docs[(:!]`
+
+Both `cliff.toml` and `cliff-release-notes.toml` change the
+Documentation parser from `^doc` to `^docs[(:!]`, aligning with
+`st-commit`'s `ALLOWED_TYPES` and the Conventional Commits standard.
+
+### 3. Add `build` and `revert` parser entries (both cliff configs)
+
+| Type | Group name |
+|------|-----------|
+| `build` | Build |
+| `revert` | Reverts |
+
+### 4. Add `revert` to `st-commit` `ALLOWED_TYPES`
+
+`commit.py` line 21 adds `"revert"` to the tuple. `build` is already
+present.
+
+### 5. Update documentation
+
+`docs/repository-standards.md` line 45 adds `revert` to the type
+list.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/standard_tooling/configs/cliff.toml` | Tighten all regexes, fix `doc`->`docs`, add `build`/`revert` |
+| `src/standard_tooling/configs/cliff-release-notes.toml` | Same as above |
+| `src/standard_tooling/bin/commit.py` | Add `revert` to `ALLOWED_TYPES` |
+| `docs/repository-standards.md` | Add `revert` to type list |
+
+## Backward compatibility
+
+Existing `doc:` commits in git history will no longer match
+`^docs[(:!]`. This is acceptable: `doc:` was never a valid
+conventional-commit type, and any historical `doc:` commits were
+created before `st-commit` standardized on `docs`.
+
+Existing `build:` commits already work — they just lacked a changelog
+group and were silently filtered by `filter_unconventional = true`.
+Adding the parser entry surfaces them.
+
+`revert:` commits from `git revert` use Git's own format
+(`Revert "original message"`), not conventional-commit format, so
+they are unaffected by `commit_parsers`. Only manually-crafted
+`revert:` commits through `st-commit` will match the new entry.

--- a/src/standard_tooling/bin/commit.py
+++ b/src/standard_tooling/bin/commit.py
@@ -18,7 +18,18 @@ from pathlib import Path
 
 from standard_tooling.lib import config, git
 
-ALLOWED_TYPES = ("feat", "fix", "docs", "style", "refactor", "test", "chore", "ci", "build")
+ALLOWED_TYPES = (
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "test",
+    "chore",
+    "ci",
+    "build",
+    "revert",
+)
 
 _PROTECTED_BRANCHES = {"develop", "release", "main"}
 

--- a/src/standard_tooling/configs/cliff-release-notes.toml
+++ b/src/standard_tooling/configs/cliff-release-notes.toml
@@ -22,16 +22,18 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_parsers = [
-  { message = "^feat", group = "Features" },
-  { message = "^fix", group = "Bug fixes" },
-  { message = "^doc", group = "Documentation" },
-  { message = "^perf", group = "Performance" },
-  { message = "^refactor", group = "Refactoring" },
-  { message = "^style", group = "Styling" },
-  { message = "^test", group = "Testing" },
-  { message = "^ci", group = "CI" },
+  { message = "^feat[(:!]", group = "Features" },
+  { message = "^fix[(:!]", group = "Bug fixes" },
+  { message = "^docs[(:!]", group = "Documentation" },
+  { message = "^perf[(:!]", group = "Performance" },
+  { message = "^refactor[(:!]", group = "Refactoring" },
+  { message = "^style[(:!]", group = "Styling" },
+  { message = "^test[(:!]", group = "Testing" },
+  { message = "^build[(:!]", group = "Build" },
+  { message = "^ci[(:!]", group = "CI" },
+  { message = "^revert[(:!]", group = "Reverts" },
   { message = "^chore\\(release\\):", skip = true },
-  { message = "^chore", group = "Chores" },
+  { message = "^chore[(:!]", group = "Chores" },
 ]
 protect_breaking_commits = false
 filter_commits = false

--- a/src/standard_tooling/configs/cliff.toml
+++ b/src/standard_tooling/configs/cliff.toml
@@ -28,16 +28,18 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_parsers = [
-  { message = "^feat", group = "Features" },
-  { message = "^fix", group = "Bug fixes" },
-  { message = "^doc", group = "Documentation" },
-  { message = "^perf", group = "Performance" },
-  { message = "^refactor", group = "Refactoring" },
-  { message = "^style", group = "Styling" },
-  { message = "^test", group = "Testing" },
-  { message = "^ci", group = "CI" },
+  { message = "^feat[(:!]", group = "Features" },
+  { message = "^fix[(:!]", group = "Bug fixes" },
+  { message = "^docs[(:!]", group = "Documentation" },
+  { message = "^perf[(:!]", group = "Performance" },
+  { message = "^refactor[(:!]", group = "Refactoring" },
+  { message = "^style[(:!]", group = "Styling" },
+  { message = "^test[(:!]", group = "Testing" },
+  { message = "^build[(:!]", group = "Build" },
+  { message = "^ci[(:!]", group = "CI" },
+  { message = "^revert[(:!]", group = "Reverts" },
   { message = "^chore\\(release\\):", skip = true },
-  { message = "^chore", group = "Chores" },
+  { message = "^chore[(:!]", group = "Chores" },
 ]
 protect_breaking_commits = false
 filter_commits = false

--- a/tests/standard_tooling/test_commit.py
+++ b/tests/standard_tooling/test_commit.py
@@ -103,6 +103,22 @@ def test_parse_args_with_scope_and_body() -> None:
     assert args.body == "Fixed edge case"
 
 
+def test_parse_args_revert_type() -> None:
+    args = parse_args(
+        [
+            "--type",
+            "revert",
+            "--scope",
+            "auth",
+            "--message",
+            "undo token change",
+            "--agent",
+            "claude",
+        ]
+    )
+    assert args.commit_type == "revert"
+
+
 def test_parse_args_invalid_type() -> None:
     with pytest.raises(SystemExit):
         parse_args(["--type", "invalid", "--scope", "core", "--message", "x", "--agent", "claude"])


### PR DESCRIPTION
# Pull Request

## Summary

- Tighten git-cliff commit parser regexes for precision, fix doc to docs, add build and revert types

## Issue Linkage

- Ref #598

## Testing

- markdownlint
- ci: shellcheck

## Notes

- - All commit_parsers patterns in both cliff.toml and cliff-release-notes.toml
  now use [(:!] after the type name, matching only valid conventional-commit
  continuations (colon, open-paren for scope, or bang for breaking change).
- Fixed ^doc to ^docs[(:!] to align with st-commit's ALLOWED_TYPES and the
  Conventional Commits standard.
- Added build and revert parser entries (groups: Build, Reverts) so these
  types appear in changelogs instead of being silently filtered.
- Added revert to ALLOWED_TYPES in st-commit for partial-revert workflows.
- Updated docs/repository-standards.md type list.
- Commitlint (Node.js) was evaluated and dropped — st-commit already
  enforces type validation, making a second validator redundant.