### PR TITLE
feat(validate): add license_finder to Ruby audit registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = ["ruff", "mypy", "ty", "pytest", "pytest-cov", "pip-audit", "pip-licenses"
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-standard_tooling = ["data/*.json", "configs/*.yaml", "configs/*.toml"]
+standard_tooling = ["data/*.json", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/standard_tooling/configs/ruby/license_finder.yml
+++ b/src/standard_tooling/configs/ruby/license_finder.yml
@@ -1,0 +1,31 @@
+---
+- - :permit
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:16.258089464 Z
+- - :permit
+  - Simplified BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:17.028709111 Z
+- - :permit
+  - New BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:17.705662790 Z
+- - :permit
+  - ruby
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:18.316100224 Z
+- - :permit
+  - GPL-3.0-or-later
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-03-01 20:49:18.971984481 Z

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -97,7 +97,10 @@ _REGISTRY: dict[str, dict[CheckKind, list[list[str]]]] = {
         CheckKind.LINT: [["bundle", "exec", "rubocop"]],
         CheckKind.TYPECHECK: [["bundle", "exec", "steep", "check"]],
         CheckKind.TEST: [["bundle", "exec", "rake"]],
-        CheckKind.AUDIT: [["bundle", "exec", "bundle-audit", "check", "--update"]],
+        CheckKind.AUDIT: [
+            ["bundle", "exec", "bundle-audit", "check", "--update"],
+            ["license_finder", "--decisions-file={configs}/ruby/license_finder.yml"],
+        ],
     },
     "rust": {
         CheckKind.INSTALL: [["cargo", "fetch"]],

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -131,7 +131,4 @@ def language_commands(language: str, kind: CheckKind) -> list[list[str]]:
     if not cmds:
         return []
     configs_dir = str(files("standard_tooling.configs"))
-    return [
-        [arg.replace("{configs}", configs_dir) for arg in cmd]
-        for cmd in cmds
-    ]
+    return [[arg.replace("{configs}", configs_dir) for arg in cmd] for cmd in cmds]

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -8,6 +8,7 @@ per-repo — the standard defines them centrally.
 from __future__ import annotations
 
 from enum import Enum
+from importlib.resources import files
 
 
 class CheckKind(Enum):
@@ -116,8 +117,18 @@ def language_commands(language: str, kind: CheckKind) -> list[list[str]]:
 
     Returns an empty list if the language is not in the registry or
     has no entry for the given check kind.
+
+    Any argument containing ``{configs}`` is expanded to the resolved
+    path of the ``standard_tooling.configs`` package directory.
     """
     lang_entry = _REGISTRY.get(language)
     if lang_entry is None:
         return []
-    return list(lang_entry.get(kind, []))
+    cmds = lang_entry.get(kind, [])
+    if not cmds:
+        return []
+    configs_dir = str(files("standard_tooling.configs"))
+    return [
+        [arg.replace("{configs}", configs_dir) for arg in cmd]
+        for cmd in cmds
+    ]

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -127,8 +127,7 @@ def language_commands(language: str, kind: CheckKind) -> list[list[str]]:
     lang_entry = _REGISTRY.get(language)
     if lang_entry is None:
         return []
-    cmds = lang_entry.get(kind, [])
-    if not cmds:
-        return []
     configs_dir = str(files("standard_tooling.configs"))
-    return [[arg.replace("{configs}", configs_dir) for arg in cmd] for cmd in cmds]
+    return [
+        [arg.replace("{configs}", configs_dir) for arg in cmd] for cmd in lang_entry.get(kind, [])
+    ]

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from standard_tooling.lib.validate_commands import (
     CheckKind,
     language_commands,
@@ -205,3 +207,22 @@ def test_shell_install_commands() -> None:
 def test_none_language_returns_empty() -> None:
     cmds = language_commands("none", CheckKind.LINT)
     assert cmds == []
+
+
+def test_configs_placeholder_is_resolved() -> None:
+    """Commands containing {configs} must resolve to a real path."""
+    cmds = language_commands("ruby", CheckKind.AUDIT)
+    for cmd in cmds:
+        for arg in cmd:
+            assert "{configs}" not in arg, f"Unresolved placeholder in: {arg}"
+
+
+def test_configs_placeholder_resolves_to_existing_directory() -> None:
+    """The resolved {configs} path must point to a real file."""
+    cmds = language_commands("ruby", CheckKind.AUDIT)
+    license_finder_cmds = [c for c in cmds if c[0] == "license_finder"]
+    if not license_finder_cmds:
+        return
+    decisions_arg = license_finder_cmds[0][1]
+    path = decisions_arg.split("=", 1)[1]
+    assert Path(path).exists(), f"Resolved path does not exist: {path}"

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -155,6 +155,18 @@ def test_ruby_test_commands() -> None:
 def test_ruby_audit_commands() -> None:
     joined = _joined(language_commands("ruby", CheckKind.AUDIT))
     assert any("bundle-audit" in c for c in joined)
+    assert any("license_finder" in c for c in joined)
+
+
+def test_ruby_audit_license_finder_decisions_file() -> None:
+    cmds = language_commands("ruby", CheckKind.AUDIT)
+    license_finder_cmds = [c for c in cmds if c[0] == "license_finder"]
+    assert len(license_finder_cmds) == 1
+    decisions_arg = license_finder_cmds[0][1]
+    assert decisions_arg.startswith("--decisions-file=")
+    path = decisions_arg.split("=", 1)[1]
+    assert path.endswith("ruby/license_finder.yml")
+    assert "{configs}" not in decisions_arg
 
 
 # -- Rust ---------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Add license_finder to Ruby audit registry with shipped decisions file

## Issue Linkage

- Ref #603

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

- Add `license_finder` license compliance checking to the centralized Ruby AUDIT command registry, closing the gap where `st-validate --check audit` for Ruby only checked for known vulnerabilities (via `bundle-audit`) but not license policy compliance.
- Ship a static `license_finder` decisions file at `configs/ruby/license_finder.yml` containing the five permitted licenses currently enforced by mq-rest-admin-ruby (MIT, Simplified BSD, New BSD, ruby, GPL-3.0-or-later).
- Introduce `{configs}` placeholder expansion in `language_commands()` so registry entries can reference package-shipped config files resolved at runtime via `importlib.resources`.

## Issue Linkage

- Ref #603

## Testing

- 34 tests in `test_validate_commands.py` (3 new), 804 total project tests pass
- 100% branch coverage maintained
- Full `st-docker-run -- uv run st-validate` passes

## Notes

- Prerequisite: `license_finder` must be pre-installed in the dev-ruby container image (standard-tooling-docker#155) before the audit command will work at runtime in consuming repos.
- The `{configs}` placeholder pattern is intentionally minimal — it will be revisited once Rust and Java get similar config-shipped audit files.
- Design spec: `docs/superpowers/specs/2026-05-08-ruby-license-finder-design.md`