### PR TITLE
Apply alignment review fixes to VERGIL rename plan

### DIFF
--- a/.commit-msg.tmp
+++ b/.commit-msg.tmp
@@ -1,0 +1,8 @@
+docs: move rename plan to docs/plans/
+
+Spec stays in docs/specs/, plan moves to docs/plans/ to match
+the project convention.
+
+Issue: #551
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

--- a/docs/plans/2026-05-11-vergil-rename.md
+++ b/docs/plans/2026-05-11-vergil-rename.md
@@ -529,7 +529,7 @@ Note: test files without `st_` prefix (`test_config.py`,
 `test_release.py`, `test_validate_commands.py`,
 `test_validate_common.py`, `test_version.py`) stay as-is.
 
-- [ ] **Step 3: Update pyproject.toml — package name and metadata**
+- [ ] **Step 3: Update pyproject.toml — package name, metadata, and package-data**
 
 Change the `[project]` section:
 
@@ -538,6 +538,13 @@ Change the `[project]` section:
 name = "vergil-tooling"
 version = "2.0.0"
 description = "VERGIL — Validation Engine for Repository Governance, Integration & Lifecycle"
+```
+
+Update `[tool.setuptools.package-data]`:
+
+```toml
+[tool.setuptools.package-data]
+vergil_tooling = ["data/*.json", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml"]
 ```
 
 - [ ] **Step 4: Update pyproject.toml — console scripts**
@@ -730,7 +737,25 @@ Review these files manually to confirm string references are correct:
 - `src/vergil_tooling/bin/vrg_finalize_repo.py` — subprocess calls to
   `vrg-docker-run` and `vrg-validate`
 
-- [ ] **Step 4: Update string references in lib and test files**
+- [ ] **Step 4: Update dependency-key references in test fixtures**
+
+The TOML dependency key renames to `vergil` (not `vergil-tooling`).
+These targeted replacements must run **before** the blanket
+`standard-tooling` → `vergil-tooling` pattern in Step 5, or the
+wrong substitution wins.
+
+```bash
+find tests/vergil_tooling -name '*.py' -exec sed -i '' \
+  -e 's/standard-tooling = "v1\.4"/vergil = "v2.0"/g' \
+  -e 's/dependencies\["standard-tooling"\]/dependencies["vergil"]/g' \
+  -e 's/match="standard-tooling"/match="vergil"/g' \
+  {} +
+```
+
+Review `test_config.py` and `test_docker_cache.py` manually — both
+have TOML fixture strings where the dependency key appears.
+
+- [ ] **Step 5: Update string references in lib and test files**
 
 ```bash
 find src/vergil_tooling/lib tests/vergil_tooling -name '*.py' -exec sed -i '' \
@@ -740,20 +765,24 @@ find src/vergil_tooling/lib tests/vergil_tooling -name '*.py' -exec sed -i '' \
   -e 's/st-validate/vrg-validate/g' \
   -e 's/st-docker-run/vrg-docker-run/g' \
   -e 's/st-finalize-repo/vrg-finalize-repo/g' \
+  -e 's/ST_COMMIT_CONTEXT/VRG_COMMIT_CONTEXT/g' \
+  -e 's/ST_DOCKER_INSTALL_TAG/VRG_DOCKER_INSTALL_TAG/g' \
+  -e 's/st_install_tag/vrg_install_tag/g' \
   {} +
 ```
 
-- [ ] **Step 5: Verify no old string references remain**
+- [ ] **Step 6: Verify no old string references remain**
 
 ```bash
 grep -rn '"st-' src/ tests/ --include="*.py"
 grep -rn "standard-tooling" src/ tests/ --include="*.py"
+grep -rn "ST_COMMIT_CONTEXT\|ST_DOCKER_INSTALL_TAG\|st_install_tag" tests/ --include="*.py"
 ```
 
 Expected: Zero matches (excluding any that legitimately reference the
 old name in a historical context — these should be rare).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add -A
@@ -793,6 +822,10 @@ consumer-refresh = """\
 uv tool install --python 3.14 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v<VERSION>'
 """
 ```
+
+Note: `[project.co-authors]` bot account names (`wphillipmoore-claude`,
+`wphillipmoore-codex`) stay as-is — they are GitHub usernames, not
+repo/org references. Rename separately if needed.
 
 - [ ] **Step 3: Update pre-commit hook**
 
@@ -1091,7 +1124,25 @@ grep -rn "standard-tooling\|standard_tooling\|wphillipmoore\|st-commit\|st-valid
 
 Expected: Zero matches.
 
-- [ ] **Step 9: Commit, push, PR, merge, release v2.0.0**
+- [ ] **Step 9: Verify plugin namespace resolution**
+
+Install the plugin from the new repo and confirm skills resolve under
+the new `vergil:*` namespace:
+
+```bash
+claude mcp add-plugin vergil-project/vergil-claude-plugin
+```
+
+Verify at least one skill is callable:
+
+```bash
+# In a Claude Code session, confirm /vergil:publish (or similar) loads
+```
+
+If the namespace doesn't resolve, check `plugin.json` `"name"` field
+and the plugin registration mechanism.
+
+- [ ] **Step 10: Commit, push, PR, merge, release v2.0.0**
 
 Commit message: `feat!: rename to vergil-claude-plugin under vergil-project org`
 
@@ -1187,6 +1238,15 @@ Also update version tags: `@v1.x` → `@v2.0`.
 Replace references to `standard-tooling`, `st-*` commands, and
 `wphillipmoore` org with the new names. Each repo's CLAUDE.md is
 different — review manually after sed.
+
+Also check for plugin skill namespace references:
+
+```bash
+grep -rn "standard-tooling:" --include="*.md" .
+```
+
+Replace `standard-tooling:` → `vergil:` (e.g.,
+`standard-tooling:publish` → `vergil:publish`).
 
 - [ ] **Step H: Update any other references**
 

--- a/docs/plans/2026-05-11-vergil-rename.md
+++ b/docs/plans/2026-05-11-vergil-rename.md
@@ -19,7 +19,7 @@ releases a minor version bump for each.
 Git, GHCR (container registry), GitHub Actions workflows
 
 **Spec:**
-[`docs/specs/2026-05-11-vergil-rename-design.md`](2026-05-11-vergil-rename-design.md)
+[`docs/specs/2026-05-11-vergil-rename-design.md`](../specs/2026-05-11-vergil-rename-design.md)
 
 ---
 

--- a/docs/specs/2026-05-11-vergil-rename-design.md
+++ b/docs/specs/2026-05-11-vergil-rename-design.md
@@ -1,0 +1,187 @@
+# VERGIL Rename Design
+
+**Issue:** [#551](https://github.com/wphillipmoore/standard-tooling/issues/551)
+**Milestone:** v2.0
+**Date:** 2026-05-11
+
+## Summary
+
+Rename the standard-tooling project suite to VERGIL (Validation Engine
+for Repository Governance, Integration & Lifecycle). This covers
+renaming all four core repositories, transferring them to a new GitHub
+organization, updating the Python package and CLI prefix, and sweeping
+all consumer repos to update references. The CLI architecture stays
+as-is (individual scripts); the Click-based unified `vergil` command is
+a separate effort.
+
+## Naming Inventory
+
+### GitHub organization
+
+Create a new org: **`vergil-project`**
+
+### Repository renames and transfers
+
+| Current (`wphillipmoore/`) | New (`vergil-project/`) |
+|---|---|
+| `standard-tooling` | `vergil-tooling` |
+| `standard-actions` | `vergil-actions` |
+| `standard-tooling-docker` | `vergil-docker` |
+| `standard-tooling-plugin` | `vergil-claude-plugin` |
+
+### Python package
+
+| Artifact | Old | New |
+|---|---|---|
+| PyPI package | *(unpublished)* | `vergil-tooling` |
+| Python module | `standard_tooling` | `vergil_tooling` |
+| Source directory | `src/standard_tooling/` | `src/vergil_tooling/` |
+| Test directory | `tests/standard_tooling/` | `tests/vergil_tooling/` |
+
+### CLI prefix
+
+All console scripts change from `st-*` to `vrg-*`:
+
+`st-commit` → `vrg-commit`, `st-validate` → `vrg-validate`,
+`st-docker-run` → `vrg-docker-run`, etc.
+
+### Environment variables
+
+All `ST_`-prefixed environment variables change to `VRG_`:
+
+`ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`, etc.
+
+### Config file
+
+| Artifact | Old | New |
+|---|---|---|
+| Config filename | `standard-tooling.toml` | `vergil.toml` |
+| Dependency key | `[dependencies] standard-tooling = "v1.4"` | `[dependencies] vergil = "v2.0"` |
+
+The config file represents the VERGIL system, not a specific repo. A
+single version pins all four core repos — they are released in lockstep
+and guaranteed consistent within a version.
+
+### Versioning
+
+- **Four core repos:** v1.x → v2.0.0 (may iterate to v2.0.x during
+  stabilization)
+- **Consumer repos:** minor version bump (1.x → 1.x+1) to reflect the
+  dependency rename; no consumer-side logic changes
+
+## Execution Model
+
+### Preconditions
+
+All repos frozen. No in-flight PRs, no active development across the
+fleet. Single engineer, single execution window (target: one
+morning/day).
+
+### Phase 1 — Core repos
+
+**Step 1: Create the org**
+
+Create `vergil-project` GitHub org with the owner account.
+
+**Step 2: Rename, transfer, update, and release in dependency order**
+
+The four repos have a dependency chain that determines sequencing:
+
+1. **`vergil-docker`** — base layer, no dependencies on the other three
+2. **`vergil-actions`** — reusable workflows, references docker images
+3. **`vergil-tooling`** — CLI tools, references actions and docker
+4. **`vergil-claude-plugin`** — consumes vergil-tooling
+
+For each repo:
+
+1. Rename the repo on GitHub
+2. Transfer to the `vergil-project` org
+3. Update all internal references (imports, URLs, config, workflow
+   `uses:` lines)
+4. For vergil-tooling specifically: rename the Python module
+   (`src/standard_tooling/` → `src/vergil_tooling/`), update
+   `pyproject.toml`, rename CLI entry points `st-*` → `vrg-*`
+5. Release v2.0.0 (may iterate to v2.0.x if issues surface)
+6. Verify the release before moving to the next repo
+
+GitHub redirects from the old `wphillipmoore/*` URLs remain active
+throughout, providing a safety net.
+
+### Phase 2 — Consumer sweep
+
+Once all four core repos are stable at v2.0.x, sweep through each of
+the ~10-12 consumer repos:
+
+1. Rename `standard-tooling.toml` → `vergil.toml`
+2. Update config: `[dependencies] vergil = "v2.0"`
+3. Update `.githooks/pre-commit` (`st-commit` → `vrg-commit`,
+   `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`)
+4. Update workflow files (`uses: wphillipmoore/standard-actions/...` →
+   `uses: vergil-project/vergil-actions/...`)
+5. Update `uv tool install` references
+6. Update `CLAUDE.md` / `AGENTS.md` references
+7. Minor version bump, release, verify
+
+### Definition of done
+
+Every repo in the fleet has completed a successful release under the
+new names. For the four core repos, that means a v2.0.x release through
+the full publish workflow. For consumer repos, that means a minor
+version release with updated references.
+
+## Out of Scope
+
+- **CLI redesign** — the Click-based unified `vergil` subcommand is a
+  separate issue
+- **README / marketing material** — separate effort after the rename
+  lands
+- **`standards-and-conventions` repo** — historical reference, not part
+  of the rename
+- **PyPI bare `vergil` name** — issue #561 continues independently; if
+  acquired later, triggers a separate deprecation cycle
+- **Diogenes rename** — separate process following the same playbook
+- **GitHub redirect cleanup** — redirects are maintained indefinitely
+  by GitHub; all consumer references are updated in Phase 2 regardless
+
+## Risks
+
+### GitHub rename + transfer ordering
+
+Renaming and transferring a repo to an org creates a redirect chain.
+The recommended order is transfer-then-rename: this moves the repo to
+`vergil-project/standard-tooling` first, then renames it to
+`vergil-project/vergil-tooling`. This keeps the org as the stable
+anchor while the name changes. GitHub maintains the full redirect
+chain either way.
+
+### Git remotes on local clones
+
+Local checkouts and worktrees will still have `origin` pointing at old
+URLs. Git follows redirects, but remotes should be updated to avoid
+relying on them. The plan should include a local cleanup step.
+
+### Claude Code plugin namespace
+
+Skills currently appear as `standard-tooling:*` (e.g.,
+`standard-tooling:publish`). The plugin namespace is determined by the
+plugin's registration. The plan must account for how the namespace is
+configured and ensure skills resolve correctly under the new name.
+
+### Rollback
+
+Given the frozen fleet and single engineer, rollback is
+straightforward: transfer repos back to `wphillipmoore`, rename back to
+`standard-*`. GitHub redirects work in both directions. There is no
+existing PyPI presence for `standard-tooling`, so no published package
+to worry about.
+
+## Reusable Playbook
+
+This rename establishes a pattern for future project renames (notably
+the Diogenes rename of `ai-research-methodology`):
+
+1. Create a `<name>-project` GitHub org
+2. Rename and transfer repos in dependency order
+3. Update all internal references
+4. Release, verify
+5. Sweep consumer repos

--- a/docs/specs/2026-05-11-vergil-rename-design.md
+++ b/docs/specs/2026-05-11-vergil-rename-design.md
@@ -62,10 +62,45 @@ The config file represents the VERGIL system, not a specific repo. A
 single version pins all four core repos — they are released in lockstep
 and guaranteed consistent within a version.
 
+**Full field inventory** — every section/field containing an old name:
+
+| Section | Field | Change |
+|---|---|---|
+| `[dependencies]` | `standard-tooling = "v1.4"` | `vergil = "v2.0"` |
+| `[publish]` | `consumer-refresh` (contains `standard-tooling @ git+https://github.com/wphillipmoore/...`) | Update package name, GitHub org, and version tag |
+| `[docker]` | `image-prefix` | No rename needed, but GHCR prefix in code changes (see Container registry) |
+| `[project.co-authors]` | `wphillipmoore-claude`, `wphillipmoore-codex` | Decision point: bot accounts stay as-is unless renamed separately |
+
+### Container registry
+
+All dev container images move from `ghcr.io/wphillipmoore/*` to
+`ghcr.io/vergil-project/*`:
+
+| Image | Old | New |
+|---|---|---|
+| Prod base | `ghcr.io/wphillipmoore/prod-base` | `ghcr.io/vergil-project/prod-base` |
+| Dev base | `ghcr.io/wphillipmoore/dev-base` | `ghcr.io/vergil-project/dev-base` |
+
+The hardcoded GHCR prefix in `src/standard_tooling/lib/docker.py`
+(`_GHCR = "ghcr.io/wphillipmoore"`) changes to
+`ghcr.io/vergil-project`.
+
+GHCR packages are scoped to the owning user/org. Transferring a repo
+does not automatically move its container packages. After
+`vergil-docker` is transferred and renamed, all images must be
+re-published to `ghcr.io/vergil-project/*` before downstream repos
+can pull them. During the consumer sweep, images must be available at
+both the old and new GHCR paths — consumers not yet swept still
+reference the old prefix.
+
 ### Versioning
 
+v2.0 is scoped to the rename. The intent is minimum necessary breaking
+changes; execution-time fixes may introduce additional breaks as
+needed, but no unrelated breaking changes are bundled.
+
 - **Four core repos:** v1.x → v2.0.0 (may iterate to v2.0.x during
-  stabilization)
+  stabilization). The `v2.0` tag tracks the latest patch level.
 - **Consumer repos:** minor version bump (1.x → 1.x+1) to reflect the
   dependency rename; no consumer-side logic changes
 
@@ -75,7 +110,8 @@ and guaranteed consistent within a version.
 
 All repos frozen. No in-flight PRs, no active development across the
 fleet. Single engineer, single execution window (target: one
-morning/day).
+morning/day). Phase 1 (core repos) must complete before breaking.
+Phase 2 (consumer sweep) can resume in a separate window if needed.
 
 ### Phase 1 — Core repos
 
