### PR TITLE
fix(ci): specify container-tag in publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,4 +15,5 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: python
+      container-tag: "3.14"
     secrets: inherit


### PR DESCRIPTION
# Pull Request

## Summary

- specify container-tag in publish-release workflow

## Issue Linkage

- Ref #642

## Testing

- markdownlint
- ci: shellcheck

## Notes

- ## Summary

Add `container-tag: "3.14"` to the publish-release workflow caller.

The reusable workflow at standard-actions@v1.5 defaults `container-tag` to `"latest"`, but no language-specific dev container image has a `:latest` tag — only versioned tags (e.g., `dev-python:3.12`). This caused the v1.4.29 publish to fail at container initialization with "manifest unknown".

Ref #642
Related: https://github.com/wphillipmoore/standard-actions/issues/402