### PR TITLE
fix(github-config): allow_forking 422 on user repos; require [ci]

### DIFF
--- a/src/standard_tooling/bin/st_github_config.py
+++ b/src/standard_tooling/bin/st_github_config.py
@@ -84,7 +84,8 @@ def _fetch_remote_config(repo: str) -> StConfig:
 def _audit_repo(repo: str, config: StConfig) -> ConfigDiff:
     """Compute diff between desired and actual state for a repo."""
     result = fetch_actual_state(repo)
-    desired = compute_desired_state(config, visibility=result.visibility)
+    is_org = result.owner_type == "Organization"
+    desired = compute_desired_state(config, visibility=result.visibility, is_org=is_org)
     return compute_diff(desired=desired, actual=result.state)
 
 
@@ -101,7 +102,8 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
 def _apply_repo(repo: str, config: StConfig) -> list[str]:
     """Apply desired state to a repo. Returns branches with legacy protection removed."""
     result = fetch_actual_state(repo)
-    desired = compute_desired_state(config, visibility=result.visibility)
+    is_org = result.owner_type == "Organization"
+    desired = compute_desired_state(config, visibility=result.visibility, is_org=is_org)
     return apply_desired_state(repo, desired)
 
 

--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -73,7 +73,7 @@ class StConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
-    ci: CiConfig | None
+    ci: CiConfig
     github: GithubOverrides
     publish: PublishConfig
 
@@ -115,22 +115,23 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
     markdownlint = MarkdownlintConfig(ignore=ml_ignore)
 
     ci_raw = raw.get("ci")
