### PR TITLE
refactor(config): consolidate [dependencies] to single 'vergil' key

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -104,8 +104,8 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         co_authors[name] = trailer
 
     deps = raw.get("dependencies", {})
-    if "vergil-tooling" not in deps:
-        msg = f"{CONFIG_FILE}: [dependencies] must contain 'vergil-tooling'"
+    if "vergil" not in deps:
+        msg = f"{CONFIG_FILE}: [dependencies] must contain 'vergil'"
         raise ConfigError(msg)
 
     ml_raw = raw.get("markdownlint", {})
@@ -184,7 +184,7 @@ def read_config(repo_root: Path) -> StConfig:
 
 
 def vrg_install_tag(repo_root: Path) -> str:
-    """Return the ``[dependencies].vergil-tooling`` value for runtime install.
+    """Return the ``[dependencies].vergil`` value for runtime install.
 
     Checks ``VRG_DOCKER_INSTALL_TAG`` env var first (override).
     """
@@ -192,4 +192,4 @@ def vrg_install_tag(repo_root: Path) -> str:
     if override:
         return override
     cfg = read_config(repo_root)
-    return cfg.dependencies["vergil-tooling"]
+    return cfg.dependencies["vergil"]

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -31,7 +31,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]
@@ -78,7 +77,6 @@ agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 """
 
 _VALID_TOML = _BASE_TOML + '\n[ci]\nversions = ["3.14"]\n'
@@ -133,9 +131,9 @@ def test_read_config_malformed_co_author(tmp_path: Path) -> None:
 
 
 def test_read_config_missing_dependencies_key(tmp_path: Path) -> None:
-    toml = _VALID_TOML.replace('vergil = "v2.0"\nvergil-tooling = "v2.0"', 'other = "v1.0"')
+    toml = _VALID_TOML.replace('vergil = "v2.0"', 'other = "v1.0"')
     (tmp_path / "vergil.toml").write_text(toml)
-    with pytest.raises(ConfigError, match="vergil-tooling"):
+    with pytest.raises(ConfigError, match=r"must contain 'vergil'"):
         read_config(tmp_path)
 
 
@@ -272,7 +270,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]
@@ -309,7 +306,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_docker_cache.py
+++ b/tests/vergil_tooling/test_docker_cache.py
@@ -32,7 +32,6 @@ primary-language = "go"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -305,7 +305,7 @@ def _st_config(
 ) -> StConfig:
     return StConfig(
         project=_project(language=language, release_model=release_model),
-        dependencies={"vergil-tooling": "v1.4"},
+        dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
         publish=PublishConfig(release=False, docs=True),
@@ -1277,7 +1277,7 @@ def test_compute_desired_state_includes_publish() -> None:
 def test_compute_desired_state_publish_release_true() -> None:
     config = StConfig(
         project=_project(),
-        dependencies={"vergil-tooling": "v1.4"},
+        dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(),
         publish=PublishConfig(release=True, docs=True),

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -27,7 +27,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_version.py
+++ b/tests/vergil_tooling/test_version.py
@@ -21,7 +21,6 @@ def _write_toml(tmp_path: Path, language: str) -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         f'primary-language = "{language}"\n\n[dependencies]\nvergil = "v2.0"\n'
-        f'vergil-tooling = "v2.0"\n'
         f'\n[ci]\nversions = ["3.14"]\n'
     )
 
@@ -95,7 +94,6 @@ def test_show_with_version_file_override(tmp_path: Path) -> None:
         'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         'primary-language = "shell"\nversion-file = "custom/VERSION"\n\n'
         '[dependencies]\nvergil = "v2.0"\n'
-        'vergil-tooling = "v2.0"\n'
         '\n[ci]\nversions = ["3.14"]\n'
     )
     custom_dir = tmp_path / "custom"

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -28,7 +28,6 @@ agent = "Co-Authored-By: test-agent <test-agent@test.com>"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_vrg_docker_cache.py
+++ b/tests/vergil_tooling/test_vrg_docker_cache.py
@@ -22,7 +22,6 @@ primary-language = "go"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_vrg_docker_docs.py
+++ b/tests/vergil_tooling/test_vrg_docker_docs.py
@@ -107,7 +107,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_vrg_docker_run.py
+++ b/tests/vergil_tooling/test_vrg_docker_run.py
@@ -124,7 +124,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]

