### PR TITLE
docs: add VERGIL org governance design spec and implementation plan

### DIFF
--- a/docs/plans/2026-05-11-org-governance-setup.md
+++ b/docs/plans/2026-05-11-org-governance-setup.md
@@ -1,0 +1,1005 @@
+# VERGIL Org Governance Setup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Set up the `vergil-project` GitHub org with the full governance
+model (identity separation, branch protection, credential management,
+tooling) so that the VERGIL migration (separate plan) can proceed into a
+properly configured org.
+
+**Architecture:** Three-phase approach — manual infrastructure setup
+(accounts, org, credentials), codebase preparation (remove escape hatches,
+consolidate co-author config), and post-migration governance activation
+(org-level rulesets, verification). The codebase changes are small and
+testable; the manual setup is scripted via `gh` CLI where possible.
+
+**Tech Stack:** GitHub API via `gh` CLI, Python (standard-tooling
+codebase), macOS Keychain via `security` CLI, GitHub Apps (JWT/PyJWT)
+
+**Spec:** `docs/specs/2026-05-11-org-governance-design.md`
+
+**Relationship to VERGIL rename plan:** This plan is Plan A (org setup).
+The existing rename plan (`docs/plans/2026-05-11-vergil-rename.md`) is
+Plan B (migration). Plan A must complete through Task 9 before Plan B
+begins. Tasks 10–14 execute after Plan B completes.
+
+**Task ordering within Phase 1:** Tasks 1 and 4 must complete before
+Task 2 (PATs require the org to exist and the agent account to be
+created). Task 2 must complete before Task 3 (Keychain storage needs
+the PAT values). Task 6 requires the org to exist (Task 4).
+
+---
+
+## Phase 1: Manual Infrastructure Setup
+
+These tasks are performed once, mostly via the GitHub web UI and `gh`
+CLI. They establish the identities, credentials, and org that the rest
+of the plan depends on.
+
+### Task 1: Create `wphillipmoore-agent` GitHub Account
+
+**Files:** None (GitHub web UI)
+
+This replaces the per-harness accounts (`wphillipmoore-claude`,
+`wphillipmoore-codex`) with a single agent identity.
+
+- [ ] **Step 1: Create the GitHub account**
+
+  Go to <https://github.com/signup>. Create account:
+  - Username: `wphillipmoore-agent`
+  - Email: a dedicated email address (not your primary)
+  - The account must have a profile that identifies it as an AI agent
+    identity belonging to you
+
+- [ ] **Step 2: Configure the account profile**
+
+  Set the profile bio to indicate this is an AI agent identity:
+  - Name: `wphillipmoore-agent`
+  - Bio: "AI agent identity for @wphillipmoore"
+  - No avatar needed — the default is fine
+
+- [ ] **Step 3: Enable 2FA on the account**
+
+  Go to Settings → Password and authentication → Enable two-factor
+  authentication. Use your authenticator app.
+
+- [ ] **Step 4: Verify the account exists**
+
+  ```bash
+  gh api users/wphillipmoore-agent --jq '.login'
+  ```
+
+  Expected: `wphillipmoore-agent`
+
+- [ ] **Step 5: Note the GitHub-assigned noreply email**
+
+  ```bash
+  gh api users/wphillipmoore-agent --jq '.id'
+  ```
+
+  The noreply email will be:
+  `<ID>+wphillipmoore-agent@users.noreply.github.com`
+
+  Record this — it is needed for the co-author trailer in Task 6.
+
+### Task 2: Generate Fine-Grained PATs
+
+**Files:** None (GitHub web UI)
+
+Two PATs: one for the human identity, one for the agent identity.
+
+- [ ] **Step 1: Generate the human PAT**
+
+  Go to <https://github.com/settings/personal-access-tokens/new>
+  (logged in as `wphillipmoore`).
+
+  - Token name: `vergil-human`
+  - Expiration: 1 year (maximum for fine-grained)
+  - Resource owner: `vergil-project` (once the org exists — do this
+    step after Task 3)
+  - Repository access: All repositories
+  - Permissions:
+    - Administration: Read and write
+    - Contents: Read and write
+    - Issues: Read and write
+    - Pull requests: Read and write
+    - Actions: Read and write
+    - Metadata: Read (auto-granted)
+
+  Copy the token value.
+
+- [ ] **Step 2: Generate the agent PAT**
+
+  Go to <https://github.com/settings/personal-access-tokens/new>
+  (logged in as `wphillipmoore-agent`).
+
+  - Token name: `vergil-agent`
+  - Expiration: 1 year
+  - Resource owner: `vergil-project` (once the org exists and the
+    agent account is invited — do this step after Task 4)
+  - Repository access: All repositories
+  - Permissions:
+    - Contents: Read and write
+    - Issues: Read and write
+    - Pull requests: Read and write
+    - Metadata: Read (auto-granted)
+  - **Not granted:** Administration, Actions, org settings, secrets,
+    deployments
+
+  Copy the token value.
+
+- [ ] **Step 3: Verify PAT scopes are correct**
+
+  For each token, verify it can only do what it should:
+
+  ```bash
+  # Human PAT — should succeed
+  GH_TOKEN=<human-pat> gh api user --jq '.login'
+  # Expected: wphillipmoore
+
+  # Agent PAT — should succeed
+  GH_TOKEN=<agent-pat> gh api user --jq '.login'
+  # Expected: wphillipmoore-agent
+  ```
+
+### Task 3: Store Credentials in macOS Keychain
+
+**Files:** None (macOS Keychain)
+
+- [ ] **Step 1: Store the human PAT**
+
+  ```bash
+  security add-generic-password \
+    -a "vergil" \
+    -s "vergil/human-pat" \
+    -w "<paste-human-pat-here>" \
+    -T "" \
+    -U
+  ```
+
+- [ ] **Step 2: Store the agent PAT**
+
+  ```bash
+  security add-generic-password \
+    -a "vergil" \
+    -s "vergil/agent-pat" \
+    -w "<paste-agent-pat-here>" \
+    -T "" \
+    -U
+  ```
+
+- [ ] **Step 3: Verify retrieval**
+
+  ```bash
+  security find-generic-password -s "vergil/human-pat" -w
+  security find-generic-password -s "vergil/agent-pat" -w
+  ```
+
+  Each should print the stored token.
+
+- [ ] **Step 4: Remove the global GH_TOKEN export**
+
+  Remove any `export GH_TOKEN=...` from your shell profile
+  (`~/.zshrc`, `~/.zprofile`, etc.). Verify:
+
+  ```bash
+  source ~/.zshrc && echo "${GH_TOKEN:-not set}"
+  ```
+
+  Expected: `not set`
+
+  **Note:** After this step, raw `gh` commands will fall back to
+  `gh auth login` state. The Vergil tooling will retrieve tokens from
+  the Keychain. This is the transitional state — full credential
+  integration happens in a later plan.
+
+### Task 4: Create `vergil-project` GitHub Org
+
+**Files:** None (GitHub web UI)
+
+- [ ] **Step 1: Create the org**
+
+  Go to <https://github.com/organizations/plan>
+  - Plan: Free
+  - Org name: `vergil-project`
+  - Contact email: your GitHub email
+  - Owner: your personal account (`wphillipmoore`)
+
+- [ ] **Step 2: Verify org creation**
+
+  ```bash
+  gh api orgs/vergil-project --jq '.login'
+  ```
+
+  Expected: `vergil-project`
+
+- [ ] **Step 3: Invite `wphillipmoore-agent` as outside collaborator**
+
+  This cannot be done until repos exist in the org. Record this as a
+  post-migration step — after repos are transferred, invite the agent
+  account as an outside collaborator with Write access to each repo.
+
+### Task 5: Configure Org Security Settings
+
+**Files:** None (`gh` CLI)
+
+- [ ] **Step 1: Require 2FA for all org members**
+
+  ```bash
+  gh api orgs/vergil-project \
+    -X PATCH \
+    -f two_factor_requirement_enabled=true
+  ```
+
+- [ ] **Step 2: Set default repository permission to Write**
+
+  ```bash
+  gh api orgs/vergil-project \
+    -X PATCH \
+    -f default_repository_permission=write
+  ```
+
+- [ ] **Step 3: Disable forking of private repos**
+
+  ```bash
+  gh api orgs/vergil-project \
+    -X PATCH \
+    -F members_can_fork_private_repositories=false
+  ```
+
+- [ ] **Step 4: Verify settings**
+
+  ```bash
+  gh api orgs/vergil-project \
+    --jq '{two_factor: .two_factor_requirement_enabled, default_perm: .default_repository_permission, fork_private: .members_can_fork_private_repositories}'
+  ```
+
+  Expected:
+  ```json
+  {
+    "two_factor": true,
+    "default_perm": "write",
+    "fork_private": false
+  }
+  ```
+
+### Task 6: Register `vergil-release` GitHub App
+
+**Files:** None (GitHub web UI + Keychain)
+
+- [ ] **Step 1: Register the App**
+
+  Go to <https://github.com/organizations/vergil-project/settings/apps/new>
+
+  - App name: `vergil-release`
+  - Homepage URL: `https://github.com/vergil-project`
+  - Webhook: uncheck "Active" (not needed)
+  - Permissions:
+    - Repository permissions:
+      - Contents: Read and write
+      - Pull requests: Read and write
+      - Metadata: Read-only
+    - No organization permissions
+    - No account permissions
+  - Where can this app be installed: Only on this account
+
+- [ ] **Step 2: Generate a private key**
+
+  On the App settings page, under "Private keys", click
+  "Generate a private key". Download the `.pem` file.
+
+- [ ] **Step 3: Store the App private key and ID in Keychain**
+
+  ```bash
+  # Store the App ID (visible on the App settings page)
+  security add-generic-password \
+    -a "vergil" \
+    -s "vergil/app-id" \
+    -w "<app-id>" \
+    -T "" \
+    -U
+
+  # Store the private key (read from the downloaded .pem file)
+  security add-generic-password \
+    -a "vergil" \
+    -s "vergil/app-private-key" \
+    -w "$(cat /path/to/downloaded-key.pem)" \
+    -T "" \
+    -U
+  ```
+
+- [ ] **Step 4: Install the App on the org**
+
+  Go to the App settings page → "Install App" → Install on
+  `vergil-project` → All repositories.
+
+- [ ] **Step 5: Verify the installation**
+
+  ```bash
+  gh api orgs/vergil-project/installations --jq '.[].app_slug'
+  ```
+
+  Expected: `vergil-release`
+
+- [ ] **Step 6: Delete the downloaded `.pem` file**
+
+  ```bash
+  rm /path/to/downloaded-key.pem
+  ```
+
+  The key is now stored in the Keychain only.
+
+---
+
+## Phase 2: Codebase Preparation
+
+These tasks modify the standard-tooling codebase before the migration.
+They are developed on a feature branch, submitted as a PR, and merged
+to `develop` through the normal workflow. All changes are TDD.
+
+### Task 7: Remove `skip_rulesets` Escape Hatch
+
+**Files:**
+- Modify: `src/standard_tooling/lib/config.py:62-63,143-146`
+- Modify: `src/standard_tooling/lib/github_config.py:310-313`
+- Modify: `tests/standard_tooling/test_config.py:264-282`
+- Modify: `tests/standard_tooling/test_github_config_lib.py:300-330`
+- Modify: `docs/specs/standard-tooling-toml.md` (remove `[github]`
+  section docs)
+
+- [ ] **Step 1: Update tests — remove skip_rulesets test cases**
+
+  In `tests/standard_tooling/test_config.py`, remove:
+  - The `_GITHUB_OVERRIDE_TOML` fixture (lines 264-270)
+  - `test_read_config_github_overrides` (lines 273-276)
+  - Update `test_read_config_no_github_section` (lines 279-282) —
+    this test should still pass but the assertion changes since
+    `GithubOverrides` will no longer exist
+
+  In `tests/standard_tooling/test_github_config_lib.py`, remove:
+  - The `skip_rulesets` parameter from the `_st_config` helper
+    (line 306)
+  - `test_compute_desired_state_skip_rulesets` (lines 328-330)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+  ```bash
+  st-docker-run -- uv run pytest tests/standard_tooling/test_config.py -v
+  st-docker-run -- uv run pytest tests/standard_tooling/test_github_config_lib.py -v
+  ```
+
+  Expected: compilation/import errors from removed test fixtures
+
+- [ ] **Step 3: Remove `GithubOverrides` dataclass from config.py**
+
+  In `src/standard_tooling/lib/config.py`:
+
+  Remove the `GithubOverrides` dataclass (lines 62-63):
+  ```python
+  # DELETE:
+  @dataclass
+  class GithubOverrides:
+      skip_rulesets: bool
+  ```
+
+  Remove the `[github]` parsing (lines 143-146):
+  ```python
+  # DELETE:
+  github_raw = raw.get("github", {})
+  github_overrides = GithubOverrides(
+      skip_rulesets=bool(github_raw.get("skip-rulesets", False)),
+  )
+  ```
+
+  Remove the `github` field from `StConfig` dataclass and its
+  assignment in the constructor.
+
+- [ ] **Step 4: Remove skip_rulesets check from github_config.py**
+
+  In `src/standard_tooling/lib/github_config.py`, change lines
+  310-313 from:
+
+  ```python
+  if not config.github.skip_rulesets:
+      rulesets.append(desired_branch_protection_ruleset())
+      rulesets.append(desired_tag_protection_ruleset())
+      rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
+  ```
+
+  To:
+
+  ```python
+  rulesets.append(desired_branch_protection_ruleset())
+  rulesets.append(desired_tag_protection_ruleset())
+  rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
+  ```
+
+  Rulesets are now always computed — no escape hatch.
+
+- [ ] **Step 5: Update the `_st_config` test helper**
+
+  In `tests/standard_tooling/test_github_config_lib.py`, remove the
+  `skip_rulesets` parameter and `github=GithubOverrides(...)` from
+  the `_st_config` helper. Remove the `GithubOverrides` import.
+
+- [ ] **Step 6: Run full validation**
+
+  ```bash
+  st-docker-run -- uv run st-validate
+  ```
+
+  Expected: all checks pass.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  st-commit --type refactor --scope config \
+    --message "remove skip-rulesets escape hatch" \
+    --body "The skip-rulesets override in [github] config is removed. Rulesets are now always enforced. No repo uses this override; the repo it was designed for (mq-rest-admin-template) is marked for archival." \
+    --agent claude
+  ```
+
+### Task 8: Consolidate Co-Author Config to Single Agent Entry
+
+**Files:**
+- Modify: `standard-tooling.toml:8-10`
+- Modify: `tests/standard_tooling/test_config.py` (update fixtures)
+
+This task updates the co-author configuration in standard-tooling's own
+config. Consumer repos will be updated during the migration (Plan B).
+
+- [ ] **Step 1: Update tests — change co-author fixtures**
+
+  In `tests/standard_tooling/test_config.py`, update `_BASE_TOML`
+  (line 78) from:
+
+  ```toml
+  [project.co-authors]
+  claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>"
+  ```
+
+  To:
+
+  ```toml
+  [project.co-authors]
+  agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"
+  ```
+
+  Update `test_read_config_valid` (lines 93-94) from:
+
+  ```python
+  assert "claude" in cfg.project.co_authors
+  assert "user-claude" in cfg.project.co_authors["claude"]
+  ```
+
+  To:
+
+  ```python
+  assert "agent" in cfg.project.co_authors
+  assert "user-agent" in cfg.project.co_authors["agent"]
+  ```
+
+  Update `test_read_config_malformed_co_author` (lines 125-126) to
+  use `agent` instead of `claude` in the replacement string.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+  ```bash
+  st-docker-run -- uv run pytest tests/standard_tooling/test_config.py -v
+  ```
+
+  Expected: assertion errors on co-author key names.
+
+- [ ] **Step 3: Update `standard-tooling.toml`**
+
+  Replace the co-author entries (lines 8-10) from:
+
+  ```toml
+  [project.co-authors]
+  claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
+  codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+  ```
+
+  To:
+
+  ```toml
+  [project.co-authors]
+  agent = "Co-Authored-By: wphillipmoore-agent <AGENT_ID+wphillipmoore-agent@users.noreply.github.com>"
+  ```
+
+  Replace `AGENT_ID` with the actual GitHub user ID from Task 1
+  Step 5.
+
+- [ ] **Step 4: Run full validation**
+
+  ```bash
+  st-docker-run -- uv run st-validate
+  ```
+
+  Expected: all checks pass.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  st-commit --type refactor --scope config \
+    --message "consolidate co-author config to single agent identity" \
+    --body "Replace per-harness co-author entries (claude, codex) with a single agent entry. The security boundary is human vs. not-human, not which AI tool produced the work." \
+    --agent claude
+  ```
+
+### Task 9: Update `st-commit` for Agent Flag Compatibility
+
+**Files:**
+- Modify: `src/standard_tooling/bin/st_commit.py`
+- Modify: `tests/standard_tooling/test_st_commit.py`
+
+The `--agent` flag currently accepts `claude` or `codex`. After Task 8,
+the only valid value in standard-tooling's own config is `agent`. But
+consumer repos may still use `claude`/`codex` until they migrate. The
+tool must continue to accept any value — it looks up the key in
+`[project.co-authors]`, so this is already the case. This task verifies
+that and updates any hardcoded references.
+
+- [ ] **Step 1: Verify the tool accepts arbitrary agent names**
+
+  Review `src/standard_tooling/bin/st_commit.py` to confirm the
+  `--agent` flag does not validate against a fixed set of names —
+  it should just be a string that is looked up in
+  `config.project.co_authors`.
+
+- [ ] **Step 2: Run existing tests**
+
+  ```bash
+  st-docker-run -- uv run pytest tests/standard_tooling/test_st_commit.py -v
+  ```
+
+  Expected: all pass. If any tests hardcode `claude` or `codex` as
+  the agent name, update them to use `agent`.
+
+- [ ] **Step 3: Commit (if any changes were needed)**
+
+  ```bash
+  st-commit --type refactor --scope commit \
+    --message "update st-commit tests for agent identity convention" \
+    --agent claude
+  ```
+
+---
+
+## Phase 3: Post-Migration Governance Activation
+
+These tasks execute after Plan B (the VERGIL rename/migration) is
+complete and all repos are in the `vergil-project` org.
+
+### Task 10: Invite Agent Account to Org Repos
+
+**Files:** None (`gh` CLI)
+
+- [ ] **Step 1: List all repos in the org**
+
+  ```bash
+  gh repo list vergil-project --json name --jq '.[].name'
+  ```
+
+- [ ] **Step 2: Invite `wphillipmoore-agent` as outside collaborator**
+
+  For each repo:
+
+  ```bash
+  gh api orgs/vergil-project/outside_collaborators/wphillipmoore-agent \
+    -X PUT \
+    -f permission=push
+  ```
+
+  Or, if the API requires per-repo invitations:
+
+  ```bash
+  for repo in $(gh repo list vergil-project --json name --jq '.[].name'); do
+    gh api repos/vergil-project/$repo/collaborators/wphillipmoore-agent \
+      -X PUT \
+      -f permission=push
+  done
+  ```
+
+- [ ] **Step 3: Accept the invitation**
+
+  Log in as `wphillipmoore-agent` and accept the collaboration
+  invitations, or use the API:
+
+  ```bash
+  GH_TOKEN=<agent-pat> gh api user/repository_invitations --jq '.[].id' | \
+    xargs -I{} gh api user/repository_invitations/{} -X PATCH
+  ```
+
+- [ ] **Step 4: Verify access**
+
+  ```bash
+  GH_TOKEN=<agent-pat> gh repo list vergil-project --json name --jq '.[].name'
+  ```
+
+  Expected: all repos listed.
+
+### Task 11: Configure Org-Level Rulesets
+
+**Files:** None (`gh` CLI)
+
+- [ ] **Step 1: Create the branch protection ruleset for `develop`**
+
+  ```bash
+  gh api orgs/vergil-project/rulesets \
+    -X POST \
+    --input - <<'JSON'
+  {
+    "name": "Branch protection (develop)",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+      "ref_name": {
+        "include": ["refs/heads/develop"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      { "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 1,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": true,
+          "required_review_thread_resolution": true
+        }
+      },
+      { "type": "required_status_checks",
+        "parameters": {
+          "strict_status_checks_policy": true,
+          "status_checks": []
+        }
+      },
+      { "type": "deletion" },
+      { "type": "non_fast_forward" }
+    ],
+    "bypass_actors": []
+  }
+  JSON
+  ```
+
+  **Note:** `bypass_actors: []` means no one can bypass — not even
+  org owners. The `require_last_push_approval` ensures the reviewer
+  is not the person who last pushed to the branch.
+
+  **Note:** `status_checks` is empty at the org level because CI
+  check names vary by repo. Per-repo CI gate rulesets (managed by
+  `vrg-repo-config`) handle this.
+
+- [ ] **Step 2: Create the branch protection ruleset for `main`**
+
+  ```bash
+  gh api orgs/vergil-project/rulesets \
+    -X POST \
+    --input - <<'JSON'
+  {
+    "name": "Branch protection (main)",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+      "ref_name": {
+        "include": ["refs/heads/main"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      { "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 1,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": true,
+          "required_review_thread_resolution": true
+        }
+      },
+      { "type": "required_status_checks",
+        "parameters": {
+          "strict_status_checks_policy": true,
+          "status_checks": []
+        }
+      },
+      { "type": "deletion" },
+      { "type": "non_fast_forward" }
+    ],
+    "bypass_actors": []
+  }
+  JSON
+  ```
+
+- [ ] **Step 3: Verify rulesets are active**
+
+  ```bash
+  gh api orgs/vergil-project/rulesets --jq '.[] | {name: .name, enforcement: .enforcement}'
+  ```
+
+  Expected:
+  ```json
+  {"name": "Branch protection (develop)", "enforcement": "active"}
+  {"name": "Branch protection (main)", "enforcement": "active"}
+  ```
+
+- [ ] **Step 4: Test the rulesets — verify direct push is blocked**
+
+  Pick a test repo in the org. Try to push directly to `develop`:
+
+  ```bash
+  cd <test-repo>
+  echo "test" >> /tmp/test-file
+  # Attempt a direct push via the API or git push — should be rejected
+  ```
+
+  Expected: push rejected with a message about branch protection.
+
+- [ ] **Step 5: Test the rulesets — verify PR without review is blocked**
+
+  Create a test PR and attempt to merge without approval:
+
+  ```bash
+  GH_TOKEN=<agent-pat> gh pr create \
+    --repo vergil-project/<test-repo> \
+    --title "test: verify branch protection" \
+    --body "Testing governance rulesets. Will delete." \
+    --head <test-branch> \
+    --base develop
+
+  # Attempt to merge without approval — should fail
+  GH_TOKEN=<agent-pat> gh pr merge <PR-NUMBER> \
+    --repo vergil-project/<test-repo> \
+    --merge
+  ```
+
+  Expected: merge rejected — required reviews not satisfied.
+
+- [ ] **Step 6: Test the rulesets — verify human approval enables merge**
+
+  Approve the test PR as the human, then merge:
+
+  ```bash
+  # Approve as human
+  GH_TOKEN=<human-pat> gh pr review <PR-NUMBER> \
+    --repo vergil-project/<test-repo> \
+    --approve
+
+  # Merge as human
+  GH_TOKEN=<human-pat> gh pr merge <PR-NUMBER> \
+    --repo vergil-project/<test-repo> \
+    --merge
+  ```
+
+  Expected: merge succeeds.
+
+- [ ] **Step 7: Clean up test branch**
+
+  ```bash
+  gh api repos/vergil-project/<test-repo>/git/refs/heads/<test-branch> -X DELETE
+  ```
+
+### Task 12: Update `vrg-repo-config` for Org-Aware Scope
+
+**Files:**
+- Modify: `src/standard_tooling/lib/github_config.py`
+- Modify: `tests/standard_tooling/test_github_config_lib.py`
+
+After the migration, `vrg-repo-config` (renamed from
+`st-github-config`) must skip branch protection rulesets for org repos
+since those are managed at the org level by `vrg-org-config`.
+
+**Note:** This task uses the post-rename filenames. The actual file
+paths will reflect the VERGIL rename.
+
+- [ ] **Step 1: Write the failing test**
+
+  In the github_config_lib test file, add:
+
+  ```python
+  def test_compute_desired_state_org_skips_branch_protection() -> None:
+      state = compute_desired_state(
+          _st_config(), visibility="public", is_org=True,
+      )
+      ruleset_names = [r.name for r in state.rulesets]
+      assert "Branch protection" not in ruleset_names
+      assert "Tag protection" in ruleset_names
+      assert "CI gates" in ruleset_names
+
+  def test_compute_desired_state_personal_includes_branch_protection() -> None:
+      state = compute_desired_state(
+          _st_config(), visibility="public", is_org=False,
+      )
+      ruleset_names = [r.name for r in state.rulesets]
+      assert "Branch protection" in ruleset_names
+      assert "Tag protection" in ruleset_names
+      assert "CI gates" in ruleset_names
+  ```
+
+- [ ] **Step 2: Run tests to verify the first test fails**
+
+  ```bash
+  st-docker-run -- uv run pytest tests/standard_tooling/test_github_config_lib.py::test_compute_desired_state_org_skips_branch_protection -v
+  ```
+
+  Expected: FAIL — branch protection is currently always included.
+
+- [ ] **Step 3: Update `compute_desired_state`**
+
+  In `src/standard_tooling/lib/github_config.py`, change the ruleset
+  computation to condition branch protection on `is_org`:
+
+  ```python
+  def compute_desired_state(config: StConfig, *, visibility: str, is_org: bool) -> DesiredState:
+      rulesets: list[DesiredRuleset] = []
+      if not is_org:
+          rulesets.append(desired_branch_protection_ruleset())
+      rulesets.append(desired_tag_protection_ruleset())
+      rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
+  ```
+
+  For org repos, branch protection is managed at the org level
+  (Task 11). For personal repos, the per-repo tool manages it.
+
+- [ ] **Step 4: Run tests to verify both pass**
+
+  ```bash
+  st-docker-run -- uv run pytest tests/standard_tooling/test_github_config_lib.py -v -k "org_skips_branch_protection or personal_includes_branch_protection"
+  ```
+
+  Expected: both PASS.
+
+- [ ] **Step 5: Run full validation**
+
+  ```bash
+  st-docker-run -- uv run st-validate
+  ```
+
+  Expected: all checks pass.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  st-commit --type feat --scope github-config \
+    --message "skip branch protection rulesets for org repos" \
+    --body "Org repos have branch protection managed at the org level via rulesets. The per-repo tool now skips branch protection for org repos and only manages tag protection and CI gates." \
+    --agent claude
+  ```
+
+### Task 13: Update Migration Plan Task 1
+
+**Files:**
+- Modify: `docs/plans/2026-05-11-vergil-rename.md`
+
+- [ ] **Step 1: Update Task 1 to reference org setup as prerequisite**
+
+  Replace the current Task 1 Steps 3-5 (which create the org from
+  scratch) with a verification step:
+
+  ```markdown
+  ### Step 3: Verify org setup is complete
+
+  The `vergil-project` org was created and configured as part of the
+  org governance setup plan
+  (`docs/plans/2026-05-11-org-governance-setup.md`). Verify it is
+  ready:
+
+  ` ``bash
+  gh api orgs/vergil-project --jq '.login'
+  # Expected: vergil-project
+
+  gh api orgs/vergil-project/rulesets --jq '.[].name'
+  # Expected: Branch protection (develop), Branch protection (main)
+  ` ``
+
+  If either check fails, complete the org governance setup plan
+  before proceeding.
+  ```
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  st-commit --type docs --scope plans \
+    --message "update migration plan to reference org governance setup" \
+    --agent claude
+  ```
+
+### Task 14: End-to-End Verification
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Verify identity separation**
+
+  ```bash
+  # Agent can push a branch
+  GH_TOKEN=<agent-pat> git push origin test-verify-branch
+
+  # Agent cannot merge without approval
+  GH_TOKEN=<agent-pat> gh pr create \
+    --repo vergil-project/<test-repo> \
+    --title "test: identity verification" \
+    --body "Verifying governance model." \
+    --head test-verify-branch \
+    --base develop
+
+  GH_TOKEN=<agent-pat> gh pr merge <PR> --merge
+  # Expected: FAIL — review required
+
+  # Human approves
+  GH_TOKEN=<human-pat> gh pr review <PR> --approve
+
+  # Human merges
+  GH_TOKEN=<human-pat> gh pr merge <PR> --merge
+  # Expected: SUCCESS
+  ```
+
+- [ ] **Step 2: Verify credential isolation**
+
+  ```bash
+  # Agent PAT cannot administer
+  GH_TOKEN=<agent-pat> gh api orgs/vergil-project \
+    -X PATCH \
+    -f description="test"
+  # Expected: 403 Forbidden
+
+  # Human PAT can administer
+  GH_TOKEN=<human-pat> gh api orgs/vergil-project \
+    -X PATCH \
+    -f description="VERGIL — Validation Engine for Repository Governance, Integration & Lifecycle"
+  # Expected: 200 OK
+  ```
+
+- [ ] **Step 3: Verify GitHub App**
+
+  ```bash
+  # Verify the App is installed
+  GH_TOKEN=<human-pat> gh api orgs/vergil-project/installations \
+    --jq '.[].app_slug'
+  # Expected: vergil-release
+  ```
+
+- [ ] **Step 4: Clean up test branches and PRs**
+
+  Remove any test branches and close any test PRs created during
+  verification.
+
+- [ ] **Step 5: Record completion**
+
+  The org governance setup is complete. Plan B (the VERGIL
+  rename/migration) can now proceed.
+
+---
+
+## Deferred to Separate Plans
+
+The following items are described in the governance design spec but
+are substantial engineering projects that warrant their own
+spec → plan → implementation cycles:
+
+1. **`vrg-org-config` tool** — automated enforcement of org-level
+   settings and rulesets. Currently, org configuration is manual
+   (Tasks 5, 11). The tool automates this for auditability and
+   repeatability.
+
+2. **Credential selection integration** — building the `keyring`-based
+   credential retrieval into all Vergil tools so that each tool
+   automatically selects the correct PAT based on its role. Currently,
+   credentials are manually set via `GH_TOKEN`.
+
+3. **`vrg-release` mechanized release workflow** — the fully automated
+   release tool that uses the GitHub App for PR creation and the human
+   PAT for approval/merge. Currently, the release workflow uses
+   `st-prepare-release` + `st-merge-when-green` with manual
+   intervention.
+
+4. **Cross-human review CI check (#719)** — required at humans > 1.
+
+5. **`vrg-setup-credentials` utility** — guided setup for new
+   contributors to store their PATs and App key in the platform's
+   secure credential store.
+
+These items do not block the org setup or migration. They improve
+automation and enforcement over time.

--- a/docs/plans/2026-05-11-org-governance-setup.md
+++ b/docs/plans/2026-05-11-org-governance-setup.md
@@ -24,7 +24,7 @@ codebase), macOS Keychain via `security` CLI, GitHub Apps (JWT/PyJWT)
 **Relationship to VERGIL rename plan:** This plan is Plan A (org setup).
 The existing rename plan (`docs/plans/2026-05-11-vergil-rename.md`) is
 Plan B (migration). Plan A must complete through Task 9 before Plan B
-begins. Tasks 10–14 execute after Plan B completes.
+begins. Tasks 10–15 execute after Plan B completes.
 
 **Task ordering within Phase 1:** Tasks 1 and 4 must complete before
 Task 2 (PATs require the org to exist and the agent account to be
@@ -907,9 +907,168 @@ paths will reflect the VERGIL rename.
     --agent claude
   ```
 
-### Task 14: End-to-End Verification
+### Task 14: Create Deferred Work Issues in New Org
+
+**Files:** None (`gh` CLI)
+
+Create issues in the `vergil-project` org for all deferred work items
+so they are tracked where the work will be done — not left behind in
+the pre-migration issue tracker.
+
+- [ ] **Step 1: Identify the target repo for governance issues**
+
+  Governance tooling issues belong in `vergil-tooling` (the renamed
+  standard-tooling). Verify it exists:
+
+  ```bash
+  gh repo view vergil-project/vergil-tooling --json name --jq '.name'
+  ```
+
+  Expected: `vergil-tooling`
+
+- [ ] **Step 2: Create issue for `vrg-org-config` tool**
+
+  ```bash
+  gh issue create --repo vergil-project/vergil-tooling \
+    --title "feat: build vrg-org-config tool for automated org-level configuration" \
+    --body-file /tmp/issue-vrg-org-config.md
+  ```
+
+  Body content:
+  > Automate enforcement of org-level settings and rulesets. Currently,
+  > org configuration is manual (gh CLI commands in the governance
+  > setup plan). The tool should support audit, diff, and apply modes
+  > — matching the pattern of vrg-repo-config — for org security
+  > settings, org-level rulesets, outside collaborator management, and
+  > GitHub App installation verification.
+  >
+  > **Spec:** docs/specs/2026-05-11-org-governance-design.md, Section 7
+  >
+  > **Depends on:** VERGIL migration complete
+
+- [ ] **Step 3: Create issue for credential selection integration**
+
+  ```bash
+  gh issue create --repo vergil-project/vergil-tooling \
+    --title "feat: integrate keyring-based credential selection into all vrg-* tools" \
+    --body-file /tmp/issue-credential-integration.md
+  ```
+
+  Body content:
+  > Build keyring-based credential retrieval into all Vergil tools so
+  > each tool automatically selects the correct PAT based on its role.
+  > Development tools retrieve the agent PAT, administrative tools
+  > retrieve the human PAT. No manual GH_TOKEN switching required.
+  >
+  > Includes a pluggable backend interface (macOS Keychain, Linux
+  > Secret Service, Windows Credential Manager) via the keyring Python
+  > library.
+  >
+  > **Spec:** docs/specs/2026-05-11-org-governance-design.md, Section 3
+  > (Credential Tooling subsection)
+
+- [ ] **Step 4: Create issue for `vrg-release` mechanized workflow**
+
+  ```bash
+  gh issue create --repo vergil-project/vergil-tooling \
+    --title "feat: build vrg-release fully mechanized release workflow" \
+    --body-file /tmp/issue-vrg-release.md
+  ```
+
+  Body content:
+  > Build the fully automated release tool that orchestrates the
+  > entire release process: create release branch, update changelog,
+  > open PR to main (using GitHub App identity), wait for CI, approve
+  > and merge (using human PAT), back-merge to develop, tag release,
+  > clean up.
+  >
+  > This replaces the current st-prepare-release + st-merge-when-green
+  > workflow. The release tool uses two credentials: the GitHub App for
+  > PR authorship and the human PAT for approval and merge.
+  >
+  > **Prerequisite:** Credential selection integration must be complete.
+  >
+  > **Spec:** docs/specs/2026-05-11-org-governance-design.md, Section 4
+
+- [ ] **Step 5: Create issue for cross-human review CI check**
+
+  ```bash
+  gh issue create --repo vergil-project/vergil-tooling \
+    --title "feat: cross-human review CI check for multi-contributor orgs" \
+    --body-file /tmp/issue-cross-human-review.md
+  ```
+
+  Body content:
+  > Implement a CI status check that enforces cross-human
+  > accountability for PR reviews. When a PR is opened by an AI agent
+  > account (e.g., alice-agent), the check ensures the approver is a
+  > different human than the agent's owner.
+  >
+  > Includes a scale-of-one safety valve: if the org has only one
+  > human member, the check short-circuits with exit 0.
+  >
+  > **Requirement:** Mandatory the moment a second human joins the org.
+  >
+  > **Spec:** docs/specs/2026-05-11-org-governance-design.md, Section 2
+  > (Cross-Human Review subsection)
+  >
+  > **Pre-migration issue:** wphillipmoore/standard-tooling#719
+
+- [ ] **Step 6: Create issue for `vrg-setup-credentials` utility**
+
+  ```bash
+  gh issue create --repo vergil-project/vergil-tooling \
+    --title "feat: build vrg-setup-credentials guided contributor onboarding" \
+    --body-file /tmp/issue-vrg-setup-credentials.md
+  ```
+
+  Body content:
+  > Build a guided setup utility for new contributors to store their
+  > PATs and App key in the platform's secure credential store.
+  > Prompts for each token, validates format and scopes, and writes
+  > entries under the standard credential names (vergil/human-pat,
+  > vergil/agent-pat, etc.).
+  >
+  > **Spec:** docs/specs/2026-05-11-org-governance-design.md, Section 3
+  > (Credential Tooling subsection)
+
+- [ ] **Step 7: Create issue for `.github` profile repo and Claude Code permissions**
+
+  ```bash
+  gh issue create --repo vergil-project/vergil-tooling \
+    --title "feat: set up .github profile repo and Claude Code permission model" \
+    --body-file /tmp/issue-github-repo-sandbox.md
+  ```
+
+  Body content:
+  > Two related setup tasks for the org:
+  >
+  > 1. Create the vergil-project/.github repository for org-level
+  >    configuration (org README, default community health files,
+  >    CONTRIBUTING.md, issue/PR templates).
+  >
+  > 2. Design a proper Claude Code permission model to move away from
+  >    YOLO/bypass mode. Define the minimal set of allowed operations
+  >    for AI agent sessions.
+  >
+  > **Pre-migration issue:** wphillipmoore/standard-tooling#718
+
+- [ ] **Step 8: Verify all issues are created**
+
+  ```bash
+  gh issue list --repo vergil-project/vergil-tooling \
+    --json number,title \
+    --jq '.[] | "\(.number): \(.title)"'
+  ```
+
+  Expected: all six issues listed.
+
+### Task 15: End-to-End Verification
 
 **Files:** None (manual verification)
+
+This is the final gate. All deferred issues are created (Task 14),
+all governance is active, and the org is ready for production use.
 
 - [ ] **Step 1: Verify identity separation**
 

--- a/docs/specs/2026-05-11-org-governance-design.md
+++ b/docs/specs/2026-05-11-org-governance-design.md
@@ -624,6 +624,71 @@ authenticated actor and the expected role.
 - Repo-specific branch protections beyond org defaults (unlikely
   to be needed initially)
 
+## Section 7: Tooling Impact
+
+### Configuration Enforcement Tools
+
+The current `st-github-config` tool evolves into two separate tools
+with distinct operational cadences:
+
+**`vrg-org-config`** (new) — manages org-level settings:
+
+- Org security settings (2FA requirement, default permissions)
+- Org-level rulesets (branch protection, required reviews, no
+  standing bypass) that cascade to all repos
+- Outside collaborator defaults
+- GitHub App installation verification
+- Run rarely — org-level configuration changes infrequently
+
+**`vrg-repo-config`** (evolution of `st-github-config`) — manages
+per-repo settings:
+
+- Repository settings (merge strategies, wiki, projects, etc.)
+- Security settings (secret scanning, push protection)
+- Actions permissions (allowed actions patterns)
+- CI gate rulesets (language-specific required status checks)
+- Tag protection rulesets
+- For personal repos (not in an org): also manages branch protection
+  rulesets, since there is no org layer to cascade from
+
+The tool detects whether the repo is in an org at runtime by
+querying the GitHub API (`owner.type`), as it already does today.
+The `is_org` flag determines the scope of enforcement — org repos
+get a narrower per-repo scope because the governance enforcement
+is handled by the org layer above.
+
+### Naming Convention
+
+Tool names abstract away "GitHub" — `org-config` and `repo-config`
+rather than `github-config`. This keeps the door open for future
+forge portability (e.g., Gitea) without renaming the tools.
+
+### Uniform Rigor
+
+The same governance standard applies to all repos, personal or org.
+The `is_org` flag determines the *mechanism* of enforcement (org-level
+rulesets vs. per-repo branch protection), not the *standard*. A
+personal repo receives the same branch protection rules as an org
+repo — the tool simply manages them at the repo level instead of
+relying on org-level cascading.
+
+### Escape Hatch Removal
+
+The `skip-rulesets` override in `[github]` config is removed. There
+are no escape hatches. If a repo cannot comply with the standard
+rulesets, the correct response is to fix the repo or the tooling,
+not to bypass enforcement. The override was added for a repo that
+is being archived and is not used by any active repo.
+
+### Configuration File Changes
+
+No new fields are added to `vergil.toml` for org detection — the
+tool queries the GitHub API at runtime. The `[github]` section
+loses the `skip-rulesets` field and gains no replacements. The
+long-term direction is for `vergil.toml` to declare what the repo
+*is* (language, CI config, project metadata), not how the repo is
+*managed* — management policy is hardcoded and uniform.
+
 ## Dependencies
 
 - VERGIL rename (#717 context, separate plan) — org must exist before

--- a/docs/specs/2026-05-11-org-governance-design.md
+++ b/docs/specs/2026-05-11-org-governance-design.md
@@ -35,12 +35,16 @@ contributions. The org needs a governance model that:
 
 ## Section 1: Identity Model
 
-Each contributor has exactly two GitHub identities:
+There are three categories of GitHub identity in the org:
 
 | Identity | Represents | Role |
 |---|---|---|
-| `<username>` | The human | Reviews, approvals, merges, administration, releases |
+| `<username>` | The human | Reviews, approvals, merges, administration |
 | `<username>-agent` | That human's AI agents | All development work, regardless of harness or model |
+| `vergil-release[bot]` | The org's GitHub App | Mechanized automation (release PRs, version bumps) |
+
+Each contributor has the first two. The third is an org-level GitHub App
+shared by all contributors.
 
 ### Rules
 
@@ -52,6 +56,10 @@ Each contributor has exactly two GitHub identities:
 - Agent accounts are **outside collaborators** in the org, never org
   members. Org membership inherently signals "this is a human who is
   accountable."
+- The GitHub App identity is used exclusively for mechanized automation —
+  deterministic workflows with no AI decision-making. PRs authored by the
+  App are visually distinct (`[bot]` suffix) and immediately communicate
+  "no human or AI authored this."
 - Creating an agent identity is a requirement for any contributor who uses
   AI tools. Contributors who do not use AI operate under the standard
   open-source model with their human identity only.
@@ -78,6 +86,11 @@ are retired. A new `wphillipmoore-agent` account is created. Existing
 commit history remains attributed to the old accounts (Git does not
 rewrite attribution). All new work uses the `-agent` convention.
 
+The co-author entries in the project config also migrate: the
+per-harness entries (`claude`, `codex`) are replaced with a single
+`agent` entry. This is coordinated with the VERGIL rename (which
+changes the config filename) so both changes land together.
+
 ## Section 2: Branch Protection Rulesets
 
 GitHub org-level rulesets define protection rules once and apply them
@@ -95,7 +108,34 @@ protection — new repos automatically inherit the governance model.
 - Require review from someone other than the PR author
 - Require status checks to pass (CI must be green)
 - Require branches to be up to date before merging
-- No bypass — not even for org owners
+- No standing bypass permissions (see No Standing Bypass Policy)
+
+#### Why "Require Up to Date" Is Retained
+
+The "require branches to be up to date" rule guarantees that CI ran
+on the exact code that will land on the target branch. Without it,
+a PR can pass CI against a stale version of `develop` — another PR
+merges, changing the baseline, and the first PR's CI results no
+longer reflect reality. Two PRs that touch unrelated code can still
+break each other through transitive dependencies, shared state, or
+configuration changes. Dropping this rule opens a correctness hole
+that contradicts the project's commitment to extreme hygiene and
+full coverage.
+
+The cost is merge serialization: at scale of multiple active
+contributors, only one PR can merge at a time, and the rest must
+rebase and re-run CI after each merge. At scale of one, this cost
+is negligible.
+
+**Future mitigation: GitHub merge queue.** GitHub Teams (paid plan)
+offers a merge queue feature that eliminates the serialization
+penalty while preserving the safety guarantee. The merge queue
+batches approved PRs, creates a combined test branch, runs CI once
+on the batch, and merges them together. If CI fails, it bisects to
+find the broken PR. This is the correct long-term solution — it
+closes the correctness hole without the serialization cost. When the
+org moves to a paid plan, merge queue should be enabled on `develop`
+and `main` as a priority.
 
 ### Rules for `main`
 
@@ -108,24 +148,30 @@ All rules from `develop`, plus:
 ### Release Workflow and Branch Protection
 
 The release workflow creates PRs that must satisfy the same review
-rules as any other PR. Since the release tool runs under the human's
-credentials, and the "require review from someone other than the PR
-author" rule applies, the release PRs are opened by the human's
-agent account and approved by the human. This means the release tool
-uses the agent PAT to create the PR and the human PAT to approve and
-merge it — maintaining the same author/reviewer separation that
-governs all other PRs.
+rules as any other PR. Release PRs are authored by the org's GitHub
+App (`vergil-release[bot]`) and approved by the human who triggered
+the release. The App identity is distinct from both the human and
+the agent, so the "require review from someone other than the PR
+author" rule is satisfied without reusing any contributor's
+credentials for a purpose they weren't designed for.
 
-### No Bypass Policy
+### No Standing Bypass Policy
 
-There are no bypass permissions for any identity, including org owners.
-If a situation requires bypassing a rule, that is an exceptional
-circumstance handled by temporarily modifying the ruleset — and it
-represents a failure in the tooling or process that should be addressed.
+No identity has standing bypass permissions, including org owners.
+Org owners are held to the same standards as everyone else. The act
+of running the mechanized release tool (as a human, with human
+credentials) is what satisfies the merge requirement for `main`, not
+a bypass.
 
-Org owners are held to the same standards as everyone else. The act of
-running the mechanized release tool (as a human, with human credentials)
-is what satisfies the merge requirement for `main`, not a bypass.
+If a situation requires circumventing a rule, the org owner must
+temporarily modify the ruleset, perform the operation, and restore
+the ruleset. This is a deliberate friction — the cost of modifying
+rules should be high enough to discourage casual use but not so high
+that it blocks incident response. Ruleset modifications are logged
+in the org audit trail. Any modification that enables a merge
+without the normal review process is treated as an incident to be
+retrospected: what broke, why the normal path couldn't be used, and
+what tooling or process change would prevent recurrence.
 
 ### Cross-Human Review (Future, #719)
 
@@ -133,6 +179,10 @@ At scale of 2+ human contributors, a CI status check enforces that the
 PR approver is a different human than the agent's owner. The check
 parses the PR author against the `<username>-agent` naming convention
 and rejects approval from the same human.
+
+PRs authored by the GitHub App (`vergil-release[bot]`) are exempt from
+cross-human review — they are mechanized automation, not AI work, and
+any org member's human identity may approve them.
 
 At scale of one, the check short-circuits (exit 0) — the single-human
 model (agent authors, human reviews) is sufficient.
@@ -151,9 +201,10 @@ provides no identity separation and no enforcement capability.
 ### New Model
 
 No `GH_TOKEN` in the shell environment by default. Two PATs per
-contributor, stored securely, selected per-operation based on role.
+contributor plus a shared GitHub App for mechanized automation,
+selected per-operation based on role.
 
-### Credential Storage
+### Per-Contributor Credential Storage
 
 Two fine-grained PATs per contributor, stored in a secure credential
 store (macOS Keychain or equivalent):
@@ -169,44 +220,244 @@ store (macOS Keychain or equivalent):
   - Explicitly excluded: administration, actions, merge via API,
     org settings, secrets, deployments
 
-### Credential Selection
+### GitHub App (Mechanized Automation)
 
-- AI agent sessions receive the agent PAT at launch time (via session
-  launch mechanism — shell wrapper, Claude Code hook, or equivalent)
-- Administrative and release tooling retrieves the human PAT from the
-  credential store
-- **Development tools never touch the human token. Administrative tools
-  never touch the agent token.**
+A GitHub App (`vergil-release`) is installed org-wide and used
+exclusively for mechanized automation — operations that are
+deterministic and involve no AI decision-making.
 
-### The `gh` CLI
+**App permissions:**
 
-The `gh` CLI (which the Vergil tools shell out to) respects `GH_TOKEN`
-as its authentication source. Credential selection can be implemented
-by setting `GH_TOKEN` to the appropriate value before invoking `gh`. No
-changes to `gh` itself are needed.
+- Contents: Write (create branches, push commits)
+- Pull requests: Write (create and update PRs)
+- Metadata: Read (required by GitHub)
+
+The App does not need merge, administration, or approval permissions.
+Approval and merge are always performed by a human PAT.
+
+**Private key storage:**
+
+The App's private key is stored in the secure credential store
+alongside the PATs. Contributors who run releases need access to it.
+At scale of one, this is a single entry in the macOS Keychain. At
+scale of many, the key is distributed via a shared secret store.
+
+**Token exchange:**
+
+The release tool reads the private key, generates a short-lived JWT,
+and exchanges it for a GitHub App installation token via the GitHub
+API. Installation tokens expire after 1 hour — there are no
+long-lived automation credentials. The token exchange is a small
+function in the release tool (~20 lines of Python with `PyJWT`).
+
+**CI usage:**
+
+GitHub Actions workflows already use this pattern via
+`actions/create-github-app-token`. The existing App (currently in
+the personal account) is migrated to the `vergil-project` org as
+part of the VERGIL rename. The CI and local release tool use the
+same App with the same private key.
+
+### Credential Tooling
+
+#### Core Principle
+
+**The tool selects the credential, not the developer.** No global
+`GH_TOKEN`, no manual env var switching. Each Vergil tool knows
+which role it operates in and retrieves the correct credential from
+the platform's secure store at invocation time. The developer's
+only responsibility is a one-time setup: store the credentials
+using a setup utility.
+
+This means all GitHub-facing operations flow through Vergil
+tooling (`vrg-*`). Raw `gh` and `git` commands are fine for
+read-only use (inspecting state, triaging problems), but any
+operation that authenticates against the GitHub API should go
+through a tool that enforces correct credential context. This is
+the long-term direction — not an immediate ban on raw `gh`, but
+the design principle that drives tooling decisions.
+
+#### Standard Credential Names
+
+All platforms use the same logical names for credential entries.
+The secure store backend varies by platform, but the names are
+consistent:
+
+| Credential | Store entry name | Used by |
+|---|---|---|
+| Human PAT | `vergil/human-pat` | Admin tools, approval/merge steps |
+| Agent PAT | `vergil/agent-pat` | Development tools, AI agent sessions |
+| App private key | `vergil/app-private-key` | Release tool (PR creation step) |
+| App ID | `vergil/app-id` | Release tool (token exchange) |
+
+#### Platform-Specific Secure Storage
+
+Three platforms are supported. Contributors on other platforms are
+responsible for porting the mechanism; the tooling provides a
+pluggable backend interface.
+
+| Platform | Backend | Lookup mechanism |
+|---|---|---|
+| macOS | Keychain | `security find-generic-password` (or `keyring` Python library) |
+| Linux | Secret Service (GNOME Keyring, KWallet) | `keyring` Python library via `SecretService` backend |
+| Windows | Windows Credential Manager | `keyring` Python library via `WinVault` backend |
+
+The `keyring` Python library provides a unified API across all
+three platforms. The Vergil tooling uses `keyring` as the
+abstraction layer, with the platform-native backend selected
+automatically. Contributors store credentials once via a setup
+command (`vrg-setup-credentials` or equivalent) that prompts for
+each token and writes it to the platform's secure store under the
+standard names.
+
+#### Credential Isolation by Context
+
+Each tool category retrieves only the credential it needs. No tool
+has access to credentials outside its role:
+
+- **Development tools** (`vrg-commit`, `vrg-submit-pr`, etc.) —
+  retrieve the agent PAT. Never touch the human PAT or App key.
+- **AI agent sessions** — launched with the agent PAT injected via
+  session launch hook (Claude Code hook, shell wrapper, or
+  equivalent). The hook retrieves the agent PAT from the secure
+  store and sets `GH_TOKEN` for the session. The human PAT and App
+  key are never exposed to the agent session.
+- **Administrative tools** — retrieve the human PAT. Never touch
+  the agent PAT.
+- **Release tool** (`vrg-release`) — retrieves both the human PAT
+  and the App private key. Sets `GH_TOKEN` per-invocation: the App
+  installation token for PR creation steps, the human PAT for
+  approval and merge steps. Credentials are scoped to the
+  subprocess, not the parent shell.
+- **The App identity is never used for development or
+  administration.** Development tools never touch the human token
+  or the App key. Administrative tools never touch the agent token.
+
+#### The `gh` CLI
+
+The `gh` CLI respects `GH_TOKEN` as its authentication source.
+Vergil tools set `GH_TOKEN` in the subprocess environment when
+invoking `gh` — the token is scoped to that invocation, not
+exported to the parent shell. The `gh auth login` state is not
+used; if `GH_TOKEN` is absent, the tool fails with an explicit
+error rather than falling back to ambient credentials.
+
+#### What the Tooling Cannot Enforce
+
+The credential tooling controls what happens inside Vergil tools.
+It cannot prevent a contributor from globally exporting a token in
+their shell profile or using the wrong credential with raw `gh`
+commands. These scenarios are addressed by:
+
+- **Guidelines and setup utilities** that make the correct path
+  easy and the incorrect path require deliberate effort
+- **Post-facto auditing** via the org audit log, which reveals
+  when operations were performed under an unexpected identity
+- **GitHub-side hard gates** (PAT scope, branch protection) that
+  limit the damage from credential misuse regardless of what
+  happens on the developer's machine
 
 ### Enforcement Model
 
 - **Hard gates:** PAT scope restrictions (agent PATs cannot perform admin
-  operations), branch protection rulesets (agent accounts cannot merge),
-  required reviews (agent PRs require human approval)
+  operations), App permission restrictions (the App cannot merge or
+  approve), branch protection rulesets (agent accounts and the App
+  cannot merge), required reviews (all PRs require human approval)
 - **Post-facto auditing:** Verify that contributors used the correct
   credentials for the type of work performed. The org audit log tracks
   the authenticated actor for every operation — discrepancies between
-  the actor and the expected role are flagged.
+  the actor and the expected role are flagged. The three-identity model
+  (human, agent, App) makes misuse visible: an agent token performing
+  admin work or a human token creating development PRs both stand out.
+
+### Credential Lifecycle
+
+#### Rotation Schedule
+
+All fine-grained PATs are created with a 1-year expiration. The App
+private key does not expire automatically and is rotated on the same
+annual cadence.
+
+Rotation is proactive, not reactive — credentials are refreshed
+before they expire, not after they break something. The governance
+tooling includes a credential audit command (`vrg-credential-audit`
+or equivalent) that reports:
+
+- All PATs and App keys in use across the org
+- Expiration dates and time remaining
+- Last-used timestamps (via GitHub API token metadata)
+- Stale credentials: tokens that exist but have not been used in a
+  configurable window (e.g., 90 days) — these indicate inactive
+  contributors whose access should be reviewed
+- Approaching expiration: tokens within 30 days of expiry trigger a
+  warning
+
+This audit runs on a regular schedule (monthly or as a CI job) and
+surfaces a report to org owners. The goal is that no credential
+expires unexpectedly during work — expiration during an active
+session represents a failure in the audit and reporting process.
+
+#### Compromise Response
+
+Upon reported or suspected compromise of any credential:
+
+1. **Immediately revoke** the compromised credential (PAT or App
+   private key) via GitHub settings
+2. **Halt operations** that depend on the compromised credential —
+   no new PRs, merges, or releases until replacement credentials
+   are provisioned
+3. **Audit recent activity** under the compromised identity using the
+   org audit log — review all operations performed since the
+   estimated compromise window
+4. **Issue replacement credentials** with the same scope and
+   expiration policy
+5. **Retrospect** — how was the credential exposed, and what process
+   or tooling change prevents recurrence
+
+The blast radius depends on which credential is compromised:
+
+| Credential | Blast radius | Immediate risk |
+|---|---|---|
+| Agent PAT | Can push branches, create PRs and issues | Branch protection prevents merging; spam PRs and malicious branch content are possible |
+| Human PAT | Can approve, merge, administer | Full access to protected branches and org settings |
+| App private key | Can create PRs as automation identity | Cannot merge or approve; similar to agent PAT but org-wide |
+
+Human PAT compromise is the most severe — it should trigger
+immediate rotation of all credentials for that contributor and a
+full audit of recent merge and admin activity.
+
+#### Observability
+
+The credential audit is not a one-time check — it is ongoing
+observability into the org's credential namespace. Over time, this
+surfaces patterns that inform governance decisions:
+
+- Contributors whose tokens are never used may be stale and should
+  have access reviewed
+- Contributors who use tokens heavily may need broader scope or
+  dedicated tooling support
+- Unusual usage patterns (agent token performing admin-like
+  operations, human token creating development PRs) indicate
+  credential misuse even when the operations succeed
+
+The org audit log is the primary data source. GitHub exposes token
+metadata (last used, permissions) via the API, which the credential
+audit tool consumes.
 
 ### For Future Contributors
 
 The pattern is documentable: create a `<username>-agent` account,
 generate two scoped PATs, store them in your credential manager, and
-the tooling selects the right one. Contributors who do not use AI agents
-have one token and everything works normally.
+the tooling selects the right one. The GitHub App private key is
+shared with contributors who need to run releases. Contributors who
+do not use AI agents have one token and everything works normally.
 
 ## Section 4: Release Workflow Mechanization
 
 The release workflow is the one process that currently creates and merges
-PRs autonomously. Under the new model, it must run entirely under human
-credentials.
+PRs autonomously. Under the new model, it is fully mechanized — PR
+creation runs under the GitHub App identity, and approval and merge run
+under the human's credentials. No AI decision-making is involved.
 
 ### Current Flow (AI-Assisted, Honor System)
 
@@ -219,26 +470,30 @@ credentials.
 
 1. Human runs `vrg-release` — a single Python command that orchestrates
    the entire release
-2. It retrieves both credentials from the credential store
-3. Using the agent PAT: creates the release branch, updates changelog,
+2. It retrieves the human PAT and the GitHub App private key from the
+   credential store
+3. It generates a short-lived App installation token via JWT exchange
+4. Using the App token: creates the release branch, updates changelog,
    opens PR to `main`
-4. It waits for CI to pass
-5. Using the human PAT: approves and merges the PR to `main`
-6. Using the agent PAT: creates the back-merge PR to `develop`
-7. Using the human PAT: approves and merges the back-merge PR
-8. Using the human PAT: tags the release, cleans up branches
+5. It waits for CI to pass
+6. Using the human PAT: approves and merges the PR to `main`
+7. Using the App token: creates the back-merge PR to `develop`
+8. Using the human PAT: approves and merges the back-merge PR
+9. Using the human PAT: tags the release, cleans up branches
 
 ### Key Properties
 
 - The entire release is triggered by one human decision: running the
   command
-- PR creation uses the agent PAT (so the author is the agent),
-  approval and merge use the human PAT (so the reviewer is the
-  human) — branch protection is satisfied by the same
-  author/reviewer separation that governs all other PRs
+- PR creation uses the GitHub App (so the author is
+  `vergil-release[bot]`), approval and merge use the human PAT (so
+  the reviewer is the human) — branch protection is satisfied by the
+  author/reviewer separation, and the audit trail cleanly
+  distinguishes mechanized automation from both human and AI work
 - No AI agent *decision-making* at any point — this is deterministic,
-  mechanical code promotion, even though it uses the agent identity
-  for PR authorship
+  mechanical code promotion, and the App identity makes that visible
+- The App installation token expires after 1 hour — if the release
+  takes longer than expected, the tool re-generates the token
 - The dependency update step (which currently involves AI judgment)
   must also be mechanized — deterministic resolution, not AI
   interpretation
@@ -287,10 +542,27 @@ must be deterministic, tested, and scriptable.
 These items are deferred as future work:
 
 - How external contributors' AI agents are handled (must they follow
-  the same identity convention, or is that only for org members?)
+  the same identity convention, or is that only for org members?).
+  This is a prerequisite for the cross-human review check (#719) —
+  the check parses the `<username>-agent` naming convention to
+  identify the owning human, so #719 must account for contributors
+  who may not follow the convention.
+- Community policies for non-AI contributors (standard open-source
+  contribution model, but the review and quality bar needs defining)
 - Detailed auditing procedures for verifying credential compliance
 - Automated tooling for evaluating AI-generated contributions during
   code review
+
+### What Is Explicitly Out of Scope
+
+Autonomous AI contributions — AI agents operating without a human
+in the loop — are not supported. Every contribution must have a
+human who directed the work, reviewed the output, and takes
+accountability for the result. An unaccountable AI cannot be held
+responsible for what it produces, and this project's governance
+model is built on the assumption that humans run things. This is
+not a temporary constraint pending better AI tooling; it is a
+foundational design decision.
 
 ## Section 6: Org-Level Configuration
 
@@ -306,9 +578,25 @@ These items are deferred as future work:
 ### Org-Level Rulesets
 
 - `main` and `develop` are protected in every repo
-- Required PR reviews, required CI status checks, no bypass
+- Required PR reviews, required CI status checks, no standing bypass
 - New repos automatically inherit the governance model without
   per-repo configuration
+
+### GitHub App
+
+A GitHub App (`vergil-release`) is registered under the org and
+installed org-wide. New repos automatically receive the App's
+permissions without per-repo configuration.
+
+- **App ID and private key** are stored as org-level Actions secrets
+  (`APP_ID`, `APP_PRIVATE_KEY`) for CI workflows, and in the secure
+  credential store for local release tool use
+- The existing GitHub App (currently on the personal account) is
+  migrated to the org as part of the VERGIL rename — this is not a
+  new App, it is the same App re-homed
+- App permissions are limited to Contents:Write, Pull requests:Write,
+  and Metadata:Read — it cannot merge, approve, administer, or
+  access secrets
 
 ### Default Community Health Files
 
@@ -342,6 +630,8 @@ authenticated actor and the expected role.
   governance is applied
 - `.github` profile repo (#718) — community health files and org README
 - Cross-human review CI check (#719) — required at humans > 1
+- GitHub App migration — existing App re-homed to `vergil-project` org
+  as part of the VERGIL rename
 - Release workflow mechanization — required before branch protection
   rules can be fully enforced without breaking the release flow
 
@@ -351,6 +641,9 @@ authenticated actor and the expected role.
 |---|---|
 | Agent PAT scope too narrow, blocking legitimate development operations | Start with the documented scope, widen if specific operations fail — prefer fixing tooling over widening scope |
 | Release workflow not mechanized before branch protection is enforced | Phase the rollout: enable rulesets after `vrg-release` is functional |
+| GitHub App private key distribution at scale | At scale of one, the key is in the macOS Keychain. At scale of many, use a shared secret store. The key is only needed by contributors who run releases, not all contributors |
+| App installation token expires mid-release | The release tool detects expiry and re-generates the token. Installation tokens live 1 hour; releases complete in minutes |
 | Contributors resist the two-identity requirement | Document the rationale clearly; the bar for contribution is higher than most OSS projects, and that is intentional |
+| Merge serialization on `develop` at scale | Acceptable at scale of one. At scale of many, enable GitHub merge queue (requires Teams plan) to batch PRs without losing the "up to date" guarantee |
 | Single human bottleneck for all reviews | Acceptable at scale of one; at scale of 2+, cross-review distributes the load |
 | Credential management adds friction to development workflow | Invest in tooling that makes credential selection invisible — the developer should not think about tokens |

--- a/docs/specs/2026-05-11-org-governance-design.md
+++ b/docs/specs/2026-05-11-org-governance-design.md
@@ -1,0 +1,356 @@
+# VERGIL Org Governance Design
+
+**Issue:** #717
+**Date:** 2026-05-11
+**Status:** Draft
+
+## Problem
+
+The VERGIL migration moves repositories from a personal GitHub account to
+the `vergil-project` GitHub org. The existing security model — a single
+human using a single PAT for all operations, with AI agents sharing those
+credentials — is insufficient for an org that aims to accept external
+contributions. The org needs a governance model that:
+
+- Distinguishes human work from AI-generated work at the identity level
+- Enforces human review of all changes before they reach protected branches
+- Restricts AI agents to the minimum permissions required for development
+- Scales from one contributor to many without redesigning the model
+- Mechanizes administrative operations so AI agents never need human
+  credentials
+
+## Foundational Principles
+
+1. **AI is a nondeterministic system operating in a space that demands
+   deterministic results.** The governance model exists to bridge that gap.
+2. **AI contributions are welcome. Unaccountable AI contributions are not.**
+   Every change must have a human who reviewed it, understands it, and takes
+   responsibility for it.
+3. **The speed limit is human comprehension, not code generation.** AI agents
+   can pile up PRs as fast as they want. Nothing ships until a human
+   understands what it does and why.
+4. **Where enforcement can be hard-gated, it must be. Where it cannot,
+   compliance must be audited post-facto.** The system assumes good faith
+   but verifies through auditing.
+
+## Section 1: Identity Model
+
+Each contributor has exactly two GitHub identities:
+
+| Identity | Represents | Role |
+|---|---|---|
+| `<username>` | The human | Reviews, approvals, merges, administration, releases |
+| `<username>-agent` | That human's AI agents | All development work, regardless of harness or model |
+
+### Rules
+
+- The human identity is the accountable party. The agent identity exists to
+  make AI-assisted work distinguishable from human work.
+- One agent identity per human — not per harness, not per model. Which
+  harness or model produced the work is captured in metadata (commit
+  trailers, PR descriptions), not at the identity level.
+- Agent accounts are **outside collaborators** in the org, never org
+  members. Org membership inherently signals "this is a human who is
+  accountable."
+- Creating an agent identity is a requirement for any contributor who uses
+  AI tools. Contributors who do not use AI operate under the standard
+  open-source model with their human identity only.
+- "The AI did it" is not a defense. You are accountable for everything
+  your agent produces.
+
+### Naming Convention
+
+The agent account name follows the pattern `<username>-agent`. This
+convention is load-bearing — the cross-human review CI check (#719)
+parses the PR author's username to identify the owning human.
+
+### Metadata Capture
+
+The specific harness and model used for a contribution are recorded in
+commit trailers (e.g., `Co-Authored-By:`) and PR descriptions. This is
+telemetry for auditing and analysis, not a security boundary. The
+security boundary is human vs. not-human.
+
+### Migration
+
+The existing accounts `wphillipmoore-claude` and `wphillipmoore-codex`
+are retired. A new `wphillipmoore-agent` account is created. Existing
+commit history remains attributed to the old accounts (Git does not
+rewrite attribution). All new work uses the `-agent` convention.
+
+## Section 2: Branch Protection Rulesets
+
+GitHub org-level rulesets define protection rules once and apply them
+across all repos. This is a significant advantage over per-repo branch
+protection — new repos automatically inherit the governance model.
+
+### Protected Branches
+
+`main` and `develop` in all repos.
+
+### Rules for `develop`
+
+- Require a pull request before merging (no direct pushes)
+- Require at least 1 approving review
+- Require review from someone other than the PR author
+- Require status checks to pass (CI must be green)
+- Require branches to be up to date before merging
+- No bypass — not even for org owners
+
+### Rules for `main`
+
+All rules from `develop`, plus:
+
+- Restrict who can push/merge to org owners only
+- This is the release gate — only the mechanized release workflow
+  (running under human credentials) can promote code to `main`
+
+### Release Workflow and Branch Protection
+
+The release workflow creates PRs that must satisfy the same review
+rules as any other PR. Since the release tool runs under the human's
+credentials, and the "require review from someone other than the PR
+author" rule applies, the release PRs are opened by the human's
+agent account and approved by the human. This means the release tool
+uses the agent PAT to create the PR and the human PAT to approve and
+merge it — maintaining the same author/reviewer separation that
+governs all other PRs.
+
+### No Bypass Policy
+
+There are no bypass permissions for any identity, including org owners.
+If a situation requires bypassing a rule, that is an exceptional
+circumstance handled by temporarily modifying the ruleset — and it
+represents a failure in the tooling or process that should be addressed.
+
+Org owners are held to the same standards as everyone else. The act of
+running the mechanized release tool (as a human, with human credentials)
+is what satisfies the merge requirement for `main`, not a bypass.
+
+### Cross-Human Review (Future, #719)
+
+At scale of 2+ human contributors, a CI status check enforces that the
+PR approver is a different human than the agent's owner. The check
+parses the PR author against the `<username>-agent` naming convention
+and rejects approval from the same human.
+
+At scale of one, the check short-circuits (exit 0) — the single-human
+model (agent authors, human reviews) is sufficient.
+
+This check is an absolute requirement the moment a second human joins
+the org.
+
+## Section 3: Credential Management
+
+### Current State
+
+A single `GH_TOKEN` is exported globally in the shell environment. All
+operations — human and AI — authenticate as the same GitHub user. This
+provides no identity separation and no enforcement capability.
+
+### New Model
+
+No `GH_TOKEN` in the shell environment by default. Two PATs per
+contributor, stored securely, selected per-operation based on role.
+
+### Credential Storage
+
+Two fine-grained PATs per contributor, stored in a secure credential
+store (macOS Keychain or equivalent):
+
+- **Human PAT** — full org owner/member privileges, used for
+  administration, approvals, merges, and releases
+- **Agent PAT** — scoped to the minimum permissions required for
+  development:
+  - Contents: Write (push branches, create commits)
+  - Pull requests: Write (open and update PRs)
+  - Issues: Write (create and update issues)
+  - Scoped to repos in the `vergil-project` org only
+  - Explicitly excluded: administration, actions, merge via API,
+    org settings, secrets, deployments
+
+### Credential Selection
+
+- AI agent sessions receive the agent PAT at launch time (via session
+  launch mechanism — shell wrapper, Claude Code hook, or equivalent)
+- Administrative and release tooling retrieves the human PAT from the
+  credential store
+- **Development tools never touch the human token. Administrative tools
+  never touch the agent token.**
+
+### The `gh` CLI
+
+The `gh` CLI (which the Vergil tools shell out to) respects `GH_TOKEN`
+as its authentication source. Credential selection can be implemented
+by setting `GH_TOKEN` to the appropriate value before invoking `gh`. No
+changes to `gh` itself are needed.
+
+### Enforcement Model
+
+- **Hard gates:** PAT scope restrictions (agent PATs cannot perform admin
+  operations), branch protection rulesets (agent accounts cannot merge),
+  required reviews (agent PRs require human approval)
+- **Post-facto auditing:** Verify that contributors used the correct
+  credentials for the type of work performed. The org audit log tracks
+  the authenticated actor for every operation — discrepancies between
+  the actor and the expected role are flagged.
+
+### For Future Contributors
+
+The pattern is documentable: create a `<username>-agent` account,
+generate two scoped PATs, store them in your credential manager, and
+the tooling selects the right one. Contributors who do not use AI agents
+have one token and everything works normally.
+
+## Section 4: Release Workflow Mechanization
+
+The release workflow is the one process that currently creates and merges
+PRs autonomously. Under the new model, it must run entirely under human
+credentials.
+
+### Current Flow (AI-Assisted, Honor System)
+
+1. AI agent runs `st-prepare-release` — creates release branch, updates
+   changelog, opens PR to `main`
+2. AI agent runs `st-merge-when-green` — waits for CI, merges to `main`
+3. AI agent opens back-merge PR from `main` to `develop`, merges it
+
+### New Flow (Fully Mechanized, Human Credentials)
+
+1. Human runs `vrg-release` — a single Python command that orchestrates
+   the entire release
+2. It retrieves both credentials from the credential store
+3. Using the agent PAT: creates the release branch, updates changelog,
+   opens PR to `main`
+4. It waits for CI to pass
+5. Using the human PAT: approves and merges the PR to `main`
+6. Using the agent PAT: creates the back-merge PR to `develop`
+7. Using the human PAT: approves and merges the back-merge PR
+8. Using the human PAT: tags the release, cleans up branches
+
+### Key Properties
+
+- The entire release is triggered by one human decision: running the
+  command
+- PR creation uses the agent PAT (so the author is the agent),
+  approval and merge use the human PAT (so the reviewer is the
+  human) — branch protection is satisfied by the same
+  author/reviewer separation that governs all other PRs
+- No AI agent *decision-making* at any point — this is deterministic,
+  mechanical code promotion, even though it uses the agent identity
+  for PR authorship
+- The dependency update step (which currently involves AI judgment)
+  must also be mechanized — deterministic resolution, not AI
+  interpretation
+- Fully covered by unit and integration tests
+
+### Impact on Existing Tools
+
+- `st-merge-when-green` in its current form (callable by AI agents)
+  is no longer a standalone operation for normal development — PRs
+  wait for human approval and human-initiated merge
+- It may survive as an internal function called by the mechanized
+  release tool, but it is no longer an AI-accessible entry point
+- `st-prepare-release` evolves into the front half of `vrg-release`
+
+### The Broader Principle
+
+If an operation requires human credentials, it must be fully
+mechanized. No AI agent should ever need the human token, and no
+human should have to do mechanical button-clicking that could be
+scripted. This raises the bar on administrative operations — they
+must be deterministic, tested, and scriptable.
+
+## Section 5: Contributor Guidelines
+
+### For Contributors Using AI
+
+- You must create a `<username>-agent` GitHub account for AI-assisted
+  development
+- All AI-assisted work must be committed and PR'd under the agent
+  identity
+- All reviews, approvals, and merges are performed under your human
+  identity
+- You are accountable for everything your agent produces
+- PRs must pass CI (the full validation pipeline)
+- At 2+ human contributors, cross-human review is required — you cannot
+  approve your own agent's PRs (#719)
+
+### For Contributors Not Using AI
+
+- Standard open-source contribution model: fork, branch, PR, review
+- PRs require approval from an org member
+- No requirement to create an agent account
+
+### What Is Not Yet Defined
+
+These items are deferred as future work:
+
+- How external contributors' AI agents are handled (must they follow
+  the same identity convention, or is that only for org members?)
+- Detailed auditing procedures for verifying credential compliance
+- Automated tooling for evaluating AI-generated contributions during
+  code review
+
+## Section 6: Org-Level Configuration
+
+### Org Security Settings
+
+- Require two-factor authentication for all org members
+- Default repository permission for org members: **Write** (push
+  branches; merge is gated by rulesets, not repo permissions)
+- Outside collaborators (agent accounts): granted **Write** on
+  specific repos as needed
+- Do not allow forking of private repos (if any exist)
+
+### Org-Level Rulesets
+
+- `main` and `develop` are protected in every repo
+- Required PR reviews, required CI status checks, no bypass
+- New repos automatically inherit the governance model without
+  per-repo configuration
+
+### Default Community Health Files
+
+These live in the `.github` profile repo (#718):
+
+- `CONTRIBUTING.md` — contributor guidelines from Section 5
+- Pull request template
+- Issue templates
+- Org-level README
+
+Any repo without its own versions inherits the org defaults.
+
+### Audit Log
+
+GitHub org audit logs track who did what across all repos. This is
+the backstop for the trust-but-verify model: if someone uses the
+wrong credentials, the audit log shows the discrepancy between the
+authenticated actor and the expected role.
+
+### What Stays Per-Repo
+
+- CI workflow files (`.github/workflows/`)
+- CODEOWNERS files (when the team grows enough to need path-based
+  review assignment)
+- Repo-specific branch protections beyond org defaults (unlikely
+  to be needed initially)
+
+## Dependencies
+
+- VERGIL rename (#717 context, separate plan) — org must exist before
+  governance is applied
+- `.github` profile repo (#718) — community health files and org README
+- Cross-human review CI check (#719) — required at humans > 1
+- Release workflow mechanization — required before branch protection
+  rules can be fully enforced without breaking the release flow
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Agent PAT scope too narrow, blocking legitimate development operations | Start with the documented scope, widen if specific operations fail — prefer fixing tooling over widening scope |
+| Release workflow not mechanized before branch protection is enforced | Phase the rollout: enable rulesets after `vrg-release` is functional |
+| Contributors resist the two-identity requirement | Document the rationale clearly; the bar for contribution is higher than most OSS projects, and that is intentional |
+| Single human bottleneck for all reviews | Acceptable at scale of one; at scale of 2+, cross-review distributes the load |
+| Credential management adds friction to development workflow | Invest in tooling that makes credential selection invisible — the developer should not think about tokens |

--- a/paad/pushback-reviews/2026-05-12-org-governance-design-pushback.md
+++ b/paad/pushback-reviews/2026-05-12-org-governance-design-pushback.md
@@ -1,0 +1,134 @@
+# Pushback Review: VERGIL Org Governance Design
+
+**Date:** 2026-05-12
+**Spec:** docs/specs/2026-05-11-org-governance-design.md
+**Commit:** 2eff7ed
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. The spec's assumptions about
+the current state of `st-merge-when-green`, `st-prepare-release`,
+`st-commit`, and the VERGIL rename spec were all verified against the
+codebase and found accurate.
+
+## Issues Reviewed
+
+### [1] Release workflow auto-approval undermines Principle 3
+- **Category:** Contradiction
+- **Severity:** Serious
+- **Issue:** The spec had `vrg-release` using the agent PAT to create
+  release PRs and the human PAT to auto-approve them in the same script.
+  This technically satisfied branch protection but violated Principle 3
+  ("nothing ships until a human understands what it does and why") and
+  misattributed mechanized automation as AI-authored work in the audit
+  trail.
+- **Resolution:** Introduced a GitHub App (`vergil-release`) as a third
+  identity category for mechanized automation. The App creates release
+  PRs (visually distinct as `vergil-release[bot]`), and the human PAT
+  approves and merges. This gives a clean three-way audit trail: human /
+  AI / automation. The existing GitHub App (used in CI for version bump
+  PRs) is migrated to the org rather than creating a new one. Updated
+  Sections 1, 2, 3, 4, and 6.
+
+### [2] "No bypass" policy is practically bypass-with-extra-steps
+- **Category:** Ambiguity
+- **Severity:** Serious
+- **Issue:** The spec said "there are no bypass permissions" but an org
+  owner can temporarily modify the ruleset, merge, and restore it — which
+  is a bypass with extra steps. The framing created false assurance, and
+  the audit trail for ruleset modification is harder to correlate than a
+  single bypass event.
+- **Resolution:** Reframed as "No Standing Bypass Policy." The policy is
+  honest about what it is: no standing bypass permission, but exceptions
+  require deliberate ruleset modification. Any such modification is
+  treated as an incident to be retrospected.
+
+### [3] No credential compromise or rotation plan
+- **Category:** Omission
+- **Severity:** Moderate
+- **Issue:** Section 3 defined credential storage and selection but said
+  nothing about rotation schedules, compromise response, PAT expiration,
+  or ongoing observability of the credential namespace.
+- **Resolution:** Added a comprehensive Credential Lifecycle subsection
+  covering: 1-year PAT expiration with proactive rotation, a credential
+  audit tool (`vrg-credential-audit`) reporting on expiration, staleness,
+  and usage patterns, a five-step compromise response procedure with a
+  blast-radius table, and ongoing observability of the credential
+  namespace as an operational concern.
+
+### [4] "Require branches to be up to date" creates merge serialization
+- **Category:** Feasibility
+- **Severity:** Moderate
+- **Issue:** The "require up to date" rule serializes all merges to
+  `develop` — at scale of multiple contributors, only one PR can merge
+  at a time, and the rest must rebase and re-run CI. GitHub merge queue
+  solves this but requires a paid plan.
+- **Resolution:** Retained the rule with an explicit rationale (dropping
+  it opens a correctness hole that contradicts the project's commitment
+  to extreme hygiene). Documented GitHub merge queue as the correct
+  long-term solution when the org moves to a paid plan. Added a
+  corresponding entry in the Risks table.
+
+### [5] Credential selection mechanism is underspecified
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** Section 3 said credentials were selected "via session launch
+  mechanism — shell wrapper, Claude Code hook, or equivalent" without
+  specifying invariants, platform support, credential naming, or the
+  boundary between what tooling can enforce and what falls to guidelines.
+- **Resolution:** Replaced the Credential Selection and `gh` CLI
+  subsections with a comprehensive Credential Tooling section
+  establishing: the core principle ("the tool selects the credential,
+  not the developer"), standard credential names across all platforms,
+  platform-specific secure storage backends (macOS Keychain, Linux
+  Secret Service, Windows Credential Manager) using the `keyring` Python
+  library as abstraction, credential isolation by tool context, per-
+  subprocess `GH_TOKEN` scoping, and an honest accounting of what the
+  tooling cannot enforce on developer machines.
+
+### [6] Co-author metadata migration not coordinated with rename
+- **Category:** Omission
+- **Severity:** Minor
+- **Issue:** The governance spec retired `wphillipmoore-claude` and
+  `wphillipmoore-codex` in favor of `wphillipmoore-agent` but did not
+  mention updating the co-author config entries in `standard-tooling.toml`.
+- **Resolution:** Added a note in the Migration subsection that the
+  per-harness co-author entries (`claude`, `codex`) are replaced with a
+  single `agent` entry, coordinated with the VERGIL rename.
+
+### [7] External contributor governance deferral affects #719
+- **Category:** Omission
+- **Severity:** Minor
+- **Issue:** The cross-human review check (#719) parses the
+  `<username>-agent` naming convention. External contributors who don't
+  follow the convention would break the check.
+- **Resolution:** Added a note in the deferral section flagging the #719
+  dependency. Also added a "What Is Explicitly Out of Scope" subsection
+  rejecting autonomous AI contributions as a foundational design decision.
+  Added an exemption for App-authored PRs in the cross-human review
+  section.
+
+## Unresolved Issues
+
+None — all issues were addressed.
+
+## Consistency Pass
+
+A final read-through after all edits caught and fixed three additional
+issues:
+
+1. Section 4 intro still said "entirely under human credentials" after
+   the App identity was introduced — updated to reflect the App + human
+   credential split
+2. Cross-human review section did not account for App-authored PRs
+   (`vergil-release[bot]` doesn't match the `-agent` pattern) — added
+   explicit exemption
+3. Section 6 Org-Level Rulesets still said "no bypass" instead of "no
+   standing bypass" — aligned to the renamed policy terminology
+
+## Summary
+
+- **Issues found:** 7
+- **Issues resolved:** 7
+- **Unresolved:** 0
+- **Spec status:** Ready for implementation planning


### PR DESCRIPTION
# Pull Request

## Summary

- Design spec and implementation plan for org-level security, identity separation, credential management, and contributor model

## Issue Linkage

- Ref #717

## Notes

- Adds the design spec and implementation plan for setting up the
`vergil-project` GitHub org with a full governance model before
beginning the VERGIL migration.

### Design spec highlights

- **Three-identity model:** human (`<username>`), AI agent
  (`<username>-agent`), and org GitHub App (`vergil-release[bot]`)
- **Branch protection:** org-level rulesets on `main` and `develop`,
  required reviews, no standing bypass for anyone including org owners
- **Credential management:** two PATs per contributor (human + agent),
  GitHub App for mechanized automation, keychain-based storage with
  per-operation credential selection
- **Release workflow:** fully mechanized under human credentials via
  dual-credential orchestration (App authors PRs, human approves/merges)
- **Contributor guidelines:** humans accountable for all AI output,
  cross-human review required at scale of 2+ contributors
- **Tooling impact:** `vrg-org-config` and `vrg-repo-config` split,
  `skip_rulesets` escape hatch removed, uniform rigor for all repos

### Implementation plan structure

15 tasks across 3 phases:
- **Phase 1** (Tasks 1-6): Manual infrastructure setup
- **Phase 2** (Tasks 7-9): Codebase preparation
- **Phase 3** (Tasks 10-15): Post-migration governance activation

Task 14 creates issues in the new org for all deferred work items.

### Related issues

- #718: `.github` profile repo and Claude Code permission model
- #719: Cross-human review CI check for multi-contributor orgs