### PR TITLE
refactor(config): codebase preparation for org governance model

### DIFF
--- a/docs/plans/2026-05-11-org-governance-setup.md
+++ b/docs/plans/2026-05-11-org-governance-setup.md
@@ -26,10 +26,12 @@ The existing rename plan (`docs/plans/2026-05-11-vergil-rename.md`) is
 Plan B (migration). Plan A must complete through Task 9 before Plan B
 begins. Tasks 10–15 execute after Plan B completes.
 
-**Task ordering within Phase 1:** Tasks 1 and 4 must complete before
-Task 2 (PATs require the org to exist and the agent account to be
-created). Task 2 must complete before Task 3 (Keychain storage needs
-the PAT values). Task 6 requires the org to exist (Task 4).
+**Task ordering within Phase 1:** Task 4 must complete before Task 2
+(human PAT requires the org to exist as resource owner). Task 2 must
+complete before Task 3 (Keychain storage needs the PAT value). Task 6
+requires the org to exist (Task 4). Task 1 (agent account creation)
+is independent of Phase 1 PAT work — the agent PAT is created in
+Phase 3 (Task 10) after the agent is invited to the org.
 
 ---
 
@@ -85,11 +87,14 @@ This replaces the per-harness accounts (`wphillipmoore-claude`,
 
   Record this — it is needed for the co-author trailer in Task 6.
 
-### Task 2: Generate Fine-Grained PATs
+### Task 2: Generate Human Fine-Grained PAT
 
 **Files:** None (GitHub web UI)
 
-Two PATs: one for the human identity, one for the agent identity.
+Only the human PAT is created in Phase 1. The agent PAT requires the
+agent account to be an org collaborator, which cannot happen until
+repos exist in the org (post-migration). The agent PAT is created in
+Phase 3, Task 10.
 
 - [ ] **Step 1: Generate the human PAT**
 
@@ -98,8 +103,8 @@ Two PATs: one for the human identity, one for the agent identity.
 
   - Token name: `vergil-human`
   - Expiration: 1 year (maximum for fine-grained)
-  - Resource owner: `vergil-project` (once the org exists — do this
-    step after Task 3)
+  - Resource owner: `vergil-project` (requires Task 4 — org must
+    exist first)
   - Repository access: All repositories
   - Permissions:
     - Administration: Read and write
@@ -111,43 +116,19 @@ Two PATs: one for the human identity, one for the agent identity.
 
   Copy the token value.
 
-- [ ] **Step 2: Generate the agent PAT**
-
-  Go to <https://github.com/settings/personal-access-tokens/new>
-  (logged in as `wphillipmoore-agent`).
-
-  - Token name: `vergil-agent`
-  - Expiration: 1 year
-  - Resource owner: `vergil-project` (once the org exists and the
-    agent account is invited — do this step after Task 4)
-  - Repository access: All repositories
-  - Permissions:
-    - Contents: Read and write
-    - Issues: Read and write
-    - Pull requests: Read and write
-    - Metadata: Read (auto-granted)
-  - **Not granted:** Administration, Actions, org settings, secrets,
-    deployments
-
-  Copy the token value.
-
-- [ ] **Step 3: Verify PAT scopes are correct**
-
-  For each token, verify it can only do what it should:
+- [ ] **Step 2: Verify PAT scope is correct**
 
   ```bash
-  # Human PAT — should succeed
   GH_TOKEN=<human-pat> gh api user --jq '.login'
   # Expected: wphillipmoore
-
-  # Agent PAT — should succeed
-  GH_TOKEN=<agent-pat> gh api user --jq '.login'
-  # Expected: wphillipmoore-agent
   ```
 
-### Task 3: Store Credentials in macOS Keychain
+### Task 3: Store Human PAT in macOS Keychain
 
 **Files:** None (macOS Keychain)
+
+Only the human PAT is stored now. The agent PAT is created and stored
+in Phase 3, Task 10.
 
 - [ ] **Step 1: Store the human PAT**
 
@@ -160,27 +141,15 @@ Two PATs: one for the human identity, one for the agent identity.
     -U
   ```
 
-- [ ] **Step 2: Store the agent PAT**
-
-  ```bash
-  security add-generic-password \
-    -a "vergil" \
-    -s "vergil/agent-pat" \
-    -w "<paste-agent-pat-here>" \
-    -T "" \
-    -U
-  ```
-
-- [ ] **Step 3: Verify retrieval**
+- [ ] **Step 2: Verify retrieval**
 
   ```bash
   security find-generic-password -s "vergil/human-pat" -w
-  security find-generic-password -s "vergil/agent-pat" -w
   ```
 
-  Each should print the stored token.
+  Should print the stored token.
 
-- [ ] **Step 4: Remove the global GH_TOKEN export**
+- [ ] **Step 3: Remove the global GH_TOKEN export**
 
   Remove any `export GH_TOKEN=...` from your shell profile
   (`~/.zshrc`, `~/.zprofile`, etc.). Verify:
@@ -606,21 +575,60 @@ complete and all repos are in the `vergil-project` org.
 
 - [ ] **Step 3: Accept the invitation**
 
-  Log in as `wphillipmoore-agent` and accept the collaboration
-  invitations, or use the API:
-
-  ```bash
-  GH_TOKEN=<agent-pat> gh api user/repository_invitations --jq '.[].id' | \
-    xargs -I{} gh api user/repository_invitations/{} -X PATCH
-  ```
+  Log in as `wphillipmoore-agent` in the GitHub web UI and accept
+  the collaboration invitations. (The agent PAT scoped to
+  `vergil-project` does not exist yet — it is created in Step 5
+  after the agent has org access.)
 
 - [ ] **Step 4: Verify access**
 
+  Log in as `wphillipmoore-agent` in the web UI and confirm the
+  org's repos are visible at
+  `https://github.com/orgs/vergil-project/repositories`.
+
+- [ ] **Step 5: Generate the agent PAT**
+
+  Now that the agent account is a collaborator in the org, create its
+  fine-grained PAT scoped to `vergil-project`.
+
+  Go to <https://github.com/settings/personal-access-tokens/new>
+  (logged in as `wphillipmoore-agent`).
+
+  - Token name: `vergil-agent`
+  - Expiration: 1 year
+  - Resource owner: `vergil-project`
+  - Repository access: All repositories
+  - Permissions:
+    - Contents: Read and write
+    - Issues: Read and write
+    - Pull requests: Read and write
+    - Metadata: Read (auto-granted)
+  - **Not granted:** Administration, Actions, org settings, secrets,
+    deployments
+
+  Copy the token value.
+
+- [ ] **Step 6: Store the agent PAT in macOS Keychain**
+
   ```bash
-  GH_TOKEN=<agent-pat> gh repo list vergil-project --json name --jq '.[].name'
+  security add-generic-password \
+    -a "vergil" \
+    -s "vergil/agent-pat" \
+    -w "<paste-agent-pat-here>" \
+    -T "" \
+    -U
   ```
 
-  Expected: all repos listed.
+- [ ] **Step 7: Verify agent PAT**
+
+  ```bash
+  # Verify identity
+  GH_TOKEN=<agent-pat> gh api user --jq '.login'
+  # Expected: wphillipmoore-agent
+
+  # Verify Keychain retrieval
+  security find-generic-password -s "vergil/agent-pat" -w
+  ```
 
 ### Task 11: Configure Org-Level Rulesets
 

--- a/src/standard_tooling/bin/st_commit.py
+++ b/src/standard_tooling/bin/st_commit.py
@@ -75,7 +75,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--scope", required=True, help="Conventional commit scope")
     parser.add_argument("--message", required=True, help="Commit description")
     parser.add_argument("--body", default="", help="Detailed commit body")
-    parser.add_argument("--agent", required=True, help="AI tool identity (e.g. claude, codex)")
+    parser.add_argument(
+        "--agent", required=True, help="AI agent identity (key in [project.co-authors])"
+    )
     return parser.parse_args(argv)
 
 

--- a/src/standard_tooling/lib/config.py
+++ b/src/standard_tooling/lib/config.py
@@ -59,11 +59,6 @@ class CiConfig:
 
 
 @dataclass
-class GithubOverrides:
-    skip_rulesets: bool
-
-
-@dataclass
 class PublishConfig:
     release: bool
     docs: bool
@@ -80,7 +75,6 @@ class StConfig:
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
     ci: CiConfig
-    github: GithubOverrides
     publish: PublishConfig
     docker: DockerConfig
 
@@ -140,11 +134,6 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         integration_tests=bool(ci_raw.get("integration-tests", False)),
     )
 
