### PR TITLE
fix(github-config): replace hardcoded wphillipmoore/* with vergil-project/* in action patterns

### DIFF
--- a/src/vergil_tooling/bin/vrg_generate_commands.py
+++ b/src/vergil_tooling/bin/vrg_generate_commands.py
@@ -92,7 +92,7 @@ def load_commands(mapping_data_path: Path) -> list[CommandSpec]:
 # ---------------------------------------------------------------------------
 
 MQSC_REF_URL = "https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands"
-PYTHON_DOCS_BASE_URL = "https://wphillipmoore.github.io/mq-rest-admin-python"
+PYTHON_DOCS_BASE_URL = "https://vergil-project.github.io/mq-rest-admin-python"
 
 
 def _python_docstring(cmd: CommandSpec, mapping_pages: frozenset[str]) -> str:

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -92,7 +92,7 @@ _BASE_ACTION_PATTERNS = [
     "actions/*",
     "docker/*",
     "github/*",
-    "wphillipmoore/*",
+    "vergil-project/*",
 ]
 
 _LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -90,7 +90,7 @@ def test_desired_actions_permissions_base_only() -> None:
         "actions/*",
         "docker/*",
         "github/*",
-        "wphillipmoore/*",
+        "vergil-project/*",
     ]
 
 
@@ -102,7 +102,7 @@ def test_desired_actions_permissions_with_language_patterns() -> None:
         "docker/*",
         "github/*",
         "swatinem/*",
-        "wphillipmoore/*",
+        "vergil-project/*",
     ]
 
 
@@ -114,7 +114,7 @@ def test_desired_actions_permissions_python() -> None:
         "docker/*",
         "github/*",
         "pypa/*",
-        "wphillipmoore/*",
+        "vergil-project/*",
     ]
 
 
@@ -375,7 +375,7 @@ def test_fetch_actual_state_repo_settings() -> None:
                 "can_approve_pull_request_reviews": False,
             }
         if endpoint == "repos/o/r/actions/permissions/selected-actions":
-            return {"patterns_allowed": ["actions/*", "wphillipmoore/*"]}
+            return {"patterns_allowed": ["actions/*", "vergil-project/*"]}
         return {}
 
     with (
@@ -398,7 +398,7 @@ def test_fetch_actual_state_repo_settings() -> None:
     assert actual.actions_permissions.default_workflow_permissions == "read"
     assert actual.actions_permissions.patterns_allowed == [
         "actions/*",
-        "wphillipmoore/*",
+        "vergil-project/*",
     ]
     assert actual.rulesets == []
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace hardcoded wphillipmoore/* with vergil-project/* in _BASE_ACTION_PATTERNS and fix stale GitHub Pages URL

## Issue Linkage

- Ref #766

## Notes

- The base action patterns list in github_config.py still referenced wphillipmoore/* after the org migration to vergil-project. This caused vrg-github-config audit to fail on any repo whose GitHub Actions permissions had been correctly updated to vergil-project/*. Existing repos passed only because vrg-github-config apply had previously written wphillipmoore/* to their GitHub config, and GitHub's redirect mechanism silently resolved the mismatch. Also fixes a stale GitHub Pages URL in vrg_generate_commands.py.