### PR TITLE
docs: Claude Code permission model design spec and implementation plan

### DIFF
--- a/docs/plans/2026-05-14-permission-model.md
+++ b/docs/plans/2026-05-14-permission-model.md
@@ -15,7 +15,7 @@ update CLAUDE.md guidance, deploy project settings to consuming repos,
 deploy vergil-tooling's own permission config, switch the global
 default mode, then observe and refine.
 
-**Tech Stack:** Python CLI tools (click), Claude Code settings (JSON),
+**Tech Stack:** Python CLI tools (argparse), Claude Code settings (JSON),
 vergil plugin hooks (JSON + bash), CLAUDE.md (markdown)
 
 **Spec:** `docs/specs/2026-05-14-permission-model-design.md`
@@ -29,88 +29,221 @@ having `vrg-git` and `vrg-gh` available before the deny rules go live.
 
 ### Task 1: `vrg-git` Wrapper
 
+**Requirement:** Spec Section 2 — validate git subcommands and flags
+before execution; deny dangerous operations; log all invocations.
+
 **Files:**
-`src/vergil_tooling/cli/vrg_git.py`,
+`src/vergil_tooling/bin/vrg_git.py`,
 `tests/test_vrg_git.py`,
 `pyproject.toml` (console script entry)
 
-Build the `vrg-git` CLI tool per the spec's Section 2.
+#### RED — Subcommand allowlist
 
-- [ ] Create `src/vergil_tooling/cli/vrg_git.py` — Python CLI that
-      accepts arbitrary arguments after `vrg-git`, validates the first
-      argument (subcommand) against the allowlist, checks remaining
-      arguments against the per-subcommand denied-flags list, then
-      executes `git` via `subprocess.run` with `shell=False`
-- [ ] Implement the subcommand allowlist from the spec: `status`,
-      `log`, `diff`, `show`, `branch`, `ls-remote`, `rev-parse`,
-      `worktree add`, `worktree list`, `worktree remove`, `add`,
+- [ ] Write tests that each allowed subcommand (`status`, `log`,
+      `diff`, `show`, `branch`, `ls-remote`, `rev-parse`, `add`,
       `push`, `fetch`, `pull`, `checkout`, `switch`, `stash`, `merge`,
-      `cherry-pick`, `rebase`
-- [ ] Implement flag deny lists per-subcommand:
-      - `branch`: deny `-D`, `--force`
-      - `push`: deny `--force`, `--force-with-lease`, `-f`
-      - `checkout`: deny `-- .`, `-- *` (broad restore patterns;
-        specific-file `-- path/to/file` is allowed)
-      - `rebase`: deny `-i`, `--interactive`
-- [ ] Implement the explicit deny list: `commit`, `reset`, `clean`,
-      `config`, `remote`, `reflog`, `gc`, `prune`, `filter-branch`,
-      `replace` — with clear error messages naming the denied
-      subcommand and suggesting the VRG alternative where one exists
-      (e.g., "use vrg-commit instead of git commit")
-- [ ] Handle compound subcommands: `worktree add`, `worktree list`,
-      `worktree remove` — validate the first two arguments as a pair
-- [ ] Reject unrecognized subcommands with a clear error message
-- [ ] Add invocation logging: command, arguments, allowed/denied,
-      timestamp — append to a local log file
-      (`~/.local/share/vergil/vrg-git.log` or similar)
+      `cherry-pick`, `rebase`) passes validation and reaches
+      `subprocess.run` (mock the subprocess call)
+- [ ] Write tests that compound subcommands (`worktree add`,
+      `worktree list`, `worktree remove`) pass validation when the
+      first two arguments are provided as a pair
+- [ ] Write a test that an unrecognized subcommand (e.g., `bisect`)
+      exits non-zero with a clear error message
+- [ ] Write a test that invoking `vrg-git` with no arguments exits
+      non-zero with a usage message
+- [ ] Expected failure: no implementation exists yet
+- [ ] If any test passes unexpectedly: the test is not isolating
+      correctly — it may be calling real `git` instead of validating
+      through the wrapper
+
+#### GREEN — Subcommand allowlist
+
+- [ ] Create `src/vergil_tooling/bin/vrg_git.py` with a `main()`
+      entry point that reads `sys.argv[1:]`, validates the first
+      argument against the subcommand allowlist (dict lookup), and
+      calls `subprocess.run(["git"] + args, shell=False)`
+- [ ] Handle compound subcommands by checking whether the first
+      argument is `worktree` and validating the pair
+- [ ] Reject unrecognized subcommands with exit code 1 and a message
+      naming the rejected subcommand
 - [ ] Add `vrg-git` console script entry point in `pyproject.toml`
-- [ ] Write tests:
-      - Each allowed subcommand passes validation
-      - Each denied subcommand is rejected with appropriate message
-      - Each denied flag on an allowed subcommand is rejected
-      - Unrecognized subcommand is rejected
-      - Arguments are passed through to `git` without shell expansion
-      - Logging produces entries on both allow and deny
+- [ ] All RED tests pass
+
+#### RED — Denied subcommands
+
+- [ ] Write tests that each explicitly denied subcommand (`commit`,
+      `reset`, `clean`, `config`, `remote`, `reflog`, `gc`, `prune`,
+      `filter-branch`, `replace`) exits non-zero with a message naming
+      the denied subcommand
+- [ ] Write a test that `commit` denial message suggests `vrg-commit`
+- [ ] Expected failure: denied subcommands are not yet distinguished
+      from unrecognized ones (both rejected, but error messages differ)
+
+#### GREEN — Denied subcommands
+
+- [ ] Add an explicit deny list that is checked before the
+      unrecognized-subcommand fallback, with per-subcommand error
+      messages that suggest the VRG alternative where one exists
+- [ ] All RED tests pass
+
+#### RED — Flag deny lists
+
+- [ ] Write tests that denied flags on allowed subcommands are
+      rejected:
+      - `branch -D`, `branch --force`
+      - `push --force`, `push --force-with-lease`, `push -f`
+      - `checkout -- .`, `checkout -- *`
+      - `rebase -i`, `rebase --interactive`
+- [ ] Write tests that the same subcommands with allowed flags pass:
+      - `branch -d some-branch` (safe delete)
+      - `push origin feature/foo` (normal push)
+      - `checkout -- src/specific/file.py` (specific-file restore)
+      - `rebase main` (non-interactive)
+- [ ] Expected failure: no flag validation exists yet
+
+#### GREEN — Flag deny lists
+
+- [ ] Add per-subcommand flag scanning that checks remaining arguments
+      against deny lists before passing through to `subprocess.run`
+- [ ] For `checkout`: deny `--` followed by `.` or `*` specifically,
+      not `--` followed by a file path
+- [ ] All RED tests pass
+
+#### RED — Invocation logging
+
+- [ ] Write a test that a successful (allowed) invocation appends a
+      log entry with command, arguments, "allowed", and timestamp
+- [ ] Write a test that a denied invocation appends a log entry with
+      command, arguments, "denied", and timestamp
+- [ ] Write a test that the log directory is created if it does not
+      exist
+- [ ] Expected failure: no logging exists yet
+
+#### GREEN — Invocation logging
+
+- [ ] Add logging that appends to a local log file
+      (`~/.local/share/vergil/vrg-git.log` or similar) on every
+      invocation, recording command, arguments, allowed/denied, and
+      timestamp
+- [ ] Create the log directory if it does not exist
+- [ ] All RED tests pass
+
+#### REFACTOR
+
+- [ ] Review for duplicated validation logic that should be extracted
+      (allowlist lookup, flag scanning, error formatting)
+- [ ] Check whether the deny list error messages are consistent in
+      format
+- [ ] Verify the subprocess call uses `shell=False` and passes
+      arguments as a list, not a string
+- [ ] Look for hard-coded paths that should be configurable or use
+      platform-appropriate defaults
 
 ### Task 2: `vrg-gh` Wrapper
 
