### PR TITLE
feat(ci): add ops workflow for scheduled GitHub config audit

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -1,0 +1,17 @@
+name: Ops
+
+on:
+  schedule:
+    - cron: '15 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  github-config:
+    uses: wphillipmoore/standard-actions/.github/workflows/ops-github-config.yml@v1.5
+    permissions:
+      contents: read
+      issues: write


### PR DESCRIPTION
# Pull Request

## Summary

- Add an ops.yml workflow shim that calls the ops-github-config reusable workflow from standard-actions on a daily cron schedule. This enables automated GitHub configuration drift detection with issue-based tracking. Depends on standard-actions#424.

## Issue Linkage

- Ref #174

## Testing

- markdownlint
- ci: shellcheck

## Notes

- -