### PR TITLE
feat(validate): add Java license allowlist to centralized audit

### DIFF
--- a/docs/specs/2026-05-08-java-license-audit-design.md
+++ b/docs/specs/2026-05-08-java-license-audit-design.md
@@ -1,0 +1,127 @@
+# Centralize Java License Audit
+
+**Issue:** [#600](https://github.com/wphillipmoore/standard-tooling/issues/600)
+**Date:** 2026-05-08
+**Status:** Draft
+
+## Problem
+
+The Java audit entry in `validate_commands.py` runs the Maven license
+plugin without policy enforcement flags. The bespoke audit job in
+mq-rest-admin-java adds three critical `-D` properties that the
+centralized registry omits:
+
+- `-Dlicense.failIfWarning=true` — fail on violations (without this,
+  the check is decorative)
+- `-Dlicense.includedLicenses=...` — org-wide license allowlist
+- `-Dlicense.excludedScopes=test` — skip test-only dependencies
+
+Without these flags, `st-validate --check audit` for Java runs the
+license plugin without blocking on policy violations.
+
+## Decision
+
+Add a `_MAVEN_LICENSES_ALLOWLIST` constant to `validate_commands.py`
+and pass it along with the other `-D` flags in the Java audit command.
+This mirrors the existing Go (`_GO_LICENSES_ALLOWLIST`) and Python
+(`_PIP_LICENSES_ALLOWLIST`) patterns.
+
+### Allowlist
+
+The initial set comes from the bespoke audit job in
+mq-rest-admin-java. The Maven license plugin matches against the
+`<license><name>` value declared in each dependency's POM, so this
+list includes both SPDX identifiers and human-readable variants
+(notably three Apache variants). Pipe-delimited per Maven convention:
+
+```
+Apache 2.0|Apache-2.0|The Apache License, Version 2.0|BSD-2-Clause|BSD-3-Clause|GPL-3.0-or-later|ISC|MIT License|MPL-2.0
+```
+
+### Plugin version
+
+No version pin in the registry. The repo's POM controls plugin
+versions, consistent with how other Maven plugins (spotless,
+checkstyle) are managed and how other languages handle tool versions.
+
+### Scope exclusions
+
+- **Config-driven allowlist (`standard-tooling.toml`):** Deferred.
+  No demonstrated need with one Java repo. The Go design (#604)
+  explicitly deferred the same thing.
+- **Unified cross-language allowlist:** Deferred. Python's
+  `pip-licenses` uses PyPI classifiers, Go's `go-licenses` uses
+  SPDX identifiers, and Maven uses POM-declared license names — a
+  shared constant would require a mapping layer with no payoff.
+- **Plugin version pin:** Left to the repo's POM (see above).
+- **Replacing the bespoke audit job in mq-rest-admin-java:** Follow-up
+  work in the Java repo after this lands and is released.
+- **Test gap (#617):** Factored into a separate issue.
+
+## Change
+
+**File:** `src/standard_tooling/lib/validate_commands.py`
+
+Add a module-level constant:
+
+```python
+_MAVEN_LICENSES_ALLOWLIST = "|".join(
+    [
+        "Apache 2.0",
+        "Apache-2.0",
+        "The Apache License, Version 2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "GPL-3.0-or-later",
+        "ISC",
+        "MIT License",
+        "MPL-2.0",
+    ]
+)
+```
+
+Update the Java audit registry entry from:
+
+```python
+CheckKind.AUDIT: [
+    ["./mvnw", "dependency:tree", "-B", "-q"],
+    ["./mvnw", "org.codehaus.mojo:license-maven-plugin:add-third-party", "-B"],
+],
+```
+
+to:
+
+```python
+CheckKind.AUDIT: [
+    ["./mvnw", "dependency:tree", "-B", "-q"],
+    [
+        "./mvnw",
+        "org.codehaus.mojo:license-maven-plugin:add-third-party",
+        "-Dlicense.excludedScopes=test",
+        "-Dlicense.failIfWarning=true",
+        f"-Dlicense.includedLicenses={_MAVEN_LICENSES_ALLOWLIST}",
+        "-B",
+    ],
+],
+```
+
+**File:** `tests/standard_tooling/test_validate_commands.py`
+
+Update `test_java_audit_commands` to verify the `-D` flags are present.
+
+Add `test_java_audit_maven_licenses_allowlist_intact` to verify the
+allowlist contains the expected number of licenses (9) and includes
+key entries. Mirrors `test_go_audit_go_licenses_allowlist_intact`.
+
+## Validation
+
+`st-docker-run -- uv run st-validate`
+
+## Related
+
+- [#604](https://github.com/wphillipmoore/standard-tooling/issues/604) —
+  Go license allowlist (merged, same pattern)
+- [#603](https://github.com/wphillipmoore/standard-tooling/issues/603) —
+  Ruby license_finder centralization
+- [#617](https://github.com/wphillipmoore/standard-tooling/issues/617) —
+  Java test gap (factored out of #600)

--- a/docs/specs/2026-05-08-java-license-audit-plan.md
+++ b/docs/specs/2026-05-08-java-license-audit-plan.md
@@ -1,0 +1,153 @@
+# Java License Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add license policy enforcement flags to the centralized Java audit command so `st-validate --check audit` blocks on license violations.
+
+**Architecture:** Add a `_MAVEN_LICENSES_ALLOWLIST` pipe-joined constant to `validate_commands.py` and pass it with `-Dlicense.failIfWarning=true` and `-Dlicense.excludedScopes=test` in the Java audit registry entry. Mirrors the existing Go and Python allowlist patterns.
+
+**Tech Stack:** Python, pytest
+
+---
+
+### Task 1: Add failing test for Java audit allowlist flag
+
+**Files:**
+- Modify: `tests/standard_tooling/test_validate_commands.py:126-129`
+
+- [ ] **Step 1: Update `test_java_audit_commands` to assert the `-D` flags**
+
+Replace the existing test at line 126:
+
+```python
+def test_java_audit_commands() -> None:
+    joined = _joined(language_commands("java", CheckKind.AUDIT))
+    assert any("dependency:tree" in c for c in joined)
+    assert any("license-maven-plugin" in c for c in joined)
+    assert any("-Dlicense.failIfWarning=true" in c for c in joined)
+    assert any("-Dlicense.includedLicenses=" in c for c in joined)
+    assert any("-Dlicense.excludedScopes=test" in c for c in joined)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/standard_tooling/test_validate_commands.py::test_java_audit_commands -v`
+
+Expected: FAIL — the current Java audit command has no `-D` flags.
+
+---
+
+### Task 2: Add failing allowlist integrity test
+
+**Files:**
+- Modify: `tests/standard_tooling/test_validate_commands.py` (add after `test_java_audit_commands`)
+
+- [ ] **Step 1: Add `test_java_audit_maven_licenses_allowlist_intact`**
+
+Add this test immediately after `test_java_audit_commands`:
+
+```python
+def test_java_audit_maven_licenses_allowlist_intact() -> None:
+    cmds = language_commands("java", CheckKind.AUDIT)
+    license_cmd = [c for c in cmds if any("license-maven-plugin" in arg for arg in c)]
+    assert len(license_cmd) == 1
+    flag = [arg for arg in license_cmd[0] if arg.startswith("-Dlicense.includedLicenses=")]
+    assert len(flag) == 1
+    licenses = flag[0].split("=", 1)[1].split("|")
+    assert "MIT License" in licenses
+    assert "Apache-2.0" in licenses
+    assert len(licenses) == 9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/standard_tooling/test_validate_commands.py::test_java_audit_maven_licenses_allowlist_intact -v`
+
+Expected: FAIL — no `-Dlicense.includedLicenses=` argument exists yet.
+
+---
+
+### Task 3: Add the allowlist constant and update the Java audit entry
+
+**Files:**
+- Modify: `src/standard_tooling/lib/validate_commands.py:54` (add constant after `_GO_LICENSES_ALLOWLIST`)
+- Modify: `src/standard_tooling/lib/validate_commands.py:89-92` (update Java audit entry)
+
+- [ ] **Step 1: Add `_MAVEN_LICENSES_ALLOWLIST` constant**
+
+Add the following after the `_GO_LICENSES_ALLOWLIST` block (after line 54):
+
+```python
+_MAVEN_LICENSES_ALLOWLIST = "|".join(
+    [
+        "Apache 2.0",
+        "Apache-2.0",
+        "The Apache License, Version 2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "GPL-3.0-or-later",
+        "ISC",
+        "MIT License",
+        "MPL-2.0",
+    ]
+)
+```
+
+- [ ] **Step 2: Update the Java audit registry entry**
+
+Replace the current Java `CheckKind.AUDIT` value (lines 90-92):
+
+```python
+        CheckKind.AUDIT: [
+            ["./mvnw", "dependency:tree", "-B", "-q"],
+            [
+                "./mvnw",
+                "org.codehaus.mojo:license-maven-plugin:add-third-party",
+                "-Dlicense.excludedScopes=test",
+                "-Dlicense.failIfWarning=true",
+                f"-Dlicense.includedLicenses={_MAVEN_LICENSES_ALLOWLIST}",
+                "-B",
+            ],
+        ],
+```
+
+- [ ] **Step 3: Run the two new/updated tests to verify they pass**
+
+Run: `uv run pytest tests/standard_tooling/test_validate_commands.py::test_java_audit_commands tests/standard_tooling/test_validate_commands.py::test_java_audit_maven_licenses_allowlist_intact -v`
+
+Expected: Both PASS.
+
+- [ ] **Step 4: Run the full test suite to check for regressions**
+
+Run: `uv run pytest tests/standard_tooling/test_validate_commands.py -v`
+
+Expected: All tests PASS. No other language entries are affected.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/standard_tooling/lib/validate_commands.py tests/standard_tooling/test_validate_commands.py
+```
+
+Commit message:
+```
+feat(validate): add Java license allowlist to centralized audit (#600)
+```
+
+---
+
+### Task 4: Run full validation
+
+- [ ] **Step 1: Run `st-validate` in the dev container**
+
+Run: `st-docker-run -- uv run st-validate`
+
+Expected: All checks pass (lint, typecheck, test, audit).
+
+- [ ] **Step 2: Commit any fixups if needed**
+
+If `st-validate` flags formatting or lint issues, fix and commit separately:
+
+```
+fix(validate): address lint/format issues from st-validate
+```

--- a/src/standard_tooling/lib/validate_commands.py
+++ b/src/standard_tooling/lib/validate_commands.py
@@ -53,6 +53,20 @@ _GO_LICENSES_ALLOWLIST = ",".join(
     ]
 )
 
+_MAVEN_LICENSES_ALLOWLIST = "|".join(
+    [
+        "Apache 2.0",
+        "Apache-2.0",
+        "The Apache License, Version 2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "GPL-3.0-or-later",
+        "ISC",
+        "MIT License",
+        "MPL-2.0",
+    ]
+)
+
 _REGISTRY: dict[str, dict[CheckKind, list[list[str]]]] = {
     "python": {
         CheckKind.INSTALL: [["uv", "sync", "--frozen", "--group", "dev"]],
@@ -89,7 +103,14 @@ _REGISTRY: dict[str, dict[CheckKind, list[list[str]]]] = {
         CheckKind.TEST: [["./mvnw", "verify", "-B"]],
         CheckKind.AUDIT: [
             ["./mvnw", "dependency:tree", "-B", "-q"],
-            ["./mvnw", "org.codehaus.mojo:license-maven-plugin:add-third-party", "-B"],
+            [
+                "./mvnw",
+                "org.codehaus.mojo:license-maven-plugin:add-third-party",
+                "-Dlicense.excludedScopes=test",
+                "-Dlicense.failIfWarning=true",
+                f"-Dlicense.includedLicenses={_MAVEN_LICENSES_ALLOWLIST}",
+                "-B",
+            ],
         ],
     },
     "ruby": {

--- a/tests/standard_tooling/test_validate_commands.py
+++ b/tests/standard_tooling/test_validate_commands.py
@@ -127,6 +127,21 @@ def test_java_audit_commands() -> None:
     joined = _joined(language_commands("java", CheckKind.AUDIT))
     assert any("dependency:tree" in c for c in joined)
     assert any("license-maven-plugin" in c for c in joined)
+    assert any("-Dlicense.failIfWarning=true" in c for c in joined)
+    assert any("-Dlicense.includedLicenses=" in c for c in joined)
+    assert any("-Dlicense.excludedScopes=test" in c for c in joined)
+
+
+def test_java_audit_maven_licenses_allowlist_intact() -> None:
+    cmds = language_commands("java", CheckKind.AUDIT)
+    license_cmd = [c for c in cmds if any("license-maven-plugin" in arg for arg in c)]
+    assert len(license_cmd) == 1
+    flag = [arg for arg in license_cmd[0] if arg.startswith("-Dlicense.includedLicenses=")]
+    assert len(flag) == 1
+    licenses = flag[0].split("=", 1)[1].split("|")
+    assert "MIT License" in licenses
+    assert "Apache-2.0" in licenses
+    assert len(licenses) == 9
 
 
 # -- Ruby ---------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Add Java license allowlist to centralized audit

## Issue Linkage

- Ref #600

## Testing

- markdownlint
- ci: shellcheck

## Notes

- The Java audit entry in `validate_commands.py` previously ran the Maven
license plugin without policy enforcement flags, making the check
decorative. This adds:

- `_MAVEN_LICENSES_ALLOWLIST` constant with 9 pipe-delimited license
  names imported from the bespoke audit job in mq-rest-admin-java
- `-Dlicense.failIfWarning=true` to fail on violations
- `-Dlicense.includedLicenses=...` with the org-wide allowlist
- `-Dlicense.excludedScopes=test` to skip test-only dependencies
- No plugin version pin (left to the repo's POM)

Mirrors the established Go (`_GO_LICENSES_ALLOWLIST`) and Python
(`_PIP_LICENSES_ALLOWLIST`) patterns.

Test gap factored out to #617.