### PR TITLE
Add 8 new repo-level settings to st-github-config

### DIFF
--- a/src/standard_tooling/bin/github_config.py
+++ b/src/standard_tooling/bin/github_config.py
@@ -83,9 +83,9 @@ def _fetch_remote_config(repo: str) -> StConfig:
 
 def _audit_repo(repo: str, config: StConfig) -> ConfigDiff:
     """Compute diff between desired and actual state for a repo."""
-    desired = compute_desired_state(config)
-    actual = fetch_actual_state(repo)
-    return compute_diff(desired=desired, actual=actual)
+    result = fetch_actual_state(repo)
+    desired = compute_desired_state(config, visibility=result.visibility)
+    return compute_diff(desired=desired, actual=result.state)
 
 
 def _print_diff(repo: str, diff: ConfigDiff) -> None:
@@ -100,7 +100,8 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
 
 def _apply_repo(repo: str, config: StConfig) -> list[str]:
     """Apply desired state to a repo. Returns branches with legacy protection removed."""
-    desired = compute_desired_state(config)
+    result = fetch_actual_state(repo)
+    desired = compute_desired_state(config, visibility=result.visibility)
     return apply_desired_state(repo, desired)
 
 

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -30,6 +30,14 @@ class DesiredRepoSettings:
     has_issues: bool
     has_projects: bool
     has_wiki: bool
+    allow_forking: bool
+    allow_update_branch: bool
+    has_downloads: bool
+    merge_commit_title: str
+    merge_commit_message: str
+    squash_merge_commit_title: str
+    squash_merge_commit_message: str
+    web_commit_signoff_required: bool
 
 
 @dataclass
@@ -86,7 +94,7 @@ _ALLOWED_ACTION_PATTERNS = [
 ]
 
 
-def desired_repo_settings() -> DesiredRepoSettings:
+def desired_repo_settings(*, visibility: str) -> DesiredRepoSettings:
     return DesiredRepoSettings(
         default_branch="develop",
         allow_auto_merge=False,
@@ -97,6 +105,14 @@ def desired_repo_settings() -> DesiredRepoSettings:
         has_issues=True,
         has_projects=True,
         has_wiki=True,
+        allow_forking=visibility == "public",
+        allow_update_branch=True,
+        has_downloads=False,
+        merge_commit_title="MERGE_MESSAGE",
+        merge_commit_message="PR_TITLE",
+        squash_merge_commit_title="COMMIT_OR_PR_TITLE",
+        squash_merge_commit_message="COMMIT_MESSAGES",
+        web_commit_signoff_required=True,
     )
 
 
@@ -276,7 +292,7 @@ def desired_ci_gates_ruleset(
     )
 
 
-def compute_desired_state(config: StConfig) -> DesiredState:
+def compute_desired_state(config: StConfig, *, visibility: str) -> DesiredState:
     """Compute the full desired GitHub configuration from a repo's StConfig."""
     rulesets: list[DesiredRuleset] = []
 
@@ -293,7 +309,7 @@ def compute_desired_state(config: StConfig) -> DesiredState:
     )
 
     return DesiredState(
-        repo_settings=desired_repo_settings(),
+        repo_settings=desired_repo_settings(visibility=visibility),
         security=desired_security_settings(),
         actions_permissions=desired_actions_permissions(),
         rulesets=rulesets,

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -363,9 +363,7 @@ def fetch_actual_state(repo: str) -> FetchResult:
     repo_data = github.read_json("api", f"repos/{repo}")
 
     visibility = (
-        str(repo_data.get("visibility", "private"))
-        if isinstance(repo_data, dict)
-        else "private"
+        str(repo_data.get("visibility", "private")) if isinstance(repo_data, dict) else "private"
     )
 
     sa_raw = repo_data.get("security_and_analysis") if isinstance(repo_data, dict) else None

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -627,6 +627,14 @@ def _apply_repo_settings(repo: str, settings: DesiredRepoSettings) -> None:
             "has_issues": settings.has_issues,
             "has_projects": settings.has_projects,
             "has_wiki": settings.has_wiki,
+            "allow_forking": settings.allow_forking,
+            "allow_update_branch": settings.allow_update_branch,
+            "has_downloads": settings.has_downloads,
+            "merge_commit_title": settings.merge_commit_title,
+            "merge_commit_message": settings.merge_commit_message,
+            "squash_merge_commit_title": settings.squash_merge_commit_title,
+            "squash_merge_commit_message": settings.squash_merge_commit_message,
+            "web_commit_signoff_required": settings.web_commit_signoff_required,
         },
     )
 

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -81,6 +81,12 @@ class DesiredState:
     publish: DesiredPublishConfig
 
 
