### PR TITLE
docs: replace stale standard-tooling and wphillipmoore references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ exactly one container per run:
   registry.
 
 Dev container images are maintained in
-[vergil-docker](https://github.com/wphillipmoore/vergil-docker).
+[vergil-docker](https://github.com/vergil-project/vergil-docker).
 
 ```bash
 # Build the dev image (one-time)
@@ -209,7 +209,7 @@ Shared libraries under `src/vergil_tooling/lib/`:
 ### Docker Dev Images
 
 Dev container images (Dockerfiles, build script, publish workflow) are
-maintained in [vergil-docker](https://github.com/wphillipmoore/vergil-docker).
+maintained in [vergil-docker](https://github.com/vergil-project/vergil-docker).
 
 The `vrg-docker-test` entry point auto-detects the project
 language (Gemfile, pyproject.toml, go.mod, pom.xml/mvnw) and runs the test
@@ -226,7 +226,7 @@ it in a thin `scripts/dev/test.sh`. Environment overrides:
 Consumed via `git config core.hooksPath .githooks`:
 
 - `pre-commit` — Env-var-plus-`GIT_REFLOG_ACTION` gate. Admits commits
-  with `ST_COMMIT_CONTEXT=1` (set by `vrg-commit`) and admits derived
+  with `VRG_COMMIT_CONTEXT=1` (set by `vrg-commit`) and admits derived
   workflows (`amend`, `cherry-pick`, `revert`, `rebase*`, `merge*`).
   Rejects raw `git commit -m "..."`. The five branch / context checks
   (detached HEAD, protected branches, branch prefix, issue number,

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ git config core.hooksPath .githooks
 Consumed via `git config core.hooksPath .githooks`:
 
 - `pre-commit` — env-var-plus-`GIT_REFLOG_ACTION` gate. Admits
-  `vrg-commit`-driven commits (`ST_COMMIT_CONTEXT=1`) and derived
+  `vrg-commit`-driven commits (`VRG_COMMIT_CONTEXT=1`) and derived
   workflows (`amend`, `cherry-pick`, `revert`, `rebase*`, `merge*`).
   Rejects raw `git commit`. Branch / context validation lives in
   `vrg-commit` itself.

--- a/docs/git-hooks-and-validation.md
+++ b/docs/git-hooks-and-validation.md
@@ -33,7 +33,7 @@ entry points that share a common set of validators:
   ensuring standards are enforced even when hooks are not
   installed.
 - **Claude Code plugin hooks** (delivered by
-  [`vergil-claude-plugin`](https://github.com/wphillipmoore/vergil-claude-plugin))
+  [`vergil-claude-plugin`](https://github.com/vergil-project/vergil-claude-plugin))
   enforce a subset of the same rules at the agent-tool level —
   catching problems before they reach the `git commit` that the
   pre-commit hook would evaluate. Covered in detail in the plugin
@@ -63,7 +63,7 @@ raw `git commit`.
 ### pre-commit
 
 The pre-commit hook is an env-var gate: it admits commits
-driven by `vrg-commit` (which sets `ST_COMMIT_CONTEXT=1`) and
+driven by `vrg-commit` (which sets `VRG_COMMIT_CONTEXT=1`) and
 derived workflows (`amend`, `cherry-pick`, `revert`, `rebase`,
 `merge`), and rejects everything else. The five commit-context
 checks below live in `vrg-commit` itself and run before `git
@@ -173,7 +173,7 @@ The following table shows where each validation runs:
 
 - **pre-commit**: runs locally on every `git commit`
 - **plugin**: PreToolUse/PostToolUse hooks from
-  [`vergil-claude-plugin`](https://github.com/wphillipmoore/vergil-claude-plugin)
+  [`vergil-claude-plugin`](https://github.com/vergil-project/vergil-claude-plugin)
   fire when Claude Code invokes Bash / Write / Edit tools. Catches
   patterns earlier than a `git commit` would — including ones that
   never reach git (e.g., raw `gh pr create`, heredoc escaping bugs).

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -55,7 +55,7 @@ Create `.claude/settings.json` in your repo:
     "vergil-tooling-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin"
       }
     }
   },
@@ -69,7 +69,7 @@ Commit this file — it's part of the repo's reproducible setup.
 
 !!! note "Plugin install is a known rough edge"
     The install/update flow for the plugin itself is tracked in
-    [vergil-claude-plugin#46](https://github.com/wphillipmoore/vergil-claude-plugin/issues/46).
+    [vergil-claude-plugin#46](https://github.com/vergil-project/vergil-claude-plugin/issues/46).
     For now, this settings.json entry is enough for Claude Code to
     discover and enable the plugin on the next session restart.
 

--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -231,7 +231,7 @@ Jobs that remain inline keep their names unchanged:
 ## Dev container images
 
 Published to `ghcr.io/vergil-project/dev-<language>:<version>` from the
-[vergil-docker](https://github.com/wphillipmoore/vergil-docker)
+[vergil-docker](https://github.com/vergil-project/vergil-docker)
 repository.
 
 ### Available images

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -92,7 +92,7 @@ Create it in your repo:
 ```bash
 #!/usr/bin/env bash
 # Admit vrg-commit-driven commits.
-if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then exit 0; fi
+if [[ "${VRG_COMMIT_CONTEXT:-}" == "1" ]]; then exit 0; fi
 # Admit derived-commit workflows (amend, cherry-pick, revert, rebase, merge).
 case "${GIT_REFLOG_ACTION:-}" in
   amend|cherry-pick|revert|rebase*|merge*) exit 0 ;;
@@ -111,7 +111,7 @@ git config core.hooksPath .githooks
 ```
 
 The gate admits commits from `vrg-commit` (which sets
-`ST_COMMIT_CONTEXT=1`) and from derived workflows like rebase and
+`VRG_COMMIT_CONTEXT=1`) and from derived workflows like rebase and
 cherry-pick. All branch/context checks (detached HEAD, protected
 branches, branch prefix, issue number) live in `vrg-commit` itself.
 
@@ -172,7 +172,7 @@ Create `.claude/settings.json` in your repo:
     "vergil-tooling-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin"
       }
     }
   },
@@ -199,7 +199,7 @@ What the plugin provides:
   but never finalized.
 
 See the plugin's own
-[Hooks reference](https://github.com/wphillipmoore/vergil-claude-plugin/blob/develop/docs/site/docs/hooks/index.md)
+[Hooks reference](https://github.com/vergil-project/vergil-claude-plugin/blob/develop/docs/site/docs/hooks/index.md)
 for the full list.
 
 !!! warning "Plugin install is a known rough edge"
@@ -208,7 +208,7 @@ for the full list.
     default branch. Updates can be slow to propagate and the local
     `~/.claude/plugins/marketplaces/` and `…/cache/` directories
     sometimes need manual refreshing. All tracked in
-    [vergil-claude-plugin#46](https://github.com/wphillipmoore/vergil-claude-plugin/issues/46).
+    [vergil-claude-plugin#46](https://github.com/vergil-project/vergil-claude-plugin/issues/46).
     The settings above are enough to get going; plan on
     occasionally running `git pull` in
     `~/.claude/plugins/marketplaces/vergil-tooling-marketplace/`

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -70,7 +70,7 @@ mechanisms. Both exist; they complement each other.
 | Layer | Where it runs | Catches |
 |---|---|---|
 | **Pre-commit git hook** | `.githooks/pre-commit` checked into each repo; enabled via `git config core.hooksPath .githooks`. The hook is an env-var gate that admits `vrg-commit`-driven commits and rejects raw `git commit`. The five branch/context checks live in `vrg-commit` itself. | Detached HEAD • direct commits to protected branches • wrong branch prefix • missing issue number in branch name |
-| **Plugin PreToolUse hooks** | Delivered by the [`vergil-claude-plugin`](https://github.com/wphillipmoore/vergil-claude-plugin). Fires on Claude Code's `Bash`/`Write`/`Edit` tool invocations. | Raw `git commit` (forces `vrg-commit`) • Raw `gh pr create` (forces `vrg-submit-pr`) • commits originating from outside `.worktrees/*` on repos that have adopted the worktree convention • heredoc syntax in CLI args • associative-array bashisms |
+| **Plugin PreToolUse hooks** | Delivered by the [`vergil-claude-plugin`](https://github.com/vergil-project/vergil-claude-plugin). Fires on Claude Code's `Bash`/`Write`/`Edit` tool invocations. | Raw `git commit` (forces `vrg-commit`) • Raw `gh pr create` (forces `vrg-submit-pr`) • commits originating from outside `.worktrees/*` on repos that have adopted the worktree convention • heredoc syntax in CLI args • associative-array bashisms |
 
 **Why both?** The pre-commit hook catches anyone (human or agent)
 running git directly. The plugin catches patterns at the
@@ -81,7 +81,7 @@ close the loop.
 For the pre-commit-hook detail, see
 [Git Hooks and Validation][hooks-doc].
 For the plugin hook detail, see
-[vergil-claude-plugin/docs → Hooks](https://github.com/wphillipmoore/vergil-claude-plugin/blob/develop/docs/site/docs/hooks/index.md).
+[vergil-claude-plugin/docs → Hooks](https://github.com/vergil-project/vergil-claude-plugin/blob/develop/docs/site/docs/hooks/index.md).
 
 ## Developing a change
 
@@ -205,7 +205,7 @@ This section is the user-level "how to."
 - Any feature branch, even for solo sequential work. The convention
   keeps the main tree clean; once the plugin-level CWD check is
   active (release tracked in
-  [vergil-claude-plugin#46](https://github.com/wphillipmoore/vergil-claude-plugin/issues/46))
+  [vergil-claude-plugin#46](https://github.com/vergil-project/vergil-claude-plugin/issues/46))
   committing from the main tree will be blocked.
 
 ### Creating a worktree for an issue
@@ -331,7 +331,7 @@ The hook that fired will print a reason. Common signals:
 ### My plugin cache is stale
 
 Until plugin release automation is fully stood up
-([vergil-claude-plugin#46](https://github.com/wphillipmoore/vergil-claude-plugin/issues/46)),
+([vergil-claude-plugin#46](https://github.com/vergil-project/vergil-claude-plugin/issues/46)),
 the plugin is consumed from a local checkout and its cache under
 `~/.claude/plugins/cache/vergil-tooling-marketplace/`. If you're
 running an old version of a hook:
@@ -369,4 +369,4 @@ confirm the file is clean; then proceed.
 
 [hooks-doc]: https://github.com/vergil-project/vergil-tooling/blob/develop/docs/git-hooks-and-validation.md
 [worktree-spec]: https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/worktree-convention.md
-[plugin-hooks]: https://github.com/wphillipmoore/vergil-claude-plugin/blob/develop/docs/site/docs/hooks/index.md
+[plugin-hooks]: https://github.com/vergil-project/vergil-claude-plugin/blob/develop/docs/site/docs/hooks/index.md

--- a/docs/site/docs/guides/releasing.md
+++ b/docs/site/docs/guides/releasing.md
@@ -111,7 +111,7 @@ patches within a minor.
    (and anywhere else the documentation pins a minor) to the new
    tag.
 
-[docker-frag]: https://github.com/wphillipmoore/vergil-docker/blob/develop/docker/common/vergil-tooling-uv.dockerfile
+[docker-frag]: https://github.com/vergil-project/vergil-docker/blob/develop/docker/common/vergil-tooling-uv.dockerfile
 
 ### Consumer steps
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -14,7 +14,7 @@ They drive git, `gh`, SSH, and Docker operations. Installed via
 
 Construct standards-compliant conventional commits with co-author
 resolution. Performs five branch/context checks before committing
-and sets `ST_COMMIT_CONTEXT=1` so the `.githooks/pre-commit` gate
+and sets `VRG_COMMIT_CONTEXT=1` so the `.githooks/pre-commit` gate
 admits the commit.
 
 | Attribute | Value |

--- a/docs/site/docs/reference/hooks/pre-commit.md
+++ b/docs/site/docs/reference/hooks/pre-commit.md
@@ -3,7 +3,7 @@
 **Path:** `.githooks/pre-commit`
 
 The pre-commit hook is an env-var gate that admits `vrg-commit`-driven
-commits (via `ST_COMMIT_CONTEXT=1`) and derived workflows (amend,
+commits (via `VRG_COMMIT_CONTEXT=1`) and derived workflows (amend,
 cherry-pick, revert, rebase, merge), and rejects raw `git commit`.
 
 The five branch/context checks below live in `vrg-commit` itself and

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: Standard Tooling
+site_name: VERGIL Tooling
 site_description: Shared development tooling for git hooks, validation, and automation
-repo_url: https://github.com/wphillipmoore/standard-tooling
-repo_name: wphillipmoore/standard-tooling
+repo_url: https://github.com/vergil-project/vergil-tooling
+repo_name: vergil-project/vergil-tooling
 
 docs_dir: docs
 strict: true

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -225,7 +225,7 @@ def test_main_unknown_agent(tmp_path: Path) -> None:
 # Task 1.1 — branch / context validation
 # --------------------------------------------------------------------------
 #
-# Five checks ported from src/standard_tooling/bin/pre_commit_hook.py into
+# Five checks ported from src/vergil_tooling/bin/pre_commit_hook.py into
 # vrg-commit. Each check has a rejection-path and a happy-path test.
 # Reference: docs/specs/host-level-tool.md "Migration / vergil-tooling
 # itself" step 1; docs/plans/host-level-tool-plan.md Task 1.1.
@@ -469,5 +469,5 @@ def test_validate_admits_safe_body_content(tmp_path: Path, body: str) -> None:
 # --------------------------------------------------------------------------
 # Task 1.2 — `git.run` is responsible for setting VRG_COMMIT_CONTEXT=1
 # (issue #295 moved the contract from commit.py to lib/git.py). The
-# pinning test for that contract lives in tests/standard_tooling/test_git.py;
+# pinning test for that contract lives in tests/vergil_tooling/test_git.py;
 # commit.py just calls `git.run("commit", ...)` and trusts the helper.


### PR DESCRIPTION
# Pull Request

## Summary

- Fix remaining old env var names, org URLs, and site name across docs and test comments

## Issue Linkage

- Ref #747

## Notes

- Twelve files across README, CLAUDE.md, site docs, git-hooks-and-validation.md, and test comments still referenced the old ST_COMMIT_CONTEXT env var name, wphillipmoore org URLs for vergil-docker and vergil-claude-plugin, or the old "Standard Tooling" site name.

All specs, plans, paad reviews, and changelog entries are left frozen. Intentional wphillipmoore references (co-author username, standards-and-conventions repo, GitHub Actions allow-pattern for consumer repos, GitHub Pages domain) are also left as-is.