### PR TITLE
feat(github-config): make allowed action patterns language-specific

### DIFF
--- a/docs/plans/2026-05-09-language-specific-action-patterns.md
+++ b/docs/plans/2026-05-09-language-specific-action-patterns.md
@@ -1,0 +1,161 @@
+# Language-Specific Action Patterns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `_ALLOWED_ACTION_PATTERNS` into a base set and per-language sets so each repo only gets the action patterns relevant to its primary language.
+
+**Architecture:** Replace the single `_ALLOWED_ACTION_PATTERNS` list with `_BASE_ACTION_PATTERNS` and `_LANGUAGE_ACTION_PATTERNS` dict. Thread `primary_language: str` into `desired_actions_permissions()` and its call site in `compute_desired_state()`.
+
+**Tech Stack:** Python, pytest
+
+---
+
+### File Map
+
+- **Modify:** `src/standard_tooling/lib/github_config.py` — data constants, function signature, call site
+- **Modify:** `tests/standard_tooling/test_github_config_lib.py` — update and add tests
+
+### Task 1: Update tests for the new signature and language-specific behavior
+
+**Files:**
+- Modify: `tests/standard_tooling/test_github_config_lib.py:84-91` (existing test)
+- Modify: `tests/standard_tooling/test_github_config_lib.py:322-324` (existing test)
+
+- [ ] **Step 1: Rewrite `test_desired_actions_permissions` to cover base-only and base+language cases**
+
+Replace lines 84–91 with:
+
+```python
+def test_desired_actions_permissions_base_only() -> None:
+    a = desired_actions_permissions("go")
+    assert a.default_workflow_permissions == "read"
+    assert a.can_approve_pull_request_reviews is False
+    assert a.allowed_actions == "selected"
+    assert a.patterns_allowed == [
+        "actions/*",
+        "docker/*",
+        "github/*",
+        "wphillipmoore/*",
+    ]
+
+
+def test_desired_actions_permissions_with_language_patterns() -> None:
+    a = desired_actions_permissions("rust")
+    assert a.patterns_allowed == [
+        "actions-rust-lang/*",
+        "actions/*",
+        "docker/*",
+        "github/*",
+        "swatinem/*",
+        "wphillipmoore/*",
+    ]
+
+
+def test_desired_actions_permissions_python() -> None:
+    a = desired_actions_permissions("python")
+    assert a.patterns_allowed == [
+        "actions/*",
+        "astral-sh/*",
+        "docker/*",
+        "github/*",
+        "pypa/*",
+        "wphillipmoore/*",
+    ]
+```
+
+- [ ] **Step 2: Update `test_compute_desired_state_includes_actions`**
+
+The `_st_config()` helper defaults to `language="python"`, so the test
+at line 322–324 needs no signature changes — just verify it picks up
+language-specific patterns. Replace with:
+
+```python
+def test_compute_desired_state_includes_actions() -> None:
+    state = compute_desired_state(_st_config(), visibility="public")
+    assert state.actions_permissions.allowed_actions == "selected"
+    assert "pypa/*" in state.actions_permissions.patterns_allowed
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `st-docker-run -- uv run pytest tests/standard_tooling/test_github_config_lib.py::test_desired_actions_permissions_base_only tests/standard_tooling/test_github_config_lib.py::test_desired_actions_permissions_with_language_patterns tests/standard_tooling/test_github_config_lib.py::test_desired_actions_permissions_python tests/standard_tooling/test_github_config_lib.py::test_compute_desired_state_includes_actions -v`
+
+Expected: FAIL — `desired_actions_permissions()` does not accept a positional argument yet.
+
+### Task 2: Implement the data constants and function changes
+
+**Files:**
+- Modify: `src/standard_tooling/lib/github_config.py:90-140` (constants and function)
+- Modify: `src/standard_tooling/lib/github_config.py:320` (call site)
+
+- [ ] **Step 1: Replace `_ALLOWED_ACTION_PATTERNS` with `_BASE_ACTION_PATTERNS` and `_LANGUAGE_ACTION_PATTERNS`**
+
+Replace lines 90–100 with:
+
+```python
+_BASE_ACTION_PATTERNS = [
+    "actions/*",
+    "docker/*",
+    "github/*",
+    "wphillipmoore/*",
+]
+
+_LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {
+    "python": ["astral-sh/*", "pypa/*"],
+    "ruby": ["ruby/*"],
+    "rust": ["actions-rust-lang/*", "swatinem/*"],
+}
+```
+
+- [ ] **Step 2: Update `desired_actions_permissions()` to accept `primary_language`**
+
+Replace lines 134–140 with:
+
+```python
+def desired_actions_permissions(primary_language: str) -> DesiredActionsPermissions:
+    patterns = sorted(
+        set(_BASE_ACTION_PATTERNS) | set(_LANGUAGE_ACTION_PATTERNS.get(primary_language, []))
+    )
+    return DesiredActionsPermissions(
+        default_workflow_permissions="read",
+        can_approve_pull_request_reviews=False,
+        allowed_actions="selected",
+        patterns_allowed=patterns,
+    )
+```
+
+- [ ] **Step 3: Update the call site in `compute_desired_state()`**
+
+Replace line 320:
+
+```python
+        actions_permissions=desired_actions_permissions(),
+```
+
+with:
+
+```python
+        actions_permissions=desired_actions_permissions(config.project.primary_language),
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `st-docker-run -- uv run pytest tests/standard_tooling/test_github_config_lib.py -v`
+
+Expected: All tests PASS.
+
+### Task 3: Run full validation and commit
+
+- [ ] **Step 1: Run full validation**
+
+Run: `st-docker-run -- uv run st-validate`
+
+Expected: All checks pass (lint, typecheck, tests, audit).
+
+- [ ] **Step 2: Commit**
+
+```bash
+st-commit
+```
+
+Commit message: `feat(github-config): make allowed action patterns language-specific (#613)`

