### PR TITLE
fix(templates): replace Fixes with Ref in PR template to match CI linkage rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,7 @@
 
 ## Issue Linkage
 
-- Fixes # (default; use when no acceptance criteria exist)
-- Ref # (use when acceptance criteria exist)
-- Work is not complete until the issue is closed.
+- Ref #
 - If no issue exists, open one before any work begins.
 
 ## Testing


### PR DESCRIPTION
# Pull Request

## Summary

- Replace Fixes with Ref in PR template to match CI linkage rules

## Issue Linkage

- Ref #650

## Testing

- markdownlint
- ci: shellcheck

## Notes

- The PR template recommended Fixes as the default issue linkage keyword, but st_pr_issue_linkage.py rejects all auto-close keywords. This caused friction (CI rejects, manual edit required) and risked premature issue closure in consuming repos without the gate. Replaced with Ref exclusively, matching the convention enforced by st_pr_issue_linkage, st_commit, and st_submit_pr.