+@dataclass
+class FetchResult:
+    state: DesiredState
+    visibility: str
+
+
 _ALLOWED_ACTION_PATTERNS = [
     "actions-rust-lang/*",
     "actions/*",
@@ -352,9 +358,15 @@ def _normalize_rules(rules: Sequence[object]) -> list[dict[str, object]]:
     return normalized
 
 
-def fetch_actual_state(repo: str) -> DesiredState:
+def fetch_actual_state(repo: str) -> FetchResult:
     """Fetch the current GitHub configuration for a repo via gh api."""
     repo_data = github.read_json("api", f"repos/{repo}")
+
+    visibility = (
+        str(repo_data.get("visibility", "private"))
+        if isinstance(repo_data, dict)
+        else "private"
+    )
 
     sa_raw = repo_data.get("security_and_analysis") if isinstance(repo_data, dict) else None
     sa: dict[str, object] = cast("dict[str, object]", sa_raw) if isinstance(sa_raw, dict) else {}
@@ -385,6 +397,30 @@ def fetch_actual_state(repo: str) -> DesiredState:
         if isinstance(repo_data, dict)
         else False,
         has_wiki=bool(repo_data.get("has_wiki", False)) if isinstance(repo_data, dict) else False,
+        allow_forking=bool(repo_data.get("allow_forking", False))
+        if isinstance(repo_data, dict)
+        else False,
+        allow_update_branch=bool(repo_data.get("allow_update_branch", False))
+        if isinstance(repo_data, dict)
+        else False,
+        has_downloads=bool(repo_data.get("has_downloads", False))
+        if isinstance(repo_data, dict)
+        else False,
+        merge_commit_title=str(repo_data.get("merge_commit_title", ""))
+        if isinstance(repo_data, dict)
+        else "",
+        merge_commit_message=str(repo_data.get("merge_commit_message", ""))
+        if isinstance(repo_data, dict)
+        else "",
+        squash_merge_commit_title=str(repo_data.get("squash_merge_commit_title", ""))
+        if isinstance(repo_data, dict)
+        else "",
+        squash_merge_commit_message=str(repo_data.get("squash_merge_commit_message", ""))
+        if isinstance(repo_data, dict)
+        else "",
+        web_commit_signoff_required=bool(repo_data.get("web_commit_signoff_required", False))
+        if isinstance(repo_data, dict)
+        else False,
     )
 
     ss_raw = sa.get("secret_scanning")
@@ -473,12 +509,15 @@ def fetch_actual_state(repo: str) -> DesiredState:
                 )
             )
 
-    return DesiredState(
-        repo_settings=repo_settings,
-        security=security,
-        actions_permissions=actions_permissions,
-        rulesets=rulesets,
-        publish=DesiredPublishConfig(release=False, docs=False),
+    return FetchResult(
+        state=DesiredState(
+            repo_settings=repo_settings,
+            security=security,
+            actions_permissions=actions_permissions,
+            rulesets=rulesets,
+            publish=DesiredPublishConfig(release=False, docs=False),
+        ),
+        visibility=visibility,
     )
 
 

--- a/tests/standard_tooling/test_github_config_cli.py
+++ b/tests/standard_tooling/test_github_config_cli.py
@@ -284,9 +284,12 @@ def test_audit_repo_calls_compute_and_diff() -> None:
         ) as mock_diff,
     ):
         result = _audit_repo("o/r", cfg)
