### PR TITLE
feat(github-config): default --repo to current git remote, drop --yes

### DIFF
--- a/src/standard_tooling/bin/st_github_config.py
+++ b/src/standard_tooling/bin/st_github_config.py
@@ -27,24 +27,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     for name in ("audit", "diff", "apply"):
         sp = sub.add_parser(name)
-        sp.add_argument("--repo", help="Single repo (OWNER/REPO)")
+        sp.add_argument(
+            "--repo",
+            help="Single repo (OWNER/REPO); defaults to current git remote",
+        )
         sp.add_argument("--owner", help="GitHub owner (project mode)")
         sp.add_argument("--project", help="GitHub Project number")
         sp.add_argument(
             "--config",
             help="Local path to standard-tooling.toml (overrides remote fetch)",
         )
-        if name == "apply":
-            sp.add_argument(
-                "--yes",
-                action="store_true",
-                help="Skip confirmation prompt",
-            )
 
     args = parser.parse_args(argv)
 
-    if not args.repo and not (getattr(args, "owner", None) and getattr(args, "project", None)):
-        parser.error("--repo or --owner/--project required")
+    has_owner = getattr(args, "owner", None)
+    has_project = getattr(args, "project", None)
+    if bool(has_owner) != bool(has_project):
+        parser.error("--owner and --project must be specified together")
 
     return args
 
@@ -53,7 +52,9 @@ def _resolve_repos(args: argparse.Namespace) -> list[str]:
     """Return list of repos to operate on."""
     if args.repo:
         return [args.repo]
-    return github.list_project_repos(args.owner, args.project)
+    if args.owner and args.project:
+        return github.list_project_repos(args.owner, args.project)
+    return [github.current_repo()]
 
 
 def _load_local_config(path: str) -> StConfig:
@@ -133,15 +134,6 @@ def main(argv: list[str] | None = None) -> int:
     if not non_compliant:
         print("All repos compliant, nothing to apply.")
         return 0
-
-    if not args.yes:
-        print(f"\nAbout to apply changes to {len(non_compliant)} repo(s):")
-        for repo in non_compliant:
-            print(f"  - {repo}")
-        answer = input("\nProceed? [y/N] ")
-        if answer.lower() != "y":
-            print("Aborted.")
-            return 1
 
     for repo in non_compliant:
         config = get_config(repo)

--- a/src/standard_tooling/lib/github.py
+++ b/src/standard_tooling/lib/github.py
@@ -179,6 +179,11 @@ def merge_state_status(pr: str) -> str:
     )
 
 
+def current_repo() -> str:
+    """Return ``OWNER/REPO`` for the current directory's git remote."""
+    return read_output("repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+
+
 def update_branch(pr: str) -> None:
     """Fast-forward merge the base branch into the PR branch.
 
@@ -187,7 +192,7 @@ def update_branch(pr: str) -> None:
     merge conflicts.
     """
     number = read_output("pr", "view", pr, "--json", "number", "--jq", ".number")
-    repo = read_output("repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+    repo = current_repo()
     read_output("api", f"repos/{repo}/pulls/{number}/update-branch", "-X", "PUT")
 
 

--- a/tests/standard_tooling/test_st_github_config.py
+++ b/tests/standard_tooling/test_st_github_config.py
@@ -45,12 +45,6 @@ def test_parse_diff_single_repo() -> None:
 def test_parse_apply_single_repo() -> None:
     args = parse_args(["apply", "--repo", "o/r"])
     assert args.command == "apply"
-    assert args.yes is False
-
-
-def test_parse_apply_with_yes() -> None:
-    args = parse_args(["apply", "--repo", "o/r", "--yes"])
-    assert args.yes is True
 
 
 def test_parse_project_mode() -> None:
@@ -59,9 +53,21 @@ def test_parse_project_mode() -> None:
     assert args.project == "3"
 
 
-def test_parse_no_target_fails() -> None:
+def test_parse_no_target_defaults() -> None:
+    args = parse_args(["audit"])
+    assert args.repo is None
+    assert args.owner is None
+    assert args.project is None
+
+
+def test_parse_owner_without_project_fails() -> None:
     with pytest.raises(SystemExit):
-        parse_args(["audit"])
+        parse_args(["audit", "--owner", "acme"])
+
+
+def test_parse_project_without_owner_fails() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["audit", "--project", "3"])
 
 
 def test_parse_config_flag_audit() -> None:
@@ -183,6 +189,15 @@ def test_resolve_repos_project_mode() -> None:
         return_value=["acme/a", "acme/b"],
     ):
         assert _resolve_repos(args) == ["acme/a", "acme/b"]
