### PR TITLE
chore(release): bump version to 1.4.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "standard-tooling"
-version = "1.4.28"
+version = "1.4.29"
 description = "Shared development tooling for managed repositories"
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "standard-tooling"
-version = "1.4.28"
+version = "1.4.29"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Pull Request

## Summary

- Abandon failed 1.4.28 release and bump to 1.4.29

## Issue Linkage

- Ref #642

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Bump version to 1.4.29 to abandon the failed 1.4.28 release.

v1.4.28 was merged to main but the publish workflow had a
startup_failure (missing language input, fixed in PR #646).
No tag, package, or GitHub Release was created for 1.4.28.
Bumping to 1.4.29 so the next release includes the workflow fix.