--- a/docs/specs/2026-05-09-language-specific-action-patterns-design.md
+++ b/docs/specs/2026-05-09-language-specific-action-patterns-design.md
@@ -1,0 +1,88 @@
+# Language-Specific Action Patterns
+
+**Issue:** [#613](https://github.com/wphillipmoore/standard-tooling/issues/613)
+**Date:** 2026-05-09
+
+## Problem
+
+`_ALLOWED_ACTION_PATTERNS` is a flat global list applied identically to
+every managed repo. Every repo gets patterns it doesn't need (e.g., Go
+repos get `ruby/*`, `pypa/*`) and language-specific patterns like
+`swatinem/*` must either be added globally or managed manually.
+
+When `st-github-config apply` runs, it strips any manually-added
+patterns that aren't in the global list — which is how `swatinem/*` was
+removed from `mq-rest-admin-rust` during the v1.5 CI workflow rollout.
+
+## Design
+
+### Data structure
+
+Replace the single `_ALLOWED_ACTION_PATTERNS` list with two constants:
+
+```python
+_BASE_ACTION_PATTERNS = [
+    "actions/*",
+    "docker/*",
+    "github/*",
+    "wphillipmoore/*",
+]
+
+_LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {
+    "python": ["astral-sh/*", "pypa/*"],
+    "ruby": ["ruby/*"],
+    "rust": ["actions-rust-lang/*", "swatinem/*"],
+}
+```
+
+- Base patterns apply to all repos regardless of language.
+- Per-language patterns are keyed by `primary_language` values from
+  `standard-tooling.toml`.
+- Languages not in the dict (go, java, shell, none, claude-plugin) get
+  only the base set.
+- The merged result is sorted for determinism.
+
+### Function signature
+
+```python
+def desired_actions_permissions(primary_language: str) -> DesiredActionsPermissions:
+```
+
+Takes `primary_language` as a plain string — only what the function
+needs.
+
+### Call site
+
+In `compute_desired_state()`:
+
+```python
+actions_permissions=desired_actions_permissions(config.project.primary_language),
+```
+
+### Merge logic
+
+```python
+patterns = sorted(
+    set(_BASE_ACTION_PATTERNS) | set(_LANGUAGE_ACTION_PATTERNS.get(primary_language, []))
+)
+```
+
+### Tests
+
+- Update `test_desired_actions_permissions` to verify base-only for a
+  language with no extras (e.g., `go`), and to verify base + language
+  patterns for a language with extras (e.g., `rust`).
+- Update `test_compute_desired_state_includes_actions` since the
+  function signature changed (the helper already takes a `language`
+  parameter).
+
+## Scope
+
+This change touches:
+
+- `src/standard_tooling/lib/github_config.py` — data constants,
+  `desired_actions_permissions()`, `compute_desired_state()`
+- `tests/standard_tooling/test_github_config_lib.py` — updated and new
+  tests
+
+No changes to config parsing, CLI entry points, or other modules.

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -87,17 +87,18 @@ class FetchResult:
     visibility: str
 
 