@@ -98,22 +134,33 @@ For each repo:
 2. Transfer to the `vergil-project` org
 3. Update all internal references (imports, URLs, config, workflow
    `uses:` lines)
-4. For vergil-tooling specifically: rename the Python module
+4. For vergil-docker specifically: re-publish all container images to
+   `ghcr.io/vergil-project/*` (GHCR packages don't move with repo
+   transfers)
+5. For vergil-tooling specifically: rename the Python module
    (`src/standard_tooling/` → `src/vergil_tooling/`), update
-   `pyproject.toml`, rename CLI entry points `st-*` → `vrg-*`
-5. Release v2.0.0 (may iterate to v2.0.x if issues surface)
-6. Verify the release before moving to the next repo
+   `pyproject.toml`, rename CLI entry points `st-*` → `vrg-*`,
+   update `_GHCR` prefix in `docker.py`
+6. Release v2.0.0 (may iterate to v2.0.x if issues surface)
+7. Verify the release before moving to the next repo
 
 GitHub redirects from the old `wphillipmoore/*` URLs remain active
 throughout, providing a safety net.
 
 ### Phase 2 — Consumer sweep
 
-Once all four core repos are stable at v2.0.x, sweep through each of
-the ~10-12 consumer repos:
+**Checkpoint:** Phase 1 must complete before breaking. Phase 2 can
+resume in a separate window if needed — core repos are the critical
+path, consumers can trail. During this gap, images remain available at
+both `ghcr.io/wphillipmoore/*` (old) and `ghcr.io/vergil-project/*`
+(new) so un-swept consumers continue to work.
+
+Once all four core repos are stable at v2.0.x, sweep through each
+consumer repo (see Appendix A for the full manifest):
 
 1. Rename `standard-tooling.toml` → `vergil.toml`
-2. Update config: `[dependencies] vergil = "v2.0"`
+2. Update all config fields (see Config file inventory above):
+   `[dependencies]`, `[publish] consumer-refresh`, etc.
 3. Update `.githooks/pre-commit` (`st-commit` → `vrg-commit`,
    `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`)
 4. Update workflow files (`uses: wphillipmoore/standard-actions/...` →
@@ -182,6 +229,43 @@ the Diogenes rename of `ai-research-methodology`):
 
 1. Create a `<name>-project` GitHub org
 2. Rename and transfer repos in dependency order
-3. Update all internal references
-4. Release, verify
-5. Sweep consumer repos
+3. Re-publish container images to the new GHCR scope
+4. Update all internal references
+5. Release, verify
+6. Sweep consumer repos
+
+## Appendix A: Consumer Repo Manifest
+
+Repos under `wphillipmoore/` that consume standard-tooling (have a
+`standard-tooling.toml` or reference `st-*` tools). Verify each
+before execution day — repos may be archived or added between now
+and then.
+
+| Repository | Notes |
+|---|---|
+| `ai-research-methodology` | Also the future Diogenes rename candidate |
+| `career-strategy` | |
+| `cognition` | |
+| `home-equity-project` | |
+| `lunatick-racing` | |
+| `mempalace` | |
+| `mnemosys-core` | |
+| `mnemosys-ios` | |
+| `mnemosys-operations` | |
+| `mq-rest-admin-common` | |
+| `mq-rest-admin-dev-environment` | |
+| `mq-rest-admin-go` | |
+| `mq-rest-admin-java` | |
+| `mq-rest-admin-python` | |
+| `mq-rest-admin-ruby` | |
+| `mq-rest-admin-rust` | |
+| `paad` | Claude Code plugin — may have skill namespace references |
+| `the-infrastructure-mindset` | |
+| `renegade-dotfiles` | Verify: may not consume standard-tooling |
+
+**Not consumers** (no sweep needed):
+
+- `cpan-afs-command`, `cpan-netapp`, `perl5-MQSeries` — legacy Perl,
+  pre-dates standard-tooling
+- `standards-and-conventions` — historical reference, explicitly out
+  of scope

