### PR TITLE
docs: .github profile repository design spec and implementation plan

### DIFF
--- a/docs/plans/2026-05-14-github-profile-repo.md
+++ b/docs/plans/2026-05-14-github-profile-repo.md
@@ -1,0 +1,306 @@
+# `.github` Profile Repository — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the `vergil-project/.github` repository with the org
+profile README, default community health files, and VERGIL tooling
+harness. Then consolidate duplicated templates out of the four
+existing repos.
+
+**Architecture:** Three-phase approach — prerequisites (Discussions,
+license gaps), `.github` repo creation with all content, and
+consolidation (remove per-repo duplicates after verifying inheritance).
+
+**Tech Stack:** GitHub API via `gh` CLI, markdown, YAML
+
+**Spec:** `docs/specs/2026-05-14-github-profile-repo-design.md`
+
+**Spec correction:** The design spec lists the LICENSE as "MIT". The
+actual license across VERGIL repos is GPL-3. Additionally,
+vergil-docker and vergil-claude-plugin are missing LICENSE files
+entirely — this is addressed in Task 2.
+
+---
+
+## Phase 1: Prerequisites
+
+These tasks address gaps discovered during design that must be resolved
+before the `.github` repo is created.
+
+### Task 1: Enable GitHub Discussions on All Four Repos
+
+**Files:** None (GitHub API / web UI)
+
+SUPPORT.md references GitHub Discussions as the channel for questions
+and general conversation. Discussions must be enabled before
+SUPPORT.md goes live.
+
+- [ ] Enable Discussions on `vergil-project/vergil-tooling` via
+      `gh repo edit --enable-discussions`
+- [ ] Enable Discussions on `vergil-project/vergil-actions`
+- [ ] Enable Discussions on `vergil-project/vergil-docker`
+- [ ] Enable Discussions on `vergil-project/vergil-claude-plugin`
+- [ ] Verify: visit each repo's Discussions tab in browser to confirm
+      it is active
+
+### Task 2: Add Missing LICENSE Files
+
+**Files:** `LICENSE` in vergil-docker, vergil-claude-plugin
+
+vergil-tooling and vergil-actions have GPL-3 licenses.
+vergil-docker and vergil-claude-plugin do not. GitHub does not
+inherit LICENSE files — each repo must have its own. These must
+exist before CONTRIBUTING.md references a unified license.
+
+- [ ] Copy GPL-3 LICENSE to vergil-docker (PR)
+- [ ] Copy GPL-3 LICENSE to vergil-claude-plugin (PR)
+- [ ] Verify: GitHub shows "GPL-3.0" badge on both repos
+
+---
+
+## Phase 2: Create the `.github` Repository
+
+All content is created in a single repo. Tasks are ordered by
+dependency — the repo must exist before files can be pushed, and
+some files reference others.
+
+### Task 3: Create the Repository
+
+**Files:** None (GitHub API)
+
+- [ ] Create `vergil-project/.github` as a **public** repository
+      via `gh repo create vergil-project/.github --public --description "Org-level configuration, community health files, and profile for the vergil-project organization"`
+- [ ] Clone locally to the standard project directory
+- [ ] Initialize with `develop` as the default branch (matching
+      all other VERGIL repos)
+
+### Task 4: VERGIL Tooling Harness
+
+**Files:** `vergil.toml`, `.githooks/pre-commit`, `.claude/settings.json`, `CLAUDE.md`
+
+Minimal tooling setup so the repo follows the same development
+workflow as the other four repos.
+
+- [ ] Create `vergil.toml` with `primary-language = "none"` and the
+      five required `[project]` fields. No `[ci]`, `[publish]`, or
+      `[dependencies]` sections initially — add them if needed when
+      CI is configured in Task 10.
+
+      ```toml
+      [project]
+      repository-type = "documentation"
+      versioning-scheme = "semver"
+      branching-model = "library-release"
+      release-model = "tagged-release"
+      primary-language = "none"
+
+      [project.co-authors]
+      wphillipmoore-agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
+      ```
+
+- [ ] Copy `.githooks/pre-commit` from vergil-tooling (identical
+      across all repos)
+- [ ] Create `.claude/settings.json` with vergil plugin marketplace
+      config (identical to other repos)
+- [ ] Create `CLAUDE.md` — minimal agent guidance: docs-only repo,
+      no Python, use `vrg-commit`, validation via
+      `vrg-docker-run -- uv run vrg-validate`
+- [ ] Create `LICENSE` — GPL-3 (matching other VERGIL repos)
+- [ ] Verify: `git config core.hooksPath .githooks` works, raw
+      `git commit` is rejected, `vrg-commit` works
+
+### Task 5: Issue Templates and PR Template
+
+**Files:** `ISSUE_TEMPLATE/issue.yml`, `ISSUE_TEMPLATE/config.yml`, `pull_request_template.md`
+
+Migrated from the per-repo copies. These are identical across all
+four repos today.
+
+- [ ] Copy `ISSUE_TEMPLATE/issue.yml` from vergil-tooling
+- [ ] Copy `ISSUE_TEMPLATE/config.yml` from vergil-tooling
+- [ ] Copy `pull_request_template.md` from vergil-tooling
+- [ ] Verify: content is byte-identical to the per-repo versions
+
+### Task 6: CODE_OF_CONDUCT.md
+
+**Files:** `CODE_OF_CONDUCT.md`
+
+- [ ] Adopt Contributor Covenant v2.1 — use the canonical text from
+      https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+- [ ] Set enforcement contact to the project maintainer (Phillip
+      Moore, email from the existing author section)
+- [ ] Review: ensure the text is unmodified except for the
+      enforcement contact section
+
+### Task 7: SECURITY.md
+
+**Files:** `SECURITY.md`
+
+- [ ] Write vulnerability reporting instructions — preferred channel
+      is GitHub's private vulnerability reporting feature (if enabled
+      on the org) or private email
+- [ ] Define scope: CLI tooling (vergil-tooling), container images
+      (vergil-docker), CI workflows (vergil-actions),
+      vergil-claude-plugin configuration and hook definitions
+- [ ] Define out-of-scope: vulnerabilities in upstream dependencies
+- [ ] Set response commitment: acknowledge within 7 days, target fix
+      or mitigation plan within 30 days (adjust if these timelines
+      don't feel realistic)
+- [ ] Enable private vulnerability reporting on the org if not
+      already enabled
+
+### Task 8: CONTRIBUTING.md
+
+**Files:** `CONTRIBUTING.md`
+
+The largest file. Content draws from the org governance spec (#717,
+Section 5) and the existing development workflow documentation.
+
+- [ ] Write "How the project works" section — four-repo architecture
+      overview, what each component does, how they relate
+- [ ] Write "Development setup" section — prerequisites (Docker, uv),
+      installing vergil-tooling via `uv tool install`, enabling git
+      hooks via `git config core.hooksPath .githooks`
+- [ ] Write "Workflow" section — branch from `develop`, use
+      `vrg-commit`, use `vrg-submit-pr`, validate via
+      `vrg-docker-run -- uv run vrg-validate`
+- [ ] Write "For contributors using AI tools" section — identity
+      model (`<username>-agent`), accountability principle, agent
+      identity for commits, human identity for reviews
+- [ ] Write "For contributors not using AI" section — fork/branch/PR,
+      same quality bar
+- [ ] Write "What to expect from review" section — human approval
+      required, CI must pass, cross-human review at 2+ contributors
+- [ ] Write "Template override convention" section — document the
+      all-or-nothing inheritance rule for template directories
+- [ ] Review: ensure all claims are consistent with the org
+      governance spec and current tooling behavior
+
+### Task 9: SUPPORT.md
+
+**Files:** `SUPPORT.md`
+
+- [ ] Write support channels: GitHub Issues for bugs and feature
+      requests, GitHub Discussions for questions and conversation
+- [ ] Link to docs site for reference material
+- [ ] State clearly: community project, no SLA-backed support
+- [ ] Verify: Discussions links point to working URLs (depends on
+      Task 1 being complete)
+
+### Task 10: Root README.md
+
+**Files:** `README.md`
+
+Short description of what the `.github` repo is, not the org profile.
+
+- [ ] Write one-paragraph description: this repo holds org-level
+      default configuration for the vergil-project organization
+- [ ] Explain which files live here and how GitHub's default community
+      health file inheritance works
+- [ ] Document the template override convention (all-or-nothing per
+      directory)
+- [ ] Link to the profile README (`profile/README.md`) and
+      CONTRIBUTING.md
+- [ ] Note the `.github/.github/workflows/` nesting and why it exists
+
+### Task 11: Org Profile README
+
+**Files:** `profile/README.md`
+
+Adapted from the existing draft at
+`/Users/pmoore/dev/github/career-strategy/drafts/vergil-readme-draft.md`.
+
+- [ ] Copy the draft as the starting point
+- [ ] Update repo URLs: `wphillipmoore/` → `vergil-project/`
+- [ ] Update docs site URL to post-rename location
+- [ ] Update repo name: `vergil-plugin` → `vergil-claude-plugin`
+- [ ] Update tool names: `st-commit` → `vrg-commit`,
+      `st-validate` → `vrg-validate`,
+      `st-prepare-release` → `vrg-prepare-release`
+- [ ] Update "Current state" to reflect v2.x and completed rename
+- [ ] Add link to `CONTRIBUTING.md` as a call to action
+- [ ] Add link to docs site
+- [ ] Review: verify all URLs resolve, all repo names are correct,
+      numbers in "By the numbers" table are still accurate
+
+### Task 12: CI Workflow
+
+**Files:** `.github/workflows/ci.yml`
+
+Minimal CI — this is a docs-only repo. The workflow must handle
+`primary-language = "none"` in `vergil.toml`.
+
+- [ ] Determine which vergil-actions reusable workflows are
+      compatible with `language: none` (or whether a new value is
+      needed). At minimum: `ci-quality.yml` for common checks
+      (markdownlint, yamllint, shellcheck, actionlint).
+- [ ] If vergil-actions workflows require a language value, open a
+      follow-up issue to add `none` support — use a minimal inline
+      workflow in the meantime
+- [ ] Write `ci.yml` referencing the appropriate reusable workflows
+- [ ] Verify: push a test branch and confirm CI runs the common
+      checks without errors
+
+---
+
+## Phase 3: Consolidation
+
+After the `.github` repo is live and inheritance is verified, remove
+the duplicated files from the four existing repos.
+
+### Task 13: Verify Inheritance
+
+**Files:** None (manual testing)
+
+Before removing per-repo files, confirm that org-level defaults
+actually work.
+
+- [ ] Navigate to vergil-tooling → Issues → New issue. Confirm the
+      org-level issue template appears.
+- [ ] Navigate to vergil-actions → Issues → New issue. Confirm the
+      same.
+- [ ] Open a draft PR on one repo. Confirm the PR template from the
+      `.github` repo is populated.
+- [ ] Navigate to vergil-tooling → Insights → Community Standards (or
+      equivalent). Confirm CONTRIBUTING.md, CODE_OF_CONDUCT.md,
+      SECURITY.md, and SUPPORT.md appear as inherited.
+
+**Important:** At this point, per-repo copies still exist. GitHub
+should prefer the per-repo copies (the all-or-nothing rule). To
+truly test inheritance, temporarily rename one repo's
+`ISSUE_TEMPLATE/` directory and confirm the org default takes over,
+then rename it back. This verifies the fallback mechanism.
+
+### Task 14: Remove Per-Repo Duplicates
+
+**Files:** Issue templates and PR templates in all four repos
+
+One PR per repo. These can run in parallel since they're independent.
+
+- [ ] vergil-tooling: remove `.github/ISSUE_TEMPLATE/issue.yml`,
+      `.github/ISSUE_TEMPLATE/config.yml`,
+      `.github/pull_request_template.md`
+- [ ] vergil-actions: remove the same three files
+- [ ] vergil-docker: remove the same three files
+- [ ] vergil-claude-plugin: remove the same three files
+- [ ] After merging all four PRs, verify inheritance again: create a
+      test issue on each repo and confirm the org template appears
+
+### Task 15: Post-Consolidation Verification
+
+**Files:** None (manual testing)
+
+Final verification that everything works end-to-end.
+
+- [ ] Create a real issue on one repo using the inherited template —
+      confirm all fields work (type dropdown, problem/goal,
+      acceptance criteria)
+- [ ] Confirm blank issues are still disabled (config.yml inheritance)
+- [ ] Open a PR on one repo — confirm the PR template appears
+- [ ] Visit the org profile page — confirm `profile/README.md`
+      renders correctly
+- [ ] Spot-check community health files: visit a repo's
+      "Community Standards" page and confirm all files show as present

--- a/docs/plans/2026-05-14-github-profile-repo.md
+++ b/docs/plans/2026-05-14-github-profile-repo.md
@@ -30,6 +30,19 @@ entirely — this is addressed in Task 2.
 These tasks address gaps discovered during design that must be resolved
 before the `.github` repo is created.
 
+### Task 0: Upstream Tooling Fix (vergil-tooling)
+
+**Files:** None (separate vergil-tooling change)
+
+The `vergil.toml` config parser currently requires
+`[dependencies].vergil-tooling`. This is a migration artifact being
+consolidated to just `[dependencies].vergil`. That change must land
+before Task 4's `vergil.toml` (which omits `[dependencies]`) can
+pass validation.
+
+- [ ] Verify the config parser accepts `[dependencies].vergil`
+      without requiring `vergil-tooling`
+
 ### Task 1: Enable GitHub Discussions on All Four Repos
 
 **Files:** None (GitHub API / web UI)

--- a/docs/specs/2026-05-14-github-profile-repo-design.md
+++ b/docs/specs/2026-05-14-github-profile-repo-design.md
@@ -1,0 +1,238 @@
+# `.github` Profile Repository Design
+
+**Issue:** #753
+**Date:** 2026-05-14
+**Status:** Draft
+
+## Problem
+
+The `vergil-project` GitHub org has four repositories with identical
+community health files (issue templates, PR templates) duplicated in
+each. There is no org-level README, no CONTRIBUTING.md, no SECURITY.md,
+no CODE_OF_CONDUCT.md, and no SUPPORT.md. The org profile page is
+blank.
+
+GitHub's `.github` profile repository provides org-level defaults that
+are inherited by any repo that does not have its own copies. This design
+consolidates duplicated files into the org-level repo, adds the missing
+community health files, and establishes the org's public-facing profile.
+
+## Approach
+
+**Full consolidation with documented override convention (Approach C).**
+All default community health files live in the `.github` repo. Per-repo
+copies are removed. If a repo ever needs custom templates, it adds its
+own full directory — GitHub's inheritance is all-or-nothing per
+directory, not per file. This override mechanism is documented in
+CONTRIBUTING.md so future contributors understand the model.
+
+## Section 1: Repository Structure
+
+```
+vergil-project/.github/
+├── profile/
+│   └── README.md                  # Org profile page (public-facing)
+├── ISSUE_TEMPLATE/
+│   ├── issue.yml                  # Default issue template (migrated)
+│   └── config.yml                 # Disables blank issues
+├── pull_request_template.md       # Default PR template (migrated)
+├── CONTRIBUTING.md                # Contributor guidelines
+├── SECURITY.md                    # Vulnerability reporting policy
+├── CODE_OF_CONDUCT.md             # Contributor Covenant v2.1
+├── SUPPORT.md                     # Where to get help
+├── .github/
+│   └── workflows/
+│       └── ci.yml                 # CI for this repo (common checks only)
+├── .githooks/
+│   └── pre-commit                 # Standard vrg-commit gate
+├── .claude/
+│   └── settings.json              # Vergil plugin marketplace config
+├── CLAUDE.md                      # Agent guidance for this repo
+├── vergil.toml                    # Minimal config (no primary_language)
+├── README.md                      # Repo-level: what this repo is
+└── LICENSE                        # MIT
+```
+
+### Key decisions
+
+- The `.github` repo **must be public** for default community health
+  files to be inherited by other repos.
+- `profile/README.md` is the polished marketing-facing README (adapted
+  from the existing draft). Root `README.md` is a short description of
+  what the `.github` repo is and how org-level defaults work.
+- The `.github/.github/workflows/` nesting is correct — the repo's own
+  CI config lives in its own `.github/` directory like any other repo.
+- `vergil.toml` omits `primary_language` so `vrg-validate` runs only
+  common checks (markdownlint, yamllint, shellcheck, actionlint).
+- No `FUNDING.yml` — GitHub Sponsors is a future concern.
+- No `workflow-templates/` — the four VERGIL repos are infrastructure,
+  not a pattern that gets replicated. Workflow templates add value in
+  orgs where new repos are stamped out frequently.
+
+## Section 2: Community Health Files
+
+### CONTRIBUTING.md
+
+Content outline:
+
+- **How the project works** — brief orientation to the four-repo
+  architecture and how they relate.
+- **Development setup** — prerequisites (Docker, `uv`), installing
+  vergil-tooling via `uv tool install`, enabling git hooks.
+- **Workflow** — branch from `develop`, use `vrg-commit` for commits,
+  use `vrg-submit-pr` for PRs, all validation runs via
+  `vrg-docker-run -- uv run vrg-validate`.
+- **For contributors using AI tools** — the identity model
+  (`<username>-agent` account), accountability principle, all AI work
+  committed under the agent identity, all reviews under the human
+  identity. Drawn from the org governance spec (#717, Section 5).
+- **For contributors not using AI** — standard fork/branch/PR model,
+  same quality bar.
+- **What to expect from review** — PRs require human approval, CI must
+  pass, cross-human review at 2+ contributors.
+- **Template override convention** — if a repo needs custom issue or PR
+  templates, it must provide the full set in its own directory.
+  GitHub's org-level defaults are all-or-nothing per directory — a
+  repo with any file in `.github/ISSUE_TEMPLATE/` loses all org
+  defaults for that directory.
+
+### SECURITY.md
+
+- **Reporting** — private email or GitHub's private vulnerability
+  reporting feature (if enabled on the org).
+- **Scope** — what counts as a security issue: the CLI tooling, the
+  container images, the CI workflows, the Claude Code plugin hooks.
+- **Response commitment** — acknowledgment and fix timelines, realistic
+  for a small project that intends to grow.
+- **Out of scope** — vulnerabilities in upstream dependencies that
+  should be reported to the upstream maintainer.
+
+### CODE_OF_CONDUCT.md
+
+- Adopt the **Contributor Covenant v2.1** — the industry standard,
+  widely recognized. Adopting a recognized standard is stronger than
+  writing a custom one.
+- Enforcement section names the project maintainer as the contact.
+
+### SUPPORT.md
+
+- **GitHub Issues** for bugs and feature requests.
+- **GitHub Discussions** for questions and general conversation (if
+  Discussions are enabled on the org).
+- **Docs site** for reference material.
+- Clear statement that this is a community project, not a commercial
+  product with SLA-backed support.
+
+## Section 3: Org Profile README
+
+The `profile/README.md` is adapted from the existing draft at
+`career-strategy/drafts/vergil-readme-draft.md`.
+
+### Updates needed
+
+- Repo URLs: `wphillipmoore/` to `vergil-project/`.
+- Docs site URL: updated to post-rename location.
+- Repo name: `vergil-plugin` to `vergil-claude-plugin`.
+- Tool names: `st-commit`, `st-validate`, `st-prepare-release` to
+  `vrg-commit`, `vrg-validate`, `vrg-prepare-release`.
+- "Current state" section: updated to reflect v2.x status and the
+  completed rename.
+
+### Structural decisions
+
+- The "By the numbers" table and architecture diagram stay — they
+  demonstrate scope concisely.
+- The "Author" section stays — personal credibility is part of the
+  story.
+- The "Components" table becomes the primary navigation to the four
+  repos.
+- Link to `CONTRIBUTING.md` at the bottom as a call to action.
+- Link to the docs site for detailed reference material.
+
+### Root README.md (separate from the profile)
+
+- One paragraph: "This repository holds org-level default configuration
+  for the vergil-project GitHub organization."
+- Explains what files live here and how GitHub's default community
+  health file inheritance works.
+- Documents the template override convention.
+- Links to the profile README and CONTRIBUTING.md.
+
+## Section 4: Consolidation
+
+### Removed from all four repos
+
+Once the org-level defaults are in place, the identical per-repo copies
+are removed from vergil-tooling, vergil-actions, vergil-docker, and
+vergil-claude-plugin:
+
+- `.github/ISSUE_TEMPLATE/issue.yml`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/pull_request_template.md`
+
+### What stays per-repo
+
+- `.github/workflows/` — CI workflows are per-repo by nature.
+- `.githooks/` — local to each clone, not inheritable via GitHub.
+- `.claude/settings.json` — Claude Code config, not a GitHub feature.
+- `CLAUDE.md` — agent guidance specific to each codebase.
+- `vergil.toml` — repo-specific project config.
+- `LICENSE` — must exist per-repo (GitHub does not inherit licenses).
+- `README.md` — each repo has its own description.
+
+### Rollout order
+
+1. Create the `.github` repo with all org-level files.
+2. Verify inheritance — create a test issue in one repo, confirm the
+   org template appears.
+3. Remove per-repo copies in coordinated PRs (one per repo, can be
+   parallel).
+4. Verify again post-removal — confirm templates still work via
+   inheritance.
+
+### Risk mitigation
+
+- Restoring per-repo files is a one-commit fix per repo if inheritance
+  breaks unexpectedly.
+- Empty `.github/ISSUE_TEMPLATE/` directories are removed entirely
+  after migration (Git does not track empty directories).
+
+### Template override edge case
+
+Documented in CONTRIBUTING.md: if a repo needs a custom issue template,
+it must recreate the full `ISSUE_TEMPLATE/` directory with all
+templates. GitHub does not merge per-repo templates with org defaults —
+the presence of any file in the per-repo directory replaces the entire
+org default for that directory. Standalone files (CONTRIBUTING.md,
+SECURITY.md, etc.) inherit independently on a per-file basis.
+
+## GitHub Inheritance Reference
+
+Summary of GitHub's `.github` repo inheritance behavior, documented here
+for clarity:
+
+| File type | Inheritance model | Override behavior |
+|---|---|---|
+| Standalone files (CONTRIBUTING, SECURITY, etc.) | Per-file fallback | Repo's own file hides org default for that file only |
+| Template directories (ISSUE_TEMPLATE/) | Per-directory fallback | Any file in repo's directory replaces entire org directory |
+| PR template | Per-file fallback | Repo's own template hides org default |
+| Profile README | Not inherited | Only displays on org profile page |
+| Workflow templates | Copied, not inherited | Templates are starting points, not live defaults |
+| LICENSE | Not inherited | Must exist per-repo |
+| .githooks, CLAUDE.md, vergil.toml | Not GitHub features | Per-repo only, never inherited |
+
+## Dependencies
+
+- Org governance spec (#717) — contributor guidelines in
+  CONTRIBUTING.md draw from Section 5.
+- VERGIL rename — complete. URLs in the profile README reflect the
+  current `vergil-project/` org.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Inheritance not working as expected | Verify with a test issue before removing per-repo copies |
+| Future repo needs custom templates but developer doesn't know about the all-or-nothing rule | Documented in CONTRIBUTING.md and in the `.github` repo's root README |
+| `vergil.toml` without `primary_language` causes `vrg-validate` to fail | Verify during implementation; may need a `docs` or `none` designation |
+| `.github/.github/workflows/` nesting confuses contributors | Documented in root README; inherent to how GitHub handles the `.github` repo |

--- a/docs/specs/2026-05-14-github-profile-repo-design.md
+++ b/docs/specs/2026-05-14-github-profile-repo-design.md
@@ -50,7 +50,7 @@ vergil-project/.github/
 ├── CLAUDE.md                      # Agent guidance for this repo
 ├── vergil.toml                    # Minimal config (no primary_language)
 ├── README.md                      # Repo-level: what this repo is
-└── LICENSE                        # MIT
+└── LICENSE                        # GPL-3
 ```
 
 ### Key decisions
@@ -236,6 +236,10 @@ for clarity:
   CONTRIBUTING.md draw from Section 5.
 - VERGIL rename — complete. URLs in the profile README reflect the
   current `vergil-project/` org.
+- Missing LICENSE files — vergil-docker and vergil-claude-plugin do
+  not have LICENSE files. These must be added (GPL-3, matching
+  vergil-tooling and vergil-actions) before CONTRIBUTING.md can
+  reference a unified license across the org.
 
 ## Risks
 

--- a/docs/specs/2026-05-14-github-profile-repo-design.md
+++ b/docs/specs/2026-05-14-github-profile-repo-design.md
@@ -62,8 +62,11 @@ vergil-project/.github/
   what the `.github` repo is and how org-level defaults work.
 - The `.github/.github/workflows/` nesting is correct — the repo's own
   CI config lives in its own `.github/` directory like any other repo.
-- `vergil.toml` omits `primary_language` so `vrg-validate` runs only
-  common checks (markdownlint, yamllint, shellcheck, actionlint).
+- `vergil.toml` uses `primary-language = "none"` so `vrg-validate`
+  runs only common checks (markdownlint, yamllint, shellcheck,
+  actionlint). All five `[project]` fields are required by the
+  config parser; a value of `"none"` is the mechanism for skipping
+  language-specific checks.
 - No `FUNDING.yml` — GitHub Sponsors is a future concern.
 - No `workflow-templates/` — the four VERGIL repos are infrastructure,
   not a pattern that gets replicated. Workflow templates add value in
@@ -101,7 +104,9 @@ Content outline:
 - **Reporting** — private email or GitHub's private vulnerability
   reporting feature (if enabled on the org).
 - **Scope** — what counts as a security issue: the CLI tooling, the
-  container images, the CI workflows, the Claude Code plugin hooks.
+  container images, the CI workflows, and the vergil-claude-plugin
+  configuration and hook definitions. Exact scope to be refined
+  during implementation.
 - **Response commitment** — acknowledgment and fix timelines, realistic
   for a small project that intends to grow.
 - **Out of scope** — vulnerabilities in upstream dependencies that
@@ -117,8 +122,8 @@ Content outline:
 ### SUPPORT.md
 
 - **GitHub Issues** for bugs and feature requests.
-- **GitHub Discussions** for questions and general conversation (if
-  Discussions are enabled on the org).
+- **GitHub Discussions** for questions and general conversation.
+  Discussions must be enabled on all four repos as a prerequisite.
 - **Docs site** for reference material.
 - Clear statement that this is a community project, not a commercial
   product with SLA-backed support.
@@ -126,7 +131,7 @@ Content outline:
 ## Section 3: Org Profile README
 
 The `profile/README.md` is adapted from the existing draft at
-`career-strategy/drafts/vergil-readme-draft.md`.
+`/Users/pmoore/dev/github/career-strategy/drafts/vergil-readme-draft.md`.
 
 ### Updates needed
 
@@ -160,6 +165,9 @@ The `profile/README.md` is adapted from the existing draft at
 
 ## Section 4: Consolidation
 
+This section covers follow-up work in the four consuming repos,
+after the `.github` repo is created and inheritance is verified.
+
 ### Removed from all four repos
 
 Once the org-level defaults are in place, the identical per-repo copies
@@ -182,12 +190,13 @@ vergil-claude-plugin:
 
 ### Rollout order
 
-1. Create the `.github` repo with all org-level files.
-2. Verify inheritance — create a test issue in one repo, confirm the
+1. Enable GitHub Discussions on all four repos.
+2. Create the `.github` repo with all org-level files.
+3. Verify inheritance — create a test issue in one repo, confirm the
    org template appears.
-3. Remove per-repo copies in coordinated PRs (one per repo, can be
+4. Remove per-repo copies in coordinated PRs (one per repo, can be
    parallel).
-4. Verify again post-removal — confirm templates still work via
+5. Verify again post-removal — confirm templates still work via
    inheritance.
 
 ### Risk mitigation
@@ -234,5 +243,5 @@ for clarity:
 |---|---|
 | Inheritance not working as expected | Verify with a test issue before removing per-repo copies |
 | Future repo needs custom templates but developer doesn't know about the all-or-nothing rule | Documented in CONTRIBUTING.md and in the `.github` repo's root README |
-| `vergil.toml` without `primary_language` causes `vrg-validate` to fail | Verify during implementation; may need a `docs` or `none` designation |
+| CI workflow untested with `primary-language = "none"` | Verify during implementation that vergil-actions CI steps handle this config correctly |
 | `.github/.github/workflows/` nesting confuses contributors | Documented in root README; inherent to how GitHub handles the `.github` repo |


### PR DESCRIPTION
# Pull Request

## Summary

- Design spec and implementation plan for the vergil-project/.github profile repository

## Issue Linkage

- Ref #753

## Notes

- Design spec and implementation plan for the vergil-project/.github profile repository.

The spec covers: repository structure, community health files (CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md, SUPPORT.md), org profile README adapted from the existing draft, and consolidation of duplicated templates out of the four existing repos.

The plan is organized in three phases: prerequisites (enable Discussions, add missing LICENSE files), .github repo creation (12 tasks covering all content), and consolidation (verify inheritance, remove per-repo duplicates, final verification).

Key decisions documented:
- Full consolidation with documented override convention (GitHub's all-or-nothing template inheritance)
- vergil.toml uses primary-language = "none" for docs-only repo
- Contributor Covenant v2.1 for code of conduct
- GPL-3 license (matching existing repos; spec correction from original "MIT" noted in plan)
- GitHub Discussions as a prerequisite for SUPPORT.md