-    ci: CiConfig | None = None
-    if ci_raw is not None:
-        versions = ci_raw.get("versions")
-        if versions is None:
-            msg = f"{CONFIG_FILE}: [ci] missing required field 'versions'"
-            raise ConfigError(msg)
-        if not isinstance(versions, list) or not versions:
-            msg = f"{CONFIG_FILE}: [ci].versions must be a list with at least one entry"
-            raise ConfigError(msg)
-        if not all(isinstance(v, str) for v in versions):
-            msg = f"{CONFIG_FILE}: [ci].versions entries must be strings"
-            raise ConfigError(msg)
-        ci = CiConfig(
-            versions=versions,
-            integration_tests=bool(ci_raw.get("integration-tests", False)),
-        )
+    if ci_raw is None:
+        msg = f"{CONFIG_FILE}: missing required section [ci]"
+        raise ConfigError(msg)
+    versions = ci_raw.get("versions")
+    if versions is None:
+        msg = f"{CONFIG_FILE}: [ci] missing required field 'versions'"
+        raise ConfigError(msg)
+    if not isinstance(versions, list) or not versions:
+        msg = f"{CONFIG_FILE}: [ci].versions must be a list with at least one entry"
+        raise ConfigError(msg)
+    if not all(isinstance(v, str) for v in versions):
+        msg = f"{CONFIG_FILE}: [ci].versions entries must be strings"
+        raise ConfigError(msg)
+    ci = CiConfig(
+        versions=versions,
+        integration_tests=bool(ci_raw.get("integration-tests", False)),
+    )
 
     github_raw = raw.get("github", {})
     github_overrides = GithubOverrides(

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -30,7 +30,7 @@ class DesiredRepoSettings:
     has_issues: bool
     has_projects: bool
     has_wiki: bool
-    allow_forking: bool
+    allow_forking: bool | None
     allow_update_branch: bool
     has_downloads: bool
     merge_commit_title: str
@@ -85,6 +85,7 @@ class DesiredState:
 class FetchResult:
     state: DesiredState
     visibility: str
+    owner_type: str
 
 
 _BASE_ACTION_PATTERNS = [
@@ -101,7 +102,7 @@ _LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {
 }
 
 
-def desired_repo_settings(*, visibility: str) -> DesiredRepoSettings:
+def desired_repo_settings(*, visibility: str, is_org: bool) -> DesiredRepoSettings:
     return DesiredRepoSettings(
         default_branch="develop",
         allow_auto_merge=False,
@@ -112,7 +113,7 @@ def desired_repo_settings(*, visibility: str) -> DesiredRepoSettings:
         has_issues=True,
         has_projects=True,
         has_wiki=True,
-        allow_forking=visibility == "public",
+        allow_forking=(visibility == "public") if is_org else None,
         allow_update_branch=True,
         has_downloads=False,
         merge_commit_title="MERGE_MESSAGE",
@@ -302,16 +303,14 @@ def desired_ci_gates_ruleset(
     )
 
 
-def compute_desired_state(config: StConfig, *, visibility: str) -> DesiredState:
+def compute_desired_state(config: StConfig, *, visibility: str, is_org: bool) -> DesiredState:
     """Compute the full desired GitHub configuration from a repo's StConfig."""
     rulesets: list[DesiredRuleset] = []
 
     if not config.github.skip_rulesets:
         rulesets.append(desired_branch_protection_ruleset())
         rulesets.append(desired_tag_protection_ruleset())
-
-        if config.ci is not None:
-            rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
+        rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
 
     publish = DesiredPublishConfig(
         release=config.publish.release,
@@ -319,7 +318,7 @@ def compute_desired_state(config: StConfig, *, visibility: str) -> DesiredState:
     )
 
     return DesiredState(
-        repo_settings=desired_repo_settings(visibility=visibility),
+        repo_settings=desired_repo_settings(visibility=visibility, is_org=is_org),
         security=desired_security_settings(),
         actions_permissions=desired_actions_permissions(config.project.primary_language),
         rulesets=rulesets,
@@ -369,6 +368,12 @@ def fetch_actual_state(repo: str) -> FetchResult:
     visibility = (
         str(repo_data.get("visibility", "private")) if isinstance(repo_data, dict) else "private"
     )
+
+    owner_raw = repo_data.get("owner") if isinstance(repo_data, dict) else None
+    owner: dict[str, object] = (
+        cast("dict[str, object]", owner_raw) if isinstance(owner_raw, dict) else {}
+    )
+    owner_type = str(owner.get("type", "User"))
 
     sa_raw = repo_data.get("security_and_analysis") if isinstance(repo_data, dict) else None
     sa: dict[str, object] = cast("dict[str, object]", sa_raw) if isinstance(sa_raw, dict) else {}
@@ -520,6 +525,7 @@ def fetch_actual_state(repo: str) -> FetchResult:
             publish=DesiredPublishConfig(release=False, docs=False),
         ),
         visibility=visibility,
+        owner_type=owner_type,
     )
 
 
@@ -550,6 +556,8 @@ def _diff_dataclass(
     items: list[DiffItem],
 ) -> None:
     if not hasattr(desired, "__dataclass_fields__"):
+        if desired is None:
+            return
         if desired != actual:
             items.append(DiffItem(field=prefix, expected=desired, actual=actual))
         return
@@ -616,29 +624,27 @@ def compute_diff(*, desired: DesiredState, actual: DesiredState) -> ConfigDiff:
 
 
 def _apply_repo_settings(repo: str, settings: DesiredRepoSettings) -> None:
-    github.write_json(
-        "PATCH",
-        f"repos/{repo}",
-        {
-            "default_branch": settings.default_branch,
-            "allow_auto_merge": settings.allow_auto_merge,
-            "delete_branch_on_merge": settings.delete_branch_on_merge,
-            "allow_merge_commit": settings.allow_merge_commit,
-            "allow_squash_merge": settings.allow_squash_merge,
-            "allow_rebase_merge": settings.allow_rebase_merge,
-            "has_issues": settings.has_issues,
-            "has_projects": settings.has_projects,
-            "has_wiki": settings.has_wiki,
-            "allow_forking": settings.allow_forking,
-            "allow_update_branch": settings.allow_update_branch,
-            "has_downloads": settings.has_downloads,
-            "merge_commit_title": settings.merge_commit_title,
-            "merge_commit_message": settings.merge_commit_message,
-            "squash_merge_commit_title": settings.squash_merge_commit_title,
-            "squash_merge_commit_message": settings.squash_merge_commit_message,
-            "web_commit_signoff_required": settings.web_commit_signoff_required,
-        },
-    )
+    body: dict[str, object] = {
+        "default_branch": settings.default_branch,
+        "allow_auto_merge": settings.allow_auto_merge,
+        "delete_branch_on_merge": settings.delete_branch_on_merge,
+        "allow_merge_commit": settings.allow_merge_commit,
+        "allow_squash_merge": settings.allow_squash_merge,
+        "allow_rebase_merge": settings.allow_rebase_merge,
+        "has_issues": settings.has_issues,
+        "has_projects": settings.has_projects,
+        "has_wiki": settings.has_wiki,
+        "allow_update_branch": settings.allow_update_branch,
+        "has_downloads": settings.has_downloads,
+        "merge_commit_title": settings.merge_commit_title,
+        "merge_commit_message": settings.merge_commit_message,
+        "squash_merge_commit_title": settings.squash_merge_commit_title,
+        "squash_merge_commit_message": settings.squash_merge_commit_message,
+        "web_commit_signoff_required": settings.web_commit_signoff_required,
+    }
+    if settings.allow_forking is not None:
+        body["allow_forking"] = settings.allow_forking
+    github.write_json("PATCH", f"repos/{repo}", body)
 
 
 def _apply_security_settings(repo: str, security: DesiredSecuritySettings) -> None:

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -32,6 +32,9 @@ primary-language = "python"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 
@@ -62,7 +65,7 @@ def test_env_override_skips_file_read(tmp_path: Path) -> None:
 
 # -- read_config (standard-tooling.toml) --------------------------------------
 
-_VALID_TOML = """\
+_BASE_TOML = """\
 [project]
 repository-type = "library"
 versioning-scheme = "semver"
@@ -76,6 +79,8 @@ claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>
 [dependencies]
 standard-tooling = "v1.4"
 """
+
+_VALID_TOML = _BASE_TOML + '\n[ci]\nversions = ["3.14"]\n'
 
 
 def test_read_config_valid(tmp_path: Path) -> None:
@@ -204,7 +209,7 @@ def test_read_config_markdownlint_ignore_not_a_list(tmp_path: Path) -> None:
 # -- [ci] section --------------------------------------------------------------
 
 _CI_TOML = (
-    _VALID_TOML
+    _BASE_TOML
     + """
 [ci]
 versions = ["3.12", "3.13", "3.14"]
@@ -220,7 +225,7 @@ def test_read_config_ci_section(tmp_path: Path) -> None:
 
 
 def test_read_config_ci_no_integration_tests(tmp_path: Path) -> None:
-    toml = _VALID_TOML + '[ci]\nversions = ["3.14"]\n'
+    toml = _BASE_TOML + '[ci]\nversions = ["3.14"]\n'
     (tmp_path / "standard-tooling.toml").write_text(toml)
     cfg = read_config(tmp_path)
     assert cfg.ci is not None
@@ -228,30 +233,30 @@ def test_read_config_ci_no_integration_tests(tmp_path: Path) -> None:
 
 
 def test_read_config_ci_missing_versions(tmp_path: Path) -> None:
-    toml = _VALID_TOML + "[ci]\nintegration-tests = true\n"
+    toml = _BASE_TOML + "[ci]\nintegration-tests = true\n"
     (tmp_path / "standard-tooling.toml").write_text(toml)
     with pytest.raises(ConfigError, match="versions"):
         read_config(tmp_path)
 
 
 def test_read_config_ci_empty_versions(tmp_path: Path) -> None:
-    toml = _VALID_TOML + "[ci]\nversions = []\n"
+    toml = _BASE_TOML + "[ci]\nversions = []\n"
     (tmp_path / "standard-tooling.toml").write_text(toml)
     with pytest.raises(ConfigError, match="versions.*at least one"):
         read_config(tmp_path)
 
 
 def test_read_config_ci_versions_not_strings(tmp_path: Path) -> None:
-    toml = _VALID_TOML + "[ci]\nversions = [3.12, 3.13]\n"
+    toml = _BASE_TOML + "[ci]\nversions = [3.12, 3.13]\n"
     (tmp_path / "standard-tooling.toml").write_text(toml)
     with pytest.raises(ConfigError, match="versions.*strings"):
         read_config(tmp_path)
 
 
-def test_read_config_no_ci_section(tmp_path: Path) -> None:
-    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
-    cfg = read_config(tmp_path)
-    assert cfg.ci is None
+def test_read_config_no_ci_section_raises(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_BASE_TOML)
+    with pytest.raises(ConfigError, match=r"missing required section \[ci\]"):
+        read_config(tmp_path)
 
 
 # -- [github] section ---------------------------------------------------------
@@ -290,6 +295,9 @@ primary-language = "python"
 [dependencies]
 standard-tooling = "v1.4"
 
+[ci]
+versions = ["3.14"]
+
 [publish]
 release = true
 docs = true
@@ -322,6 +330,9 @@ primary-language = "python"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 
 [publish]
 release = true

--- a/tests/standard_tooling/test_docker_cache.py
+++ b/tests/standard_tooling/test_docker_cache.py
@@ -32,6 +32,9 @@ primary-language = "go"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -40,7 +40,7 @@ from standard_tooling.lib.github_config import (
 
 
 def test_desired_repo_settings_are_fixed() -> None:
-    s = desired_repo_settings(visibility="public")
+    s = desired_repo_settings(visibility="public", is_org=True)
     assert s.default_branch == "develop"
     assert s.allow_auto_merge is False
     assert s.delete_branch_on_merge is True
@@ -53,17 +53,17 @@ def test_desired_repo_settings_are_fixed() -> None:
 
 
 def test_desired_repo_settings_public_allows_forking() -> None:
-    s = desired_repo_settings(visibility="public")
+    s = desired_repo_settings(visibility="public", is_org=True)
     assert s.allow_forking is True
 
 
 def test_desired_repo_settings_private_disallows_forking() -> None:
-    s = desired_repo_settings(visibility="private")
+    s = desired_repo_settings(visibility="private", is_org=True)
     assert s.allow_forking is False
 
 
 def test_desired_repo_settings_new_hardcoded_values() -> None:
-    s = desired_repo_settings(visibility="public")
+    s = desired_repo_settings(visibility="public", is_org=True)
     assert s.allow_update_branch is True
     assert s.has_downloads is False
     assert s.merge_commit_title == "MERGE_MESSAGE"
@@ -315,7 +315,7 @@ def _st_config(
 
 
 def test_compute_desired_state_has_three_rulesets() -> None:
-    state = compute_desired_state(_st_config(), visibility="public")
+    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
     assert len(state.rulesets) == 3
     names = [r.name for r in state.rulesets]
     assert "Branch protection" in names
@@ -324,31 +324,22 @@ def test_compute_desired_state_has_three_rulesets() -> None:
 
 
 def test_compute_desired_state_skip_rulesets() -> None:
-    state = compute_desired_state(_st_config(skip_rulesets=True), visibility="public")
+    state = compute_desired_state(_st_config(skip_rulesets=True), visibility="public", is_org=True)
     assert state.rulesets == []
 
 
-def test_compute_desired_state_no_ci_section() -> None:
-    cfg = _st_config()
-    cfg.ci = None
-    state = compute_desired_state(cfg, visibility="public")
-    assert len(state.rulesets) == 2
-    names = [r.name for r in state.rulesets]
-    assert "CI gates" not in names
-
-
 def test_compute_desired_state_includes_repo_settings() -> None:
-    state = compute_desired_state(_st_config(), visibility="public")
+    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
     assert state.repo_settings.default_branch == "develop"
 
 
 def test_compute_desired_state_includes_security() -> None:
-    state = compute_desired_state(_st_config(), visibility="public")
+    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
     assert state.security.secret_scanning == "enabled"  # noqa: S105
 
 
 def test_compute_desired_state_includes_actions() -> None:
-    state = compute_desired_state(_st_config(), visibility="public")
+    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
     assert state.actions_permissions.allowed_actions == "selected"
     assert "pypa/*" in state.actions_permissions.patterns_allowed
 
@@ -873,15 +864,15 @@ def test_fetch_vulnerability_alerts_disabled() -> None:
 
 
 def test_diff_identical_states_is_empty() -> None:
-    state = compute_desired_state(_st_config(), visibility="public")
+    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
     diff = compute_diff(desired=state, actual=state)
     assert diff.is_compliant()
     assert diff.items == []
 
 
 def test_diff_detects_repo_setting_mismatch() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public")
-    actual = compute_desired_state(_st_config(), visibility="public")
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
     actual.repo_settings.allow_auto_merge = True
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -889,8 +880,8 @@ def test_diff_detects_repo_setting_mismatch() -> None:
 
 
 def test_diff_detects_missing_ruleset() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public")
-    actual = compute_desired_state(_st_config(), visibility="public")
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
     actual.rulesets = []
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -898,8 +889,8 @@ def test_diff_detects_missing_ruleset() -> None:
 
 
 def test_diff_detects_extra_ruleset() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public")
-    actual = compute_desired_state(_st_config(), visibility="public")
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
     actual.rulesets.append(
         DesiredRuleset(
             name="Extra",
@@ -916,8 +907,8 @@ def test_diff_detects_extra_ruleset() -> None:
 
 
 def test_diff_detects_actions_permission_mismatch() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public")
-    actual = compute_desired_state(_st_config(), visibility="public")
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
     actual.actions_permissions.default_workflow_permissions = "write"
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -925,8 +916,8 @@ def test_diff_detects_actions_permission_mismatch() -> None:
 
 
 def test_diff_detects_security_mismatch() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public")
-    actual = compute_desired_state(_st_config(), visibility="public")
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
     actual.security.vulnerability_alerts = True
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -934,8 +925,8 @@ def test_diff_detects_security_mismatch() -> None:
 
 
 def test_diff_detects_new_repo_setting_drift() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public")
-    actual = compute_desired_state(_st_config(), visibility="public")
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
     actual.repo_settings.merge_commit_title = "PR_TITLE"
     actual.repo_settings.web_commit_signoff_required = False
     diff = compute_diff(desired=desired, actual=actual)
@@ -950,7 +941,7 @@ def test_diff_detects_new_repo_setting_drift() -> None:
 
 
 def test_apply_repo_settings_calls_write_json() -> None:
-    settings = desired_repo_settings(visibility="public")
+    settings = desired_repo_settings(visibility="public", is_org=True)
     with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     mock_write.assert_called_once()
@@ -963,7 +954,7 @@ def test_apply_repo_settings_calls_write_json() -> None:
 
 
 def test_apply_repo_settings_includes_new_fields() -> None:
-    settings = desired_repo_settings(visibility="public")
+    settings = desired_repo_settings(visibility="public", is_org=True)
     with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
@@ -1145,7 +1136,7 @@ def test_ruleset_body_structure() -> None:
 
 
 def test_apply_desired_state_orchestrates_all() -> None:
-    state = compute_desired_state(_st_config(), visibility="public")
+    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
     with (
         patch("standard_tooling.lib.github_config._apply_repo_settings") as mock_repo,
         patch("standard_tooling.lib.github_config._apply_security_settings") as mock_sec,
@@ -1283,7 +1274,7 @@ def test_normalize_rules_skips_non_dict_entries() -> None:
 
 def test_compute_desired_state_includes_publish() -> None:
     config = _st_config()
-    state = compute_desired_state(config, visibility="public")
+    state = compute_desired_state(config, visibility="public", is_org=True)
     assert state.publish is not None
     assert state.publish.release is False
     assert state.publish.docs is True
@@ -1298,6 +1289,120 @@ def test_compute_desired_state_publish_release_true() -> None:
         github=GithubOverrides(skip_rulesets=False),
         publish=PublishConfig(release=True, docs=True),
     )
-    state = compute_desired_state(config, visibility="public")
+    state = compute_desired_state(config, visibility="public", is_org=True)
     assert state.publish.release is True
     assert state.publish.docs is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #666: allow_forking on user-owned repos
+# ---------------------------------------------------------------------------
+
+
+def test_desired_repo_settings_user_repo_allow_forking_is_none() -> None:
+    s = desired_repo_settings(visibility="public", is_org=False)
+    assert s.allow_forking is None
+
+
+def test_desired_repo_settings_org_repo_allow_forking_set() -> None:
+    s = desired_repo_settings(visibility="public", is_org=True)
+    assert s.allow_forking is True
+    s2 = desired_repo_settings(visibility="private", is_org=True)
+    assert s2.allow_forking is False
+
+
+def test_apply_repo_settings_omits_allow_forking_when_none() -> None:
+    settings = desired_repo_settings(visibility="public", is_org=False)
+    with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_repo_settings("o/r", settings)
+    body = mock_write.call_args[0][2]
+    assert "allow_forking" not in body
+
+
+def test_apply_repo_settings_includes_allow_forking_for_org() -> None:
+    settings = desired_repo_settings(visibility="public", is_org=True)
+    with patch("standard_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_repo_settings("o/r", settings)
+    body = mock_write.call_args[0][2]
+    assert body["allow_forking"] is True
+
+
+def test_diff_skips_allow_forking_when_desired_is_none() -> None:
+    desired = compute_desired_state(_st_config(), visibility="public", is_org=False)
+    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    actual.repo_settings.allow_forking = False
+    diff = compute_diff(desired=desired, actual=actual)
+    assert not any(d.field == "repo_settings.allow_forking" for d in diff.items)
+
+
+def test_fetch_actual_state_extracts_owner_type_organization() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "owner": {"type": "Organization"},
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        result = fetch_actual_state("o/r")
+
+    assert result.owner_type == "Organization"
+
+
+def test_fetch_actual_state_defaults_owner_type_to_user() -> None:
+    repo_json: dict[str, object] = {
+        "default_branch": "develop",
+        "security_and_analysis": {},
+    }
+
+    def mock_read_json(*args: str) -> dict[str, object] | list[object]:
+        endpoint = args[1] if len(args) > 1 else ""
+        if endpoint == "repos/o/r":
+            return repo_json
+        if endpoint == "repos/o/r/rulesets":
+            return []
+        if endpoint == "repos/o/r/actions/permissions":
+            return {"allowed_actions": "all"}
+        if endpoint == "repos/o/r/actions/permissions/workflow":
+            return {
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        return {}
+
+    with (
+        patch(
+            "standard_tooling.lib.github_config.github.read_json",
+            side_effect=mock_read_json,
+        ),
+        patch(
+            "standard_tooling.lib.github_config._fetch_vulnerability_alerts",
+            return_value=False,
+        ),
+    ):
+        result = fetch_actual_state("o/r")
+
+    assert result.owner_type == "User"

--- a/tests/standard_tooling/test_st_commit.py
+++ b/tests/standard_tooling/test_st_commit.py
@@ -29,6 +29,9 @@ codex = "Co-Authored-By: test-codex <codex@test.com>"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 

--- a/tests/standard_tooling/test_st_docker_cache.py
+++ b/tests/standard_tooling/test_st_docker_cache.py
@@ -22,6 +22,9 @@ primary-language = "go"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 

--- a/tests/standard_tooling/test_st_finalize_repo.py
+++ b/tests/standard_tooling/test_st_finalize_repo.py
@@ -83,6 +83,7 @@ def _make_profile(tmp_path: Path, model: str) -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "{model}"\nrelease-model = "tagged-release"\n'
         f'primary-language = "python"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+        f'\n[ci]\nversions = ["3.14"]\n'
     )
 
 

--- a/tests/standard_tooling/test_st_github_config.py
+++ b/tests/standard_tooling/test_st_github_config.py
@@ -18,6 +18,7 @@ from standard_tooling.bin.st_github_config import (
     parse_args,
 )
 from standard_tooling.lib.config import (
+    CiConfig,
     GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
@@ -195,6 +196,9 @@ primary-language = "python"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 
@@ -263,7 +267,7 @@ def _make_config() -> StConfig:
         ),
         dependencies={"standard-tooling": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
-        ci=None,
+        ci=CiConfig(versions=["3.14"], integration_tests=False),
         github=GithubOverrides(skip_rulesets=True),
         publish=PublishConfig(release=False, docs=True),
     )
@@ -285,7 +289,10 @@ def test_audit_repo_calls_compute_and_diff() -> None:
     ):
         result = _audit_repo("o/r", cfg)
     mock_fetch.assert_called_once_with("o/r")
-    mock_desired.assert_called_once_with(cfg, visibility=mock_fetch.return_value.visibility)
+    is_org = mock_fetch.return_value.owner_type == "Organization"
+    mock_desired.assert_called_once_with(
+        cfg, visibility=mock_fetch.return_value.visibility, is_org=is_org
+    )
     mock_diff.assert_called_once_with(
         desired=mock_desired.return_value,
         actual=mock_fetch.return_value.state,
@@ -305,7 +312,10 @@ def test_apply_repo_calls_apply_desired_state() -> None:
     ):
         _apply_repo("o/r", cfg)
     mock_fetch.assert_called_once_with("o/r")
-    mock_desired.assert_called_once_with(cfg, visibility=mock_fetch.return_value.visibility)
+    is_org = mock_fetch.return_value.owner_type == "Organization"
+    mock_desired.assert_called_once_with(
+        cfg, visibility=mock_fetch.return_value.visibility, is_org=is_org
+    )
     mock_apply.assert_called_once_with("o/r", mock_desired.return_value)
 
 

--- a/tests/standard_tooling/test_st_repo_profile.py
+++ b/tests/standard_tooling/test_st_repo_profile.py
@@ -25,6 +25,9 @@ claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 

--- a/tests/standard_tooling/test_st_validate.py
+++ b/tests/standard_tooling/test_st_validate.py
@@ -34,6 +34,7 @@ def _write_config(tmp_path: Path, language: str) -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+        f'\n[ci]\nversions = ["3.14"]\n'
     )
 
 

--- a/tests/standard_tooling/test_st_version.py
+++ b/tests/standard_tooling/test_st_version.py
@@ -19,6 +19,7 @@ def _write_toml(tmp_path: Path, language: str = "shell") -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+        f'\n[ci]\nversions = ["3.14"]\n'
     )
 
 

--- a/tests/standard_tooling/test_validate_common.py
+++ b/tests/standard_tooling/test_validate_common.py
@@ -27,6 +27,9 @@ primary-language = "python"
 
 [dependencies]
 standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
 """
 
 

--- a/tests/standard_tooling/test_version.py
+++ b/tests/standard_tooling/test_version.py
@@ -21,6 +21,7 @@ def _write_toml(tmp_path: Path, language: str) -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+        f'\n[ci]\nversions = ["3.14"]\n'
     )
 
 
@@ -93,6 +94,7 @@ def test_show_with_version_file_override(tmp_path: Path) -> None:
         'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         'primary-language = "shell"\nversion-file = "custom/VERSION"\n\n'
         '[dependencies]\nstandard-tooling = "v1.4"\n'
+        '\n[ci]\nversions = ["3.14"]\n'
     )
     custom_dir = tmp_path / "custom"
     custom_dir.mkdir()


### PR DESCRIPTION
# Pull Request

## Summary

- Fix allow_forking HTTP 422 on user-owned repos; require [ci] config section

## Issue Linkage

- Ref #666

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Two fixes for `st-github-config apply` on user-owned (non-Organization) repos:

**1. `allow_forking` HTTP 422 crash**

GitHub's `repos/{repo}` PATCH endpoint rejects `allow_forking` for user-owned
repos with HTTP 422. `_apply_repo_settings()` was sending this field
unconditionally. Now `DesiredRepoSettings.allow_forking` is `bool | None` --
set to `None` for user-owned repos, which omits it from the PATCH payload.
`FetchResult` gained an `owner_type` field (extracted from `owner.type` in the
API response) so callers can distinguish user vs org repos.

**2. `[ci]` section is now required in `standard-tooling.toml`**

Previously, a missing `[ci]` section was silently accepted, which meant repos
without CI configuration would have their existing CI gates ruleset flagged
for deletion during audit/apply. Since CI is fundamental to the tooling
ecosystem, `[ci]` is now a required section -- `read_config()` raises
`ConfigError` if it is absent. All test fixtures across 12 test files were
updated to include the `[ci]` section.