-    github_raw = raw.get("github", {})
-    github_overrides = GithubOverrides(
-        skip_rulesets=bool(github_raw.get("skip-rulesets", False)),
-    )
-
     publish_raw = raw.get("publish", {})
     publish = PublishConfig(
         release=bool(publish_raw.get("release", False)),
@@ -172,7 +161,6 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         dependencies=dict(deps),
         markdownlint=markdownlint,
         ci=ci,
-        github=github_overrides,
         publish=publish,
         docker=docker,
     )

--- a/src/standard_tooling/lib/github_config.py
+++ b/src/standard_tooling/lib/github_config.py
@@ -307,10 +307,9 @@ def compute_desired_state(config: StConfig, *, visibility: str, is_org: bool) ->
     """Compute the full desired GitHub configuration from a repo's StConfig."""
     rulesets: list[DesiredRuleset] = []
 
-    if not config.github.skip_rulesets:
-        rulesets.append(desired_branch_protection_ruleset())
-        rulesets.append(desired_tag_protection_ruleset())
-        rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
+    rulesets.append(desired_branch_protection_ruleset())
+    rulesets.append(desired_tag_protection_ruleset())
+    rulesets.append(desired_ci_gates_ruleset(config.project, config.ci))
 
     publish = DesiredPublishConfig(
         release=config.publish.release,

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -6,8 +6,7 @@ release-model = "tagged-release"
 primary-language = "python"
 
 [project.co-authors]
-claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
-codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
 
 [publish]
 release = true

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -73,7 +73,7 @@ release-model = "tagged-release"
 primary-language = "python"
 
 [project.co-authors]
-claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>"
+agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"
 
 [dependencies]
 standard-tooling = "v1.4"
@@ -90,8 +90,8 @@ def test_read_config_valid(tmp_path: Path) -> None:
     assert cfg.project.branching_model == "library-release"
     assert cfg.project.release_model == "tagged-release"
     assert cfg.project.primary_language == "python"
-    assert "claude" in cfg.project.co_authors
-    assert "user-claude" in cfg.project.co_authors["claude"]
+    assert "agent" in cfg.project.co_authors
+    assert "user-agent" in cfg.project.co_authors["agent"]
     assert cfg.dependencies["standard-tooling"] == "v1.4"
 
 
@@ -122,11 +122,11 @@ def test_read_config_invalid_enum(tmp_path: Path) -> None:
 
 def test_read_config_malformed_co_author(tmp_path: Path) -> None:
     toml = _VALID_TOML.replace(
-        'claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>"',
-        'claude = "not a valid trailer"',
+        'agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"',
+        'agent = "not a valid trailer"',
     )
     (tmp_path / "standard-tooling.toml").write_text(toml)
-    with pytest.raises(ConfigError, match="co-author.*claude"):
+    with pytest.raises(ConfigError, match="co-author.*agent"):
         read_config(tmp_path)
 
 
@@ -141,7 +141,7 @@ def test_read_config_no_co_authors(tmp_path: Path) -> None:
     lines = [
         ln
         for ln in _VALID_TOML.splitlines(keepends=True)
-        if "co-authors" not in ln.lower() and "claude" not in ln
+        if "co-authors" not in ln.lower() and "agent" not in ln
     ]
     (tmp_path / "standard-tooling.toml").write_text("".join(lines))
     cfg = read_config(tmp_path)

--- a/tests/standard_tooling/test_config.py
+++ b/tests/standard_tooling/test_config.py
@@ -10,7 +10,6 @@ import pytest
 from standard_tooling.lib.config import (
     CiConfig,
     ConfigError,
-    GithubOverrides,
     MarkdownlintConfig,
     read_config,
     st_install_tag,
@@ -257,29 +256,6 @@ def test_read_config_no_ci_section_raises(tmp_path: Path) -> None:
     (tmp_path / "standard-tooling.toml").write_text(_BASE_TOML)
     with pytest.raises(ConfigError, match=r"missing required section \[ci\]"):
         read_config(tmp_path)
-
-
-# -- [github] section ---------------------------------------------------------
-
-_GITHUB_OVERRIDE_TOML = (
-    _VALID_TOML
-    + """
-[github]
-skip-rulesets = true
-"""
-)
-
-
-def test_read_config_github_overrides(tmp_path: Path) -> None:
-    (tmp_path / "standard-tooling.toml").write_text(_GITHUB_OVERRIDE_TOML)
-    cfg = read_config(tmp_path)
-    assert cfg.github == GithubOverrides(skip_rulesets=True)
-
-
-def test_read_config_no_github_section(tmp_path: Path) -> None:
-    (tmp_path / "standard-tooling.toml").write_text(_VALID_TOML)
-    cfg = read_config(tmp_path)
-    assert cfg.github == GithubOverrides(skip_rulesets=False)
 
 
 # -- [publish] section --------------------------------------------------------

--- a/tests/standard_tooling/test_github_config_lib.py
+++ b/tests/standard_tooling/test_github_config_lib.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from standard_tooling.lib.config import (
     CiConfig,
     DockerConfig,
-    GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
     PublishConfig,
@@ -303,14 +302,12 @@ def _st_config(
     release_model: str = "tagged-release",
     versions: list[str] | None = None,
     integration_tests: bool = False,
-    skip_rulesets: bool = False,
 ) -> StConfig:
     return StConfig(
         project=_project(language=language, release_model=release_model),
         dependencies={"standard-tooling": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
-        github=GithubOverrides(skip_rulesets=skip_rulesets),
         publish=PublishConfig(release=False, docs=True),
         docker=DockerConfig(image_prefix="prod"),
     )
@@ -323,11 +320,6 @@ def test_compute_desired_state_has_three_rulesets() -> None:
     assert "Branch protection" in names
     assert "Tag protection" in names
     assert "CI gates" in names
-
-
-def test_compute_desired_state_skip_rulesets() -> None:
-    state = compute_desired_state(_st_config(skip_rulesets=True), visibility="public", is_org=True)
-    assert state.rulesets == []
 
 
 def test_compute_desired_state_includes_repo_settings() -> None:
@@ -1288,7 +1280,6 @@ def test_compute_desired_state_publish_release_true() -> None:
         dependencies={"standard-tooling": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(),
-        github=GithubOverrides(skip_rulesets=False),
         publish=PublishConfig(release=True, docs=True),
         docker=DockerConfig(image_prefix="prod"),
     )

--- a/tests/standard_tooling/test_st_commit.py
+++ b/tests/standard_tooling/test_st_commit.py
@@ -24,8 +24,7 @@ release-model = "tagged-release"
 primary-language = "python"
 
 [project.co-authors]
-claude = "Co-Authored-By: test <test@test.com>"
-codex = "Co-Authored-By: test-codex <codex@test.com>"
+agent = "Co-Authored-By: test-agent <test-agent@test.com>"
 
 [dependencies]
 standard-tooling = "v1.4"
@@ -77,12 +76,12 @@ def _commit_environment(
 
 def test_parse_args_required() -> None:
     args = parse_args(
-        ["--type", "feat", "--scope", "core", "--message", "add thing", "--agent", "claude"]
+        ["--type", "feat", "--scope", "core", "--message", "add thing", "--agent", "agent"]
     )
     assert args.commit_type == "feat"
     assert args.scope == "core"
     assert args.message == "add thing"
-    assert args.agent == "claude"
+    assert args.agent == "agent"
     assert args.body == ""
 
 
@@ -98,7 +97,7 @@ def test_parse_args_with_scope_and_body() -> None:
             "--body",
             "Fixed edge case",
             "--agent",
-            "codex",
+            "agent",
         ]
     )
     assert args.commit_type == "fix"
@@ -116,7 +115,7 @@ def test_parse_args_revert_type() -> None:
             "--message",
             "undo token change",
             "--agent",
-            "claude",
+            "agent",
         ]
     )
     assert args.commit_type == "revert"
@@ -124,13 +123,13 @@ def test_parse_args_revert_type() -> None:
 
 def test_parse_args_invalid_type() -> None:
     with pytest.raises(SystemExit):
-        parse_args(["--type", "invalid", "--scope", "core", "--message", "x", "--agent", "claude"])
+        parse_args(["--type", "invalid", "--scope", "core", "--message", "x", "--agent", "agent"])
 
 
 def test_main_no_staged_changes(tmp_path: Path) -> None:
     with _commit_environment(tmp_path, has_staged=False):
         result = main(
-            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "claude"]
+            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "agent"]
         )
     assert result == 1
 
@@ -148,11 +147,11 @@ def test_main_with_staged_changes(tmp_path: Path) -> None:
         patch("standard_tooling.bin.st_commit.git.run", side_effect=capture_run),
     ):
         result = main(
-            ["--type", "feat", "--scope", "core", "--message", "add feature", "--agent", "claude"]
+            ["--type", "feat", "--scope", "core", "--message", "add feature", "--agent", "agent"]
         )
     assert result == 0
     assert commit_file_content.startswith("feat(core): add feature\n")
-    assert "Co-Authored-By: test <test@test.com>" in commit_file_content
+    assert "Co-Authored-By: test-agent <test-agent@test.com>" in commit_file_content
 
 
 def test_main_with_scope_and_body(tmp_path: Path) -> None:
@@ -178,13 +177,13 @@ def test_main_with_scope_and_body(tmp_path: Path) -> None:
                 "--body",
                 "Fixed edge case",
                 "--agent",
-                "claude",
+                "agent",
             ]
         )
     assert result == 0
     assert "fix(lint): correct regex" in commit_file_content
     assert "Fixed edge case" in commit_file_content
-    assert "Co-Authored-By: test <test@test.com>" in commit_file_content
+    assert "Co-Authored-By: test-agent <test-agent@test.com>" in commit_file_content
 
 
 # --------------------------------------------------------------------------
@@ -230,7 +229,7 @@ def test_main_unknown_agent(tmp_path: Path) -> None:
 # Reference: docs/specs/host-level-tool.md "Migration / standard-tooling
 # itself" step 1; docs/plans/host-level-tool-plan.md Task 1.1.
 
-_DEFAULT_ARGS = ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "claude"]
+_DEFAULT_ARGS = ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "agent"]
 
 
 # Check 1: detached HEAD
@@ -431,7 +430,7 @@ def test_validate_rejects_autoclose_keywords_in_body(tmp_path: Path, body: str) 
                 "--body",
                 body,
                 "--agent",
-                "claude",
+                "agent",
             ]
         )
     assert result == 1
@@ -460,7 +459,7 @@ def test_validate_admits_safe_body_content(tmp_path: Path, body: str) -> None:
                 "--body",
                 body,
                 "--agent",
-                "claude",
+                "agent",
             ]
         )
     assert result == 0

--- a/tests/standard_tooling/test_st_github_config.py
+++ b/tests/standard_tooling/test_st_github_config.py
@@ -20,7 +20,6 @@ from standard_tooling.bin.st_github_config import (
 from standard_tooling.lib.config import (
     CiConfig,
     DockerConfig,
-    GithubOverrides,
     MarkdownlintConfig,
     ProjectConfig,
     PublishConfig,
@@ -284,7 +283,6 @@ def _make_config() -> StConfig:
         dependencies={"standard-tooling": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=CiConfig(versions=["3.14"], integration_tests=False),
-        github=GithubOverrides(skip_rulesets=True),
         publish=PublishConfig(release=False, docs=True),
         docker=DockerConfig(image_prefix="prod"),
     )


### PR DESCRIPTION
# Pull Request

## Summary

- Remove skip-rulesets escape hatch, consolidate co-author config to single agent identity, update st-commit for agent flag compatibility

## Issue Linkage

- Ref #551

## Notes

- Phase 2 of the org governance setup plan (docs/plans/2026-05-11-org-governance-setup.md, Tasks 7-9).

Three changes:

1. **Remove skip_rulesets escape hatch** — GithubOverrides dataclass, [github] config parsing, and conditional in compute_desired_state all removed. Rulesets are now always enforced. No consumer repo uses this override.

2. **Consolidate co-author config** — Replace per-harness co-author entries (claude, codex) with single agent entry pointing to the new wphillipmoore-agent GitHub account (ID 284101533). The security boundary is human vs. not-human, not which AI tool produced the work.

3. **Update st-commit** — Help text and all test fixtures updated from claude/codex to agent. The --agent flag was already a generic string lookup, so no behavioral change beyond the help text.