### PR TITLE
feat: add [publish] config section and github-config desired-state support

### DIFF
--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -63,12 +63,19 @@ class GithubOverrides:
 
 
 @dataclass
+class PublishConfig:
+    release: bool
+    docs: bool
+
+
+@dataclass
 class StConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
     ci: CiConfig | None
     github: GithubOverrides
+    publish: PublishConfig
 
 
 def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
@@ -130,6 +137,12 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         skip_rulesets=bool(github_raw.get("skip-rulesets", False)),
     )
 
+    publish_raw = raw.get("publish", {})
+    publish = PublishConfig(
+        release=bool(publish_raw.get("release", False)),
+        docs=bool(publish_raw.get("docs", True)),
+    )
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -144,6 +157,7 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         markdownlint=markdownlint,
         ci=ci,
         github=github_overrides,
+        publish=publish,
     )
 
 

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -59,11 +59,18 @@ class DesiredRuleset:
 
 
 @dataclass
+class DesiredPublishConfig:
+    release: bool
+    docs: bool
+
+
+@dataclass
 class DesiredState:
     repo_settings: DesiredRepoSettings
     security: DesiredSecuritySettings
     actions_permissions: DesiredActionsPermissions
     rulesets: list[DesiredRuleset]
+    publish: DesiredPublishConfig
 
 
 _ALLOWED_ACTION_PATTERNS = [
@@ -280,11 +287,17 @@ def compute_desired_state(config: StConfig) -> DesiredState:
         if config.ci is not None:
             rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
 
+    publish = DesiredPublishConfig(
+        release=config.publish.release,
+        docs=config.publish.docs,
+    )
+
     return DesiredState(
         repo_settings=desired_repo_settings(),
         security=desired_security_settings(),
         actions_permissions=desired_actions_permissions(),
         rulesets=rulesets,
+        publish=publish,
     )
 
 
@@ -449,6 +462,7 @@ def fetch_actual_state(repo: str) -> DesiredState:
         security=security,
         actions_permissions=actions_permissions,
         rulesets=rulesets,
+        publish=DesiredPublishConfig(release=False, docs=False),
     )
 
 

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -10,6 +10,8 @@ claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@u
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
 [publish]
+release = true
+docs = true
 consumer-refresh = """\
 uv tool install --python 3.14 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v<VERSION>'
 """

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -275,3 +275,60 @@ def test_read_config_no_github_section(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
     cfg = read_config(tmp_path)
     assert cfg.github == GithubOverrides(skip_rulesets=False)
+
+
+# -- [publish] section --------------------------------------------------------
+
+_PUBLISH_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+
+[publish]
+release = true
+docs = true
+"""
+
+
+def test_publish_section_parsed(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_PUBLISH_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.publish is not None
+    assert cfg.publish.release is True
+    assert cfg.publish.docs is True
+
+
+def test_publish_section_defaults_when_absent(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_INSTALL_TAG_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.publish is not None
+    assert cfg.publish.release is False
+    assert cfg.publish.docs is True
+
+
+_PUBLISH_RELEASE_ONLY_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+
+[publish]
+release = true
+"""
+
+
+def test_publish_docs_defaults_true(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_PUBLISH_RELEASE_ONLY_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.publish.docs is True

--- a/tests/standard_tooling/test_github_config_cli.py
+++ b/tests/standard_tooling/test_github_config_cli.py
@@ -21,6 +21,7 @@ from standard_tooling.lib.config import (
     GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
+    PublishConfig,
     StConfig,
 )
 from standard_tooling.lib.github_config import ConfigDiff, DiffItem
@@ -264,6 +265,7 @@ def _make_config() -> StConfig:
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=None,
         github=GithubOverrides(skip_rulesets=True),
+        publish=PublishConfig(release=False, docs=True),
     )
 
 

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -1053,3 +1053,30 @@ def test_normalize_rules_skips_non_dict_entries() -> None:
     result = _normalize_rules(rules)
     assert len(result) == 1
     assert result[0] == {"type": "deletion"}
+
+
+# ---------------------------------------------------------------------------
+# Publish config in desired state
+# ---------------------------------------------------------------------------
+
+
+def test_compute_desired_state_includes_publish() -> None:
+    config = _st_config()
+    state = compute_desired_state(config)
+    assert state.publish is not None
+    assert state.publish.release is False
+    assert state.publish.docs is True
+
+
+def test_compute_desired_state_publish_release_true() -> None:
+    config = StConfig(
+        project=_project(),
+        dependencies={"standard-tooling": "v1.4"},
+        markdownlint=MarkdownlintConfig(ignore=[]),
+        ci=_ci(),
+        github=GithubOverrides(skip_rulesets=False),
+        publish=PublishConfig(release=True, docs=True),
+    )
+    state = compute_desired_state(config)
+    assert state.publish.release is True
+    assert state.publish.docs is True

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -11,6 +11,7 @@ from standard_tooling.lib.config import (
     GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
+    PublishConfig,
     StConfig,
 )
 from standard_tooling.lib.github_config import (
@@ -259,6 +260,7 @@ def _st_config(
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
         github=GithubOverrides(skip_rulesets=skip_rulesets),
+        publish=PublishConfig(release=False, docs=True),
     )
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add publish config schema and desired-state support for workflow rationalization

## Issue Linkage

- Ref wphillipmoore/standard-actions#318

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Phase 1 foundations for the publish/docs workflow rationalization. Adds
the config schema and desired-state model support needed before the
reusable workflows can be built in standard-actions (Phase 2).

Changes:
- Add PublishConfig dataclass to config.py with release (default false)
  and docs (default true) fields; the [publish] section is optional
- Thread publish config into DesiredPublishConfig on DesiredState in
  st-github-config for naming validation (validated, not enforced via
  rulesets — these are post-merge workflows)
- Add release=true and docs=true to standard-tooling's own
  standard-tooling.toml