### PR TITLE
Add swatinem/* to allowed action patterns

### DIFF
--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -74,6 +74,7 @@ _ALLOWED_ACTION_PATTERNS = [
     "github/*",
     "pypa/*",
     "ruby/*",
+    "swatinem/*",
     "wphillipmoore/*",
 ]
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add swatinem/* to allowed action patterns

## Issue Linkage

- Ref #609

## Testing

- markdownlint
- ci: shellcheck

## Notes

- The actions-rust-lang/setup-rust-toolchain action internally uses swatinem/rust-cache,
which was not in the centralized _ALLOWED_ACTION_PATTERNS list. This caused Rust CI
jobs to fail at the "Set up job" step when the repo has allowed actions locked to
selected patterns.

Adds swatinem/* to the allow list in alphabetical order so st-github-config apply
sets it automatically for all managed repos.