### PR TITLE
feat(ci): update workflow refs to new CI/CD filenames

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,13 +13,13 @@ permissions:
 
 jobs:
   docs:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-docs.yml@v1.5
+    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
     with:
       language: python
       container-tag: "3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
 
-  release:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.5
+  version:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-version-bump.yml@v1.5
     with:
       language: python
       run-release: ${{ inputs.run-release != 'false' }}


### PR DESCRIPTION
# Pull Request

## Summary

- Switch ci.yml and cd.yml to use renamed standard-actions workflows (ci-version-bump, cd-release, cd-docs) and flip job key to version

## Issue Linkage

- Ref wphillipmoore/standard-actions#383

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -