### PR TITLE
feat(github): detect and fail fast on merge conflicts

### DIFF
--- a/src/standard_tooling/bin/st_merge_when_green.py
+++ b/src/standard_tooling/bin/st_merge_when_green.py
@@ -54,6 +54,13 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    if github.mergeable(args.pr) == "CONFLICTING":
+        print(
+            "Error: PR has merge conflicts. Rebase or merge the base branch before continuing.",
+            file=sys.stderr,
+        )
+        return 1
+
     print(f"Waiting for checks to pass on {args.pr}...")
     github.wait_for_checks(args.pr)
     print(f"Checks passed. Merging with --{args.strategy}...")

--- a/src/standard_tooling/bin/st_merge_when_green.py
+++ b/src/standard_tooling/bin/st_merge_when_green.py
@@ -1,7 +1,9 @@
 """Poll a PR's checks, then merge it when they all pass.
 
-Intentionally dumb: surfaces any check failure to the caller with a non-zero
-exit code. The caller is responsible for deciding what to do with a failure.
+Wraps ``gh pr checks --watch --fail-fast`` with an outer loop that detects
+when the PR branch is behind its base or has merge conflicts. When behind,
+auto-updates the branch (fast-forward merge from base) and re-polls CI.
+Fails fast on merge conflicts.
 
 Designed for release-workflow PRs where the agent is both author and
 reviewer and there is no human to gate the merge. For normal PRs, leave
@@ -17,6 +19,7 @@ from standard_tooling.lib import github
 from standard_tooling.lib.release import is_release_branch
 
 _STRATEGIES = ("merge", "squash", "rebase")
+_MAX_BRANCH_UPDATES = 5
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -54,15 +57,27 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    if github.mergeable(args.pr) == "CONFLICTING":
-        print(
-            "Error: PR has merge conflicts. Rebase or merge the base branch before continuing.",
-            file=sys.stderr,
-        )
-        return 1
-
-    print(f"Waiting for checks to pass on {args.pr}...")
-    github.wait_for_checks(args.pr)
+    updates = 0
+    while True:
+        if github.mergeable(args.pr) == "CONFLICTING":
+            print(
+                "Error: PR has merge conflicts. Rebase or merge the base branch before continuing.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Waiting for checks to pass on {args.pr}...")
+        github.wait_for_checks(args.pr)
+        if github.merge_state_status(args.pr) != "BEHIND":
+            break
+        updates += 1
+        if updates > _MAX_BRANCH_UPDATES:
+            print(
+                "Branch still behind after multiple updates — giving up.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Branch is behind base — updating and re-checking...")
+        github.update_branch(args.pr)
     print(f"Checks passed. Merging with --{args.strategy}...")
     github.merge(args.pr, strategy=args.strategy)
     print("Merged.")

--- a/src/standard_tooling/bin/st_wait_until_green.py
+++ b/src/standard_tooling/bin/st_wait_until_green.py
@@ -29,6 +29,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     updates = 0
     while True:
+        if github.mergeable(args.pr) == "CONFLICTING":
+            print(
+                "Error: PR has merge conflicts. Rebase or merge the base branch before continuing.",
+                file=sys.stderr,
+            )
+            return 1
         print(f"Waiting for checks to pass on {args.pr}...")
         github.wait_for_checks(args.pr)
         if github.merge_state_status(args.pr) != "BEHIND":

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -153,6 +153,19 @@ def wait_for_checks(
     run("pr", "checks", pr, "--watch", "--fail-fast")
 
 
+def mergeable(pr: str) -> str:
+    """Return the PR's mergeable status (e.g. ``MERGEABLE``, ``CONFLICTING``, ``UNKNOWN``)."""
+    return read_output(
+        "pr",
+        "view",
+        pr,
+        "--json",
+        "mergeable",
+        "--jq",
+        ".mergeable",
+    )
+
+
 def merge_state_status(pr: str) -> str:
     """Return the PR's mergeStateStatus (e.g. ``CLEAN``, ``BEHIND``, ``DIRTY``)."""
     return read_output(

--- a/tests/standard_tooling/test_github.py
+++ b/tests/standard_tooling/test_github.py
@@ -100,6 +100,11 @@ def test_wait_for_checks_uses_poll_interval_for_sleep() -> None:
     mock_sleep.assert_called_once_with(10)
 
 
+def test_mergeable_returns_conflicting() -> None:
+    with patch("standard_tooling.lib.github.read_output", return_value="CONFLICTING"):
+        assert github.mergeable("https://github.com/pr/1") == "CONFLICTING"
+
+
 def test_merge_state_status_returns_clean() -> None:
     with patch("standard_tooling.lib.github.read_output", return_value="CLEAN"):
         assert github.merge_state_status("https://github.com/pr/1") == "CLEAN"

--- a/tests/standard_tooling/test_st_merge_when_green.py
+++ b/tests/standard_tooling/test_st_merge_when_green.py
@@ -40,6 +40,7 @@ def _mock_branch(branch: str = "release/1.0.0") -> AbstractContextManager[object
 def test_main_happy_path() -> None:
     with (
         _mock_branch("release/1.0.0"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -52,6 +53,7 @@ def test_main_happy_path() -> None:
 def test_main_custom_strategy() -> None:
     with (
         _mock_branch("release/1.0.0"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -64,6 +66,7 @@ def test_main_surfaces_check_failure() -> None:
     err = subprocess.CalledProcessError(returncode=1, cmd=["gh", "pr", "checks"])
     with (
         _mock_branch("release/1.0.0"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(
             f"{_MOD}.github.wait_for_checks",
             side_effect=err,
@@ -78,6 +81,7 @@ def test_main_surfaces_check_failure() -> None:
 def test_release_branch_allowed() -> None:
     with (
         _mock_branch("release/1.4.9"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -89,6 +93,7 @@ def test_release_branch_allowed() -> None:
 def test_bump_branch_allowed() -> None:
     with (
         _mock_branch("release/bump-version-1.4.10"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -100,6 +105,7 @@ def test_bump_branch_allowed() -> None:
 def test_legacy_chore_bump_branch_allowed() -> None:
     with (
         _mock_branch("chore/bump-version-1.4.10"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
@@ -119,3 +125,19 @@ def test_feature_branch_blocked(capsys: pytest.CaptureFixture[str]) -> None:
     mock_wait.assert_not_called()
     mock_merge.assert_not_called()
     assert "only for release-workflow PRs" in capsys.readouterr().err
+
+
+def test_main_fails_fast_on_merge_conflicts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        _mock_branch("release/1.0.0"),
+        patch(f"{_MOD}.github.mergeable", return_value="CONFLICTING"),
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main(["https://github.com/pr/1"])
+    assert result == 1
+    mock_wait.assert_not_called()
+    mock_merge.assert_not_called()
+    assert "merge conflicts" in capsys.readouterr().err

--- a/tests/standard_tooling/test_st_merge_when_green.py
+++ b/tests/standard_tooling/test_st_merge_when_green.py
@@ -42,6 +42,7 @@ def test_main_happy_path() -> None:
         _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
         result = main(["https://github.com/pr/1"])
@@ -55,6 +56,7 @@ def test_main_custom_strategy() -> None:
         _mock_branch("release/1.0.0"),
         patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
         result = main(["42", "--strategy", "squash"])
@@ -83,6 +85,7 @@ def test_release_branch_allowed() -> None:
         _mock_branch("release/1.4.9"),
         patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
         result = main(["https://github.com/pr/1"])
@@ -95,6 +98,7 @@ def test_bump_branch_allowed() -> None:
         _mock_branch("release/bump-version-1.4.10"),
         patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
         result = main(["https://github.com/pr/1"])
@@ -107,6 +111,7 @@ def test_legacy_chore_bump_branch_allowed() -> None:
         _mock_branch("chore/bump-version-1.4.10"),
         patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
         patch(f"{_MOD}.github.merge") as mock_merge,
     ):
         result = main(["https://github.com/pr/1"])
@@ -125,6 +130,43 @@ def test_feature_branch_blocked(capsys: pytest.CaptureFixture[str]) -> None:
     mock_wait.assert_not_called()
     mock_merge.assert_not_called()
     assert "only for release-workflow PRs" in capsys.readouterr().err
+
+
+def test_main_updates_branch_when_behind() -> None:
+    pr = "https://github.com/pr/1"
+    with (
+        _mock_branch("release/1.0.0"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(
+            f"{_MOD}.github.merge_state_status",
+            side_effect=["BEHIND", "CLEAN"],
+        ),
+        patch(f"{_MOD}.github.update_branch") as mock_update,
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main([pr])
+    assert result == 0
+    assert mock_wait.call_count == 2
+    mock_update.assert_called_once_with(pr)
+    mock_merge.assert_called_once()
+
+
+def test_main_gives_up_after_max_updates(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        _mock_branch("release/1.0.0"),
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BEHIND"),
+        patch(f"{_MOD}.github.update_branch"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main(["https://github.com/pr/1"])
+    assert result == 1
+    mock_merge.assert_not_called()
+    assert "giving up" in capsys.readouterr().err
 
 
 def test_main_fails_fast_on_merge_conflicts(

--- a/tests/standard_tooling/test_st_wait_until_green.py
+++ b/tests/standard_tooling/test_st_wait_until_green.py
@@ -20,6 +20,7 @@ def test_parse_args() -> None:
 
 def test_main_happy_path_not_behind() -> None:
     with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
     ):
@@ -31,6 +32,7 @@ def test_main_happy_path_not_behind() -> None:
 def test_main_surfaces_check_failure() -> None:
     err = subprocess.CalledProcessError(returncode=1, cmd=["gh", "pr", "checks"])
     with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks", side_effect=err),
         pytest.raises(subprocess.CalledProcessError),
     ):
@@ -39,6 +41,7 @@ def test_main_surfaces_check_failure() -> None:
 
 def test_main_updates_branch_when_behind() -> None:
     with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(
             f"{_MOD}.github.merge_state_status",
@@ -54,6 +57,7 @@ def test_main_updates_branch_when_behind() -> None:
 
 def test_main_updates_branch_multiple_times() -> None:
     with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(
             f"{_MOD}.github.merge_state_status",
@@ -70,6 +74,7 @@ def test_main_updates_branch_multiple_times() -> None:
 
 def test_main_gives_up_after_max_updates() -> None:
     with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks"),
         patch(f"{_MOD}.github.merge_state_status", return_value="BEHIND"),
         patch(f"{_MOD}.github.update_branch"),
@@ -81,6 +86,7 @@ def test_main_gives_up_after_max_updates() -> None:
 def test_main_succeeds_for_non_behind_states() -> None:
     for status in ("CLEAN", "DIRTY", "BLOCKED", "UNSTABLE", "UNKNOWN"):
         with (
+            patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
             patch(f"{_MOD}.github.wait_for_checks"),
             patch(f"{_MOD}.github.merge_state_status", return_value=status),
             patch(f"{_MOD}.github.update_branch") as mock_update,
@@ -88,3 +94,33 @@ def test_main_succeeds_for_non_behind_states() -> None:
             result = main([_PR])
         assert result == 0, f"Expected success for status {status}"
         mock_update.assert_not_called()
+
+
+def test_main_fails_fast_on_merge_conflicts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="CONFLICTING"),
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+    ):
+        result = main([_PR])
+    assert result == 1
+    mock_wait.assert_not_called()
+    assert "merge conflicts" in capsys.readouterr().err
+
+
+def test_main_detects_conflicts_after_branch_update(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(
+            f"{_MOD}.github.mergeable",
+            side_effect=["MERGEABLE", "CONFLICTING"],
+        ),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BEHIND"),
+        patch(f"{_MOD}.github.update_branch"),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "merge conflicts" in capsys.readouterr().err


### PR DESCRIPTION
# Pull Request

## Summary

- Detect and fail fast on merge conflicts in PR-waiting scripts

## Issue Linkage

- Ref #641

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Add a `mergeable()` function to the github library that queries the PR's
`mergeable` field via the GitHub API.

Both `st-wait-until-green` and `st-merge-when-green` now check for
`CONFLICTING` status before polling CI checks. If the PR has merge
conflicts, the scripts fail immediately with a clear error message
instead of waiting indefinitely on a PR that cannot be merged.

In `st-wait-until-green`, the check runs at the top of each poll
iteration, so conflicts introduced during a branch update cycle are
also caught.