### PR TITLE
chore(release): next-cycle dependency updates for v2.0.7

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -20,4 +20,4 @@ versions = ["3.12", "3.13", "3.14"]
 integration-tests = false
 
 [dependencies]
-vergil = "v2.0.6"
+vergil = "v2.0.7"


### PR DESCRIPTION
# Pull Request

## Summary

- Update vergil dependency from v2.0.6 to v2.0.7 following the v2.0.7 release.

## Issue Linkage

- Ref #757

## Notes

- -