### PR TITLE
feat(docker): make image prefix configurable

### DIFF
--- a/src/standard_tooling/bin/st_docker_docs.py
+++ b/src/standard_tooling/bin/st_docker_docs.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from standard_tooling.lib import git
+
+if TYPE_CHECKING:
+    from pathlib import Path
 from standard_tooling.lib.config import ConfigError, read_config
 from standard_tooling.lib.docker import docker_platform
 

--- a/src/standard_tooling/bin/st_docker_docs.py
+++ b/src/standard_tooling/bin/st_docker_docs.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 from standard_tooling.lib import git
+from standard_tooling.lib.config import ConfigError, read_config
 from standard_tooling.lib.docker import docker_platform
 
 
@@ -22,15 +24,26 @@ def _usage(port: str) -> None:
     print("  build   Build the static documentation site")
     print()
     print("Environment variables:")
-    print("  DOCKER_DOCS_IMAGE  Docker image (default: ghcr.io/wphillipmoore/dev-base:latest)")
+    print("  DOCKER_DOCS_IMAGE  Docker image (default: ghcr.io/wphillipmoore/prod-base:latest)")
     print("  MKDOCS_CONFIG      Path to mkdocs.yml (default: docs/site/mkdocs.yml)")
     print("  DOCS_PORT          Host port for serve (default: 8000)")
+
+
+def _docs_image(repo_root: Path) -> str:
+    env_image = os.environ.get("DOCKER_DOCS_IMAGE")
+    if env_image:
+        return env_image
+    try:
+        cfg = read_config(repo_root)
+        prefix = cfg.docker.image_prefix
+    except (FileNotFoundError, ConfigError):
+        prefix = "prod"
+    return f"ghcr.io/wphillipmoore/{prefix}-base:latest"
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
 
-    image = os.environ.get("DOCKER_DOCS_IMAGE", "ghcr.io/wphillipmoore/dev-base:latest")
     config = os.environ.get("MKDOCS_CONFIG", "docs/site/mkdocs.yml")
     port = os.environ.get("DOCS_PORT", "8000")
 
@@ -54,6 +67,7 @@ def main(argv: list[str] | None = None) -> int:
         mkdocs_cmd += " " + " ".join(extra_args)
 
     repo_root = git.repo_root()
+    image = _docs_image(repo_root)
 
     container_cmd = mkdocs_cmd
     if (repo_root / "pyproject.toml").is_file():

--- a/src/standard_tooling/bin/st_docker_run.py
+++ b/src/standard_tooling/bin/st_docker_run.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 from standard_tooling.lib import git
+from standard_tooling.lib.config import ConfigError, read_config
 from standard_tooling.lib.docker import (
     assert_docker_available,
     build_docker_args,
@@ -44,6 +46,14 @@ examples:
 """
 
 
+def _image_prefix(repo_root: Path) -> str:
+    try:
+        cfg = read_config(repo_root)
+        return cfg.docker.image_prefix
+    except (FileNotFoundError, ConfigError):
+        return "prod"
+
+
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
 
@@ -74,13 +84,14 @@ def main(argv: list[str] | None = None) -> int:
 
     repo_root = git.repo_root()
     lang = detect_language(repo_root)
+    prefix = _image_prefix(repo_root)
 
     env_image = os.environ.get("DOCKER_DEV_IMAGE")
     if env_image:
         image = env_image
         image_source = "env"
     else:
-        base = default_image(lang, fallback=True)
+        base = default_image(lang, fallback=True, prefix=prefix)
         image = ensure_cached_image(repo_root, lang, base)
         image_source = "cached" if image != base else "default"
 

--- a/src/standard_tooling/bin/st_docker_run.py
+++ b/src/standard_tooling/bin/st_docker_run.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from standard_tooling.lib import git
+
+if TYPE_CHECKING:
+    from pathlib import Path
 from standard_tooling.lib.config import ConfigError, read_config
 from standard_tooling.lib.docker import (
     assert_docker_available,

--- a/src/standard_tooling/bin/st_docker_test.py
+++ b/src/standard_tooling/bin/st_docker_test.py
@@ -14,9 +14,9 @@ from typing import TYPE_CHECKING
 
 from standard_tooling.lib import git
 from standard_tooling.lib.docker import (
-    _DEFAULT_IMAGES,
     _DEFAULT_TEST_COMMANDS,
     build_docker_args,
+    default_image,
     detect_language,
 )
 
@@ -28,7 +28,7 @@ _detect_language = detect_language
 
 def build_test_docker_args(repo_root: Path, lang: str) -> list[str]:
     """Build the docker run argument list for test execution."""
-    image = os.environ.get("DOCKER_DEV_IMAGE") or _DEFAULT_IMAGES.get(lang, "")
+    image = os.environ.get("DOCKER_DEV_IMAGE") or default_image(lang)
     test_cmd = os.environ.get("DOCKER_TEST_CMD") or _DEFAULT_TEST_COMMANDS.get(lang, "")
     network = os.environ.get("DOCKER_NETWORK", "")
 

--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -21,6 +21,7 @@ _ENUMS: dict[str, set[str]] = {
     "branching-model": {"library-release", "application-promotion", "docs-single-branch"},
     "release-model": {"artifact-publishing", "tagged-release", "environment-promotion", "none"},
     "primary-language": {"python", "go", "java", "ruby", "rust", "shell", "none", "claude-plugin"},
+    "image-prefix": {"dev", "prod"},
 }
 
 _PROJECT_FIELDS = (
@@ -69,6 +70,11 @@ class PublishConfig:
 
 
 @dataclass
+class DockerConfig:
+    image_prefix: str
+
+
+@dataclass
 class StConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
@@ -76,6 +82,7 @@ class StConfig:
     ci: CiConfig
     github: GithubOverrides
     publish: PublishConfig
+    docker: DockerConfig
 
 
 def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
@@ -144,6 +151,14 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         docs=bool(publish_raw.get("docs", True)),
     )
 
+    docker_raw = raw.get("docker", {})
+    docker_prefix = docker_raw.get("image-prefix", "prod")
+    if docker_prefix not in _ENUMS["image-prefix"]:
+        allowed = ", ".join(sorted(_ENUMS["image-prefix"]))
+        msg = f"{CONFIG_FILE}: invalid image-prefix '{docker_prefix}' (allowed: {allowed})"
+        raise ConfigError(msg)
+    docker = DockerConfig(image_prefix=docker_prefix)
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -159,6 +174,7 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         ci=ci,
         github=github_overrides,
         publish=publish,
+        docker=docker,
     )
 
 

--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -28,8 +28,10 @@ _DEFAULT_TEST_COMMANDS: dict[str, str] = {
     "java": "./mvnw verify",
 }
 
+
 def _fallback_image(prefix: str) -> str:
     return f"{_GHCR}/{prefix}-base:latest"
+
 
 _MACHINE_TO_PLATFORM: dict[str, str] = {
     "arm64": "linux/arm64",

--- a/src/standard_tooling/lib/docker.py
+++ b/src/standard_tooling/lib/docker.py
@@ -10,13 +10,15 @@ from pathlib import Path
 
 _GHCR = "ghcr.io/wphillipmoore"
 
-_DEFAULT_IMAGES: dict[str, str] = {
-    "ruby": f"{_GHCR}/dev-ruby:3.4",
-    "python": f"{_GHCR}/dev-python:3.14",
-    "go": f"{_GHCR}/dev-go:1.26",
-    "rust": f"{_GHCR}/dev-rust:1.93",
-    "java": f"{_GHCR}/dev-java:21",
+_DEFAULT_VERSIONS: dict[str, str] = {
+    "ruby": "3.4",
+    "python": "3.14",
+    "go": "1.26",
+    "rust": "1.93",
+    "java": "21",
 }
+
+_DEFAULT_PREFIX = "prod"
 
 _DEFAULT_TEST_COMMANDS: dict[str, str] = {
     "ruby": "bundle install --jobs 4 && bundle exec rake",
@@ -26,7 +28,8 @@ _DEFAULT_TEST_COMMANDS: dict[str, str] = {
     "java": "./mvnw verify",
 }
 
-_FALLBACK_IMAGE = f"{_GHCR}/dev-base:latest"
+def _fallback_image(prefix: str) -> str:
+    return f"{_GHCR}/{prefix}-base:latest"
 
 _MACHINE_TO_PLATFORM: dict[str, str] = {
     "arm64": "linux/arm64",
@@ -56,16 +59,18 @@ def detect_language(repo_root: Path) -> str:
     return ""
 
 
-def default_image(lang: str, *, fallback: bool = False) -> str:
+def default_image(lang: str, *, fallback: bool = False, prefix: str = _DEFAULT_PREFIX) -> str:
     """Return the default Docker image for a language.
 
-    When *fallback* is True, return the dev-base image if no language
+    When *fallback* is True, return the base image if no language
     matches instead of returning an empty string.
     """
-    image = _DEFAULT_IMAGES.get(lang, "")
-    if not image and fallback:
-        return _FALLBACK_IMAGE
-    return image
+    version = _DEFAULT_VERSIONS.get(lang, "")
+    if not version and fallback:
+        return _fallback_image(prefix)
+    if not version:
+        return ""
+    return f"{_GHCR}/{prefix}-{lang}:{version}"
 
 
 def worktree_parent_gitdir(repo_root: Path) -> Path | None:

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -10,6 +10,7 @@ import pytest
 from standard_tooling.lib.config import (
     CiConfig,
     ConfigError,
+    DockerConfig,
     GithubOverrides,
     MarkdownlintConfig,
     read_config,
@@ -343,3 +344,40 @@ def test_publish_docs_defaults_true(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_PUBLISH_RELEASE_ONLY_TOML)
     cfg = read_config(tmp_path)
     assert cfg.publish.docs is True
+
+
+# -- [docker] section ----------------------------------------------------------
+
+_DOCKER_PREFIX_TOML = (
+    _VALID_TOML
+    + """
+[docker]
+image-prefix = "dev"
+"""
+)
+
+
+def test_read_config_docker_prefix(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_DOCKER_PREFIX_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.docker.image_prefix == "dev"
+
+
+def test_read_config_docker_prefix_defaults_to_prod(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.docker.image_prefix == "prod"
+
+
+def test_read_config_docker_empty_section(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[docker]\n"
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.docker.image_prefix == "prod"
+
+
+def test_read_config_docker_invalid_prefix(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '[docker]\nimage-prefix = "staging"\n'
+    (tmp_path / "standard-tooling.toml").write_text(toml)
+    with pytest.raises(ConfigError, match="image-prefix.*staging"):
+        read_config(tmp_path)

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -10,7 +10,6 @@ import pytest
 from standard_tooling.lib.config import (
     CiConfig,
     ConfigError,
-    DockerConfig,
     GithubOverrides,
     MarkdownlintConfig,
     read_config,

--- a/tests/standard_tooling/test_docker.py
+++ b/tests/standard_tooling/test_docker.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from standard_tooling.lib.docker import (
-    _FALLBACK_IMAGE,
     assert_docker_available,
     build_docker_args,
     default_image,
@@ -69,7 +68,7 @@ def test_detect_ruby_priority(tmp_path: Path) -> None:
 
 
 def test_default_image_known_lang() -> None:
-    assert "dev-python" in default_image("python")
+    assert "prod-python" in default_image("python")
 
 
 def test_default_image_unknown_no_fallback() -> None:
@@ -77,11 +76,40 @@ def test_default_image_unknown_no_fallback() -> None:
 
 
 def test_default_image_unknown_with_fallback() -> None:
-    assert default_image("unknown", fallback=True) == _FALLBACK_IMAGE
+    assert default_image("unknown", fallback=True) == "ghcr.io/wphillipmoore/prod-base:latest"
 
 
 def test_default_image_empty_with_fallback() -> None:
-    assert default_image("", fallback=True) == _FALLBACK_IMAGE
+    assert default_image("", fallback=True) == "ghcr.io/wphillipmoore/prod-base:latest"
+
+
+# -- prefix-aware default_image -----------------------------------------------
+
+
+def test_default_image_prod_prefix() -> None:
+    img = default_image("python", prefix="prod")
+    assert "prod-python" in img
+    assert "dev-python" not in img
+
+
+def test_default_image_dev_prefix() -> None:
+    img = default_image("python", prefix="dev")
+    assert "dev-python" in img
+
+
+def test_default_image_default_prefix_is_prod() -> None:
+    img = default_image("python")
+    assert "prod-python" in img
+
+
+def test_default_image_fallback_respects_prefix() -> None:
+    img = default_image("unknown", fallback=True, prefix="prod")
+    assert "prod-base" in img
+
+
+def test_default_image_fallback_dev_prefix() -> None:
+    img = default_image("unknown", fallback=True, prefix="dev")
+    assert "dev-base" in img
 
 
 # -- docker_platform ----------------------------------------------------------

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from standard_tooling.lib.config import (
     CiConfig,
+    DockerConfig,
     GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
@@ -311,6 +312,7 @@ def _st_config(
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
         github=GithubOverrides(skip_rulesets=skip_rulesets),
         publish=PublishConfig(release=False, docs=True),
+        docker=DockerConfig(image_prefix="prod"),
     )
 
 
@@ -1288,6 +1290,7 @@ def test_compute_desired_state_publish_release_true() -> None:
         ci=_ci(),
         github=GithubOverrides(skip_rulesets=False),
         publish=PublishConfig(release=True, docs=True),
+        docker=DockerConfig(image_prefix="prod"),
     )
     state = compute_desired_state(config, visibility="public", is_org=True)
     assert state.publish.release is True

--- a/tests/standard_tooling/test_st_docker_docs.py
+++ b/tests/standard_tooling/test_st_docker_docs.py
@@ -97,6 +97,37 @@ def test_non_python_repo_no_uv(tmp_path: Path) -> None:
     assert "uv" not in container_cmd
 
 
+_TOML_DEV_PREFIX = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
+
+[docker]
+image-prefix = "dev"
+"""
+
+
+def test_config_prefix_used(tmp_path: Path) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(_TOML_DEV_PREFIX)
+    with (
+        patch("standard_tooling.bin.st_docker_docs.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_docker_docs.os.execvp") as mock_exec,
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        main(["serve"])
+    args = mock_exec.call_args[0][1]
+    assert "ghcr.io/wphillipmoore/dev-base:latest" in args
+
+
 def test_common_sibling_mount(tmp_path: Path) -> None:
     common = tmp_path / ".." / "mq-rest-admin-common"
     common.mkdir(parents=True)

--- a/tests/standard_tooling/test_st_docker_run.py
+++ b/tests/standard_tooling/test_st_docker_run.py
@@ -114,6 +114,42 @@ def test_language_detected_image(tmp_path: Path) -> None:
     assert "ghcr.io/wphillipmoore/prod-python:3.14" in args
 
 
+_TOML_DEV_PREFIX = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+standard-tooling = "v1.4"
+
+[ci]
+versions = ["3.14"]
+
+[docker]
+image-prefix = "dev"
+"""
+
+
+def test_config_prefix_used(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    (tmp_path / "standard-tooling.toml").write_text(_TOML_DEV_PREFIX)
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("standard_tooling.bin.st_docker_run.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_docker_run.assert_docker_available"),
+        patch("standard_tooling.bin.st_docker_run.ensure_cached_image") as mock_cache,
+        patch("standard_tooling.bin.st_docker_run.os.execvp"),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        mock_cache.return_value = "ghcr.io/wphillipmoore/dev-python:3.14"
+        main(["--", "echo", "hi"])
+    mock_cache.assert_called_once()
+    assert mock_cache.call_args[0][2] == "ghcr.io/wphillipmoore/dev-python:3.14"
+
+
 def test_env_image_override(tmp_path: Path) -> None:
     env = {"GH_TOKEN": "tok", "DOCKER_DEV_IMAGE": "custom:img"}
     with (

--- a/tests/standard_tooling/test_st_docker_run.py
+++ b/tests/standard_tooling/test_st_docker_run.py
@@ -94,10 +94,10 @@ def test_fallback_image_no_language(tmp_path: Path) -> None:
         patch("standard_tooling.bin.st_docker_run.os.execvp") as mock_exec,
         patch.dict("os.environ", env, clear=True),
     ):
-        mock_cache.return_value = "ghcr.io/wphillipmoore/dev-base:latest"
+        mock_cache.return_value = "ghcr.io/wphillipmoore/prod-base:latest"
         main(["--", "echo", "hi"])
     args = mock_exec.call_args[0][1]
-    assert "ghcr.io/wphillipmoore/dev-base:latest" in args
+    assert "ghcr.io/wphillipmoore/prod-base:latest" in args
 
 
 def test_language_detected_image(tmp_path: Path) -> None:
@@ -111,7 +111,7 @@ def test_language_detected_image(tmp_path: Path) -> None:
     ):
         main(["--", "echo", "hi"])
     args = mock_exec.call_args[0][1]
-    assert "ghcr.io/wphillipmoore/dev-python:3.14" in args
+    assert "ghcr.io/wphillipmoore/prod-python:3.14" in args
 
 
 def test_env_image_override(tmp_path: Path) -> None:
@@ -284,7 +284,7 @@ def test_cached_image_uses_pull_never(tmp_path: Path) -> None:
 
 def test_registry_image_uses_pull_always(tmp_path: Path) -> None:
     (tmp_path / "go.mod").write_text("module example\n")
-    base = "ghcr.io/wphillipmoore/dev-go:1.26"
+    base = "ghcr.io/wphillipmoore/prod-go:1.26"
     env = {"GH_TOKEN": "tok"}
     with (
         patch("standard_tooling.bin.st_docker_run.git.repo_root", return_value=tmp_path),

--- a/tests/standard_tooling/test_st_docker_test.py
+++ b/tests/standard_tooling/test_st_docker_test.py
@@ -71,7 +71,7 @@ def test_detect_ruby_priority(tmp_path: Path) -> None:
 def test_build_docker_args_python(tmp_path: Path) -> None:
     with patch.dict("os.environ", {}, clear=True):
         args = build_test_docker_args(tmp_path, "python")
-    assert "ghcr.io/wphillipmoore/dev-python:3.14" in args
+    assert "ghcr.io/wphillipmoore/prod-python:3.14" in args
     assert "uv sync && uv run pytest tests/ -v" in args
     assert "-v" in args
 
@@ -167,7 +167,7 @@ def test_main_calls_execvp(tmp_path: Path) -> None:
     mock_exec.assert_called_once()
     call_args = mock_exec.call_args
     assert call_args[0][0] == "docker"
-    assert "ghcr.io/wphillipmoore/dev-python:3.14" in call_args[0][1]
+    assert "ghcr.io/wphillipmoore/prod-python:3.14" in call_args[0][1]
 
 
 # -- _docker_is_available ----------------------------------------------------

--- a/tests/standard_tooling/test_st_github_config.py
+++ b/tests/standard_tooling/test_st_github_config.py
@@ -19,6 +19,7 @@ from standard_tooling.bin.st_github_config import (
 )
 from standard_tooling.lib.config import (
     CiConfig,
+    DockerConfig,
     GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
@@ -270,6 +271,7 @@ def _make_config() -> StConfig:
         ci=CiConfig(versions=["3.14"], integration_tests=False),
         github=GithubOverrides(skip_rulesets=True),
         publish=PublishConfig(release=False, docs=True),
+        docker=DockerConfig(image_prefix="prod"),
     )
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Make Docker image prefix configurable via standard-tooling.toml

## Issue Linkage

- Ref #706

## Testing

- markdownlint
- ci: shellcheck

## Notes

- # Pull Request

## Summary

- Add `[docker]` section with `image-prefix` field (`dev`/`prod`) to `standard-tooling.toml` config schema
- Make `default_image()` in `docker.py` accept a `prefix` parameter, replacing hardcoded `dev-` prefix with configurable `prod`/`dev`
- Update `st-docker-run` and `st-docker-docs` to read image prefix from repo config, defaulting to `prod`
- Update `st-docker-test` to use `default_image()` instead of removed `_DEFAULT_IMAGES` dict
- Fix all downstream type errors and test assertions for the `dev-` to `prod-` default prefix change

## Issue Linkage

- Ref #706

## Testing

- 847 tests pass with 100% branch coverage
- All lint (ruff check, ruff format), type check (mypy, ty), and audit checks pass
- `st-validate` clean

## Notes

- The default prefix is `prod` (matching the new naming convention from standard-tooling-docker). Repos that want `dev-` images set `image-prefix = "dev"` in their `[docker]` section.
- This is Phase 2 of the release workflow and image naming plan. Phase 1 (standard-tooling-docker workflow restructuring) is merged.