+**Requirement:** Spec Section 3 — validate gh two-level subcommand
+pairs before execution; deny dangerous operations; log all invocations.
+
 **Files:**
-`src/vergil_tooling/cli/vrg_gh.py`,
+`src/vergil_tooling/bin/vrg_gh.py`,
 `tests/test_vrg_gh.py`,
 `pyproject.toml` (console script entry)
 
-Build the `vrg-gh` CLI tool per the spec's Section 3.
+#### RED — Two-level subcommand allowlist
 
-- [ ] Create `src/vergil_tooling/cli/vrg_gh.py` — same architecture
-      as `vrg-git`: validate the two-level subcommand pair (e.g.,
-      `issue view`, `pr checks`), then execute `gh` via
-      `subprocess.run` with `shell=False`
-- [ ] Implement the subcommand allowlist from the spec:
+- [ ] Write tests that each allowed subcommand pair passes validation
+      and reaches `subprocess.run` (mock the subprocess call):
       - `issue`: `view`, `create`, `close`, `edit`, `list`, `comment`
       - `pr`: `view`, `checks`, `list`, `diff`, `comment`, `edit`
       - `run`: `list`, `view`, `watch`
       - `repo`: `view`
       - `label`: `list`, `create`
-- [ ] Implement the explicit deny list:
-      - `pr merge`, `pr review --approve`, `pr close`, `pr create`
-      - `repo edit`, `repo create`, `repo delete`
-      - `api` (entire subcommand tree)
-      - `auth` (entire subcommand tree)
-- [ ] For `pr review`: allow the subcommand but deny `--approve`
-      flag specifically (agents can comment on PRs but not approve)
+- [ ] Write a test that an unrecognized top-level subcommand (e.g.,
+      `codespace`) exits non-zero with a clear error message
+- [ ] Write a test that an unrecognized second-level subcommand under
+      a known top-level (e.g., `issue pin`) exits non-zero
+- [ ] Write a test that invoking `vrg-gh` with no arguments exits
+      non-zero with a usage message
+- [ ] Write a test that invoking `vrg-gh` with only a top-level
+      subcommand and no second-level (e.g., `vrg-gh issue`) exits
+      non-zero
+- [ ] Expected failure: no implementation exists yet
+
+#### GREEN — Two-level subcommand allowlist
+
+- [ ] Create `src/vergil_tooling/bin/vrg_gh.py` with a `main()` entry
+      point that reads `sys.argv[1:]`, validates the first two
+      arguments as a subcommand pair against a nested allowlist (dict
+      of dicts), and calls `subprocess.run(["gh"] + args, shell=False)`
 - [ ] Reject unrecognized top-level subcommands
-- [ ] Reject unrecognized second-level subcommands under a known
-      top-level
-- [ ] Add invocation logging (same format as `vrg-git`)
+- [ ] Reject unrecognized second-level subcommands under known
+      top-level commands
+- [ ] Reject invocations with fewer than two arguments
 - [ ] Add `vrg-gh` console script entry point in `pyproject.toml`
