### PR TITLE
feat(validate): add Go license allowlist to centralized audit

### DIFF
--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -40,6 +40,18 @@ _PIP_LICENSES_ALLOWLIST = ";".join(
     ]
 )
 
+_GO_LICENSES_ALLOWLIST = ",".join(
+    [
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "GPL-3.0",
+        "ISC",
+        "MIT",
+        "MPL-2.0",
+    ]
+)
+
 _REGISTRY: dict[str, dict[CheckKind, list[list[str]]]] = {
     "python": {
         CheckKind.INSTALL: [["uv", "sync", "--frozen", "--group", "dev"]],
@@ -64,7 +76,10 @@ _REGISTRY: dict[str, dict[CheckKind, list[list[str]]]] = {
             ["go", "test", "-race", "-count=1", "-coverprofile=coverage.out", "./..."],
             ["go-test-coverage", "--config", ".testcoverage.yml"],
         ],
-        CheckKind.AUDIT: [["govulncheck", "./..."], ["go-licenses", "check", "./..."]],
+        CheckKind.AUDIT: [
+            ["govulncheck", "./..."],
+            ["go-licenses", "check", "./...", f"--allowed_licenses={_GO_LICENSES_ALLOWLIST}"],
+        ],
     },
     "java": {
         CheckKind.INSTALL: [["./mvnw", "dependency:resolve", "-B"]],

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -82,7 +82,7 @@ def test_go_test_commands() -> None:
 def test_go_audit_commands() -> None:
     joined = _joined(language_commands("go", CheckKind.AUDIT))
     assert any("govulncheck" in c for c in joined)
-    assert any("go-licenses" in c for c in joined)
+    assert any("go-licenses" in c and "--allowed_licenses=" in c for c in joined)
 
 
 def test_go_audit_go_licenses_allowlist_intact() -> None:

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -85,6 +85,18 @@ def test_go_audit_commands() -> None:
     assert any("go-licenses" in c for c in joined)
 
 
+def test_go_audit_go_licenses_allowlist_intact() -> None:
+    cmds = language_commands("go", CheckKind.AUDIT)
+    go_licenses_cmd = [c for c in cmds if c[0] == "go-licenses"]
+    assert len(go_licenses_cmd) == 1
+    flag = go_licenses_cmd[0][-1]
+    assert flag.startswith("--allowed_licenses=")
+    licenses = flag.split("=", 1)[1].split(",")
+    assert "MIT" in licenses
+    assert "Apache-2.0" in licenses
+    assert len(licenses) == 7
+
+
 # -- Java ---------------------------------------------------------------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add Go license allowlist to centralized audit

## Issue Linkage

- Ref #604

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

- Add `_GO_LICENSES_ALLOWLIST` constant to `validate_commands.py` with the org-wide SPDX license set (Apache-2.0, BSD-2-Clause, BSD-3-Clause, GPL-3.0, ISC, MIT, MPL-2.0)
- Pass `--allowed_licenses=` flag in the Go audit registry entry for `go-licenses check`, mirroring the existing Python `_PIP_LICENSES_ALLOWLIST` pattern
- Add dedicated test and strengthen existing Go audit test to verify the allowlist flag is present

## Issue Linkage

- Ref #604

## Testing

- New test `test_go_audit_go_licenses_allowlist_intact` verifies the allowlist constant structure, license count, and key entries
- Existing `test_go_audit_commands` strengthened to assert `--allowed_licenses=` is present in the `go-licenses` command
- Full `st-validate` passes (801 tests, 100% coverage)

## Notes

- GOTOOLCHAIN override excluded from scope per design discussion: the dev container packages all required tools, and missing tools should fail hard rather than being worked around with env-var overrides
- Allowlist values come from the accumulated bespoke job in mq-rest-admin-go
- Future work: extracting allowlists to config files and supporting per-repo overrides is deferred until all languages are centralized