--- a/docs/specs/2026-05-11-vergil-rename-plan.md
+++ b/docs/specs/2026-05-11-vergil-rename-plan.md
@@ -1,0 +1,1290 @@
+# VERGIL Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the standard-tooling project suite to VERGIL across
+all four core repos, a new GitHub org, and all consumer repos.
+
+**Architecture:** Two-phase execution. Phase 1 creates the
+`vergil-project` GitHub org and processes the four core repos in
+dependency order (docker → actions → tooling → plugin), transferring,
+renaming, updating internal references, and releasing v2.0.0 of each.
+Phase 2 sweeps all consumer repos to update their references and
+releases a minor version bump for each.
+
+**Tech Stack:** GitHub CLI (`gh`), Python (pyproject.toml, setuptools),
+Git, GHCR (container registry), GitHub Actions workflows
+
+**Spec:**
+[`docs/specs/2026-05-11-vergil-rename-design.md`](2026-05-11-vergil-rename-design.md)
+
+---
+
+## File Map — Key Changes by Repo
+
+### vergil-docker (standard-tooling-docker)
+
+| File | Change |
+|---|---|
+| `.github/workflows/cd-docker-publish.yml` | `ghcr.io/wphillipmoore` → `ghcr.io/vergil-project`; `wphillipmoore/standard-actions` → `vergil-project/vergil-actions` |
+| `.github/workflows/ci.yml`, `cd.yml`, `ops.yml` | `wphillipmoore/standard-actions` → `vergil-project/vergil-actions` |
+| `.githooks/pre-commit` | `st-commit` → `vrg-commit`, `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT` |
+| `docker/build.sh` | Header comment: repo URL |
+| `CLAUDE.md`, `README.md`, `CHANGELOG.md` | All `standard-tooling-docker` → `vergil-docker` references |
+| `standard-tooling.toml` | Rename file → `vergil.toml`; update `[dependencies]` key |
+
+### vergil-actions (standard-actions)
+
+| File | Change |
+|---|---|
+| `actions/shared/setup/standard-tooling/action.yml` | Rename dir → `actions/shared/setup/vergil/action.yml`; update sed patterns and install URLs |
+| `.github/workflows/*.yml` | Self-references and `wphillipmoore/standard-actions` → `vergil-project/vergil-actions`; `ghcr.io/wphillipmoore` → `ghcr.io/vergil-project` |
+| `actions/**/*.yml` | All action files: `standard-tooling` → `vergil-tooling`, `standard-actions` → `vergil-actions` |
+| `.githooks/pre-commit` | `st-commit` → `vrg-commit`, `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT` |
+| `CLAUDE.md`, `AGENTS.md`, `README.md` | All name references |
+| `standard-tooling.toml` | Rename → `vergil.toml`; update fields |
+
+### vergil-tooling (standard-tooling)
+
+| File | Change |
+|---|---|
+| `src/standard_tooling/` | Rename dir → `src/vergil_tooling/` |
+| `src/vergil_tooling/bin/st_*.py` (×18) | Rename each → `vrg_*.py` |
+| `tests/standard_tooling/` | Rename dir → `tests/vergil_tooling/` |
+| `tests/vergil_tooling/test_st_*.py` (×18) | Rename each → `test_vrg_*.py` |
+| `pyproject.toml` | Package name, all console scripts |
+| `src/vergil_tooling/lib/config.py` | `CONFIG_FILE`, dependency key, `st_install_tag` → `vrg_install_tag`, `ST_DOCKER_INSTALL_TAG` → `VRG_DOCKER_INSTALL_TAG` |
+| `src/vergil_tooling/lib/git.py` | `_GATE_ENV_VAR = "ST_COMMIT_CONTEXT"` → `"VRG_COMMIT_CONTEXT"` |
+| `src/vergil_tooling/lib/docker.py` | `_GHCR = "ghcr.io/wphillipmoore"` → `"ghcr.io/vergil-project"` |
+| `src/vergil_tooling/lib/docker_cache.py` | Import `vrg_install_tag` |
+| All `.py` files | `from standard_tooling` → `from vergil_tooling`; `import standard_tooling` → `import vergil_tooling` |
+| All `.py` bin files | String refs: `st-validate` → `vrg-validate`, `st-docker-run` → `vrg-docker-run`, etc. |
+| `.githooks/pre-commit` | `st-commit` → `vrg-commit`, `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT` |
+| `standard-tooling.toml` | Rename → `vergil.toml`; update fields |
+| `.github/workflows/*.yml` | `wphillipmoore/standard-actions` → `vergil-project/vergil-actions` |
+| `CLAUDE.md`, `AGENTS.md`, `README.md` | All references |
+| All docs under `docs/` | All `standard-tooling`, `st-*` references |
+
+### vergil-claude-plugin (standard-tooling-plugin)
+
+| File | Change |
+|---|---|
+| `.claude-plugin/plugin.json` | `"name": "standard-tooling"` → `"vergil"` |
+| `.claude-plugin/marketplace.json` | Update name, repository URL |
+| `skills/*/SKILL.md` (×8) | All `standard-tooling` references, all `st-*` command references |
+| `hooks/hooks.json` | Update any `standard-tooling` references |
+| `hooks/scripts/*.sh` | `st-commit` → `vrg-commit`, `standard-tooling` → `vergil-tooling` |
+| `hooks/scripts/lib/*.sh` | `standard-tooling.toml` → `vergil.toml`, `st-*` → `vrg-*` |
+| `.githooks/pre-commit` | `st-commit` → `vrg-commit`, `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT` |
+| `.github/workflows/*.yml` | `wphillipmoore/standard-actions` → `vergil-project/vergil-actions` |
+| `CLAUDE.md`, `AGENTS.md`, `README.md` | All references |
+| `standard-tooling.toml` | Rename → `vergil.toml`; update fields |
+
+---
+
+## Task 1: Pre-flight Checks and Org Creation
+
+**Files:** None (GitHub admin operations)
+
+- [ ] **Step 1: Verify all repos are clean**
+
+For each repo, confirm no open PRs and clean working state:
+
+```bash
+for repo in standard-tooling standard-actions standard-tooling-docker standard-tooling-plugin; do
+  echo "=== $repo ==="
+  gh pr list --repo "wphillipmoore/$repo" --state open
+done
+```
+
+Expected: Zero open PRs on each repo. If any exist, merge or close
+them before proceeding.
+
+- [ ] **Step 2: Verify consumer repos are clean**
+
+```bash
+gh repo list wphillipmoore --limit 100 --json name,isArchived \
+  --jq '.[] | select(.isArchived == false) | .name' \
+  | while read -r repo; do
+    count=$(gh pr list --repo "wphillipmoore/$repo" --state open --json number --jq 'length' 2>/dev/null)
+    if [ "${count:-0}" -gt 0 ]; then
+      echo "OPEN PRs: $repo ($count)"
+    fi
+  done
+```
+
+Expected: No open PRs on any active consumer repo.
+
+- [ ] **Step 3: Create the vergil-project GitHub org**
+
+This must be done via the GitHub web UI (Settings → Organizations →
+New organization). Select the free plan.
+
+1. Go to <https://github.com/organizations/plan>
+2. Choose "Free"
+3. Org name: `vergil-project`
+4. Contact email: your GitHub email
+5. Select "My personal account" as the owner
+
+- [ ] **Step 4: Verify org creation**
+
+```bash
+gh api orgs/vergil-project --jq '.login'
+```
+
+Expected: `vergil-project`
+
+- [ ] **Step 5: Commit checkpoint**
+
+No files changed — this is an admin-only task. Proceed to Task 2.
+
+---
+
+## Task 2: vergil-docker — Transfer, Rename, Update, and Republish
+
+**Repo:** `wphillipmoore/standard-tooling-docker` →
+`vergil-project/vergil-docker`
+
+- [ ] **Step 1: Transfer repo to org**
+
+```bash
+gh api repos/wphillipmoore/standard-tooling-docker/transfer \
+  -f new_owner=vergil-project --silent
+```
+
+Wait ~30 seconds for GitHub to process.
+
+- [ ] **Step 2: Rename repo**
+
+```bash
+gh repo rename vergil-docker --repo vergil-project/standard-tooling-docker --yes
+```
+
+- [ ] **Step 3: Verify transfer and rename**
+
+```bash
+gh repo view vergil-project/vergil-docker --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Expected: `vergil-project/vergil-docker`
+
+- [ ] **Step 4: Clone fresh and create release branch**
+
+```bash
+cd ~/dev/github
+git clone git@github.com:vergil-project/vergil-docker.git
+cd vergil-docker
+git checkout -b release/2.0.0
+```
+
+- [ ] **Step 5: Discover all references to update**
+
+```bash
+grep -rn "standard-tooling\|standard_tooling\|wphillipmoore\|st-commit\|ST_COMMIT_CONTEXT\|ghcr.io/wphillipmoore" \
+  --include="*.yml" --include="*.yaml" --include="*.sh" \
+  --include="*.md" --include="*.toml" --include="*.json" .
+```
+
+Review the output and update each file. The known targets are listed
+in the File Map above. Key changes:
+
+- [ ] **Step 6: Update workflow files**
+
+In `.github/workflows/cd-docker-publish.yml`, replace all:
+- `ghcr.io/wphillipmoore` → `ghcr.io/vergil-project`
+- `wphillipmoore/standard-actions` → `vergil-project/vergil-actions`
+
+Repeat for `ci.yml`, `cd.yml`, `ops.yml`.
+
+- [ ] **Step 7: Update pre-commit hook**
+
+In `.githooks/pre-commit`:
+- `st-commit` → `vrg-commit`
+- `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`
+
+- [ ] **Step 8: Rename config file and update contents**
+
+```bash
+git mv standard-tooling.toml vergil.toml
+```
+
+In `vergil.toml`:
+- `[dependencies]` key: `standard-tooling = "..."` → `vergil = "v2.0"`
+
+- [ ] **Step 9: Update docs and README**
+
+Replace all `standard-tooling-docker` with `vergil-docker` and all
+`wphillipmoore` with `vergil-project` in `README.md`, `CLAUDE.md`,
+and any files under `docs/`.
+
+- [ ] **Step 10: Update VERSION file**
+
+```bash
+echo "2.0.0" > VERSION
+```
+
+- [ ] **Step 11: Commit all changes**
+
+```bash
+git add -A
+vrg-commit  # or st-commit if host tools not yet updated
+```
+
+Commit message: `feat!: rename to vergil-docker under vergil-project org`
+
+- [ ] **Step 12: Push and open PR**
+
+```bash
+git push -u origin release/2.0.0
+```
+
+Open PR, wait for CI. Fix any failures, iterate.
+
+- [ ] **Step 13: Re-publish container images**
+
+After merging, trigger the CD workflow to publish images to the new
+GHCR scope (`ghcr.io/vergil-project/*`). The old images at
+`ghcr.io/wphillipmoore/*` remain available — do NOT delete them until
+all consumers are swept.
+
+Verify at least one image is available:
+
+```bash
+gh api orgs/vergil-project/packages?package_type=container --jq '.[].name'
+```
+
+- [ ] **Step 14: Tag release**
+
+Follow the repo's release workflow to create the `v2.0.0` tag and
+GitHub release.
+
+---
+
+## Task 3: vergil-actions — Transfer, Rename, Update, and Release
+
+**Repo:** `wphillipmoore/standard-actions` →
+`vergil-project/vergil-actions`
+
+- [ ] **Step 1: Transfer repo to org**
+
+```bash
+gh api repos/wphillipmoore/standard-actions/transfer \
+  -f new_owner=vergil-project --silent
+```
+
+- [ ] **Step 2: Rename repo**
+
+```bash
+gh repo rename vergil-actions --repo vergil-project/standard-actions --yes
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+gh repo view vergil-project/vergil-actions --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Expected: `vergil-project/vergil-actions`
+
+- [ ] **Step 4: Clone fresh and create release branch**
+
+```bash
+cd ~/dev/github
+git clone git@github.com:vergil-project/vergil-actions.git
+cd vergil-actions
+git checkout -b release/2.0.0
+```
+
+- [ ] **Step 5: Rename the setup action directory**
+
+The setup action at `actions/shared/setup/standard-tooling/` must be
+renamed:
+
+```bash
+git mv actions/shared/setup/standard-tooling actions/shared/setup/vergil
+```
+
+- [ ] **Step 6: Update the setup action**
+
+In `actions/shared/setup/vergil/action.yml`:
+- Name: `Install standard-tooling` → `Install vergil-tooling`
+- Description: update references
+- `pyproject.toml` detection: `standard-tooling` → `vergil-tooling`
+- Config file: `standard-tooling.toml` → `vergil.toml`
+- sed pattern: `standard-tooling` → `vergil`
+- Install URL: `standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling` → `vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling`
+
+Updated action content:
+
+```yaml
+name: Install vergil-tooling
+description: >-
+  Reads the pinned vergil version from vergil.toml
+  and installs it via uv tool install. When the consumer repo is
+  vergil-tooling itself, runs uv sync to install from source so CI
+  validates the PR's code instead of the released version.
+
+runs:
+  using: composite
+  steps:
+    - name: Mark workspace safe for git
+      shell: bash
+      run: git config --global --add safe.directory "${GITHUB_WORKSPACE:-$(pwd)}"
+
+    - name: Install vergil-tooling
+      shell: bash
+      run: |
+        if grep -q '^name = "vergil-tooling"' pyproject.toml 2>/dev/null; then
+          echo "Consumer repo is vergil-tooling itself — installing from source"
+          uv sync --frozen --group dev
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          exit 0
+        fi
+
+        TAG=$(sed -n 's/^[[:space:]]*vergil[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' vergil.toml)
+        if [ -z "${TAG:-}" ]; then
+          echo "::error::vergil.toml not found or missing version tag"
+          exit 1
+        fi
+        uv tool install "vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@${TAG}"
+```
+
+- [ ] **Step 7: Update all workflow files**
+
+Across all `.github/workflows/*.yml`:
+- `wphillipmoore/standard-actions` → `vergil-project/vergil-actions`
+  (self-references)
+- `ghcr.io/wphillipmoore` → `ghcr.io/vergil-project`
+- `standard-tooling` → `vergil-tooling` where it refers to the
+  package
+
+```bash
+find .github/workflows -name '*.yml' -exec grep -l 'wphillipmoore\|standard-actions\|standard-tooling' {} \;
+```
+
+Update each file found.
+
+- [ ] **Step 8: Update all action.yml files**
+
+```bash
+find actions -name 'action.yml' -exec grep -l 'wphillipmoore\|standard-tooling\|standard-actions' {} \;
+```
+
+Update each file: references to `standard-tooling` (the package),
+`standard-actions` (self-references), and `wphillipmoore` (org).
+
+- [ ] **Step 9: Update pre-commit hook, config, docs**
+
+- `.githooks/pre-commit`: `st-commit` → `vrg-commit`,
+  `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`
+- `git mv standard-tooling.toml vergil.toml` and update contents
+- Update `CLAUDE.md`, `AGENTS.md`, `README.md`, all `docs/` files
+- Update `VERSION` → `2.0.0`
+
+- [ ] **Step 10: Commit, push, and open PR**
+
+```bash
+git add -A
+```
+
+Commit message: `feat!: rename to vergil-actions under vergil-project org`
+
+Push, open PR, wait for CI. Note: CI workflows reference themselves,
+so there may be a bootstrap issue — the PR's workflows reference
+`vergil-project/vergil-actions` but the tag `v2.0` doesn't exist yet.
+If this happens, temporarily pin to the branch name or the commit SHA,
+then update to `@v2.0` after the first release.
+
+- [ ] **Step 11: Merge and release v2.0.0**
+
+After CI passes, merge. Create the `v2.0.0` tag and `v2.0` tracking
+tag.
+
+---
+
+## Task 4: vergil-tooling — Transfer, Rename, and Directory Renames
+
+**Repo:** `wphillipmoore/standard-tooling` →
+`vergil-project/vergil-tooling`
+
+- [ ] **Step 1: Transfer repo to org**
+
+```bash
+gh api repos/wphillipmoore/standard-tooling/transfer \
+  -f new_owner=vergil-project --silent
+```
+
+- [ ] **Step 2: Rename repo**
+
+```bash
+gh repo rename vergil-tooling --repo vergil-project/standard-tooling --yes
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+gh repo view vergil-project/vergil-tooling --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Expected: `vergil-project/vergil-tooling`
+
+- [ ] **Step 4: Update local remote**
+
+From the existing checkout:
+
+```bash
+cd ~/dev/github/standard-tooling
+git remote set-url origin git@github.com:vergil-project/vergil-tooling.git
+git fetch origin
+```
+
+- [ ] **Step 5: Create release branch**
+
+```bash
+git checkout -b release/2.0.0
+```
+
+- [ ] **Step 6: Rename Python source directory**
+
+```bash
+git mv src/standard_tooling src/vergil_tooling
+```
+
+- [ ] **Step 7: Rename test directory**
+
+```bash
+git mv tests/standard_tooling tests/vergil_tooling
+```
+
+- [ ] **Step 8: Commit directory renames**
+
+```bash
+git add -A
+```
+
+Commit message: `refactor!: rename standard_tooling module to vergil_tooling`
+
+This is committed separately to preserve `git log --follow` history
+for the directories.
+
+---
+
+## Task 5: vergil-tooling — Rename Bin and Test Files
+
+**Files:**
+- Rename: `src/vergil_tooling/bin/st_*.py` (×18) → `vrg_*.py`
+- Rename: `tests/vergil_tooling/test_st_*.py` (×18) → `test_vrg_*.py`
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Rename all bin files**
+
+```bash
+cd src/vergil_tooling/bin
+for f in st_*.py; do
+  new="vrg_${f#st_}"
+  git mv "$f" "$new"
+done
+cd ../../..
+```
+
+This renames:
+- `st_check_pr_merge.py` → `vrg_check_pr_merge.py`
+- `st_commit.py` → `vrg_commit.py`
+- `st_docker_cache.py` → `vrg_docker_cache.py`
+- `st_docker_docs.py` → `vrg_docker_docs.py`
+- `st_docker_run.py` → `vrg_docker_run.py`
+- `st_docker_test.py` → `vrg_docker_test.py`
+- `st_ensure_label.py` → `vrg_ensure_label.py`
+- `st_finalize_repo.py` → `vrg_finalize_repo.py`
+- `st_generate_commands.py` → `vrg_generate_commands.py`
+- `st_github_config.py` → `vrg_github_config.py`
+- `st_merge_when_green.py` → `vrg_merge_when_green.py`
+- `st_pr_issue_linkage.py` → `vrg_pr_issue_linkage.py`
+- `st_prepare_release.py` → `vrg_prepare_release.py`
+- `st_repo_profile.py` → `vrg_repo_profile.py`
+- `st_submit_pr.py` → `vrg_submit_pr.py`
+- `st_validate.py` → `vrg_validate.py`
+- `st_version.py` → `vrg_version.py`
+- `st_wait_until_green.py` → `vrg_wait_until_green.py`
+
+Note: `validate_common.py` has no `st_` prefix — leave it as-is.
+
+- [ ] **Step 2: Rename all test files**
+
+```bash
+cd tests/vergil_tooling
+for f in test_st_*.py; do
+  new="test_vrg_${f#test_st_}"
+  git mv "$f" "$new"
+done
+cd ../..
+```
+
+Note: test files without `st_` prefix (`test_config.py`,
+`test_docker.py`, `test_docker_cache.py`, `test_git.py`,
+`test_github.py`, `test_github_config_lib.py`, `test_labels.py`,
+`test_release.py`, `test_validate_commands.py`,
+`test_validate_common.py`, `test_version.py`) stay as-is.
+
+- [ ] **Step 3: Update pyproject.toml — package name and metadata**
+
+Change the `[project]` section:
+
+```toml
+[project]
+name = "vergil-tooling"
+version = "2.0.0"
+description = "VERGIL — Validation Engine for Repository Governance, Integration & Lifecycle"
+```
+
+- [ ] **Step 4: Update pyproject.toml — console scripts**
+
+Replace the entire `[project.scripts]` section:
+
+```toml
+[project.scripts]
+vrg-check-pr-merge = "vergil_tooling.bin.vrg_check_pr_merge:main"
+vrg-commit = "vergil_tooling.bin.vrg_commit:main"
+vrg-docker-cache = "vergil_tooling.bin.vrg_docker_cache:main"
+vrg-docker-docs = "vergil_tooling.bin.vrg_docker_docs:main"
+vrg-docker-run = "vergil_tooling.bin.vrg_docker_run:main"
+vrg-docker-test = "vergil_tooling.bin.vrg_docker_test:main"
+vrg-ensure-label = "vergil_tooling.bin.vrg_ensure_label:main"
+vrg-finalize-repo = "vergil_tooling.bin.vrg_finalize_repo:main"
+vrg-generate-commands = "vergil_tooling.bin.vrg_generate_commands:main"
+vrg-github-config = "vergil_tooling.bin.vrg_github_config:main"
+vrg-merge-when-green = "vergil_tooling.bin.vrg_merge_when_green:main"
+vrg-pr-issue-linkage = "vergil_tooling.bin.vrg_pr_issue_linkage:main"
+vrg-prepare-release = "vergil_tooling.bin.vrg_prepare_release:main"
+vrg-repo-profile = "vergil_tooling.bin.vrg_repo_profile:main"
+vrg-submit-pr = "vergil_tooling.bin.vrg_submit_pr:main"
+vrg-validate = "vergil_tooling.bin.vrg_validate:main"
+vrg-version = "vergil_tooling.bin.vrg_version:main"
+vrg-wait-until-green = "vergil_tooling.bin.vrg_wait_until_green:main"
+```
+
+- [ ] **Step 5: Commit file renames and pyproject.toml**
+
+```bash
+git add -A
+```
+
+Commit message: `refactor!: rename st-* CLI entry points to vrg-*`
+
+---
+
+## Task 6: vergil-tooling — Update Python Imports and Code Constants
+
+**Files:**
+- Modify: All `.py` files under `src/vergil_tooling/` and
+  `tests/vergil_tooling/`
+
+- [ ] **Step 1: Update all Python imports**
+
+```bash
+find src tests -name '*.py' -exec sed -i '' \
+  -e 's/from standard_tooling/from vergil_tooling/g' \
+  -e 's/import standard_tooling/import vergil_tooling/g' \
+  {} +
+```
+
+Verify no old imports remain:
+
+```bash
+grep -rn "standard_tooling" src/ tests/ --include="*.py"
+```
+
+Expected: Zero matches.
+
+- [ ] **Step 2: Update config.py constants**
+
+In `src/vergil_tooling/lib/config.py`:
+
+```python
+CONFIG_FILE = "vergil.toml"
+```
+
+Update the validation logic:
+
+```python
+    if "vergil" not in deps:
+        msg = f"{CONFIG_FILE}: [dependencies] must contain 'vergil'"
+```
+
+Rename the function and update its internals:
+
+```python
+def vrg_install_tag(repo_root: Path) -> str:
+    """Return the ``[dependencies].vergil`` value for runtime install.
+
+    Checks ``VRG_DOCKER_INSTALL_TAG`` env var first (override).
+    """
+    override = os.environ.get("VRG_DOCKER_INSTALL_TAG")
+    if override:
+        return override
+    cfg = read_config(repo_root)
+    return cfg.dependencies["vergil"]
+```
+
+- [ ] **Step 3: Update git.py env var**
+
+In `src/vergil_tooling/lib/git.py`:
+
+```python
+_GATE_ENV_VAR = "VRG_COMMIT_CONTEXT"
+```
+
+- [ ] **Step 4: Update docker.py GHCR prefix**
+
+In `src/vergil_tooling/lib/docker.py`:
+
+```python
+_GHCR = "ghcr.io/vergil-project"
+```
+
+- [ ] **Step 5: Update docker_cache.py import**
+
+In `src/vergil_tooling/lib/docker_cache.py`:
+
+```python
+from vergil_tooling.lib.config import vrg_install_tag
+```
+
+And update the call site:
+
+```python
+        tag = vrg_install_tag(repo_root)
+```
+
+- [ ] **Step 6: Verify no old constant references remain**
+
+```bash
+grep -rn "ST_COMMIT_CONTEXT\|ST_DOCKER_INSTALL_TAG\|st_install_tag\|ghcr.io/wphillipmoore" \
+  src/ --include="*.py"
+```
+
+Expected: Zero matches.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+```
+
+Commit message: `refactor!: update imports, constants, and env vars for vergil rename`
+
+---
+
+## Task 7: vergil-tooling — Update String References in CLI Tools
+
+**Files:**
+- Modify: All `src/vergil_tooling/bin/vrg_*.py` files
+
+- [ ] **Step 1: Bulk-replace st- command names in string literals**
+
+```bash
+find src/vergil_tooling/bin -name '*.py' -exec sed -i '' \
+  -e 's/st-validate-custom/vrg-validate-custom/g' \
+  -e 's/st-validate/vrg-validate/g' \
+  -e 's/st-docker-run/vrg-docker-run/g' \
+  -e 's/st-docker-test/vrg-docker-test/g' \
+  -e 's/st-docker-cache/vrg-docker-cache/g' \
+  -e 's/st-docker-docs/vrg-docker-docs/g' \
+  -e 's/st-commit/vrg-commit/g' \
+  -e 's/st-submit-pr/vrg-submit-pr/g' \
+  -e 's/st-prepare-release/vrg-prepare-release/g' \
+  -e 's/st-merge-when-green/vrg-merge-when-green/g' \
+  -e 's/st-finalize-repo/vrg-finalize-repo/g' \
+  -e 's/st-ensure-label/vrg-ensure-label/g' \
+  -e 's/st-wait-until-green/vrg-wait-until-green/g' \
+  -e 's/st-check-pr-merge/vrg-check-pr-merge/g' \
+  -e 's/st-pr-issue-linkage/vrg-pr-issue-linkage/g' \
+  -e 's/st-generate-commands/vrg-generate-commands/g' \
+  -e 's/st-github-config/vrg-github-config/g' \
+  -e 's/st-repo-profile/vrg-repo-profile/g' \
+  -e 's/st-version/vrg-version/g' \
+  {} +
+```
+
+- [ ] **Step 2: Update docstrings referencing standard-tooling**
+
+```bash
+find src/vergil_tooling -name '*.py' -exec sed -i '' \
+  -e 's/standard-tooling\.toml/vergil.toml/g' \
+  -e 's/standard-tooling/vergil-tooling/g' \
+  {} +
+```
+
+- [ ] **Step 3: Spot-check key files**
+
+Review these files manually to confirm string references are correct:
+- `src/vergil_tooling/bin/vrg_validate.py` — help text, error
+  messages, `prog=` argument
+- `src/vergil_tooling/bin/vrg_docker_run.py` — usage string, help
+  text
+- `src/vergil_tooling/bin/vrg_commit.py` — docstring referencing
+  config file
+- `src/vergil_tooling/bin/vrg_finalize_repo.py` — subprocess calls to
+  `vrg-docker-run` and `vrg-validate`
+
+- [ ] **Step 4: Update string references in lib and test files**
+
+```bash
+find src/vergil_tooling/lib tests/vergil_tooling -name '*.py' -exec sed -i '' \
+  -e 's/standard-tooling\.toml/vergil.toml/g' \
+  -e 's/standard-tooling/vergil-tooling/g' \
+  -e 's/st-commit/vrg-commit/g' \
+  -e 's/st-validate/vrg-validate/g' \
+  -e 's/st-docker-run/vrg-docker-run/g' \
+  -e 's/st-finalize-repo/vrg-finalize-repo/g' \
+  {} +
+```
+
+- [ ] **Step 5: Verify no old string references remain**
+
+```bash
+grep -rn '"st-' src/ tests/ --include="*.py"
+grep -rn "standard-tooling" src/ tests/ --include="*.py"
+```
+
+Expected: Zero matches (excluding any that legitimately reference the
+old name in a historical context — these should be rare).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+```
+
+Commit message: `refactor!: update CLI command names and string references to vrg-*`
+
+---
+
+## Task 8: vergil-tooling — Config, Hooks, Docs, and Workflows
+
+**Files:**
+- Modify: `standard-tooling.toml` (rename), `.githooks/pre-commit`,
+  `CLAUDE.md`, `AGENTS.md`, `README.md`, all `docs/`, all
+  `.github/workflows/`
+
+- [ ] **Step 1: Rename config file**
+
+```bash
+git mv standard-tooling.toml vergil.toml
+```
+
+- [ ] **Step 2: Update vergil.toml contents**
+
+Update the `[dependencies]` key and `[publish] consumer-refresh`:
+
+```toml
+[dependencies]
+vergil = "v2.0"
+```
+
+Update the `consumer-refresh` field to reference the new package name,
+org, and version:
+
+```
+consumer-refresh = """\
+uv tool install --python 3.14 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v<VERSION>'
+"""
+```
+
+- [ ] **Step 3: Update pre-commit hook**
+
+In `.githooks/pre-commit`, replace:
+- `st-commit` → `vrg-commit` (all occurrences)
+- `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT` (all occurrences)
+- `standard_tooling` → `vergil_tooling` (comment references)
+- `standard-tooling-plugin` → `vergil-claude-plugin` (comment
+  references)
+
+- [ ] **Step 4: Update workflow files**
+
+In all `.github/workflows/*.yml`:
+- `wphillipmoore/standard-actions` → `vergil-project/vergil-actions`
+
+```bash
+find .github/workflows -name '*.yml' -exec sed -i '' \
+  's|wphillipmoore/standard-actions|vergil-project/vergil-actions|g' \
+  {} +
+```
+
+Also update version tags if needed (`@v1.5` → `@v2.0` once
+vergil-actions v2.0 exists).
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+This is a large file with extensive references. Perform a targeted
+replacement:
+
+```bash
+sed -i '' \
+  -e 's/standard-tooling\.toml/vergil.toml/g' \
+  -e 's/standard-tooling-docker/vergil-docker/g' \
+  -e 's/standard-tooling-plugin/vergil-claude-plugin/g' \
+  -e 's/standard-tooling/vergil-tooling/g' \
+  -e 's/standard_tooling/vergil_tooling/g' \
+  -e 's/standard-actions/vergil-actions/g' \
+  -e 's|wphillipmoore/vergil|vergil-project/vergil|g' \
+  -e 's/st-commit/vrg-commit/g' \
+  -e 's/st-validate/vrg-validate/g' \
+  -e 's/st-docker-run/vrg-docker-run/g' \
+  -e 's/st-docker-test/vrg-docker-test/g' \
+  -e 's/st-submit-pr/vrg-submit-pr/g' \
+  -e 's/st-prepare-release/vrg-prepare-release/g' \
+  -e 's/st-merge-when-green/vrg-merge-when-green/g' \
+  -e 's/st-finalize-repo/vrg-finalize-repo/g' \
+  -e 's/st-ensure-label/vrg-ensure-label/g' \
+  -e 's/ST_COMMIT_CONTEXT/VRG_COMMIT_CONTEXT/g' \
+  -e 's/`st-\*/`vrg-\*/g' \
+  CLAUDE.md
+```
+
+Review the result manually — `CLAUDE.md` has nuanced references that
+may need manual adjustment.
+
+- [ ] **Step 6: Update AGENTS.md**
+
+Same replacement pattern as CLAUDE.md.
+
+- [ ] **Step 7: Update all documentation**
+
+```bash
+find docs -name '*.md' -exec sed -i '' \
+  -e 's/standard-tooling\.toml/vergil.toml/g' \
+  -e 's/standard-tooling-docker/vergil-docker/g' \
+  -e 's/standard-tooling-plugin/vergil-claude-plugin/g' \
+  -e 's/standard-tooling/vergil-tooling/g' \
+  -e 's/standard_tooling/vergil_tooling/g' \
+  -e 's/standard-actions/vergil-actions/g' \
+  -e 's|wphillipmoore/vergil|vergil-project/vergil|g' \
+  -e 's/st-commit/vrg-commit/g' \
+  -e 's/st-validate/vrg-validate/g' \
+  -e 's/st-docker-run/vrg-docker-run/g' \
+  -e 's/st-docker-test/vrg-docker-test/g' \
+  -e 's/st-submit-pr/vrg-submit-pr/g' \
+  -e 's/st-prepare-release/vrg-prepare-release/g' \
+  -e 's/st-merge-when-green/vrg-merge-when-green/g' \
+  -e 's/st-finalize-repo/vrg-finalize-repo/g' \
+  -e 's/st-ensure-label/vrg-ensure-label/g' \
+  -e 's/ST_COMMIT_CONTEXT/VRG_COMMIT_CONTEXT/g' \
+  {} +
+```
+
+- [ ] **Step 8: Final grep for any remaining old references**
+
+```bash
+grep -rn "standard-tooling\|standard_tooling\|standard-actions\|wphillipmoore\|st-commit\|st-validate\|st-docker\|ST_COMMIT" \
+  --include="*.py" --include="*.md" --include="*.toml" \
+  --include="*.yml" --include="*.yaml" --include="*.json" \
+  --include="*.sh" . \
+  | grep -v CHANGELOG.md | grep -v releases/ | grep -v .git/
+```
+
+Expected: Zero matches outside of historical files (CHANGELOG, release
+notes). Fix any remaining references.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+```
+
+Commit message: `refactor!: update config, hooks, docs, and workflows for vergil rename`
+
+---
+
+## Task 9: vergil-tooling — Validate and Release v2.0.0
+
+- [ ] **Step 1: Install dev dependencies**
+
+```bash
+UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+export PATH="$(pwd)/.venv-host/bin:$PATH"
+```
+
+- [ ] **Step 2: Run validation**
+
+```bash
+vrg-docker-run -- uv run vrg-validate
+```
+
+If this fails because the host tools are still named `st-*`, use the
+dev-tree override:
+
+```bash
+python -m vergil_tooling.bin.vrg_docker_run -- uv run python -m vergil_tooling.bin.vrg_validate
+```
+
+Or simply run tests directly:
+
+```bash
+uv run pytest tests/ -v
+```
+
+- [ ] **Step 3: Fix any test failures**
+
+Tests may fail due to:
+- Hardcoded `standard_tooling` or `st-*` references in test fixtures
+- Mock paths referencing old module names
+- Config file name expectations
+
+Fix each failure, re-run until green.
+
+- [ ] **Step 4: Run linting and type checking**
+
+```bash
+uv run ruff check src/ tests/
+uv run mypy src/
+```
+
+Fix any issues.
+
+- [ ] **Step 5: Commit fixes if any**
+
+```bash
+git add -A
+```
+
+Commit message: `fix: resolve test and lint failures from vergil rename`
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+git push -u origin release/2.0.0
+```
+
+Open PR, wait for CI. Note: CI uses the setup action from
+vergil-actions which now reads `vergil.toml` — if the action was
+released correctly in Task 3, this should work.
+
+- [ ] **Step 7: Iterate on failures**
+
+If CI fails, fix issues, commit, push. Each fix increments the
+potential patch level (v2.0.1, v2.0.2, ...).
+
+- [ ] **Step 8: Merge and release**
+
+After CI passes, merge. Follow the repo's release workflow to create
+the `v2.0.0` tag (or `v2.0.x` if patches were needed).
+
+---
+
+## Task 10: vergil-claude-plugin — Transfer, Rename, Update, and Release
+
+**Repo:** `wphillipmoore/standard-tooling-plugin` →
+`vergil-project/vergil-claude-plugin`
+
+- [ ] **Step 1: Transfer and rename**
+
+```bash
+gh api repos/wphillipmoore/standard-tooling-plugin/transfer \
+  -f new_owner=vergil-project --silent
+```
+
+Wait, then:
+
+```bash
+gh repo rename vergil-claude-plugin --repo vergil-project/standard-tooling-plugin --yes
+```
+
+Verify:
+
+```bash
+gh repo view vergil-project/vergil-claude-plugin --json nameWithOwner --jq '.nameWithOwner'
+```
+
+- [ ] **Step 2: Clone fresh and create release branch**
+
+```bash
+cd ~/dev/github
+git clone git@github.com:vergil-project/vergil-claude-plugin.git
+cd vergil-claude-plugin
+git checkout -b release/2.0.0
+```
+
+- [ ] **Step 3: Update plugin.json**
+
+In `.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "vergil",
+  "description": "VERGIL — shared hooks, skills, agents, and commands for all managed repositories.",
+  "version": "2.0.0",
+  "author": {
+    "name": "vergil-project"
+  },
+  "repository": "https://github.com/vergil-project/vergil-claude-plugin",
+  "license": "MIT"
+}
+```
+
+This changes the skill namespace from `standard-tooling:*` to
+`vergil:*` (e.g., `vergil:publish`, `vergil:handoff`).
+
+- [ ] **Step 4: Update marketplace.json**
+
+In `.claude-plugin/marketplace.json`, update the name, description,
+and repository URL to match.
+
+- [ ] **Step 5: Update all skill files**
+
+```bash
+find skills -name 'SKILL.md' -exec sed -i '' \
+  -e 's/standard-tooling\.toml/vergil.toml/g' \
+  -e 's/standard-tooling-plugin/vergil-claude-plugin/g' \
+  -e 's/standard-tooling/vergil-tooling/g' \
+  -e 's/standard_tooling/vergil_tooling/g' \
+  -e 's/standard-actions/vergil-actions/g' \
+  -e 's|wphillipmoore/vergil|vergil-project/vergil|g' \
+  -e 's/st-commit/vrg-commit/g' \
+  -e 's/st-validate/vrg-validate/g' \
+  -e 's/st-docker-run/vrg-docker-run/g' \
+  -e 's/st-submit-pr/vrg-submit-pr/g' \
+  -e 's/st-prepare-release/vrg-prepare-release/g' \
+  -e 's/st-merge-when-green/vrg-merge-when-green/g' \
+  -e 's/st-finalize-repo/vrg-finalize-repo/g' \
+  -e 's/ST_COMMIT_CONTEXT/VRG_COMMIT_CONTEXT/g' \
+  {} +
+```
+
+Review each skill file — skills may reference specific command names
+or config paths in their instructions.
+
+- [ ] **Step 6: Update hook scripts**
+
+```bash
+find hooks -name '*.sh' -o -name '*.json' | xargs sed -i '' \
+  -e 's/standard-tooling\.toml/vergil.toml/g' \
+  -e 's/standard-tooling/vergil-tooling/g' \
+  -e 's/st-commit/vrg-commit/g' \
+  -e 's/ST_COMMIT_CONTEXT/VRG_COMMIT_CONTEXT/g' \
+  2>/dev/null
+```
+
+Also check `hooks/scripts/lib/managed-repo-check.sh` — this may
+detect managed repos by looking for `standard-tooling.toml`.
+
+- [ ] **Step 7: Update pre-commit hook, config, docs, workflows**
+
+- `.githooks/pre-commit`: `st-commit` → `vrg-commit`,
+  `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`
+- `git mv standard-tooling.toml vergil.toml` and update contents
+- Update `CLAUDE.md`, `AGENTS.md`, `README.md`, all `docs/` files
+- Update `.github/workflows/*.yml`: `wphillipmoore/standard-actions` →
+  `vergil-project/vergil-actions`
+
+- [ ] **Step 8: Verify no old references remain**
+
+```bash
+grep -rn "standard-tooling\|standard_tooling\|wphillipmoore\|st-commit\|st-validate\|ST_COMMIT" \
+  --include="*.md" --include="*.toml" --include="*.yml" \
+  --include="*.json" --include="*.sh" . \
+  | grep -v CHANGELOG.md | grep -v releases/
+```
+
+Expected: Zero matches.
+
+- [ ] **Step 9: Commit, push, PR, merge, release v2.0.0**
+
+Commit message: `feat!: rename to vergil-claude-plugin under vergil-project org`
+
+---
+
+## Task 11: Consumer Sweep
+
+**Phase 2 checkpoint:** All four core repos must be stable and
+released at v2.0.x before starting this task.
+
+For each consumer repo in the manifest below, apply the following
+template. The repos can be processed in any order.
+
+### Consumer repo manifest
+
+| Repository | Notes |
+|---|---|
+| `ai-research-methodology` | Future Diogenes rename candidate |
+| `career-strategy` | |
+| `cognition` | |
+| `home-equity-project` | |
+| `lunatick-racing` | |
+| `mempalace` | |
+| `mnemosys-core` | |
+| `mnemosys-ios` | |
+| `mnemosys-operations` | |
+| `mq-rest-admin-common` | |
+| `mq-rest-admin-dev-environment` | |
+| `mq-rest-admin-go` | |
+| `mq-rest-admin-java` | |
+| `mq-rest-admin-python` | |
+| `mq-rest-admin-ruby` | |
+| `mq-rest-admin-rust` | |
+| `paad` | Claude Code plugin — check skill namespace refs |
+| `the-infrastructure-mindset` | |
+| `renegade-dotfiles` | Verify if it consumes vergil |
+
+### Template — per consumer repo
+
+For each repo `$REPO`:
+
+- [ ] **Step A: Clone or update**
+
+```bash
+cd ~/dev/github/$REPO
+git fetch origin
+git checkout develop  # or main, depending on repo
+git pull
+```
+
+- [ ] **Step B: Create branch**
+
+```bash
+git checkout -b chore/vergil-rename
+```
+
+- [ ] **Step C: Rename config file**
+
+```bash
+git mv standard-tooling.toml vergil.toml
+```
+
+- [ ] **Step D: Update vergil.toml**
+
+Update `[dependencies]`:
+- `standard-tooling = "v1.x"` → `vergil = "v2.0"`
+
+Update `[publish] consumer-refresh` if present:
+- Package name: `standard-tooling` → `vergil-tooling`
+- GitHub org: `wphillipmoore` → `vergil-project`
+- Repo name: `standard-tooling` → `vergil-tooling`
+
+- [ ] **Step E: Update pre-commit hook**
+
+In `.githooks/pre-commit`:
+- `st-commit` → `vrg-commit`
+- `ST_COMMIT_CONTEXT` → `VRG_COMMIT_CONTEXT`
+- `standard_tooling` → `vergil_tooling` (comment references)
+
+- [ ] **Step F: Update workflow files**
+
+```bash
+find .github/workflows -name '*.yml' -exec sed -i '' \
+  -e 's|wphillipmoore/standard-actions|vergil-project/vergil-actions|g' \
+  -e 's|ghcr.io/wphillipmoore|ghcr.io/vergil-project|g' \
+  {} +
+```
+
+Also update version tags: `@v1.x` → `@v2.0`.
+
+- [ ] **Step G: Update CLAUDE.md / AGENTS.md**
+
+Replace references to `standard-tooling`, `st-*` commands, and
+`wphillipmoore` org with the new names. Each repo's CLAUDE.md is
+different — review manually after sed.
+
+- [ ] **Step H: Update any other references**
+
+```bash
+grep -rn "standard-tooling\|st-commit\|st-validate\|st-docker\|wphillipmoore" \
+  --include="*.md" --include="*.toml" --include="*.yml" \
+  --include="*.yaml" --include="*.json" --include="*.sh" . \
+  | grep -v CHANGELOG | grep -v releases/
+```
+
+Fix any remaining references.
+
+- [ ] **Step I: Commit, push, open PR**
+
+Commit message: `chore: update references for vergil rename`
+
+Push, open PR, wait for CI.
+
+- [ ] **Step J: Merge and release**
+
+After CI passes, merge. Create a minor version release (1.x → 1.x+1).
+
+---
+
+## Task 12: Final Verification and Local Cleanup
+
+- [ ] **Step 1: Verify all releases**
+
+For each of the four core repos, confirm the release exists and
+artifacts are correct:
+
+```bash
+for repo in vergil-docker vergil-actions vergil-tooling vergil-claude-plugin; do
+  echo "=== $repo ==="
+  gh release list --repo "vergil-project/$repo" --limit 1
+done
+```
+
+- [ ] **Step 2: Verify consumer releases**
+
+For each consumer repo, confirm the minor version release exists:
+
+```bash
+gh repo list wphillipmoore --limit 100 --json name,isArchived \
+  --jq '.[] | select(.isArchived == false) | .name' \
+  | while read -r repo; do
+    echo "=== $repo ==="
+    gh release list --repo "wphillipmoore/$repo" --limit 1 2>/dev/null
+  done
+```
+
+- [ ] **Step 3: Verify host tool installation**
+
+```bash
+uv tool install --python 3.14 \
+  'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v2.0'
+```
+
+Verify the tools are available:
+
+```bash
+which vrg-commit vrg-validate vrg-docker-run
+```
+
+- [ ] **Step 4: Update local git remotes**
+
+For each local clone that still points at `wphillipmoore`:
+
+```bash
+cd ~/dev/github/standard-tooling
+git remote set-url origin git@github.com:vergil-project/vergil-tooling.git
+
+# Repeat for each repo:
+cd ~/dev/github/standard-actions  # or wherever cloned
+git remote set-url origin git@github.com:vergil-project/vergil-actions.git
+# etc.
+```
+
+- [ ] **Step 5: Update Claude Code plugin installation**
+
+Re-install the plugin from the new location. The exact mechanism
+depends on how the plugin is registered in Claude Code — update the
+plugin source URL from `wphillipmoore/standard-tooling-plugin` to
+`vergil-project/vergil-claude-plugin`.
+
+- [ ] **Step 6: Smoke test end-to-end**
+
+Pick one consumer repo and verify the full workflow:
+
+```bash
+cd ~/dev/github/<consumer-repo>
+vrg-docker-run -- uv run vrg-validate  # or language-appropriate command
+```
+
+This proves: host tools installed correctly, config file parsed,
+docker images pulled from new GHCR scope, validation runs.
+
+- [ ] **Step 7: Clean up old GHCR images (optional, deferred)**
+
+Old images at `ghcr.io/wphillipmoore/*` can be removed once all
+consumers are verified. This is optional and can be done later.

