### PR TITLE
fix(vrg-github-config): omit allow_forking for public org repos

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -113,7 +113,7 @@ def desired_repo_settings(*, visibility: str, is_org: bool) -> DesiredRepoSettin
         has_issues=True,
         has_projects=True,
         has_wiki=True,
-        allow_forking=(visibility == "public") if is_org else None,
+        allow_forking=False if (is_org and visibility == "private") else None,
         allow_update_branch=True,
         has_downloads=False,
         merge_commit_title="MERGE_MESSAGE",

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -52,9 +52,9 @@ def test_desired_repo_settings_are_fixed() -> None:
     assert s.has_wiki is True
 
 
-def test_desired_repo_settings_public_allows_forking() -> None:
+def test_desired_repo_settings_public_org_omits_forking() -> None:
     s = desired_repo_settings(visibility="public", is_org=True)
-    assert s.allow_forking is True
+    assert s.allow_forking is None
 
 
 def test_desired_repo_settings_private_disallows_forking() -> None:
@@ -952,7 +952,7 @@ def test_apply_repo_settings_includes_new_fields() -> None:
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
-    assert body["allow_forking"] is True
+    assert "allow_forking" not in body
     assert body["allow_update_branch"] is True
     assert body["has_downloads"] is False
     assert body["merge_commit_title"] == "MERGE_MESSAGE"
@@ -1300,7 +1300,7 @@ def test_desired_repo_settings_user_repo_allow_forking_is_none() -> None:
 
 def test_desired_repo_settings_org_repo_allow_forking_set() -> None:
     s = desired_repo_settings(visibility="public", is_org=True)
-    assert s.allow_forking is True
+    assert s.allow_forking is None
     s2 = desired_repo_settings(visibility="private", is_org=True)
     assert s2.allow_forking is False
 
@@ -1313,12 +1313,12 @@ def test_apply_repo_settings_omits_allow_forking_when_none() -> None:
     assert "allow_forking" not in body
 
 
-def test_apply_repo_settings_includes_allow_forking_for_org() -> None:
-    settings = desired_repo_settings(visibility="public", is_org=True)
+def test_apply_repo_settings_includes_allow_forking_for_private_org() -> None:
+    settings = desired_repo_settings(visibility="private", is_org=True)
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
-    assert body["allow_forking"] is True
+    assert body["allow_forking"] is False
 
 
 def test_diff_skips_allow_forking_when_desired_is_none() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Omit allow_forking from API calls for public org repos to avoid HTTP 422

## Issue Linkage

- Ref #740

## Notes

- GitHub rejects `allow_forking` in PATCH requests for public org-owned repos with HTTP 422: "Allow forks setting can only be changed on org-owned private repositories."

Root cause: `desired_repo_settings()` set `allow_forking = True` for all org repos, but the API only accepts this field for private org repos. Public repos are always forkable.

Fix: only set `allow_forking` (to `False`) for org-owned private repos. For public org repos and user repos, omit the field entirely (`None`).

One-line production code change + four test updates to match.