--- a/tests/vergil_tooling/test_vrg_finalize_repo.py
+++ b/tests/vergil_tooling/test_vrg_finalize_repo.py
@@ -84,7 +84,6 @@ def _make_profile(tmp_path: Path, model: str) -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "{model}"\nrelease-model = "tagged-release"\n'
         f'primary-language = "python"\n\n[dependencies]\nvergil = "v2.0"\n'
-        f'vergil-tooling = "v2.0"\n'
         f'\n[ci]\nversions = ["3.14"]\n'
     )
 

--- a/tests/vergil_tooling/test_vrg_github_config.py
+++ b/tests/vergil_tooling/test_vrg_github_config.py
@@ -211,7 +211,6 @@ primary-language = "python"
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]
@@ -281,7 +280,7 @@ def _make_config() -> StConfig:
             primary_language="python",
             co_authors={},
         ),
-        dependencies={"vergil-tooling": "v1.4"},
+        dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=CiConfig(versions=["3.14"], integration_tests=False),
         publish=PublishConfig(release=False, docs=True),

--- a/tests/vergil_tooling/test_vrg_repo_profile.py
+++ b/tests/vergil_tooling/test_vrg_repo_profile.py
@@ -25,7 +25,6 @@ claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"
 
 [ci]
 versions = ["3.14"]
@@ -76,7 +75,7 @@ def test_malformed_co_author(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 
 def test_missing_dependencies_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
-    toml = _VALID_TOML.replace('vergil = "v2.0"\nvergil-tooling = "v2.0"', 'other = "v1.0"')
+    toml = _VALID_TOML.replace('vergil = "v2.0"', 'other = "v1.0"')
     _write_toml(tmp_path, toml)
     assert main() == 1
 

--- a/tests/vergil_tooling/test_vrg_validate.py
+++ b/tests/vergil_tooling/test_vrg_validate.py
@@ -34,7 +34,6 @@ def _write_config(tmp_path: Path, language: str) -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         f'primary-language = "{language}"\n\n[dependencies]\nvergil = "v2.0"\n'
-        f'vergil-tooling = "v2.0"\n'
         f'\n[ci]\nversions = ["3.14"]\n'
     )
 

--- a/tests/vergil_tooling/test_vrg_version.py
+++ b/tests/vergil_tooling/test_vrg_version.py
@@ -19,7 +19,6 @@ def _write_toml(tmp_path: Path, language: str = "shell") -> None:
         f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
         f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
         f'primary-language = "{language}"\n\n[dependencies]\nvergil = "v2.0"\n'
-        f'vergil-tooling = "v2.0"\n'
         f'\n[ci]\nversions = ["3.14"]\n'
     )
 

--- a/vergil.toml
+++ b/vergil.toml
@@ -20,5 +20,4 @@ versions = ["3.12", "3.13", "3.14"]
 integration-tests = false
 
 [dependencies]
-vergil = "v2.0.3"
-vergil-tooling = "v2.0.6"
+vergil = "v2.0.6"


### PR DESCRIPTION
# Pull Request

## Summary

- Consolidate vergil.toml [dependencies] to a single 'vergil' key, removing the 'vergil-tooling' workaround added during the rename migration.

## Issue Linkage

- Ref #755

## Notes

- Changes config.py validation and vrg_install_tag() to read from
dependencies.vergil instead of dependencies.vergil-tooling.

Removes the redundant vergil-tooling key from this repo's vergil.toml
and updates all test fixtures to match.

Consumer repos (vergil-docker#215, vergil-actions#485,
vergil-claude-plugin#319) have chore issues filed to remove
their now-redundant vergil-tooling entries at their convenience.