--- a/paad/alignment-reviews/2026-05-11-vergil-rename-alignment.md
+++ b/paad/alignment-reviews/2026-05-11-vergil-rename-alignment.md
@@ -1,0 +1,109 @@
+# Alignment Review: VERGIL Rename
+
+**Date:** 2026-05-11
+**Commit:** e47c5e6 (pre-fix baseline; plan updated in same commit as this report)
+
+## Documents Reviewed
+
+- **Intent:** `docs/specs/2026-05-11-vergil-rename-design.md`
+- **Action:** `docs/plans/2026-05-11-vergil-rename.md`
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. The recent docker
+image-prefix refactor (`feat(docker): make image prefix configurable`)
+is consistent with the design spec, which notes `[docker] image-prefix`
+needs no rename.
+
+## Issues Reviewed
+
+### [1] Dependency key vs. project name — sed patterns can't distinguish them
+
+- **Category:** Missing coverage
+- **Severity:** Critical
+- **Documents:** Design spec "Config file" section, Plan Tasks 7-8
+- **Issue:** The design spec defines two rename targets using
+  "standard-tooling": the *package name* (`standard-tooling` →
+  `vergil-tooling`) and the *TOML dependency key* (`standard-tooling`
+  → `vergil`). The plan's blanket sed `s/standard-tooling/vergil-tooling/g`
+  would produce `vergil-tooling = "v1.4"` in test fixtures when the
+  correct value is `vergil = "v2.0"`. Affected files: `test_config.py`
+  (10+ refs), `test_docker_cache.py` (20+ refs).
+- **Resolution:** Accepted. Added a new Task 7 Step 4 with targeted
+  replacements for dependency-key patterns (`standard-tooling = "v1.4"`
+  → `vergil = "v2.0"`, `dependencies["standard-tooling"]` →
+  `dependencies["vergil"]`) that must run before the blanket
+  project-name pattern.
+
+### [2] Env var and function renames missing from test-targeted sed
+
+- **Category:** Missing coverage
+- **Severity:** Important
+- **Documents:** Design spec "Environment variables" section, Plan Tasks 6-7
+- **Issue:** Plan renames `ST_COMMIT_CONTEXT`, `ST_DOCKER_INSTALL_TAG`,
+  and `st_install_tag` in source code (Task 6) but not in test files.
+  The test-targeting sed (Task 7 Step 4, now Step 5) only handled
+  command names. Files affected: `test_pre_commit_gate.py` (10 refs),
+  `test_git.py` (7 refs), `test_config.py` (6 `st_install_tag` refs +
+  2 `ST_DOCKER_INSTALL_TAG` refs), `test_st_commit.py` (1 ref).
+- **Resolution:** Accepted. Added `ST_COMMIT_CONTEXT`,
+  `ST_DOCKER_INSTALL_TAG`, and `st_install_tag` patterns to the
+  lib/test sed command (now Task 7 Step 5) and the verification grep
+  (now Task 7 Step 6).
+
+### [3] `pyproject.toml` package-data section not addressed
+
+- **Category:** Missing coverage
+- **Severity:** Important
+- **Documents:** Design spec "Python package" section, Plan Task 5
+- **Issue:** `pyproject.toml` line 41 has
+  `standard_tooling = ["data/*.json", ...]` under
+  `[tool.setuptools.package-data]`. Plan updated `[project]` and
+  `[project.scripts]` but not this section.
+- **Resolution:** Accepted. Added `[tool.setuptools.package-data]`
+  update to Task 5 Step 3.
+
+### [4] `v2.0` tracking tag missing from most repo release tasks
+
+- **Category:** Missing coverage
+- **Severity:** Important
+- **Documents:** Design spec "Versioning" section, Plan Tasks 2, 9, 10
+- **Issue:** Only Task 3 (vergil-actions) mentions the `v2.0` tracking
+  tag. Tasks 2, 9, and 10 only reference `v2.0.0`.
+- **Resolution:** Dismissed — the release workflow's CD pipeline
+  creates tracking tags automatically. No plan change needed.
+
+### [5] Plugin namespace verification missing
+
+- **Category:** Missing coverage
+- **Severity:** Important
+- **Documents:** Design spec "Risks → Claude Code plugin namespace",
+  Plan Task 10
+- **Issue:** Design says "The plan must account for how the namespace
+  is configured and ensure skills resolve correctly under the new name."
+  Plan changed `plugin.json` name but had no verification step.
+  Consumer repos referencing `standard-tooling:publish` etc. also need
+  namespace updates.
+- **Resolution:** Accepted. Added Task 10 Step 9 (namespace
+  verification) and a `standard-tooling:` grep to Task 11 Step G.
+
+### [6] `[project.co-authors]` decision point not acknowledged
+
+- **Category:** Partially covered requirement
+- **Severity:** Minor
+- **Documents:** Design spec "Config file → Full field inventory",
+  Plan Task 8
+- **Issue:** Design flags bot account names as a decision point. Plan
+  was silent, making the decision implicit rather than explicit.
+- **Resolution:** Accepted. Added a note to Task 8 Step 2 confirming
+  co-author names stay as-is.
+
+## Unresolved Issues
+
+None — all issues were addressed or dismissed with rationale.
+
+## Alignment Summary
+
+- **Requirements:** 14 identified, 14 covered (6 gaps found and fixed)
+- **Tasks:** 12 tasks, all in scope, no orphaned tasks
+- **Status:** Aligned after fixes applied