-    mock_desired.assert_called_once_with(cfg)
     mock_fetch.assert_called_once_with("o/r")
-    mock_diff.assert_called_once()
+    mock_desired.assert_called_once_with(cfg, visibility=mock_fetch.return_value.visibility)
+    mock_diff.assert_called_once_with(
+        desired=mock_desired.return_value,
+        actual=mock_fetch.return_value.state,
+    )
     assert result.is_compliant()
 
 
@@ -296,11 +299,13 @@ def test_audit_repo_calls_compute_and_diff() -> None:
 def test_apply_repo_calls_apply_desired_state() -> None:
     cfg = _make_config()
     with (
+        patch("standard_tooling.bin.github_config.fetch_actual_state") as mock_fetch,
         patch("standard_tooling.bin.github_config.compute_desired_state") as mock_desired,
         patch("standard_tooling.bin.github_config.apply_desired_state") as mock_apply,
     ):
         _apply_repo("o/r", cfg)
-    mock_desired.assert_called_once_with(cfg)
+    mock_fetch.assert_called_once_with("o/r")
+    mock_desired.assert_called_once_with(cfg, visibility=mock_fetch.return_value.visibility)
     mock_apply.assert_called_once_with("o/r", mock_desired.return_value)
 
 

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -51,6 +51,27 @@ def test_desired_repo_settings_are_fixed() -> None:
     assert s.has_wiki is True
 
 
+def test_desired_repo_settings_public_allows_forking() -> None:
+    s = desired_repo_settings(visibility="public")
+    assert s.allow_forking is True
+
+
+def test_desired_repo_settings_private_disallows_forking() -> None:
+    s = desired_repo_settings(visibility="private")
+    assert s.allow_forking is False
+
+
+def test_desired_repo_settings_new_hardcoded_values() -> None:
+    s = desired_repo_settings(visibility="public")
+    assert s.allow_update_branch is True
+    assert s.has_downloads is False
+    assert s.merge_commit_title == "MERGE_MESSAGE"
+    assert s.merge_commit_message == "PR_TITLE"
+    assert s.squash_merge_commit_title == "COMMIT_OR_PR_TITLE"
+    assert s.squash_merge_commit_message == "COMMIT_MESSAGES"
+    assert s.web_commit_signoff_required is True
+
+
 def test_desired_security_settings() -> None:
     s = desired_security_settings()
     assert s.secret_scanning == "enabled"  # noqa: S105

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -896,6 +896,17 @@ def test_diff_detects_security_mismatch() -> None:
     assert any(d.field == "security.vulnerability_alerts" for d in diff.items)
 
 
+def test_diff_detects_new_repo_setting_drift() -> None:
+    desired = compute_desired_state(_st_config(), visibility="public")
+    actual = compute_desired_state(_st_config(), visibility="public")
+    actual.repo_settings.merge_commit_title = "PR_TITLE"
+    actual.repo_settings.web_commit_signoff_required = False
+    diff = compute_diff(desired=desired, actual=actual)
+    fields = {item.field for item in diff.items}
+    assert "repo_settings.merge_commit_title" in fields
+    assert "repo_settings.web_commit_signoff_required" in fields
+
+
 # ---------------------------------------------------------------------------
 # Apply tests
 # ---------------------------------------------------------------------------
@@ -912,6 +923,21 @@ def test_apply_repo_settings_calls_write_json() -> None:
     body = call_args[0][2]
     assert body["default_branch"] == "develop"
     assert body["delete_branch_on_merge"] is True