-- [ ] Write tests:
-      - Each allowed subcommand pair passes validation
-      - Each denied subcommand pair is rejected
-      - `api` and `auth` are rejected at the top level
-      - `pr review` without `--approve` is allowed
-      - `pr review --approve` is rejected
-      - Arguments are passed through without shell expansion
-      - Logging produces entries on both allow and deny
+- [ ] All RED tests pass
+
+#### RED — Denied subcommand pairs and top-level denials
+
+- [ ] Write tests that each explicitly denied subcommand pair exits
+      non-zero with a message naming the denied operation:
+      - `pr merge`, `pr close`, `pr create`
+      - `repo edit`, `repo create`, `repo delete`
+- [ ] Write tests that top-level denials reject the entire subtree:
+      - `api` with any arguments (e.g., `api repos/...`)
+      - `auth` with any arguments (e.g., `auth login`)
+- [ ] Expected failure: denied pairs are not yet distinguished from
+      unrecognized ones (both rejected, but error messages differ)
+
+#### GREEN — Denied subcommand pairs and top-level denials
+
+- [ ] Add an explicit deny list checked before the
+      unrecognized-subcommand fallback, with per-pair error messages
+      that suggest VRG alternatives where they exist (e.g., "use
+      vrg-submit-pr instead of gh pr create")
+- [ ] Handle top-level denials (`api`, `auth`) by rejecting before
+      checking for a second-level subcommand
+- [ ] All RED tests pass
+
+#### RED — `pr review` flag gating
+
+- [ ] Write a test that `pr review` without `--approve` passes
+      validation (agents can comment on reviews)
+- [ ] Write a test that `pr review --approve` is rejected with a
+      message explaining agents cannot approve PRs
+- [ ] Write a test that `pr review --comment -b "looks good"` passes
+- [ ] Expected failure: no per-subcommand flag validation exists yet
+
+#### GREEN — `pr review` flag gating
+
+- [ ] Add flag scanning for `pr review` that denies `--approve`
+      specifically while allowing other flags
+- [ ] All RED tests pass
+
+#### RED — Invocation logging
+
+- [ ] Write a test that a successful (allowed) invocation appends a
+      log entry with command, arguments, "allowed", and timestamp
+- [ ] Write a test that a denied invocation appends a log entry with
+      command, arguments, "denied", and timestamp
+- [ ] Expected failure: no logging exists yet
+
+#### GREEN — Invocation logging
+
+- [ ] Add logging that appends to a local log file
+      (`~/.local/share/vergil/vrg-gh.log` or similar), same format
+      as `vrg-git`
+- [ ] All RED tests pass
+
+#### REFACTOR
+
+- [ ] Review for duplicated logic shared with `vrg-git` (feeds into
+      Task 3's extraction decision)
+- [ ] Check whether error messages are consistent across all deny
+      types (top-level denied, pair denied, flag denied, unrecognized)
+- [ ] Verify the subprocess call uses `shell=False` and passes
+      arguments as a list
+- [ ] Look for hard-coded paths that should be configurable or use
+      platform-appropriate defaults
 
 ### Task 3: Shared Infrastructure
 
@@ -337,8 +470,7 @@ Task 3 (shared) ───┼── Task 4 (pattern verify) ── Task 5 (valida
                                            Task 11 (observe)
 ```
 
-Tasks 1-3 can proceed in parallel. Task 4 can begin as soon as
-Task 1 produces a working `vrg-git`. Tasks 6, 7, 8, 9 can proceed
+Tasks 1-3 can proceed in parallel. Task 4 begins after Tasks 1-3 complete. Tasks 6, 7, 8, 9 can proceed
 in parallel after Task 5 merges. Task 10 is the gating step — all
 prerequisites must be merged. Task 11 follows Task 10.
 

--- a/docs/plans/2026-05-14-permission-model.md
+++ b/docs/plans/2026-05-14-permission-model.md
@@ -1,0 +1,365 @@
+# Claude Code Permission Model — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate from `bypassPermissions` mode to a defense-in-depth
+permission model where agents operate through VRG wrapper tools with
+subcommand allowlists, Claude Code's permission layer controls what
+reaches the shell, and existing plugin hooks serve as a backstop.
+
+**Architecture:** Seven-step rollout — build wrappers, update hooks,
+update CLAUDE.md guidance, deploy project settings to consuming repos,
+deploy vergil-tooling's own permission config, switch the global
+default mode, then observe and refine.
+
+**Tech Stack:** Python CLI tools (click), Claude Code settings (JSON),
+vergil plugin hooks (JSON + bash), CLAUDE.md (markdown)
+
+**Spec:** `docs/specs/2026-05-14-permission-model-design.md`
+
+---
+
+## Phase 1: Build the Wrappers
+
+The wrappers are the foundation — everything else depends on agents
+having `vrg-git` and `vrg-gh` available before the deny rules go live.
+
+### Task 1: `vrg-git` Wrapper
+
+**Files:**
+`src/vergil_tooling/cli/vrg_git.py`,
+`tests/test_vrg_git.py`,
+`pyproject.toml` (console script entry)
+
+Build the `vrg-git` CLI tool per the spec's Section 2.
+
+- [ ] Create `src/vergil_tooling/cli/vrg_git.py` — Python CLI that
+      accepts arbitrary arguments after `vrg-git`, validates the first
+      argument (subcommand) against the allowlist, checks remaining
+      arguments against the per-subcommand denied-flags list, then
+      executes `git` via `subprocess.run` with `shell=False`
+- [ ] Implement the subcommand allowlist from the spec: `status`,
+      `log`, `diff`, `show`, `branch`, `ls-remote`, `rev-parse`,
+      `worktree add`, `worktree list`, `worktree remove`, `add`,
+      `push`, `fetch`, `pull`, `checkout`, `switch`, `stash`, `merge`,
+      `cherry-pick`, `rebase`
+- [ ] Implement flag deny lists per-subcommand:
+      - `branch`: deny `-D`, `--force`
+      - `push`: deny `--force`, `--force-with-lease`, `-f`
+      - `checkout`: deny `-- .`, `-- *` (broad restore patterns;
+        specific-file `-- path/to/file` is allowed)
+      - `rebase`: deny `-i`, `--interactive`
+- [ ] Implement the explicit deny list: `commit`, `reset`, `clean`,
+      `config`, `remote`, `reflog`, `gc`, `prune`, `filter-branch`,
+      `replace` — with clear error messages naming the denied
+      subcommand and suggesting the VRG alternative where one exists
+      (e.g., "use vrg-commit instead of git commit")
+- [ ] Handle compound subcommands: `worktree add`, `worktree list`,
+      `worktree remove` — validate the first two arguments as a pair
+- [ ] Reject unrecognized subcommands with a clear error message
+- [ ] Add invocation logging: command, arguments, allowed/denied,
+      timestamp — append to a local log file
+      (`~/.local/share/vergil/vrg-git.log` or similar)
+- [ ] Add `vrg-git` console script entry point in `pyproject.toml`
+- [ ] Write tests:
+      - Each allowed subcommand passes validation
+      - Each denied subcommand is rejected with appropriate message
+      - Each denied flag on an allowed subcommand is rejected
+      - Unrecognized subcommand is rejected
+      - Arguments are passed through to `git` without shell expansion
+      - Logging produces entries on both allow and deny
+
+### Task 2: `vrg-gh` Wrapper
+
+**Files:**
+`src/vergil_tooling/cli/vrg_gh.py`,
+`tests/test_vrg_gh.py`,
+`pyproject.toml` (console script entry)
+
+Build the `vrg-gh` CLI tool per the spec's Section 3.
+
+- [ ] Create `src/vergil_tooling/cli/vrg_gh.py` — same architecture
+      as `vrg-git`: validate the two-level subcommand pair (e.g.,
+      `issue view`, `pr checks`), then execute `gh` via
+      `subprocess.run` with `shell=False`
+- [ ] Implement the subcommand allowlist from the spec:
+      - `issue`: `view`, `create`, `close`, `edit`, `list`, `comment`
+      - `pr`: `view`, `checks`, `list`, `diff`, `comment`, `edit`
+      - `run`: `list`, `view`, `watch`
+      - `repo`: `view`
+      - `label`: `list`, `create`
+- [ ] Implement the explicit deny list:
+      - `pr merge`, `pr review --approve`, `pr close`, `pr create`
+      - `repo edit`, `repo create`, `repo delete`
+      - `api` (entire subcommand tree)
+      - `auth` (entire subcommand tree)
+- [ ] For `pr review`: allow the subcommand but deny `--approve`
+      flag specifically (agents can comment on PRs but not approve)
+- [ ] Reject unrecognized top-level subcommands
+- [ ] Reject unrecognized second-level subcommands under a known
+      top-level
+- [ ] Add invocation logging (same format as `vrg-git`)
+- [ ] Add `vrg-gh` console script entry point in `pyproject.toml`
+- [ ] Write tests:
+      - Each allowed subcommand pair passes validation
+      - Each denied subcommand pair is rejected
+      - `api` and `auth` are rejected at the top level
+      - `pr review` without `--approve` is allowed
+      - `pr review --approve` is rejected
+      - Arguments are passed through without shell expansion
+      - Logging produces entries on both allow and deny
+
+### Task 3: Shared Infrastructure
+
+**Files:**
+`src/vergil_tooling/lib/wrapper.py` (new, if warranted)
+
+Evaluate during Task 1/2 implementation whether shared code between
+the two wrappers warrants extraction. Both wrappers share: argument
+parsing pattern (allowlist lookup + flag deny), logging format,
+error message format, `subprocess.run` invocation.
+
+- [ ] If the two implementations share substantial code, extract
+      shared logic into `src/vergil_tooling/lib/wrapper.py`
+- [ ] If not, skip — prefer duplication over premature abstraction
+
+### Task 4: Verify `Bash(git *)` Pattern Matching
+
+**Files:** None (manual testing)
+
+The spec identifies a critical implementation risk: the `Bash(git *)`
+deny pattern must not match `vrg-git *` via substring matching.
+
+- [ ] Before any permission config is deployed, test Claude Code's
+      matching behavior:
+      1. Set `deny: ["Bash(git *)"]` in a test settings file
+      2. Attempt `vrg-git status` — must NOT be denied
+      3. Attempt `git status` — must be denied
+      4. Attempt `echo "git status"` — document behavior
+      5. Attempt `vrg-git status && git push` — document behavior
+         (compound command splitting per anthropics/claude-code#28784)
+- [ ] Document results in the spec or as a comment on issue #754
+- [ ] If `vrg-git` is matched by `Bash(git *)`: do not deploy the
+      global deny rules. Instead, move the git/gh deny enforcement
+      entirely to the hook layer and document the limitation. The
+      rest of the plan still proceeds — only the enforcement layer
+      for the deny changes.
+
+### Task 5: Validation and Release
+
+**Files:** `pyproject.toml` (version bump if needed)
+
+- [ ] Run `vrg-docker-run -- uv run vrg-validate` — full pipeline
+      must pass with the new wrappers and tests
+- [ ] Verify `uv tool install` installs both `vrg-git` and `vrg-gh`
+      as available console scripts
+- [ ] Commit and PR for the wrapper code (Tasks 1-3)
+
+---
+
+## Phase 2: Update Supporting Infrastructure
+
+With the wrappers available, update the guidance and hook layers to
+point agents toward them.
+
+### Task 6: Update Vergil Plugin Hook Messages
+
+**Files:** vergil-claude-plugin hooks (separate repo)
+
+Existing hooks that block raw `git` and `gh` usage should update
+their error messages to point agents to the wrappers.
+
+- [ ] `block-raw-git-commit`: update message to reference `vrg-commit`
+      (already does) and note that all `git` operations should use
+      `vrg-git`
+- [ ] `block-raw-gh-pr-create`: update message to reference
+      `vrg-submit-pr` (already does) and note that all `gh` operations
+      should use `vrg-gh`
+- [ ] `block-agent-merge`: update message to note that `vrg-gh`
+      rejects `pr merge` as well
+- [ ] `block-github-contents-api`: update message to note that
+      `vrg-gh` denies `gh api` entirely
+- [ ] No hooks are removed — they remain as Layer 3 backstops
+- [ ] Commit and PR for hook message updates
+
+### Task 7: Update CLAUDE.md Across All Repos
+
+**Files:** `CLAUDE.md` in vergil-tooling, vergil-actions,
+vergil-docker, vergil-claude-plugin
+
+Add a section to each repo's CLAUDE.md instructing agents to use
+the wrappers.
+
+- [ ] Add a "Shell command policy" section (or equivalent) to each
+      CLAUDE.md:
+      - Use `vrg-git` instead of `git` for all git operations
+      - Use `vrg-gh` instead of `gh` for all GitHub CLI operations
+      - These are not optional preferences — raw `git` and `gh` are
+        denied by the permission model
+      - If a command is not available through the wrappers, explain
+        the situation to the human who can run it via `! <command>`
+- [ ] Verify the wording is consistent across all four repos
+- [ ] One PR per repo (can run in parallel)
+
+---
+
+## Phase 3: Deploy Permission Configuration
+
+Settings files are deployed to repos and the global mode is switched.
+This is the "flip the switch" phase — everything before this was
+preparation.
+
+### Task 8: Deploy Project Settings to Consuming Repos
+
+**Files:** `.claude/settings.json` in vergil-actions, vergil-docker,
+vergil-claude-plugin
+
+Each consuming repo gets the project-level `Bash(vrg-*)` allowlist.
+
+- [ ] Update `.claude/settings.json` in vergil-actions to add:
+      ```json
+      {
+        "permissions": {
+          "allow": ["Bash(vrg-*)"]
+        }
+      }
+      ```
+      (Merged with existing plugin marketplace config)
+- [ ] Same for vergil-docker
+- [ ] Same for vergil-claude-plugin
+- [ ] Document the `.claude/settings.local.json` template for phase 1
+      read-only exceptions in CONTRIBUTING.md or developer docs — this
+      is gitignored and per-developer, so it cannot be committed
+- [ ] One PR per repo (can run in parallel)
+
+### Task 9: Deploy Permission Configuration for vergil-tooling
+
+**Files:**
+`.claude/settings.json` (project-level),
+`~/.claude/settings.json` (global, manual),
+`~/.claude/settings.local.json` (global local, manual)
+
+Deploy the full permission stack for vergil-tooling itself.
+
+- [ ] Update `.claude/settings.json` (project-level) to add the
+      `Bash(vrg-*)` allowlist (merged with existing plugin config)
+- [ ] Prepare but do not yet apply the global settings changes:
+      ```json
+      {
+        "permissions": {
+          "defaultMode": "acceptEdits",
+          "deny": ["Bash(git *)", "Bash(gh *)"]
+        }
+      }
+      ```
+      These are applied in Task 10, not here — the project-level
+      changes can be committed and merged first.
+- [ ] Prepare the `.claude/settings.local.json` template with the
+      phase 1 read-only exceptions (from the spec's Section 4)
+- [ ] Commit and PR for the project-level settings change
+
+### Task 10: Switch Global Default Mode
+
+**Files:** `~/.claude/settings.json` (manual, not committed anywhere)
+
+This is the migration moment. All wrappers, hooks, CLAUDE.md updates,
+and project settings must be deployed and merged before this step.
+
+- [ ] Confirm prerequisites:
+      - `vrg-git` and `vrg-gh` are installed and working
+      - All four repos have updated CLAUDE.md
+      - All four repos have project-level `Bash(vrg-*)` allowlist
+      - Task 4 (pattern matching verification) is complete and results
+        are documented
+- [ ] Apply global `~/.claude/settings.json`:
+      ```json
+      {
+        "permissions": {
+          "defaultMode": "acceptEdits",
+          "deny": ["Bash(git *)", "Bash(gh *)"]
+        }
+      }
+      ```
+      (If Task 4 showed substring matching, omit the deny rules and
+      rely on hook enforcement instead)
+- [ ] Apply `~/.claude/settings.local.json` with the phase 1
+      read-only exceptions
+- [ ] Remove `skipDangerousModePermissionPrompt` from global settings
+      (no longer needed when not in bypass mode)
+
+---
+
+## Phase 4: Observe and Refine
+
+### Task 11: One-Week Observation Period
+
+**Files:** None (operational)
+
+Run the new permission model for one week of normal development
+across all four repos. Collect data on prompt frequency, wrapper
+usage, and friction points.
+
+- [ ] Monitor: which commands trigger prompts most frequently?
+      Candidates for new VRG tools or allowlist additions.
+- [ ] Monitor: which wrapper subcommands are agents using most?
+      Validates the allowlist design.
+- [ ] Monitor: are agents finding workarounds or getting stuck?
+      Indicates missing allowlist entries or overly restrictive
+      wrappers.
+- [ ] Review `vrg-git` and `vrg-gh` logs for patterns
+- [ ] After one week: update issue #754 with findings and open
+      follow-up issues for any phase 2 work identified
+- [ ] If the prompt volume is unacceptably high, adjust the
+      `.claude/settings.local.json` read-only exceptions. If specific
+      `vrg-git` or `vrg-gh` subcommands are missing, add them to the
+      wrappers.
+
+---
+
+## Implementation Notes
+
+### Task Dependencies
+
+```text
+Task 1 (vrg-git) ──┐
+Task 2 (vrg-gh) ───┤
+Task 3 (shared) ───┼── Task 4 (pattern verify) ── Task 5 (validate/PR)
+                   │
+                   ├── Task 6 (hook messages)  ─┐
+                   ├── Task 7 (CLAUDE.md × 4) ──┤
+                   │                            ├── Task 10 (switch mode)
+                   ├── Task 8 (consuming repos) ┤
+                   └── Task 9 (vergil-tooling) ─┘
+                                                │
+                                           Task 11 (observe)
+```
+
+Tasks 1-3 can proceed in parallel. Task 4 can begin as soon as
+Task 1 produces a working `vrg-git`. Tasks 6, 7, 8, 9 can proceed
+in parallel after Task 5 merges. Task 10 is the gating step — all
+prerequisites must be merged. Task 11 follows Task 10.
+
+### Scope Boundaries
+
+- **In scope:** wrapper tools, permission config, CLAUDE.md updates,
+  hook message updates, pattern matching verification.
+- **Out of scope:** credential management (covered by #717, #764,
+  #765), unified `vrg` CLI (phase 2/3), `vrg-search` or other
+  read-only tool replacements (phase 2), Windows/Linux credential
+  backends (#764, #765).
+
+### Risk Mitigations
+
+- **Task 4 is a gate.** If `Bash(git *)` matches `vrg-git`, the
+  deny rules cannot go in Claude Code settings. The plan has an
+  explicit fallback: hook-only enforcement for the deny layer.
+- **Phase 1 read-only exceptions are temporary.** They live in
+  gitignored local settings so they can be tightened per-developer
+  without requiring a PR.
+- **The switch (Task 10) is reversible.** If the prompt volume is
+  unmanageable, reverting `~/.claude/settings.json` to
+  `bypassPermissions` restores the prior behavior. The wrappers and
+  hooks remain as improvements regardless.

--- a/docs/specs/2026-05-14-permission-model-design.md
+++ b/docs/specs/2026-05-14-permission-model-design.md
@@ -130,9 +130,9 @@ arguments via `subprocess.run` with `shell=False`.
 | `push` | yes | `--force`, `--force-with-lease`, `-f` | Normal push allowed; force push denied |
 | `fetch` | yes | — | Read-only |
 | `pull` | yes | — | Fast-forward branch updates |
-| `checkout` | yes | `-- .`, `-- *` (restore patterns) | Branch switching allowed; file restoration denied |
+| `checkout` | yes | `-- .`, `-- *` (restore patterns) | Branch switching allowed; broad file restoration denied. Specific-file restore (`-- path/to/file`) is allowed — the agent already has equivalent capability through the Write tool, and worktree isolation is the real safety net. |
 | `switch` | yes | — | Branch switching |
-| `stash` | yes | — | Temporary state management |
+| `stash` | yes | — | Temporary state management. All subcommands (`drop`, `clear` included) are allowed — stash is an out-of-band recovery mechanism, not a normal workflow operation. The real fix is the tooling that prevents the mistakes that lead to stash usage; in the recovery context, discarding stashed state is legitimate. |
 | `merge` | yes | — | Branch updates |
 | `cherry-pick` | yes | — | Selective commit application |
 | `rebase` | yes | `-i`, `--interactive` | Non-interactive rebase allowed; interactive denied |
@@ -142,6 +142,9 @@ arguments via `subprocess.run` with `shell=False`.
 Anything not on the allowlist is rejected by default. Notable
 denials:
 
+- `commit` — all commits flow through `vrg-commit`, which sets
+  `VRG_COMMIT_CONTEXT=1` and enforces branch prefix, issue number,
+  and worktree convention checks
 - `reset` — too dangerous in all forms
 - `clean` — file deletion
 - `config` — modifying git configuration
@@ -263,17 +266,16 @@ substring-based, the deny rules move to the hook layer instead.
 {
   "permissions": {
     "allow": [
-      "Bash(vrg-*)",
-      "Bash(vrg-git *)",
-      "Bash(vrg-gh *)"
+      "Bash(vrg-*)"
     ]
   }
 }
 ```
 
-The project layer allowlists VRG tools. All `vrg-commit`,
-`vrg-submit-pr`, `vrg-validate`, `vrg-docker-run`, `vrg-git`,
-and `vrg-gh` invocations run without prompting.
+The project layer allowlists all VRG tools via a single wildcard.
+`vrg-commit`, `vrg-submit-pr`, `vrg-validate`, `vrg-docker-run`,
+`vrg-git`, `vrg-gh`, and any future `vrg-*` tools run without
+prompting. No per-tool entries are needed.
 
 ### Project Local Settings (`.claude/settings.local.json`)
 
@@ -339,7 +341,7 @@ rejects it.
 
 ### Layer 3 — Vergil Plugin Hooks
 
-The existing 11 hooks remain as a backstop. They catch patterns
+The existing 12 hooks remain as a backstop. They catch patterns
 that slip through layers 1 and 2. Hooks exit code 2 (hard block)
 which overrides even bypass mode.
 
@@ -397,10 +399,14 @@ provides an audit trail and feeds back into phase 2 planning:
    hooks evolve their error messages)
 3. Update CLAUDE.md across all repos to instruct agents to use
    `vrg-git` and `vrg-gh` instead of raw commands
-4. Deploy the permission configuration (global deny, project allow,
-   local exceptions)
-5. Switch `defaultMode` from `bypassPermissions` to `acceptEdits`
-6. Run for a week, collect data on what prompts appear, and refine
+4. Deploy `.claude/settings.json` to each consuming repo with the
+   project-level `Bash(vrg-*)` allowlist. Provide a template
+   `settings.local.json` in documentation for the phase 1
+   read-only exceptions.
+5. Deploy the permission configuration (global deny, project allow,
+   local exceptions) for vergil-tooling itself
+6. Switch `defaultMode` from `bypassPermissions` to `acceptEdits`
+7. Run for a week, collect data on what prompts appear, and refine
 
 ### Hook Evolution
 
@@ -419,6 +425,7 @@ Existing hooks after migration:
 | `block-protected-branch-work` | Still primary — worktree convention |
 | `block-worktree-bypass-write` | Still primary — Write/Edit gating |
 | `detect-deprecation-warnings` | Still primary — observability |
+| `remind-finalize` | Still primary — operational reminder |
 
 No hooks are removed. Hooks that become backstops get a comment
 noting that the permission layer is now the primary enforcement.
@@ -462,5 +469,5 @@ planning. After a month of operation:
 | Switching from bypass mode surfaces unexpected prompt volume | Run for a week after migration, refine allowlist based on data |
 | Wrapper allowlists are too restrictive for some workflows | The human can run raw commands via `! <command>` in the prompt; each case is data for allowlist refinement |
 | Agents ignore CLAUDE.md instructions to use `vrg-git`/`vrg-gh` | Permission deny rules enforce compliance mechanically — instructions are guidance, the deny is the gate |
-| Read-only bash exceptions (phase 1) used for shell redirection attacks | Accept as known risk during phase 1; wrappers and deny rules cover the highest-risk commands (git, gh); phase 2 evaluates alternatives |
+| Read-only bash exceptions (phase 1) used for command chaining attacks (`grep foo; dangerous-cmd`) | Claude Code's documented behavior splits compound commands on shell operators and evaluates each subcommand independently — deny rules on `git`/`gh` should fire against embedded dangerous commands. However, there is a known implementation gap (anthropics/claude-code#28784) where prefix matching on the full command string can produce unexpected approvals. Primary mitigation: the `Bash(git *)` and `Bash(gh *)` deny rules cover the highest-risk commands regardless. Fallback: a PreToolUse hook that rejects shell operators in read-only-allowlisted commands can be added if the implementation gap is not resolved before phase 1 deploys. Phase 2 evaluates replacing read-only exceptions entirely. |
 | `VRG_COMMIT_CONTEXT` env var used to bypass pre-commit hook | Layers 1-3 prevent the agent from reaching `git commit`; layer 4 weakness is documented but mitigated |

--- a/docs/specs/2026-05-14-permission-model-design.md
+++ b/docs/specs/2026-05-14-permission-model-design.md
@@ -1,0 +1,466 @@
+# Claude Code Permission Model Design
+
+**Issue:** #754
+**Date:** 2026-05-14
+**Status:** Draft
+
+## Problem
+
+The VERGIL project currently runs Claude Code in `bypassPermissions`
+mode globally. All operations are auto-approved with no prompts. The
+only enforcement layer is the vergil plugin's hook system, which
+blocks specific known-dangerous patterns (raw `git commit`, raw
+`gh pr create`, agent merges, etc.) but operates as a blocklist —
+chasing individual dangerous commands rather than constraining the
+agent to a known-safe set of operations.
+
+This is insufficient for an org that aims to accept external
+contributors using AI agents. The permission model must:
+
+- Constrain agents to a validated set of operations by default
+- Channel all system interaction through VRG wrapper tools that
+  validate, constrain, and log what happens
+- Prevent agents from using raw shell primitives to work around
+  restrictions (pipes, redirection, subshells, command chaining)
+- Provide defense-in-depth through multiple independent enforcement
+  layers
+- Maintain development velocity — the constraints must not make
+  agents unusable for real work
+- Support a phased rollout that tightens over time as more
+  operations are mechanized
+
+## Strategic Goal
+
+**The agent never interacts with the system through raw shell.**
+Every operation goes through a VRG wrapper that validates,
+constrains, and logs what happens. The permission allowlist consists
+exclusively of `vrg-*` commands. If an agent needs something
+outside the allowlist, it requires human approval.
+
+This is a forcing function for tooling development: if agents keep
+getting prompted for the same operation, that is a signal to build
+a VRG tool for it. The allowlist shrinks the surface area of what
+agents can do, and every exception is a candidate for
+mechanization.
+
+## Phasing
+
+### Phase 1 (this spec)
+
+- Switch from `bypassPermissions` to `acceptEdits` as the default
+  mode
+- Build `vrg-git` and `vrg-gh` wrappers with subcommand allowlists
+  and flag validation
+- Allowlist all `vrg-*` commands in Claude Code permissions
+- Temporarily allowlist a small set of read-only bash commands with
+  documented intent to revisit
+- Deny list for raw `git` and `gh` at the global level
+- Hooks remain as the innermost enforcement layer
+- Everything not allowlisted prompts the human
+
+### Phase 2 (future)
+
+- Evaluate whether read-only bash exceptions can be replaced by
+  `vrg-search`, Explore subagent patterns, or Claude Code's native
+  `Read` tool
+- Build the unified `vrg` CLI with subcommands (replacing the
+  current `vrg-*` prefix pattern)
+- Tighten the allowlist as mechanization covers more operations
+- Each prompt-on-unknown that occurs frequently in practice is a
+  signal to build a new VRG tool
+
+### Phase 3 (future)
+
+- The ideal end state: `Bash(vrg *)` is the only allowlisted
+  pattern. All operations flow through one command with validated
+  subcommands. No raw shell access without human approval.
+
+## Section 1: Base Permission Mode
+
+**`acceptEdits`** is the default mode. The agent freely reads and
+modifies code files — that is its primary job. The vergil plugin
+hooks already enforce worktree write restrictions and block writes
+to the main worktree. Gating every file edit with a prompt would
+make development unusable.
+
+The real risk surface is shell commands, not file edits.
+`acceptEdits` auto-approves:
+
+- File reads (Read tool)
+- File edits (Edit tool)
+- File writes (Write tool)
+- Common filesystem commands (`mkdir`, `touch`, `mv`, `cp`)
+
+Shell commands not in the allowlist still prompt the human. This
+is the escalation mechanism: the agent encounters something it
+cannot do, explains the situation, and the human approves or
+denies in the moment. When the human is actively debugging with
+the agent, they approve exploratory commands as they come. When
+the agent is working autonomously, it blocks and waits.
+
+## Section 2: `vrg-git` Wrapper
+
+A Python CLI tool (consistent with the rest of vergil-tooling)
+that validates subcommands and flags before executing `git`. The
+agent never calls `git` directly — the permission model denies raw
+`git` and the hooks block it as a backstop.
+
+### Architecture
+
+The wrapper receives arguments as a Python argv list, not a shell
+string. No shell expansion, no pipes, no redirection. It validates
+against the allowlist, then execs `git` with the validated
+arguments via `subprocess.run` with `shell=False`.
+
+### Subcommand Allowlist
+
+| Subcommand | Allowed | Denied flags | Notes |
+|---|---|---|---|
+| `status` | yes | — | Read-only |
+| `log` | yes | — | Read-only |
+| `diff` | yes | — | Read-only |
+| `show` | yes | — | Read-only |
+| `branch` | yes | `-D`, `--force` | `-d` (safe delete) allowed |
+| `ls-remote` | yes | — | Read-only |
+| `rev-parse` | yes | — | Read-only |
+| `worktree add` | yes | — | Parallel agent work |
+| `worktree list` | yes | — | Read-only |
+| `worktree remove` | yes | — | Cleanup after merge |
+| `add` | yes | — | Staging files |
+| `push` | yes | `--force`, `--force-with-lease`, `-f` | Normal push allowed; force push denied |
+| `fetch` | yes | — | Read-only |
+| `pull` | yes | — | Fast-forward branch updates |
+| `checkout` | yes | `-- .`, `-- *` (restore patterns) | Branch switching allowed; file restoration denied |
+| `switch` | yes | — | Branch switching |
+| `stash` | yes | — | Temporary state management |
+| `merge` | yes | — | Branch updates |
+| `cherry-pick` | yes | — | Selective commit application |
+| `rebase` | yes | `-i`, `--interactive` | Non-interactive rebase allowed; interactive denied |
+
+### Denied Subcommands
+
+Anything not on the allowlist is rejected by default. Notable
+denials:
+
+- `reset` — too dangerous in all forms
+- `clean` — file deletion
+- `config` — modifying git configuration
+- `remote` — modifying remote configuration
+- `reflog` — not needed for normal development
+- `gc`, `prune` — maintenance operations
+- `filter-branch`, `replace` — history rewriting
+
+### Flag Validation
+
+For subcommands with dangerous flag variants, the wrapper scans
+the remaining arguments against a deny list of flags. This is
+pattern matching on known-dangerous flags, not a complete git
+argument parser.
+
+### Error Behavior
+
+When a subcommand or flag is denied, the wrapper exits with a
+clear error message explaining what was blocked and why.
+
+### Escape Hatch
+
+None in the wrapper itself. If the agent genuinely needs a denied
+operation, it explains the situation to the human, who can run the
+raw `git` command themselves via `! git <command>` in the Claude
+Code prompt.
+
+## Section 3: `vrg-gh` Wrapper
+
+Same architecture as `vrg-git` — Python CLI, argv list,
+`subprocess.run` with `shell=False`, no shell expansion.
+
+The `gh` CLI has a deep subcommand tree. The wrapper validates the
+top-level subcommand and the second-level subcommand as a pair.
+
+### Subcommand Allowlist
+
+| Subcommand | Allowed | Denied flags | Notes |
+|---|---|---|---|
+| `issue view` | yes | — | Read-only |
+| `issue create` | yes | — | Issue tracking |
+| `issue close` | yes | — | Post-finalization closure |
+| `issue edit` | yes | — | Updating metadata |
+| `issue list` | yes | — | Read-only |
+| `issue comment` | yes | — | Adding comments |
+| `pr view` | yes | — | Read-only |
+| `pr checks` | yes | — | Read-only, CI status |
+| `pr list` | yes | — | Read-only |
+| `pr diff` | yes | — | Read-only |
+| `pr comment` | yes | — | Review context |
+| `pr edit` | yes | — | Updating metadata |
+| `pr merge` | denied | — | Agents do not merge |
+| `pr review --approve` | denied | — | Agents do not approve |
+| `pr close` | denied | — | Agents do not close PRs |
+| `pr create` | denied | — | Use `vrg-submit-pr` |
+| `run list` | yes | — | Read-only, CI status |
+| `run view` | yes | — | Read-only, CI status |
+| `run watch` | yes | — | Blocking wait for CI |
+| `repo view` | yes | — | Read-only |
+| `repo edit` | denied | — | Admin operation |
+| `repo create` | denied | — | Admin operation |
+| `repo delete` | denied | — | Destructive |
+| `api` | denied | — | Raw API escape hatch |
+| `auth` | denied | — | Credential management |
+| `label list` | yes | — | Read-only |
+| `label create` | yes | — | Used by `vrg-ensure-label` |
+
+### The `gh api` Denial
+
+The `gh api` subcommand can perform any GitHub API operation —
+create repos, delete branches, modify settings, push code via the
+Contents API. The existing `block-github-contents-api` hook only
+catches writes to the Contents API specifically. Denying `gh api`
+entirely in the wrapper closes the whole escape hatch.
+
+### VRG Tools That Bypass the Wrapper
+
+Existing VRG tools that call `gh` directly in their Python code
+(`vrg-submit-pr`, `vrg-merge-when-green`, `vrg-wait-until-green`,
+`vrg-ensure-label`, `vrg-github-config`, `vrg-finalize-repo`)
+bypass the wrapper because they are already mechanized. The
+wrapper only constrains agent-initiated `gh` calls via the
+`Bash` tool.
+
+## Section 4: Permission Configuration
+
+Three layers of settings that work together.
+
+### Global User Settings (`~/.claude/settings.json`)
+
+```json
+{
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "deny": [
+      "Bash(git *)",
+      "Bash(gh *)"
+    ]
+  }
+}
+```
+
+The global layer sets the default mode and hard-denies raw `git`
+and `gh` across all projects. Deny rules at any scope cannot be
+overridden by allow rules at a lower scope — this is Claude Code's
+precedence model.
+
+**Implementation risk:** The `Bash(git *)` deny pattern must be
+verified to not match `vrg-git *` via substring matching. Claude
+Code's documentation states that bash rules match on the command
+name (the first word of each command segment), so `git` and
+`vrg-git` should be distinct. This must be verified during
+implementation before the deny rules go live. If the matching is
+substring-based, the deny rules move to the hook layer instead.
+
+### Project Settings (`.claude/settings.json`)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(vrg-*)",
+      "Bash(vrg-git *)",
+      "Bash(vrg-gh *)"
+    ]
+  }
+}
+```
+
+The project layer allowlists VRG tools. All `vrg-commit`,
+`vrg-submit-pr`, `vrg-validate`, `vrg-docker-run`, `vrg-git`,
+and `vrg-gh` invocations run without prompting.
+
+### Project Local Settings (`.claude/settings.local.json`)
+
+Gitignored. Per-developer. This is where the temporary read-only
+bash exceptions live during phase 1:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep *)",
+      "Bash(find *)",
+      "Bash(ls *)",
+      "Bash(diff *)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(wc *)",
+      "Bash(which *)",
+      "Bash(sort *)",
+      "Bash(uniq *)",
+      "Bash(stat *)",
+      "Bash(du *)",
+      "Bash(file *)"
+    ]
+  }
+}
+```
+
+These are documented as phase 2 candidates for mechanization or
+removal. Each developer can adjust based on their comfort level.
+When alternatives are found (Explore subagent, `vrg-search`,
+native `Read` tool), this list shrinks without changing committed
+project settings.
+
+### What This Means in Practice
+
+- `vrg-commit` → no prompt (project allow)
+- `vrg-git status` → no prompt (project allow)
+- `grep -r "foo" src/` → no prompt (local allow, phase 1)
+- `git push` → denied (global deny)
+- `curl https://...` → prompts the human
+- `rm -rf .` → prompts the human
+- `vrg-gh pr merge` → no Claude Code prompt, but the wrapper
+  rejects it
+
+## Section 5: Defense-in-Depth Model
+
+Four enforcement layers, each catching what the layer above misses.
+
+### Layer 1 — Claude Code Permissions (outermost)
+
+The allowlist/deny configuration from Section 4. If a command is
+not allowlisted and not denied, it prompts the human. Denied
+commands are blocked without prompt.
+
+### Layer 2 — VRG Wrappers (`vrg-git`, `vrg-gh`)
+
+Validate subcommands and flags before executing the underlying
+tool. Even if an agent gets `vrg-git reset --hard` through the
+permission layer (it is allowlisted as `vrg-git *`), the wrapper
+rejects it.
+
+### Layer 3 — Vergil Plugin Hooks
+
+The existing 11 hooks remain as a backstop. They catch patterns
+that slip through layers 1 and 2. Hooks exit code 2 (hard block)
+which overrides even bypass mode.
+
+### Layer 4 — Git-Level Hooks (`.githooks/pre-commit`)
+
+The innermost layer. The pre-commit hook rejects raw `git commit`
+without `VRG_COMMIT_CONTEXT=1`. With layers 1-3 in place, agents
+cannot reach this layer through normal operation — it exists as a
+final safety net.
+
+**Known weakness:** The `VRG_COMMIT_CONTEXT=1` environment
+variable is a shared secret between `vrg-commit` and the
+pre-commit hook. An agent that knows the variable can set it to
+bypass the hook. With layers 1-3 enforcing the `git` deny and
+the `vrg-git` wrapper rejecting `commit` as a subcommand, this
+weakness is mitigated — the agent cannot reach `git commit`
+regardless of what environment variables it sets. This is
+documented as a known weakness in layer 4 but not addressed
+because layers 1-3 close the hole.
+
+### Layer Interaction Matrix
+
+| Operation | L1 Permissions | L2 Wrapper | L3 Plugin Hook | L4 Git Hook |
+|---|---|---|---|---|
+| `vrg-commit` | allowed | n/a | n/a | admits |
+| `vrg-git push` | allowed | validates: no --force | n/a | n/a |
+| `git push` | denied | n/a | blocked | n/a |
+| `vrg-gh pr merge` | allowed | rejected | blocked | n/a |
+| `gh pr create` | denied | n/a | blocked | n/a |
+| `rm -rf .` | prompts human | n/a | n/a | n/a |
+| `vrg-git reset --hard` | allowed | rejected | n/a | n/a |
+
+Redundancy is intentional. No single layer is trusted.
+
+### Logging and Auditing
+
+The `vrg-git` and `vrg-gh` wrappers log every invocation (command,
+arguments, allowed/denied, timestamp) to a local log file. This
+provides an audit trail and feeds back into phase 2 planning:
+
+- Commands that agents are prompted for frequently are candidates
+  for new VRG tools
+- Commands that humans routinely approve are candidates for the
+  allowlist
+- Commands that humans routinely deny validate the deny list
+
+## Section 6: Migration Path
+
+### Rollout Order
+
+1. Build and ship `vrg-git` and `vrg-gh` wrappers in
+   vergil-tooling
+2. Update vergil plugin hooks to redirect agents to the wrappers
+   (existing `block-raw-git-commit` and `block-raw-gh-pr-create`
+   hooks evolve their error messages)
+3. Update CLAUDE.md across all repos to instruct agents to use
+   `vrg-git` and `vrg-gh` instead of raw commands
+4. Deploy the permission configuration (global deny, project allow,
+   local exceptions)
+5. Switch `defaultMode` from `bypassPermissions` to `acceptEdits`
+6. Run for a week, collect data on what prompts appear, and refine
+
+### Hook Evolution
+
+Existing hooks after migration:
+
+| Hook | Status |
+|---|---|
+| `block-raw-git-commit` | Backstop — L1 is primary gate |
+| `block-raw-gh-pr-create` | Backstop — L1 is primary gate |
+| `block-agent-merge` | Backstop — L2 wrapper is primary gate |
+| `block-github-contents-api` | Backstop — `gh api` denied by L2 |
+| `block-autoclose-linkage` | Still primary — validates `vrg-submit-pr` args |
+| `block-heredoc` | Still primary — bash portability |
+| `block-associative-arrays` | Still primary — bash portability |
+| `enforce-host-container-split` | Still primary — routing concern |
+| `block-protected-branch-work` | Still primary — worktree convention |
+| `block-worktree-bypass-write` | Still primary — Write/Edit gating |
+| `detect-deprecation-warnings` | Still primary — observability |
+
+No hooks are removed. Hooks that become backstops get a comment
+noting that the permission layer is now the primary enforcement.
+
+### CLAUDE.md Updates
+
+Every repo's CLAUDE.md is updated to instruct agents:
+
+- Use `vrg-git` instead of `git` for all git operations
+- Use `vrg-gh` instead of `gh` for all GitHub CLI operations
+- These are not optional preferences — raw `git` and `gh` are
+  denied by the permission model
+
+### Feedback Loop
+
+Wrapper logging plus prompt data from sessions feeds into phase 2
+planning. After a month of operation:
+
+- Which read-only bash commands are agents using most? Candidates
+  for `vrg-search` or similar tools.
+- Which wrapper subcommands are agents hitting most? Validates the
+  allowlist design.
+- Which prompts are humans approving routinely? Candidates for the
+  allowlist.
+- Which prompts are humans denying? Validates the deny list.
+
+## Dependencies
+
+- Org governance spec (#717) — the credential isolation model
+  (agent PAT vs human PAT) is the GitHub-level complement to this
+  harness-level permission model
+- `.github` profile repo (#753) — CONTRIBUTING.md will reference
+  the permission model as part of the contributor experience
+- vergil-tooling — the wrappers are new CLI tools in this package
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `Bash(git *)` deny pattern matches `vrg-git *` via substring | Verify Claude Code's matching behavior before deploying deny rules; fall back to hook-only enforcement if matching is substring-based |
+| Switching from bypass mode surfaces unexpected prompt volume | Run for a week after migration, refine allowlist based on data |
+| Wrapper allowlists are too restrictive for some workflows | The human can run raw commands via `! <command>` in the prompt; each case is data for allowlist refinement |
+| Agents ignore CLAUDE.md instructions to use `vrg-git`/`vrg-gh` | Permission deny rules enforce compliance mechanically — instructions are guidance, the deny is the gate |
+| Read-only bash exceptions (phase 1) used for shell redirection attacks | Accept as known risk during phase 1; wrappers and deny rules cover the highest-risk commands (git, gh); phase 2 evaluates alternatives |
+| `VRG_COMMIT_CONTEXT` env var used to bypass pre-commit hook | Layers 1-3 prevent the agent from reaching `git commit`; layer 4 weakness is documented but mitigated |

--- a/paad/alignment-reviews/2026-05-14-permission-model-alignment.md
+++ b/paad/alignment-reviews/2026-05-14-permission-model-alignment.md
@@ -1,0 +1,65 @@
+# Alignment Review: Claude Code Permission Model
+
+**Date:** 2026-05-14
+**Commit:** 223a300f0c55bcdda8a02bf89cd8061b60658238
+
+## Documents Reviewed
+
+- **Intent:** docs/specs/2026-05-14-permission-model-design.md
+- **Action:** docs/plans/2026-05-14-permission-model.md
+- **Design:** none (spec serves as both intent and design)
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. Verified during the
+preceding pushback review.
+
+## Issues Reviewed
+
+### [1] Plan puts new tools in `cli/` but existing convention is `bin/`
+
+- **Category:** Design gap
+- **Severity:** Important
+- **Documents:** Plan Tasks 1-2 vs codebase convention
+- **Issue:** Tasks 1 and 2 specified `src/vergil_tooling/cli/` for
+  the new wrappers, but all 13 existing tools live in
+  `src/vergil_tooling/bin/` and all pyproject.toml entry points
+  reference `vergil_tooling.bin.*`. The `cli/` directory did not
+  exist.
+- **Resolution:** Changed to `src/vergil_tooling/bin/` to follow
+  existing convention. Applied to plan.
+
+### [2] Plan says `click` but project uses `argparse`
+
+- **Category:** Design gap
+- **Severity:** Important
+- **Documents:** Plan Tech Stack header vs codebase dependencies
+- **Issue:** The plan's Tech Stack line said "Python CLI tools
+  (click)" but every existing tool uses `argparse` and `click` is
+  not a project dependency. Introducing click would add a new
+  dependency and create framework inconsistency.
+- **Resolution:** Changed to `argparse`. The user noted that `click`
+  is being considered for a future unified `vrg` CLI (v3.0 or
+  similar milestone) but does not belong in this spec/plan cycle.
+  Applied to plan.
+
+### [3] Dependency graph text contradicts diagram
+
+- **Category:** Ambiguity
+- **Severity:** Minor
+- **Documents:** Plan Implementation Notes (text vs ASCII diagram)
+- **Issue:** The text said "Task 4 can begin as soon as Task 1
+  produces a working vrg-git" but the diagram shows Task 4 after
+  Tasks 1-3 converge.
+- **Resolution:** Updated text to match the diagram: "Task 4 begins
+  after Tasks 1-3 complete." Applied to plan.
+
+## Unresolved Issues
+
+None — all issues addressed.
+
+## Alignment Summary
+
+- **Requirements:** 7 spec sections, all covered by plan tasks
+- **Tasks:** 11 total, all in scope, 0 orphaned
+- **Status:** Aligned — ready for implementation

--- a/paad/pushback-reviews/2026-05-14-permission-model-design-pushback.md
+++ b/paad/pushback-reviews/2026-05-14-permission-model-design-pushback.md
@@ -1,0 +1,118 @@
+# Pushback Review: Permission Model Design
+
+**Date:** 2026-05-14
+**Spec:** docs/specs/2026-05-14-permission-model-design.md
+**Commit:** 5cf710ee405fe36cfaeaaf761fa17627a7f11e4b
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. Recent commits (version
+bumps, VERGIL rename cleanup, config consolidation, .github profile
+spec) do not contradict the spec's assumptions. All referenced tools,
+hooks, and architecture match the current codebase.
+
+## Issues Reviewed
+
+### [1] Read-only bash exceptions are not constrained against command chaining
+
+- **Category:** Security
+- **Severity:** Serious
+- **Issue:** Phase 1 read-only exceptions (`grep`, `cat`, `find`,
+  etc.) go through raw Bash, not through a wrapper. Claude Code's
+  documented behavior splits compound commands on shell operators and
+  evaluates each subcommand independently — deny rules on `git`/`gh`
+  should fire against embedded dangerous commands. However, there is a
+  known implementation gap (anthropics/claude-code#28784) where prefix
+  matching on the full command string can produce unexpected approvals.
+  The spec's risk mitigation depends on matching behavior that is not
+  reliably enforced.
+- **Resolution:** Document both the documented matching behavior and
+  the implementation gap in the spec's Risks table. Note that deny
+  rules on `git`/`gh` provide the primary defense. Add a fallback
+  option: a PreToolUse hook that rejects shell operators in
+  read-only-allowlisted commands, deployable if the implementation gap
+  is not resolved before phase 1. Applied to spec.
+
+### [2] `git commit` not explicitly listed in denied subcommands
+
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** Section 2's "Denied Subcommands" list omitted `commit`.
+  It was implicitly denied by the allowlist approach, but given that
+  controlling `git commit` is the single most important operation the
+  permission model exists to enforce, the omission was conspicuous.
+- **Resolution:** Added `commit` to the denied subcommands list with
+  a note explaining that all commits flow through `vrg-commit`. Applied
+  to spec.
+
+### [3] `git stash drop` and `stash clear` can destroy work
+
+- **Category:** Omissions
+- **Severity:** Moderate
+- **Issue:** `stash` is allowed with no flag restrictions, but `drop`
+  and `clear` permanently delete stashed work.
+- **Resolution:** Leave unrestricted. Stash is an out-of-band recovery
+  mechanism, not a normal workflow operation. The real fix is the
+  tooling that prevents the mistakes leading to stash usage. In the
+  recovery context where an agent has stashed something and determined
+  it is no longer needed, `drop`/`clear` are legitimate. Added
+  documentation of this reasoning to the stash row in the spec.
+  Applied to spec.
+
+### [4] `git checkout -- <specific-file>` silently discards changes
+
+- **Category:** Security
+- **Severity:** Moderate
+- **Issue:** The spec denies broad restore patterns (`-- .`, `-- *`)
+  but allows specific-file restore (`-- path/to/file`), which
+  irreversibly discards uncommitted changes to the named file.
+- **Resolution:** Leave as-is. The agent already has equivalent
+  destructive capability through the Write tool (`acceptEdits` mode),
+  and worktree isolation is the real safety net. Added documentation
+  of this reasoning to the checkout row in the spec. Applied to spec.
+
+### [5] Consuming repos need `.claude/settings.json` permission updates
+
+- **Category:** Omissions
+- **Severity:** Moderate
+- **Issue:** The migration rollout covers CLAUDE.md updates and
+  vergil-tooling's own permission config, but does not include a step
+  for deploying `.claude/settings.json` to consuming repos. Without
+  it, agents in consuming repos would be prompted for every `vrg-*`
+  command.
+- **Resolution:** Added migration step 4: deploy
+  `.claude/settings.json` to each consuming repo with the `Bash(vrg-*)`
+  allowlist and provide a template `settings.local.json` for phase 1
+  read-only exceptions. Applied to spec.
+
+### [6] Redundant permission patterns in project settings
+
+- **Category:** Ambiguity
+- **Severity:** Minor
+- **Issue:** Project settings listed `Bash(vrg-*)`, `Bash(vrg-git *)`,
+  and `Bash(vrg-gh *)`. The latter two are subsets of the wildcard and
+  can never match anything it does not already cover.
+- **Resolution:** Removed redundant entries. Single `Bash(vrg-*)`
+  wildcard covers all current and future VRG tools. Applied to spec.
+
+### [7] Hook count mismatch — `remind-finalize` missing
+
+- **Category:** Contradictions
+- **Severity:** Minor
+- **Issue:** The spec said "11 hooks" but the actual `hooks.json`
+  has 12. The PostToolUse hook `remind-finalize` was missing from both
+  the count and the Hook Evolution table.
+- **Resolution:** Updated count to 12 and added `remind-finalize` to
+  the evolution table as "Still primary — operational reminder."
+  Applied to spec.
+
+## Unresolved Issues
+
+None — all issues addressed.
+
+## Summary
+
+- **Issues found:** 7
+- **Issues resolved:** 7
+- **Unresolved:** 0
+- **Spec status:** Ready for implementation


### PR DESCRIPTION
# Pull Request

## Summary

- Design spec and implementation plan for migrating from bypassPermissions to a defense-in-depth permission model with vrg-git/vrg-gh wrappers, subcommand allowlists, and Claude Code permission layering.

## Issue Linkage

- Ref #754

## Notes

- Adds the design spec (Section 1-6: base mode, vrg-git wrapper, vrg-gh wrapper, permission config, defense-in-depth model, migration path) and a phased implementation plan (11 tasks across 4 phases). Both documents have been through pushback and alignment review — reports included under paad/.