### PR TITLE
fix(vrg-gh): deduplicate accounts in gh auth status discovery

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -69,7 +69,7 @@ def _discover_accounts() -> tuple[str, str]:
         check=False,
     )
     output = result.stdout or result.stderr
-    accounts = re.findall(r"Logged in to github\.com account (\S+)", output)
+    accounts = list(dict.fromkeys(re.findall(r"Logged in to github\.com account (\S+)", output)))
     human = [a for a in accounts if not a.endswith("-agent")]
     agent = [a for a in accounts if a.endswith("-agent")]
     if len(human) != 1 or len(agent) != 1:

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -184,6 +184,30 @@ def test_discover_accounts() -> None:
     assert agent == "jdoe-agent"
 
 
+_AUTH_STATUS_DUPLICATE_HUMAN = """\
+github.com
+  ✓ Logged in to github.com account jdoe (keyring)
+  - Active account: true
+  ✓ Logged in to github.com account jdoe (token)
+  - Active account: false
+  ✓ Logged in to github.com account jdoe-agent (keyring)
+  - Active account: false
+"""
+
+
+def test_discover_accounts_deduplicates() -> None:
+    from vergil_tooling.bin.vrg_gh import _discover_accounts
+
+    with patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_AUTH_STATUS_DUPLICATE_HUMAN,
+        )
+        human, agent = _discover_accounts()
+    assert human == "jdoe"
+    assert agent == "jdoe-agent"
+
+
 _AUTH_STATUS_NO_AGENT = """\
 github.com
   ✓ Logged in to github.com account jdoe (keyring)


### PR DESCRIPTION
# Pull Request

## Summary

- Fix vrg-gh account discovery failing with duplicate gh auth entries

## Issue Linkage

- Ref #791

## Notes

- gh auth status can list the same account multiple times (e.g., keyring + token). _discover_accounts() now deduplicates before validating the count.