-_ALLOWED_ACTION_PATTERNS = [
-    "actions-rust-lang/*",
+_BASE_ACTION_PATTERNS = [
     "actions/*",
-    "astral-sh/*",
     "docker/*",
     "github/*",
-    "pypa/*",
-    "ruby/*",
-    "swatinem/*",
     "wphillipmoore/*",
 ]
+
+_LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {
+    "python": ["astral-sh/*", "pypa/*"],
+    "ruby": ["ruby/*"],
+    "rust": ["actions-rust-lang/*", "swatinem/*"],
+}
 
 
 def desired_repo_settings(*, visibility: str) -> DesiredRepoSettings:
@@ -131,12 +132,15 @@ def desired_security_settings() -> DesiredSecuritySettings:
     )
 
 
-def desired_actions_permissions() -> DesiredActionsPermissions:
+def desired_actions_permissions(primary_language: str) -> DesiredActionsPermissions:
+    patterns = sorted(
+        set(_BASE_ACTION_PATTERNS) | set(_LANGUAGE_ACTION_PATTERNS.get(primary_language, []))
+    )
     return DesiredActionsPermissions(
         default_workflow_permissions="read",
         can_approve_pull_request_reviews=False,
         allowed_actions="selected",
-        patterns_allowed=list(_ALLOWED_ACTION_PATTERNS),
+        patterns_allowed=patterns,
     )
 
 
@@ -317,7 +321,7 @@ def compute_desired_state(config: StConfig, *, visibility: str) -> DesiredState:
     return DesiredState(
         repo_settings=desired_repo_settings(visibility=visibility),
         security=desired_security_settings(),
-        actions_permissions=desired_actions_permissions(),
+        actions_permissions=desired_actions_permissions(config.project.primary_language),
         rulesets=rulesets,
         publish=publish,
     )

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -81,13 +81,41 @@ def test_desired_security_settings() -> None:
     assert s.dependabot_security_updates == "disabled"
 
 
-def test_desired_actions_permissions() -> None:
-    a = desired_actions_permissions()
+def test_desired_actions_permissions_base_only() -> None:
+    a = desired_actions_permissions("go")
     assert a.default_workflow_permissions == "read"
     assert a.can_approve_pull_request_reviews is False
     assert a.allowed_actions == "selected"
-    assert "wphillipmoore/*" in a.patterns_allowed
-    assert "actions/*" in a.patterns_allowed
+    assert a.patterns_allowed == [
+        "actions/*",
+        "docker/*",
+        "github/*",
+        "wphillipmoore/*",
+    ]
+
+
+def test_desired_actions_permissions_with_language_patterns() -> None:
+    a = desired_actions_permissions("rust")
+    assert a.patterns_allowed == [
+        "actions-rust-lang/*",
+        "actions/*",
+        "docker/*",
+        "github/*",
+        "swatinem/*",
+        "wphillipmoore/*",
+    ]
+
+
+def test_desired_actions_permissions_python() -> None:
+    a = desired_actions_permissions("python")
+    assert a.patterns_allowed == [
+        "actions/*",
+        "astral-sh/*",
+        "docker/*",
+        "github/*",
+        "pypa/*",
+        "wphillipmoore/*",
+    ]
 
 
 def test_branch_protection_ruleset() -> None:
@@ -322,6 +350,7 @@ def test_compute_desired_state_includes_security() -> None:
 def test_compute_desired_state_includes_actions() -> None:
     state = compute_desired_state(_st_config(), visibility="public")
     assert state.actions_permissions.allowed_actions == "selected"
+    assert "pypa/*" in state.actions_permissions.patterns_allowed
 
 
 # ---------------------------------------------------------------------------
@@ -990,7 +1019,7 @@ def test_apply_security_settings_disables_vuln_alerts() -> None:
 
 
 def test_apply_actions_permissions_selected() -> None:
-    perms = desired_actions_permissions()
+    perms = desired_actions_permissions("python")
     with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_actions_permissions("o/r", perms)
     assert mock_write.call_count == 3


### PR DESCRIPTION
# Pull Request

## Summary

- Split _ALLOWED_ACTION_PATTERNS into base + per-language sets

## Issue Linkage

- Ref #613

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Split the flat _ALLOWED_ACTION_PATTERNS list into _BASE_ACTION_PATTERNS
(actions/*, docker/*, github/*, wphillipmoore/*) applied to all repos,
and _LANGUAGE_ACTION_PATTERNS keyed by primary_language from
standard-tooling.toml (python, ruby, rust). Languages without entries
get only the base set.

Updated desired_actions_permissions() to accept primary_language and
merge the two sets. Updated compute_desired_state() call site to
thread through config.project.primary_language.

Addresses the issue where st-github-config apply stripped manually
added patterns like swatinem/* from Rust repos because they weren't
in the global list.