+
+
+def test_apply_repo_settings_includes_new_fields() -> None:
+    settings = desired_repo_settings(visibility="public")
+    with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_repo_settings("o/r", settings)
+    body = mock_write.call_args[0][2]
+    assert body["allow_forking"] is True
+    assert body["allow_update_branch"] is True
+    assert body["has_downloads"] is False
+    assert body["merge_commit_title"] == "MERGE_MESSAGE"
+    assert body["merge_commit_message"] == "PR_TITLE"
+    assert body["squash_merge_commit_title"] == "COMMIT_OR_PR_TITLE"
+    assert body["squash_merge_commit_message"] == "COMMIT_MESSAGES"
+    assert body["web_commit_signoff_required"] is True
 
 
 def test_apply_security_settings_enables_vuln_alerts() -> None:

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -40,7 +40,7 @@ from standard_tooling.lib.github_config import (
 
 
 def test_desired_repo_settings_are_fixed() -> None:
-    s = desired_repo_settings()
+    s = desired_repo_settings(visibility="public")
     assert s.default_branch == "develop"
     assert s.allow_auto_merge is False
     assert s.delete_branch_on_merge is True
@@ -287,7 +287,7 @@ def _st_config(
 
 
 def test_compute_desired_state_has_three_rulesets() -> None:
-    state = compute_desired_state(_st_config())
+    state = compute_desired_state(_st_config(), visibility="public")
     assert len(state.rulesets) == 3
     names = [r.name for r in state.rulesets]
     assert "Branch protection" in names
@@ -296,31 +296,31 @@ def test_compute_desired_state_has_three_rulesets() -> None:
 
 
 def test_compute_desired_state_skip_rulesets() -> None:
-    state = compute_desired_state(_st_config(skip_rulesets=True))
+    state = compute_desired_state(_st_config(skip_rulesets=True), visibility="public")
     assert state.rulesets == []
 
 
 def test_compute_desired_state_no_ci_section() -> None:
     cfg = _st_config()
     cfg.ci = None
-    state = compute_desired_state(cfg)
+    state = compute_desired_state(cfg, visibility="public")
     assert len(state.rulesets) == 2
     names = [r.name for r in state.rulesets]
     assert "CI gates" not in names
 
 
 def test_compute_desired_state_includes_repo_settings() -> None:
-    state = compute_desired_state(_st_config())
+    state = compute_desired_state(_st_config(), visibility="public")
     assert state.repo_settings.default_branch == "develop"
 
 
 def test_compute_desired_state_includes_security() -> None:
-    state = compute_desired_state(_st_config())
+    state = compute_desired_state(_st_config(), visibility="public")
     assert state.security.secret_scanning == "enabled"  # noqa: S105
 
 
 def test_compute_desired_state_includes_actions() -> None:
-    state = compute_desired_state(_st_config())
+    state = compute_desired_state(_st_config(), visibility="public")
     assert state.actions_permissions.allowed_actions == "selected"
 
 
@@ -374,7 +374,8 @@ def test_fetch_actual_state_repo_settings() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert actual.repo_settings.default_branch == "develop"
     assert actual.repo_settings.delete_branch_on_merge is True
@@ -430,7 +431,8 @@ def test_fetch_actual_state_with_rulesets() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert len(actual.rulesets) == 1
     assert actual.rulesets[0].name == "Branch protection"
@@ -470,7 +472,8 @@ def test_fetch_actual_state_no_selected_actions_skips_patterns() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert "repos/o/r/actions/permissions/selected-actions" not in call_log
     assert actual.actions_permissions.patterns_allowed == []
@@ -508,7 +511,8 @@ def test_fetch_actual_state_missing_security_and_analysis() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert actual.security.secret_scanning == "disabled"  # noqa: S105
     assert actual.security.secret_scanning_push_protection == "disabled"  # noqa: S105
@@ -556,7 +560,8 @@ def test_fetch_actual_state_rulesets_edge_cases() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     # All invalid rulesets should be skipped
     assert actual.rulesets == []
@@ -594,7 +599,8 @@ def test_fetch_actual_state_rulesets_not_a_list() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert actual.rulesets == []
 
@@ -634,7 +640,8 @@ def test_fetch_actual_state_selected_actions_non_dict_response() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert actual.actions_permissions.patterns_allowed == []
 
@@ -673,7 +680,8 @@ def test_fetch_actual_state_selected_actions_non_list_patterns() -> None:
             return_value=False,
         ),
     ):
