### PR TITLE
fix(finalize-repo): skip dirty worktrees instead of crashing

### DIFF
--- a/src/standard_tooling/bin/st_finalize_repo.py
+++ b/src/standard_tooling/bin/st_finalize_repo.py
@@ -44,6 +44,19 @@ def _run(args: list[str], *, dry_run: bool) -> None:
         git.run(*args)
 
 
+def _worktree_is_dirty(wt_path: Path) -> bool:
+    """Return True if *wt_path* has modified or untracked files."""
+    result = subprocess.run(  # noqa: S603
+        ("git", "-C", str(wt_path), "status", "--porcelain"),  # noqa: S607
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
+
+
 def _worktree_for_branch(branch: str, repo_root: Path) -> Path | None:
     """Return the worktree path that has *branch* checked out, or None.
 
@@ -189,6 +202,9 @@ def main(argv: list[str] | None = None) -> int:
         # Issue #315.
         wt = _worktree_for_branch(branch, root)
         if wt is not None:
+            if _worktree_is_dirty(wt):
+                print(f"  Skipping {branch}: worktree {wt} has uncommitted changes")
+                continue
             print(f"  Removing worktree: {wt}")
             _run(["worktree", "remove", str(wt)], dry_run=args.dry_run)
         # `git branch -D` (force) rather than `-d` because `--merged`

--- a/tests/standard_tooling/test_st_finalize_repo.py
+++ b/tests/standard_tooling/test_st_finalize_repo.py
@@ -15,6 +15,7 @@ import pytest
 from standard_tooling.bin.st_finalize_repo import (
     _check_docs_workflow_status,
     _worktree_for_branch,
+    _worktree_is_dirty,
     main,
     parse_args,
 )
@@ -385,6 +386,33 @@ def test_main_skips_docs_check_on_dry_run(tmp_path: Path) -> None:
     mock_check.assert_not_called()
 
 
+# -- _worktree_is_dirty (issue #667) -------------------------------------------
+
+
+def test_worktree_is_dirty_returns_true_when_status_output(tmp_path: Path) -> None:
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout="M  foo.py\n"),
+    ):
+        assert _worktree_is_dirty(tmp_path) is True
+
+
+def test_worktree_is_dirty_returns_false_when_clean(tmp_path: Path) -> None:
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout=""),
+    ):
+        assert _worktree_is_dirty(tmp_path) is False
+
+
+def test_worktree_is_dirty_returns_true_on_git_failure(tmp_path: Path) -> None:
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=128, stdout=""),
+    ):
+        assert _worktree_is_dirty(tmp_path) is True
+
+
 # -- _worktree_for_branch (issue #315) ---------------------------------------
 
 
@@ -473,6 +501,7 @@ def test_main_removes_worktree_before_deleting_branch(tmp_path: Path) -> None:
         patch(_MOD + ".git.run", side_effect=mock_git_run),
         patch(_MOD + ".git.merged_branches", return_value=["feature/99-x"]),
         patch(_MOD + ".git.read_output", return_value=porcelain),
+        patch(_MOD + "._worktree_is_dirty", return_value=False),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
         patch(_MOD + "._check_docs_workflow_status", return_value=None),
@@ -515,6 +544,46 @@ def test_main_skips_worktree_remove_when_branch_not_in_worktree(tmp_path: Path) 
     assert result == 0
     assert ("branch", "-D", "feature/99-x") in git_run_calls
     assert not any(c[:1] == ("worktree",) for c in git_run_calls)
+
+
+def test_main_skips_dirty_worktree(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #667: a worktree with uncommitted changes is skipped entirely
+    — neither the worktree nor the branch is removed, and finalize
+    continues with the remaining branches.
+    """
+    _make_profile(tmp_path, "library-release")
+    wt_dir = tmp_path / ".worktrees" / "issue-42-wip"
+    wt_dir.mkdir(parents=True)
+    porcelain = _porcelain(
+        (str(tmp_path), "develop"),
+        (str(wt_dir), "feature/42-wip"),
+    )
+
+    git_run_calls: list[tuple[str, ...]] = []
+
+    def mock_git_run(*args: str) -> None:
+        git_run_calls.append(args)
+
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run", side_effect=mock_git_run),
+        patch(_MOD + ".git.merged_branches", return_value=["feature/42-wip"]),
+        patch(_MOD + ".git.read_output", return_value=porcelain),
+        patch(_MOD + "._worktree_is_dirty", return_value=True),
+        patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
+        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+    ):
+        result = main([])
+
+    assert result == 0
+    assert not any(c[0] == "worktree" for c in git_run_calls)
+    assert not any(c == ("branch", "-D", "feature/42-wip") for c in git_run_calls)
+    out = capsys.readouterr().out
+    assert "Skipping feature/42-wip" in out
+    assert "uncommitted changes" in out
 
 
 def test_main_cleans_docker_cache_on_branch_delete(

--- a/tests/standard_tooling/test_st_finalize_repo.py
+++ b/tests/standard_tooling/test_st_finalize_repo.py
@@ -546,9 +546,7 @@ def test_main_skips_worktree_remove_when_branch_not_in_worktree(tmp_path: Path) 
     assert not any(c[:1] == ("worktree",) for c in git_run_calls)
 
 
-def test_main_skips_dirty_worktree(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_main_skips_dirty_worktree(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Issue #667: a worktree with uncommitted changes is skipped entirely
     — neither the worktree nor the branch is removed, and finalize
     continues with the remaining branches.


### PR DESCRIPTION
# Pull Request

## Summary

- Skip worktrees with uncommitted changes during finalization

## Issue Linkage

- Ref #667

## Testing

- markdownlint
- ci: shellcheck

## Notes

- When st-finalize-repo encounters a merged branch whose worktree has
uncommitted changes (typical in multi-agent workflows where one agent
finishes while another is still working), the tool now skips that
branch with an informational message instead of crashing.

Changes:
- Added _worktree_is_dirty() to check worktree status via
  git -C <path> status --porcelain before attempting removal
- Dirty worktrees skip both worktree removal and branch deletion
- Assumes dirty on git failure (fail-safe toward preserving work)

Tests:
- 3 unit tests for _worktree_is_dirty (dirty, clean, git failure)
- 1 integration test verifying dirty worktrees are fully skipped
- Updated existing clean-worktree test to mock the new check