--- a/paad/pushback-reviews/2026-05-11-vergil-rename-design-pushback.md
+++ b/paad/pushback-reviews/2026-05-11-vergil-rename-design-pushback.md
@@ -1,0 +1,104 @@
+# Pushback Review: VERGIL Rename Design
+
+**Date:** 2026-05-11
+**Spec:** `docs/specs/2026-05-11-vergil-rename-design.md`
+**Commit:** 169e3729d392215f409aea2cacdbf8ebfa4c94fe
+
+## Source Control Conflicts
+
+One conflict: PR #708 (`feature/706-docker-image-prefix`, merged within
+the last 2 weeks) added a `[docker] image-prefix` field to
+`standard-tooling.toml` and hardcoded `ghcr.io/wphillipmoore` in
+`src/standard_tooling/lib/docker.py`. The spec's config file section
+did not account for the `[docker]` section or the hardcoded GHCR prefix.
+Addressed in issue [1] below.
+
+## Issues Reviewed
+
+### [1] GHCR container registry migration missing entirely
+
+- **Category:** Omission
+- **Severity:** Critical
+- **Issue:** The spec covered GitHub repo renames, Python package
+  renaming, CLI prefix changes, env vars, and config files — but never
+  mentioned container images. `docker.py` hardcodes
+  `_GHCR = "ghcr.io/wphillipmoore"`, used by `st-docker-run` and
+  `st-docker-docs`. GHCR packages are org-scoped and don't move with
+  repo transfers. Without re-publishing images to
+  `ghcr.io/vergil-project/*`, the entire validation pipeline breaks
+  fleet-wide.
+- **Resolution:** Add a Container Registry section covering
+  re-publishing images, updating the `_GHCR` constant, and maintaining
+  dual-availability during the consumer sweep window.
+
+### [2] Plugin namespace flagged as risk with no mitigation
+
+- **Category:** Ambiguity
+- **Severity:** Serious
+- **Issue:** The Risks section identified that `standard-tooling:*`
+  skill names would break but provided no concrete plan for how the
+  namespace is configured or what needs to change.
+- **Resolution:** Accepted as-is. No external users exist — hard
+  cutover is fine. Plugin skill breakage during the rename window is
+  an acceptable cost handled ad hoc by the engineer and AI agents.
+
+### [3] Config file scope understates what changes
+
+- **Category:** Omission
+- **Severity:** Serious
+- **Issue:** The config section only described the filename rename and
+  `[dependencies]` key change. The actual config file also contains
+  `[publish] consumer-refresh` (with hardcoded GitHub URL and package
+  name), `[docker]` (from recently merged #706), and
+  `[project.co-authors]` (with `wphillipmoore-*` bot accounts).
+  Executors following the spec literally would miss these fields.
+- **Resolution:** Expand into a full field inventory table listing
+  every section/field containing an old name.
+
+### [4] Consumer repo inventory is vague
+
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** "~10-12 consumer repos" is too vague for an execution
+  plan requiring every repo to complete a successful release. Without
+  an exact manifest, a forgotten repo keeps referencing old names
+  indefinitely.
+- **Resolution:** Add Appendix A listing all consumer repos by name
+  with notes, generated from `gh repo list` and verified before
+  execution day.
+
+### [5] Execution window is ambitious
+
+- **Category:** Feasibility
+- **Severity:** Moderate
+- **Issue:** 4 sequential core repo releases + 10-12 consumer repo
+  releases in "one morning/day" is aggressive. Core repos are
+  sequential (dependency chain), each blocking on CI (~5-8 min).
+  If the morning target slips, the fleet stays frozen in a
+  partially-migrated state.
+- **Resolution:** Add a Phase 1 / Phase 2 checkpoint. Phase 1 (core
+  repos) must complete before breaking. Phase 2 (consumer sweep) can
+  resume in a separate window. Images remain available at both GHCR
+  paths during the gap.
+
+### [6] v2.0 semver commitment — rename-only scope
+
+- **Category:** Ambiguity
+- **Severity:** Minor
+- **Issue:** The spec bumps to v2.0.0 but doesn't state whether the
+  rename is the only breaking change, leaving the door open for
+  unrelated breaks to creep in during execution.
+- **Resolution:** Add a one-liner scoping v2.0 to the rename.
+  Execution-time fixes may introduce additional breaks as needed,
+  but no unrelated breaking changes are bundled intentionally.
+
+## Unresolved Issues
+
+None — all issues were addressed.
+
+## Summary
+
+- **Issues found:** 6
+- **Issues resolved:** 6
+- **Unresolved:** 0
+- **Spec status:** Updated and ready for implementation planning


### PR DESCRIPTION
# Pull Request

## Summary

- Alignment review of the rename plan against the design spec, with six fixes applied

## Issue Linkage

- Ref #551

## Notes

- Alignment review of the VERGIL rename plan against its design spec.

## Changes

**Plan fixes** (`docs/plans/2026-05-11-vergil-rename.md`):

1. **Dependency-key vs. project-name sed ordering** (Task 7) — added a
   new Step 4 with targeted replacements for TOML dependency-key
   patterns (`standard-tooling` → `vergil`, not `vergil-tooling`) that
   must run before the blanket project-name pattern.
2. **Env var and function renames in tests** (Task 7) — added
   `ST_COMMIT_CONTEXT`, `ST_DOCKER_INSTALL_TAG`, and `st_install_tag`
   to the test-targeting sed and verification grep.
3. **`pyproject.toml` package-data** (Task 5) — added
   `[tool.setuptools.package-data]` section update.
4. **Plugin namespace verification** (Task 10) — added a verification
   step for `vergil:*` skill resolution after the plugin rename.
5. **Co-authors decision** (Task 8) — added explicit note confirming
   bot account names stay as-is.
6. **Consumer sweep namespace grep** (Task 11) — added
   `standard-tooling:` → `vergil:` check to Step G.

**Alignment report** (`paad/alignment-reviews/2026-05-11-vergil-rename-alignment.md`):

Full alignment review covering all six issues found, their severity,
resolution, and rationale. One issue (v2.0 tracking tag) was dismissed
because the release workflow handles it automatically.