-        actual = fetch_actual_state("o/r")
+        result = fetch_actual_state("o/r")
+    actual = result.state
 
     assert actual.actions_permissions.patterns_allowed == []
 
@@ -836,15 +844,15 @@ def test_fetch_vulnerability_alerts_disabled() -> None:
 
 
 def test_diff_identical_states_is_empty() -> None:
-    state = compute_desired_state(_st_config())
+    state = compute_desired_state(_st_config(), visibility="public")
     diff = compute_diff(desired=state, actual=state)
     assert diff.is_compliant()
     assert diff.items == []
 
 
 def test_diff_detects_repo_setting_mismatch() -> None:
-    desired = compute_desired_state(_st_config())
-    actual = compute_desired_state(_st_config())
+    desired = compute_desired_state(_st_config(), visibility="public")
+    actual = compute_desired_state(_st_config(), visibility="public")
     actual.repo_settings.allow_auto_merge = True
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -852,8 +860,8 @@ def test_diff_detects_repo_setting_mismatch() -> None:
 
 
 def test_diff_detects_missing_ruleset() -> None:
-    desired = compute_desired_state(_st_config())
-    actual = compute_desired_state(_st_config())
+    desired = compute_desired_state(_st_config(), visibility="public")
+    actual = compute_desired_state(_st_config(), visibility="public")
     actual.rulesets = []
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -861,8 +869,8 @@ def test_diff_detects_missing_ruleset() -> None:
 
 
 def test_diff_detects_extra_ruleset() -> None:
-    desired = compute_desired_state(_st_config())
-    actual = compute_desired_state(_st_config())
+    desired = compute_desired_state(_st_config(), visibility="public")
+    actual = compute_desired_state(_st_config(), visibility="public")
     actual.rulesets.append(
         DesiredRuleset(
             name="Extra",
@@ -879,8 +887,8 @@ def test_diff_detects_extra_ruleset() -> None:
 
 
 def test_diff_detects_actions_permission_mismatch() -> None:
-    desired = compute_desired_state(_st_config())
-    actual = compute_desired_state(_st_config())
+    desired = compute_desired_state(_st_config(), visibility="public")
+    actual = compute_desired_state(_st_config(), visibility="public")
     actual.actions_permissions.default_workflow_permissions = "write"
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -888,8 +896,8 @@ def test_diff_detects_actions_permission_mismatch() -> None:
 
 
 def test_diff_detects_security_mismatch() -> None:
-    desired = compute_desired_state(_st_config())
-    actual = compute_desired_state(_st_config())
+    desired = compute_desired_state(_st_config(), visibility="public")
+    actual = compute_desired_state(_st_config(), visibility="public")
     actual.security.vulnerability_alerts = True
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -913,7 +921,7 @@ def test_diff_detects_new_repo_setting_drift() -> None:
 
 
 def test_apply_repo_settings_calls_write_json() -> None:
-    settings = desired_repo_settings()
+    settings = desired_repo_settings(visibility="public")
     with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     mock_write.assert_called_once()
@@ -1108,7 +1116,7 @@ def test_ruleset_body_structure() -> None:
 
 
 def test_apply_desired_state_orchestrates_all() -> None:
-    state = compute_desired_state(_st_config())
+    state = compute_desired_state(_st_config(), visibility="public")
     with (
         patch("standard_tooling.lib.github_config._apply_repo_settings") as mock_repo,
         patch("standard_tooling.lib.github_config._apply_security_settings") as mock_sec,
@@ -1246,7 +1254,7 @@ def test_normalize_rules_skips_non_dict_entries() -> None:
 
 def test_compute_desired_state_includes_publish() -> None:
     config = _st_config()
-    state = compute_desired_state(config)
+    state = compute_desired_state(config, visibility="public")
     assert state.publish is not None
     assert state.publish.release is False
     assert state.publish.docs is True
@@ -1261,6 +1269,6 @@ def test_compute_desired_state_publish_release_true() -> None:
         github=GithubOverrides(skip_rulesets=False),
         publish=PublishConfig(release=True, docs=True),
     )
-    state = compute_desired_state(config)
+    state = compute_desired_state(config, visibility="public")
     assert state.publish.release is True
     assert state.publish.docs is True

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -16,6 +16,7 @@ from standard_tooling.lib.config import (
 )
 from standard_tooling.lib.github_config import (
     DesiredRuleset,
+    FetchResult,
     _apply_actions_permissions,
     _apply_repo_settings,
     _apply_rulesets,
@@ -675,6 +676,142 @@ def test_fetch_actual_state_selected_actions_non_list_patterns() -> None:
         actual = fetch_actual_state("o/r")
 
     assert actual.actions_permissions.patterns_allowed == []
+
+
+def test_fetch_actual_state_returns_fetch_result() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "visibility": "public",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        result = fetch_actual_state("o/r")
+
+    assert isinstance(result, FetchResult)
+    assert result.visibility == "public"
+    assert result.state.repo_settings.default_branch == "develop"
+
+
+def test_fetch_actual_state_extracts_new_repo_fields() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "allow_auto_merge": False,
+        "delete_branch_on_merge": True,
+        "allow_merge_commit": True,
+        "allow_squash_merge": True,
+        "allow_rebase_merge": True,
+        "has_issues": True,
+        "has_projects": True,
+        "has_wiki": True,
+        "allow_forking": True,
+        "allow_update_branch": True,
+        "has_downloads": False,
+        "merge_commit_title": "MERGE_MESSAGE",
+        "merge_commit_message": "PR_TITLE",
+        "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
+        "squash_merge_commit_message": "COMMIT_MESSAGES",
+        "web_commit_signoff_required": True,
+        "visibility": "public",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        result = fetch_actual_state("o/r")
+
+    s = result.state.repo_settings
+    assert s.allow_forking is True
+    assert s.allow_update_branch is True
+    assert s.has_downloads is False
+    assert s.merge_commit_title == "MERGE_MESSAGE"
+    assert s.merge_commit_message == "PR_TITLE"
+    assert s.squash_merge_commit_title == "COMMIT_OR_PR_TITLE"
+    assert s.squash_merge_commit_message == "COMMIT_MESSAGES"
+    assert s.web_commit_signoff_required is True
+
+
+def test_fetch_actual_state_defaults_visibility_to_private() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        result = fetch_actual_state("o/r")
+
+    assert result.visibility == "private"
 
 
 def test_fetch_vulnerability_alerts_enabled() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add 8 new repo-level settings to st-github-config

## Issue Linkage

- Ref #610

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

- Add 8 new fields to `DesiredRepoSettings`: `allow_forking` (derived from visibility), `allow_update_branch`, `has_downloads`, `merge_commit_title`, `merge_commit_message`, `squash_merge_commit_title`, `squash_merge_commit_message`, `web_commit_signoff_required`
- Introduce `FetchResult` wrapper to thread repo `visibility` from the fetch layer through to derivation, enabling `allow_forking` to vary by public/private status
- Update the PATCH body in `_apply_repo_settings` and the CLI plumbing in `_audit_repo`/`_apply_repo` to use the new fields and visibility threading
- Full test coverage for all new behavior including drift detection

## Testing

- `st-docker-run -- uv run st-validate` — all 818 tests pass, 100% coverage, lint/typecheck/audit clean

## Notes

- No new API calls — all 8 fields come from the existing `repos/{repo}` response
- `allow_forking` is the only visibility-dependent field: `True` for public repos, `False` for private