### PR TITLE
docs(site): replace standard-tooling naming with vergil-tooling

### DIFF
--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -7,7 +7,7 @@ unfolds once you're set up, see [Git Workflow](git-workflow.md).
 
 ## Mental model — what you're installing
 
-Standard-tooling is delivered through three coordinated surfaces.
+Vergil-tooling is delivered through three coordinated surfaces.
 The setup steps below wire up each one:
 
 | Surface | What it is | How you consume it |

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,6 +1,6 @@
-# Standard Tooling
+# Vergil Tooling
 
-Standard-tooling is a Python package and script collection providing shared
+Vergil-tooling is a Python package and script collection providing shared
 development tooling for all managed repositories. It delivers CLI tools for
 commits, PRs, releases, and validation alongside bash validators and git hooks
 -- all consumed via PATH.

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -1,6 +1,6 @@
 # CLI Tools Overview
 
-Every `st-*` command provided by this package, organized by runtime
+Every CLI command provided by this package, organized by runtime
 context. Each entry documents the tool's purpose, where it runs,
 what it assumes, and how it fails when those assumptions are violated.
 

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -1,6 +1,6 @@
 # Script Reference
 
-Standard-tooling provides Python CLI tools installed as `st-*` console
+Vergil-tooling provides Python CLI tools installed as `st-*` console
 scripts, plus git hooks. For the full audit of every tool's runtime
 preconditions, host-vs-container classification, and failure modes,
 see the [CLI Tools Overview](cli-tools-overview.md).


### PR DESCRIPTION
# Pull Request

## Summary

- Replace remaining 'standard tooling' / 'Standard-tooling' references with 'vergil tooling' / 'Vergil-tooling' across four site documentation files.

## Issue Linkage

- Ref #745

## Notes

- -