### PR TITLE
chore(docs): replace st-validate-local refs with st-validate

### DIFF
--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -35,7 +35,7 @@ already be green.
 !!! note "Historical: three-tier CI"
     Earlier versions of this guide documented a third tier — push-CI — as
     a thin `workflow_call` wrapper that ran a subset of checks on every
-    push to a feature branch. That tier was removed once `st-validate-local`
+    push to a feature branch. That tier was removed once `st-validate`
     reached parity with PR-CI; the push-CI workflow added no coverage that
     PR-CI didn't already provide and created a concurrency-group deadlock
     with `ci.yml`. Integration-test coverage at push-time was deliberately
@@ -70,9 +70,9 @@ Environment overrides:
     Build the dev images locally before first use:
     `cd ../standard-tooling-docker && docker/build.sh`
 
-The `.githooks` pre-commit gate runs `st-docker-run -- uv run st-validate-local`
-on every commit, which dispatches to the per-language scripts above. Hook bypass
-(`--no-verify`) is disallowed by policy.
+The `.githooks` pre-commit gate runs `st-docker-run -- uv run st-validate`
+on every commit, which runs common checks and per-language validation. Hook
+bypass (`--no-verify`) is disallowed by policy.
 
 ## Tier 2: PR CI
 

--- a/docs/site/docs/guides/validation-matrix.md
+++ b/docs/site/docs/guides/validation-matrix.md
@@ -9,7 +9,7 @@ and its exit codes.
 | ----- | ---- | -- | ------ |
 | Branch naming | Yes | -- | `pre-commit` |
 | Repository profile | -- | Yes | `st-repo-profile` |
-| Markdown standards | -- | Yes | `st-validate-local-common` |
+| Markdown standards | -- | Yes | `st-validate` (common checks) |
 | PR issue linkage | -- | Yes | `st-pr-issue-linkage` |
 | Shellcheck | -- | Yes | CI workflow step |
 
@@ -35,7 +35,7 @@ and its exit codes.
 Validates `docs/repository-standards.md` has all six required
 attributes.
 
-### Markdown validation (st-validate-local-common)
+### Markdown validation (st-validate)
 
 **Trigger:** PR opened or updated
 

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -9,7 +9,7 @@ commits, PRs, releases, and validation alongside bash validators and git hooks
 
 **Python CLI tools** (`src/standard_tooling/`):
 `st-commit`, `st-submit-pr`, `st-prepare-release`,
-`st-finalize-repo`, `st-validate-local`
+`st-finalize-repo`, `st-validate`
 
 **Lint tools** (installed as `st-*`):
 `st-repo-profile`, `st-pr-issue-linkage`, validation drivers

--- a/docs/site/docs/reference/lint/markdown-standards.md
+++ b/docs/site/docs/reference/lint/markdown-standards.md
@@ -1,8 +1,8 @@
 # Markdown Validation
 
-Markdown validation is handled by `st-validate-local-common` as part
-of the standard validation pipeline. It runs `markdownlint` against
-published documentation using a canonical config bundled in
+Markdown validation is handled by `st-validate` (common checks) as
+part of the standard validation pipeline. It runs `markdownlint`
+against published documentation using a canonical config bundled in
 standard-tooling.
 
 ## Scope
@@ -47,7 +47,7 @@ Key rules:
 
 ## How it runs
 
-`st-validate-local` dispatches to `st-validate-local-common`, which:
+`st-validate` runs common checks, which:
 
 1. Discovers markdown files matching the scope above.
 2. Resolves the bundled `markdownlint.yaml` config.

--- a/docs/specs/host-level-tool.md
+++ b/docs/specs/host-level-tool.md
@@ -24,7 +24,7 @@ spec dictates the distribution contract they implement.
 ## Problem statement
 
 `standard-tooling` provides host-side CLI tools (`st-docker-run`,
-`st-commit`, `st-submit-pr`, `st-prepare-release`, `st-validate-local`,
+`st-commit`, `st-submit-pr`, `st-prepare-release`, `st-validate`,
 etc.) used across the entire fleet. It is **not** on PyPI and will not
 be (first-party tooling, not a public library).
 
@@ -230,7 +230,7 @@ dep in `[dependency-groups]` can remove it. The cache-first install
 ensures `st-*` commands are available on PATH regardless. Removing the
 dev dep eliminates version drift from stale `uv.lock` pins.
 
-The `uv run st-validate-local` invocation continues to work: `uv run`
+The `uv run st-validate` invocation continues to work: `uv run`
 falls back to PATH for commands not provided by the project's venv.
 
 ### Legacy: Non-Python consumers
@@ -514,9 +514,9 @@ consumer's migration has these steps:
    bootstrap scripts, and CI. (`.venv-host` is retained only in
    `standard-tooling` itself for the dev-tree-override case; it
    should not appear in any other consumer.)
-5. Verify: `st-docker-run -- uv run st-validate-local` works in a
-   fresh clone after `uv sync --group dev`; raw `git commit` is
-   refused with the gate's error.
+5. Verify: `st-docker-run -- uv run st-validate` works in a fresh
+   clone after `uv sync --group dev`; raw `git commit` is refused
+   with the gate's error.
 
 ### Non-Python consumers
 

--- a/docs/specs/standard-tooling-toml.md
+++ b/docs/specs/standard-tooling-toml.md
@@ -82,7 +82,7 @@ prefix and the presence of angle-bracketed email.
 
 ### `[markdownlint]` table
 
-Optional. Controls markdownlint behavior for `st-validate-local-common`.
+Optional. Controls markdownlint behavior for `st-validate` (common checks).
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -174,7 +174,7 @@ constant continue to read from `st-config.toml` until
 - Update error messages referencing `PROFILE_FILENAME` to
   reference `standard-tooling.toml`.
 
-### `st-validate-local` (`src/standard_tooling/bin/validate_local.py`)
+### `st-validate` (`src/standard_tooling/bin/st_validate.py`)
 
 - Replace `repo_profile.read_profile(root)` with
   `config.read_config(root)` for `primary_language`.
@@ -244,10 +244,10 @@ switch.
 
 ### Integration
 
-`st-validate-local` runs `repo_profile_cli.main()` in the
-validation pipeline. Once the validator reads from
-`standard-tooling.toml`, tier-1 validation covers the new file
-automatically. No new integration test is needed.
+`st-validate` runs `repo_profile_cli.main()` in the validation
+pipeline. Once the validator reads from `standard-tooling.toml`,
+tier-1 validation covers the new file automatically. No new
+integration test is needed.
 
 Consumer-level tests for the migration are not needed. The
 consumers read a config value and use it the same way they always


### PR DESCRIPTION
# Pull Request

## Summary

- Replace st-validate-local references with st-validate in published docs and active specs

## Issue Linkage

- Ref #615

## Testing

- markdownlint
- ci: shellcheck

## Notes

- st-validate-local was removed in v1.4.22 but six docs/spec files still
referenced it as a current command. Updated all published docs (4 files)
and active specs (2 files) to reference st-validate. Design specs and
completed plans left as historical record per the issue guidance.

Files updated:
- docs/site/docs/index.md — tool listing
- docs/site/docs/guides/validation-matrix.md — table entry + section heading
- docs/site/docs/reference/lint/markdown-standards.md — description + how-it-runs
- docs/site/docs/guides/ci-architecture.md — historical note + pre-commit command
- docs/specs/standard-tooling-toml.md — markdownlint table, consumer heading, integration
- docs/specs/host-level-tool.md — CLI list, migration note, verification command