### PR TITLE
fix(github): surface captured API output in error messages

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -16,6 +16,22 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+
+class GitHubAPIError(subprocess.CalledProcessError):
+    """``CalledProcessError`` that includes captured API output in its message."""
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        parts: list[str] = []
+        if self.stderr:
+            parts.append(f"stderr: {self.stderr.strip()}")
+        if self.stdout:
+            parts.append(f"stdout: {self.stdout.strip()}")
+        if parts:
+            return f"{base}\n{'\n'.join(parts)}"
+        return base
+
+
 _NO_CHECKS_PHRASE = "no checks reported"
 _POLL_INTERVAL_SECS = 5
 _POLL_TIMEOUT_SECS = 60
@@ -44,6 +60,9 @@ def _run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[st
             return subprocess.run(*args, **kwargs)  # noqa: S603
         except subprocess.CalledProcessError as exc:
             if attempt == _MAX_RETRIES or not _is_retryable(exc):
+                detail = ((exc.stderr or "") + (exc.stdout or "")).strip()
+                if detail:
+                    raise GitHubAPIError(exc.returncode, exc.cmd, exc.stdout, exc.stderr) from exc
                 raise
             delay = min(_BASE_DELAY_SECS * (2**attempt), _MAX_DELAY_SECS)
             delay *= 0.5 + random.random()  # noqa: S311

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -263,6 +263,32 @@ def test_delete_if_exists_returns_true_on_empty_stdout() -> None:
         assert github.delete_if_exists("repos/o/r/branches/main/protection") is True
 
 
+# --- GitHubAPIError ---
+
+
+class TestGitHubAPIError:
+    def test_is_subclass_of_called_process_error(self) -> None:
+        assert issubclass(github.GitHubAPIError, subprocess.CalledProcessError)
+
+    def test_str_includes_stderr(self) -> None:
+        exc = github.GitHubAPIError(1, ["gh"], stderr="Validation Failed")
+        assert "Validation Failed" in str(exc)
+
+    def test_str_includes_stdout(self) -> None:
+        exc = github.GitHubAPIError(1, ["gh"], output='{"message": "Not Found"}')
+        assert "Not Found" in str(exc)
+
+    def test_str_includes_both(self) -> None:
+        exc = github.GitHubAPIError(1, ["gh"], output='{"message": "Bad"}', stderr="HTTP 422")
+        msg = str(exc)
+        assert "HTTP 422" in msg
+        assert "Bad" in msg
+
+    def test_str_falls_back_to_base_when_no_output(self) -> None:
+        exc = github.GitHubAPIError(1, ["gh"])
+        assert str(exc) == str(subprocess.CalledProcessError(1, ["gh"]))
+
+
 # --- Retry logic ---
 
 
@@ -332,7 +358,7 @@ class TestRunWithRetry:
             ),
             patch("vergil_tooling.lib.github.time.sleep"),
             patch("vergil_tooling.lib.github.random.random", return_value=0.5),
-            pytest.raises(subprocess.CalledProcessError),
+            pytest.raises(github.GitHubAPIError, match="Gateway Timeout"),
         ):
             github._run_with_retry(("gh", "pr", "view"), check=True)
 
@@ -341,10 +367,21 @@ class TestRunWithRetry:
         with (
             patch("vergil_tooling.lib.github.subprocess.run", side_effect=err),
             patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
-            pytest.raises(subprocess.CalledProcessError),
+            pytest.raises(github.GitHubAPIError, match="404 Not Found"),
         ):
             github._run_with_retry(("gh", "pr", "view"), check=True)
         mock_sleep.assert_not_called()
+
+    def test_raises_plain_error_when_no_captured_output(self) -> None:
+        err = subprocess.CalledProcessError(returncode=1, cmd=["gh"])
+        err.stderr = ""
+        err.stdout = ""
+        with (
+            patch("vergil_tooling.lib.github.subprocess.run", side_effect=err),
+            pytest.raises(subprocess.CalledProcessError) as exc_info,
+        ):
+            github._run_with_retry(("gh", "pr", "view"), check=True)
+        assert type(exc_info.value) is subprocess.CalledProcessError
 
     def test_backoff_delay_increases(self) -> None:
         err = _api_error(stderr="HTTP 504 Gateway Timeout")


### PR DESCRIPTION
# Pull Request

## Summary

- Add GitHubAPIError exception that includes stderr/stdout in its message, replacing bare CalledProcessError when gh api calls fail

## Issue Linkage

- Ref #727

## Notes

- write_json, delete, and read_output used capture_output=True, so when gh api calls failed the API error message was swallowed — only a bare CalledProcessError with exit code 1 was shown. This made vrg-github-config apply failures undiagnosable. The fix adds a GitHubAPIError subclass of CalledProcessError whose __str__ appends captured stderr/stdout. _run_with_retry raises this when API output is available. Existing except CalledProcessError catches continue to work since GitHubAPIError is a subclass.