### PR TITLE
fix(cd): add missing container-tag to release job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,4 +22,5 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: python
+      container-tag: "3.14"
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "standard-tooling"
-version = "1.4.31"
+version = "1.4.32"
 description = "Shared development tooling for managed repositories"
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "standard-tooling"
-version = "1.4.31"
+version = "1.4.32"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Pull Request

## Summary

- Restore container-tag 3.14 input that was dropped during publish-to-cd workflow rename

## Issue Linkage

- Ref #657

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -