### PR TITLE
fix(docker-cache): update hardcoded org URL from wphillipmoore to vergil-project

### DIFF
--- a/src/vergil_tooling/lib/docker_cache.py
+++ b/src/vergil_tooling/lib/docker_cache.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 _SELF_PROJECT_NAME = "vergil-tooling"
 
-_ST_GIT_URL = "https://github.com/wphillipmoore/vergil-tooling"
+_ST_GIT_URL = "https://github.com/vergil-project/vergil-tooling"
 
 _CACHE_FILES: dict[str, list[str]] = {
     "python": ["uv.lock", "vergil.toml"],


### PR DESCRIPTION
# Pull Request

## Summary

- Updates the hardcoded git URL in docker_cache.py from the pre-migration org (wphillipmoore/vergil-tooling) to the new org (vergil-project/vergil-tooling). Unblocks vrg-docker-run for any repo using the new org.

## Issue Linkage

- Ref #733

## Notes

- -