+
+
+def test_resolve_repos_defaults_to_current_repo() -> None:
+    args = argparse.Namespace(repo=None, owner=None, project=None)
+    with patch(
+        "standard_tooling.bin.st_github_config.github.current_repo",
+        return_value="acme/my-repo",
+    ):
+        assert _resolve_repos(args) == ["acme/my-repo"]
 
 
 # -- _fetch_remote_config -----------------------------------------------------
@@ -337,66 +352,13 @@ def test_apply_all_compliant_does_nothing() -> None:
         patch("standard_tooling.bin.st_github_config._fetch_remote_config"),
         patch("standard_tooling.bin.st_github_config._apply_repo") as mock_apply,
     ):
-        result = main(["apply", "--repo", "o/r", "--yes"])
-    assert result == 0
-    mock_apply.assert_not_called()
-
-
-def test_apply_with_yes_applies_noncompliant() -> None:
-    call_count = [0]
-
-    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
-        call_count[0] += 1
-        return _mock_noncompliant()
-
-    with (
-        patch(
-            "standard_tooling.bin.st_github_config._audit_repo",
-            side_effect=audit_side_effect,
-        ),
-        patch(
-            "standard_tooling.bin.st_github_config._resolve_repos",
-            return_value=["o/r"],
-        ),
-        patch("standard_tooling.bin.st_github_config._fetch_remote_config"),
-        patch("standard_tooling.bin.st_github_config._apply_repo", return_value=[]) as mock_apply,
-    ):
-        result = main(["apply", "--repo", "o/r", "--yes"])
-    assert result == 0
-    mock_apply.assert_called_once()
-
-
-def test_apply_without_yes_prompts_and_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("builtins.input", lambda _: "n")
-    call_count = [0]
-
-    def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
-        call_count[0] += 1
-        return _mock_noncompliant()
-
-    with (
-        patch(
-            "standard_tooling.bin.st_github_config._audit_repo",
-            side_effect=audit_side_effect,
-        ),
-        patch(
-            "standard_tooling.bin.st_github_config._resolve_repos",
-            return_value=["o/r"],
-        ),
-        patch("standard_tooling.bin.st_github_config._fetch_remote_config"),
-        patch("standard_tooling.bin.st_github_config._apply_repo") as mock_apply,
-    ):
         result = main(["apply", "--repo", "o/r"])
-    assert result == 1
+    assert result == 0
     mock_apply.assert_not_called()
 
 
-def test_apply_without_yes_prompts_and_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("builtins.input", lambda _: "y")
-    call_count = [0]
-
+def test_apply_noncompliant() -> None:
     def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
-        call_count[0] += 1
         return _mock_noncompliant()
 
     with (
@@ -416,9 +378,7 @@ def test_apply_without_yes_prompts_and_proceeds(monkeypatch: pytest.MonkeyPatch)
     mock_apply.assert_called_once()
 
 
-def test_apply_reports_legacy_protection_removed(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("builtins.input", lambda _: "y")
-
+def test_apply_reports_legacy_protection_removed() -> None:
     def audit_side_effect(*_args: object, **_kwargs: object) -> ConfigDiff:
         return _mock_noncompliant()
 
@@ -518,7 +478,7 @@ def test_config_flag_apply_uses_local_config(tmp_path: object) -> None:
             return_value=[],
         ) as mock_apply,
     ):
-        result = main(["apply", "--repo", "o/r", "--yes", "--config", str(p)])
+        result = main(["apply", "--repo", "o/r", "--config", str(p)])
     assert result == 0
     mock_remote.assert_not_called()
     mock_apply.assert_called_once()


### PR DESCRIPTION
# Pull Request

## Summary

- Default --repo to current git remote and remove --yes confirmation prompt

## Issue Linkage

- Ref #677

## Testing



## Notes

- ## Changes

- **`github.py`**: Added `current_repo()` helper that derives `OWNER/REPO` from the current directory's git remote via `gh repo view`. Updated `update_branch()` to use it instead of inlining the same call.
- **`st_github_config.py`**: Made `--repo` optional — when omitted (and no `--owner/--project`), falls back to `github.current_repo()`. Validation now only errors on partial project-mode args (owner without project or vice versa). Removed `--yes` flag and the confirmation prompt from `apply`.
- **Tests**: Removed `--yes`-related tests, added coverage for the new default-repo path and partial-args validation.

## Rationale for dropping --yes

The confirmation prompt was unnecessary friction — the user already has to explicitly invoke `apply` (not `audit`/`diff`), and they can preview with `audit` or `diff` first.