### PR TITLE
fix(ci): pass required language input to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,4 +13,6 @@ permissions:
 jobs:
   publish:
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    with:
+      language: python
     secrets: inherit


### PR DESCRIPTION
# Pull Request

## Summary

- Add missing language input to publish-release.yml caller

## Issue Linkage

- Ref #645

## Testing

- markdownlint
- ci: shellcheck

## Notes

- The publish-release.yml caller workflow was missing the required
`language` input when calling the reusable workflow at
standard-actions@v1.5. This caused a startup_failure on every
merge to main, preventing tag creation, package publishing,
and bump PR creation.

Discovered during the v1.4.28 release (tracking issue #642).
Regression from PR #637 (migrate to reusable publish/docs workflows).