### PR TITLE
Publish identity and credential architecture to site docs

### DIFF
--- a/docs/site/docs/guides/credential-management.md
+++ b/docs/site/docs/guides/credential-management.md
@@ -1,0 +1,219 @@
+# Credential Management
+
+VERGIL uses `gh auth` as the sole credential store and selects
+credentials per-subprocess based on the operation being performed.
+No global state changes, no ambient environment variables, no
+custom keychain management.
+
+For account creation and initial setup, see
+[Account Setup](account-setup.md). For the identity model that
+credentials serve, see
+[Identity Architecture](identity-architecture.md).
+
+## Token Strategy
+
+### Classic PATs
+
+Both accounts use classic Personal Access Tokens. Fine-grained
+PATs were evaluated and abandoned:
+
+- Fine-grained PATs are scoped to a single resource owner — a
+  token for `vergil-project` cannot access `diogenes-project`.
+  Multi-org requires N×2 tokens.
+- `gh auth` stores one token per account per host. Multiple
+  fine-grained PATs for the same account cannot coexist.
+- Fine-grained PATs cannot be created by outside collaborators
+  scoped to an org. The agent account is an outside collaborator
+  by design.
+
+Classic PATs work across all repos the account has access to,
+regardless of org. One token per account covers everything.
+
+### Token Scopes
+
+**Human account:**
+
+| Scope | Purpose |
+|---|---|
+| `repo` | Full repository access |
+| `admin:org` | Org settings, collaborator management |
+| `workflow` | GitHub Actions |
+| `read:org` | Org membership visibility |
+
+**Agent account:**
+
+| Scope | Purpose |
+|---|---|
+| `repo` | Full repository access |
+| `read:org` | Org membership visibility |
+
+The agent PAT intentionally excludes `admin:org` and `workflow`.
+Token scope is not the primary security boundary — it is the
+fourth layer of defense. See
+[Permission Model](permission-model.md) for the full
+defense-in-depth architecture.
+
+## Credential Store
+
+### `gh auth` as the Single Source
+
+Both accounts are logged into `gh auth` on the developer's
+machine. No custom keychain entries, no platform-specific secure
+store abstraction. Setup is a one-time operation per machine:
+
+```bash
+gh auth login -h github.com --web -p https   # Human account
+gh auth login -h github.com --web -p https   # Agent account
+```
+
+!!! warning "`gh auth login` has no `-u` flag"
+    You cannot specify which account to log in as. Make sure you
+    are logged into the correct GitHub account in your browser
+    before authorizing the OAuth flow.
+
+After both logins, set the human account as the active default:
+
+```bash
+gh auth switch -u <your-username>
+```
+
+### Token Retrieval
+
+The tooling retrieves tokens without changing global state:
+
+```bash
+gh auth token -u <username>          # Human PAT
+gh auth token -u <username>-vergil   # Agent PAT
+```
+
+This is a read operation. It does not change the active account
+and is safe to call from parallel processes.
+
+## Credential Selection
+
+### The Core Principle
+
+The tool selects the credential, not the caller. There is no flag,
+no env var, no override. The `vrg-gh` wrapper determines the
+appropriate identity based on the command being executed. This is
+a hard security boundary.
+
+### Default: Agent Account
+
+All operations default to the agent account. Development
+operations — creating PRs, pushing branches, viewing status,
+creating issues — run under the agent identity.
+
+### Escalation to Human Account
+
+Specific operations escalate to the human account when both the
+command and its context pass validation:
+
+- **Merge:** Allowed under the human account only when the target
+  matches release workflow patterns (e.g., `release/*` branches
+  merging to `main`, back-merge from `main` to `develop`).
+- **Approval:** Allowed under the human account only for release
+  PRs authored by `vergil-release[bot]`.
+- **Other admin operations:** Denied entirely.
+
+Escalation requires both a permitted command and a validated
+context. A merge request for a feature branch is denied even
+though merges are conditionally allowed.
+
+### No Human Detection
+
+The tooling does not distinguish between a human caller and an
+agent caller. It always operates in agent-restricted mode. If a
+human runs `vrg-gh pr merge` on a feature branch, it is denied
+the same way. The human's escape hatch is raw `gh` or the GitHub
+UI.
+
+## GH_TOKEN Injection
+
+Credential selection is per-subprocess via the `GH_TOKEN`
+environment variable. The tooling never calls `gh auth switch`.
+
+### How It Works
+
+1. `_discover_accounts()` parses `gh auth status` to find the
+   `-vergil` account and derive the human account name.
+2. `_human_token()` calls `gh auth token -u <human>` and caches
+   the result for the process lifetime.
+3. `_gh_env()` builds an environment dict with `GH_TOKEN` set to
+   the appropriate token.
+4. Every `subprocess.run` call that invokes `gh` receives this
+   environment dict via the `env` parameter.
+
+Parallel sessions are fully isolated. Each process resolves its
+own token independently. No shared state, no lock contention.
+
+### Graceful Degradation
+
+If credential discovery fails (account not logged in, `gh` not
+installed), `_gh_env()` returns `None` and the subprocess inherits
+the parent environment. This allows the tooling to function in CI
+environments where credentials are provided through other
+mechanisms.
+
+## Account Discovery
+
+The discovery algorithm is deliberately simple:
+
+1. Run `gh auth status` and parse all logged-in accounts.
+2. Find the one account ending in `-vergil`.
+3. Derive the human account by stripping the suffix.
+4. If zero or more than one `-vergil` account exists, fail with
+   an explicit error.
+
+Any number of other accounts can be present — `-mimir`, legacy
+`-agent`, personal accounts — they are all ignored. Only the
+`-vergil` suffix matters.
+
+### Failure Modes
+
+- **No `-vergil` account:** Explicit error naming the convention
+  and suggesting `gh auth login`.
+- **Multiple `-vergil` accounts:** Explicit error listing the
+  accounts found.
+- **Required account not in `gh auth`:** Explicit error suggesting
+  the missing login.
+- **Never silent fallback:** The tooling never substitutes one
+  account for another. If the required credential is unavailable,
+  the operation fails.
+
+## Security Model
+
+The credential system does not depend on token scope as the
+primary enforcement mechanism. Defense in depth, in priority order:
+
+1. **Account permissions** — the agent account is an outside
+   collaborator with Write access to specific repos. It cannot
+   access repos it hasn't been invited to, regardless of token
+   scope.
+2. **Branch protection** — rulesets prevent merging without review,
+   prevent direct pushes to protected branches, require CI to
+   pass.
+3. **`vrg-gh` wrapper** — gates which operations the agent can
+   attempt and which credential is used for each.
+4. **Token scope** — the narrowest classic PAT scopes that support
+   the required operations.
+
+## Multi-Org Support
+
+A classic PAT works across all repos the account has access to,
+regardless of which org owns them. Adding a new org requires only
+inviting the agent account as an outside collaborator — no token
+changes, no credential reconfiguration.
+
+## Related
+
+- [Account Setup](account-setup.md) — creating accounts and
+  logging into `gh auth`
+- [Identity Architecture](identity-architecture.md) — the
+  two-account model and naming conventions
+- [Permission Model](permission-model.md) — enforcement layers
+  beyond credential selection
+- [Credential management design spec][cred-spec] — full decision
+  rationale and alternatives considered
+
+[cred-spec]: https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/2026-05-14-credential-management-design.md

--- a/docs/site/docs/guides/identity-architecture.md
+++ b/docs/site/docs/guides/identity-architecture.md
@@ -1,0 +1,162 @@
+# Identity Architecture
+
+VERGIL enforces a hard separation between human and AI agent
+identity at the GitHub account level. This page describes the
+identity model, the naming conventions that make it work, and how
+it extends to adversarial testing.
+
+For the step-by-step account creation process, see
+[Account Setup](account-setup.md). For how credentials are managed
+at runtime, see [Credential Management](credential-management.md).
+
+## The Three Identities
+
+Every VERGIL-managed org operates with three distinct identities:
+
+| Identity | Role | Scope |
+|---|---|---|
+| `<username>` | Human — reviews, approvals, merges, admin | Org owner or member across all orgs |
+| `<username>-vergil` | AI agents — all development work | Outside collaborator on specific repos |
+| `vergil-release[bot]` | GitHub App — mechanized release automation | Org-level installation per org |
+
+The human account owns the decision-making authority: code review,
+PR approval, merge, and administrative operations. The agent
+account does the development work: commits, pushes, PR creation,
+issue tracking. The GitHub App handles release automation that
+requires neither human judgment nor agent identity.
+
+## The `-vergil` Convention
+
+The `-vergil` suffix is load-bearing — the tooling depends on it.
+
+### How Discovery Works
+
+`vrg-gh` and `github.py` discover accounts by parsing
+`gh auth status` and finding the one account that ends in
+`-vergil`. The human account name is derived by stripping the
+suffix. No configuration file maps usernames — the convention
+itself is the configuration.
+
+```text
+gh auth status
+  ✓ Logged in to github.com account jdoe (keyring)
+  ✓ Logged in to github.com account jdoe-vergil (keyring)
+  ✓ Logged in to github.com account jdoe-mimir (keyring)
+```
+
+The tooling sees `jdoe-vergil`, derives `jdoe` as the human
+account, and ignores `jdoe-mimir` entirely. Any number of other
+accounts can be present — only the `-vergil` suffix matters.
+
+### What the Agent Account Can Do
+
+- Commit and push to feature branches
+- Create pull requests (via `vrg-submit-pr`)
+- Create and comment on issues
+- Read repository and CI status
+
+### What the Agent Account Cannot Do
+
+- Merge pull requests
+- Approve pull requests
+- Access admin settings
+- Manage org membership
+- Create or delete repositories
+
+These restrictions are enforced at multiple layers: GitHub's
+own permissions (outside collaborator with Write access), the
+`vrg-gh` wrapper's subcommand validation, and Claude Code's
+permission deny rules. See
+[Permission Model](permission-model.md) for the full
+defense-in-depth architecture.
+
+### Outside Collaborator by Design
+
+The agent account is an outside collaborator on each repo, never
+an org member. This is intentional:
+
+- Outside collaborators cannot access org-level settings
+- Access is granted per-repo, not per-org
+- Removing access is a single operation per repo
+- The account cannot see private repos it hasn't been invited to
+
+### One Account, All Orgs
+
+A single `-vergil` account works across every org the contributor
+participates in. Classic PATs are not scoped to a single org, so
+one token covers `vergil-project`, `vergils-nemesis`, and any
+future orgs. Adding a new org requires only an outside collaborator
+invitation — no new accounts, no new tokens.
+
+### Harness Independence
+
+The `-vergil` account captures all AI-driven development work
+regardless of which AI tool is being used — Claude Code, Copilot,
+Cursor, or any future harness. The specific tool is recorded in
+commit metadata (co-author trailers, PR descriptions), not at the
+identity level. The account represents "AI operating under Vergil
+discipline," not "Claude Code specifically."
+
+## The `-mimir` Convention
+
+Mimir is the adversarial testing counterpart to Vergil. Where
+Vergil represents AI operating with discipline, Mimir represents
+AI's failure modes — hallucination, false confidence, sycophancy,
+and the tendency to work around constraints rather than within
+them.
+
+A `<username>-mimir` GitHub account is the credential that attack
+tooling presents when attempting to breach Vergil-managed repos.
+It has no integration with the Vergil tooling — no suffix
+detection, no credential selection, no co-author entry. It
+operates *against* the tooling, not within it.
+
+### Identity Roles
+
+- `-vergil` accounts are the operational identity in both
+  `vergil-project` and `vergils-nemesis` repos. All development
+  work — including development of the attack tooling itself —
+  flows through the `-vergil` account using Vergil tooling.
+- `-mimir` accounts are the adversarial identity. They
+  authenticate when executing breach attempts, using raw `gh`,
+  raw `git`, and direct API calls — deliberately bypassing
+  `vrg-gh` and `vrg-commit`.
+
+### The Vergils-Nemesis Org
+
+[vergils-nemesis](https://github.com/vergils-nemesis) is the
+GitHub org for adversarial testing. It contains two kinds of
+repositories:
+
+- **Attack tooling repos** — code that implements breach attempts
+  against Vergil-managed targets. These repos are themselves
+  managed by Vergil tooling (built with discipline, used for
+  destruction).
+- **Target repos** — dummy repositories configured with Vergil
+  protections, serving as test beds for the attack tooling.
+
+The main output is attack reports documenting the success and
+failure of each breach attempt — demonstrating whether Vergil's
+guardrails hold under adversarial pressure.
+
+## The GitHub App
+
+`vergil-release[bot]` is an org-level GitHub App that handles
+mechanized release automation. It is not a contributor identity —
+it is an automation identity with its own auth flow (JWT exchange
+for short-lived installation tokens).
+
+The App creates release PRs, and the human account approves and
+merges them. This separation ensures that no single identity can
+both create and approve a release.
+
+## Related
+
+- [Account Setup](account-setup.md) — creating and configuring
+  both accounts
+- [Credential Management](credential-management.md) — how tokens
+  are stored and selected at runtime
+- [Permission Model](permission-model.md) — enforcement layers
+  that constrain agent operations
+- [Git Workflow](git-workflow.md) — the per-change development
+  cycle

--- a/docs/site/docs/guides/permission-model.md
+++ b/docs/site/docs/guides/permission-model.md
@@ -1,0 +1,315 @@
+# Permission Model
+
+VERGIL constrains AI agents to a validated set of operations
+through layered enforcement. Every system interaction flows through
+wrapper tools that validate, constrain, and log what happens. Raw
+shell access to `git` and `gh` is denied mechanically — not by
+convention, not by instruction, but by the permission system
+itself.
+
+For the identity model that permissions protect, see
+[Identity Architecture](identity-architecture.md). For how
+credentials are selected per-operation, see
+[Credential Management](credential-management.md).
+
+## Base Permission Mode
+
+**`acceptEdits`** is the target mode. The agent freely reads and
+modifies code files — that is its primary job. The real risk
+surface is shell commands, not file edits.
+
+`acceptEdits` auto-approves:
+
+- File reads (Read tool)
+- File edits (Edit tool)
+- File writes (Write tool)
+
+Shell commands not in the allowlist prompt the human. This is the
+escalation mechanism: the agent encounters something it cannot do,
+explains the situation, and the human approves or denies.
+
+!!! note "Migration status"
+    The project currently runs in `bypassPermissions` mode. The
+    migration to `acceptEdits` with the full wrapper and deny
+    configuration described here is the documented target
+    architecture.
+
+## `vrg-git` Wrapper
+
+A Python CLI tool that validates subcommands and flags before
+executing `git`. Arguments arrive as a Python argv list — no
+shell expansion, no pipes, no redirection.
+
+### Subcommand Allowlist
+
+| Subcommand | Denied Flags | Notes |
+|---|---|---|
+| `status` | — | Read-only |
+| `log` | — | Read-only |
+| `diff` | — | Read-only |
+| `show` | — | Read-only |
+| `branch` | `-D`, `--force` | Safe delete (`-d`) allowed |
+| `ls-remote` | — | Read-only |
+| `rev-parse` | — | Read-only |
+| `worktree add` | — | Parallel agent work |
+| `worktree list` | — | Read-only |
+| `worktree remove` | — | Cleanup after merge |
+| `add` | — | Staging files |
+| `push` | `--force`, `-f`, `--force-with-lease` | Normal push only |
+| `fetch` | — | Read-only |
+| `pull` | — | Fast-forward updates |
+| `checkout` | `-- .`, `-- *` | Specific-file restore allowed |
+| `switch` | — | Branch switching |
+| `stash` | — | All stash subcommands allowed |
+| `merge` | — | Branch updates |
+| `cherry-pick` | — | Selective commit application |
+| `rebase` | `-i`, `--interactive` | Non-interactive only |
+
+### Denied Subcommands
+
+Anything not on the allowlist is rejected. Notable denials:
+
+- **`commit`** — all commits flow through `vrg-commit`
+- **`reset`** — too dangerous in all forms
+- **`clean`** — file deletion
+- **`config`** — modifying git configuration
+- **`remote`** — modifying remote configuration
+- **`filter-branch`**, **`replace`** — history rewriting
+
+### Escape Hatch
+
+None in the wrapper. If the agent genuinely needs a denied
+operation, it explains the situation to the human, who runs the
+raw command via `! git <command>` in the Claude Code prompt.
+
+## `vrg-gh` Wrapper
+
+Same architecture as `vrg-git`. Validates the top-level and
+second-level subcommands as a pair.
+
+### Subcommand Allowlist
+
+| Subcommand | Notes |
+|---|---|
+| `issue view` | Read-only |
+| `issue create` | Issue tracking |
+| `issue close` | Post-finalization closure |
+| `issue edit` | Updating metadata |
+| `issue list` | Read-only |
+| `issue comment` | Adding comments |
+| `pr view` | Read-only |
+| `pr checks` | CI status |
+| `pr list` | Read-only |
+| `pr diff` | Read-only |
+| `pr comment` | Review context |
+| `pr edit` | Updating metadata |
+| `run list` | CI status |
+| `run view` | CI status |
+| `run watch` | Blocking wait for CI |
+| `repo view` | Read-only |
+| `label list` | Read-only |
+| `label create` | Used by `vrg-ensure-label` |
+
+### Denied Subcommands
+
+| Subcommand | Reason |
+|---|---|
+| `pr merge` | Agents do not merge (conditionally allowed for release workflows via credential escalation) |
+| `pr review --approve` | Agents do not approve (conditionally allowed for release workflows) |
+| `pr close` | Agents do not close PRs |
+| `pr create` | Use `vrg-submit-pr` instead |
+| `repo edit` | Admin operation |
+| `repo create` | Admin operation |
+| `repo delete` | Destructive |
+| `api` | Raw API access — can perform any operation |
+| `auth` | Credential management |
+
+### The `gh api` Denial
+
+`gh api` can perform any GitHub API operation — create repos,
+delete branches, modify settings, push code via the Contents API.
+Denying it entirely in the wrapper closes the escape hatch that
+individual hook-based blocks cannot fully cover.
+
+### Credential Selection
+
+`vrg-gh` is responsible for choosing which account's token to use
+per-command. See [Credential Management](credential-management.md)
+for the selection logic. The `pr merge` and `pr review --approve`
+entries above are conditionally allowed for release workflow
+operations under the human account.
+
+### VRG Tools That Bypass the Wrapper
+
+Mechanized VRG tools (`vrg-submit-pr`, `vrg-merge-when-green`,
+`vrg-ensure-label`, `vrg-github-config`, `vrg-finalize-repo`)
+call `gh` directly in their Python code. They bypass the wrapper
+because they are already validated — the wrapper only constrains
+agent-initiated `gh` calls via the Bash tool.
+
+## Permission Configuration
+
+### Project Settings (`.claude/settings.json`)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(vrg-*)"
+    ],
+    "deny": [
+      "Bash(git *)",
+      "Bash(*/git *)",
+      "Bash(gh *)",
+      "Bash(*/gh *)"
+    ]
+  }
+}
+```
+
+The project layer is the primary enforcement point. It allowlists
+all VRG tools via a single wildcard and hard-denies raw `git` and
+`gh`. The `*/git *` patterns cover fully qualified path
+invocations (e.g., `/usr/bin/git status`).
+
+Deny rules at any scope cannot be overridden by allow rules at any
+other scope. A deny in `.claude/settings.json` applies to everyone
+who clones the repo — no per-developer setup needed.
+
+### Global User Settings (`~/.claude/settings.json`)
+
+```json
+{
+  "permissions": {
+    "defaultMode": "acceptEdits"
+  }
+}
+```
+
+Switching `defaultMode` to `acceptEdits` makes unknown commands
+prompt the human instead of auto-approving. This is independent
+of the deny rules — raw `git`/`gh` are blocked regardless of mode.
+
+### Local Settings (`.claude/settings.local.json`)
+
+Gitignored, per-developer. Houses temporary read-only bash
+exceptions:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep *)",
+      "Bash(find *)",
+      "Bash(ls *)",
+      "Bash(diff *)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(wc *)",
+      "Bash(which *)",
+      "Bash(sort *)",
+      "Bash(uniq *)",
+      "Bash(stat *)",
+      "Bash(du *)",
+      "Bash(file *)"
+    ]
+  }
+}
+```
+
+These are documented as candidates for removal as alternatives
+are found (Explore subagent, native Read tool, future
+`vrg-search`).
+
+### What This Means in Practice
+
+| Command | Result |
+|---|---|
+| `vrg-commit` | No prompt (project allow) |
+| `vrg-git status` | No prompt (project allow) |
+| `grep -r "foo" src/` | No prompt (local allow) |
+| `git push` | Denied (project deny) |
+| `curl https://...` | Prompts the human |
+| `rm -rf .` | Prompts the human |
+| `vrg-gh pr merge` | No Claude Code prompt, but wrapper rejects it |
+
+## Defense-in-Depth
+
+Four enforcement layers, each catching what the layer above misses.
+Redundancy is intentional — no single layer is trusted.
+
+### Layer 1 — Claude Code Permissions (outermost)
+
+The allowlist/deny configuration. Denied commands are blocked
+without prompt. Unknown commands prompt the human.
+
+### Layer 2 — VRG Wrappers
+
+`vrg-git` and `vrg-gh` validate subcommands and flags before
+executing the underlying tool. Even if `vrg-git reset --hard`
+passes the permission layer (it is allowlisted as `vrg-*`), the
+wrapper rejects it.
+
+### Layer 3 — Vergil Plugin Hooks
+
+The existing hook system remains as a backstop. Hooks exit code 2
+(hard block) overrides even bypass mode. Hooks that become
+redundant with layers 1-2 are retained — they catch regressions
+if a higher layer is misconfigured.
+
+### Layer 4 — Git-Level Hooks (`.githooks/pre-commit`)
+
+The innermost layer. Rejects raw `git commit` without the
+`VRG_COMMIT_CONTEXT=1` environment variable that `vrg-commit`
+sets. With layers 1-3 in place, agents cannot reach this layer
+through normal operation.
+
+### Layer Interaction Matrix
+
+| Operation | L1 Permissions | L2 Wrapper | L3 Plugin Hook | L4 Git Hook |
+|---|---|---|---|---|
+| `vrg-commit` | allowed | n/a | n/a | admits |
+| `vrg-git push` | allowed | validates: no `--force` | n/a | n/a |
+| `git push` | denied | n/a | blocked | n/a |
+| `vrg-gh pr merge` | allowed | rejected | blocked | n/a |
+| `gh pr create` | denied | n/a | blocked | n/a |
+| `rm -rf .` | prompts human | n/a | n/a | n/a |
+| `vrg-git reset --hard` | allowed | rejected | n/a | n/a |
+
+## Phasing
+
+### Phase 1 (current target)
+
+- `acceptEdits` as default mode
+- `vrg-git` and `vrg-gh` wrappers with subcommand validation
+- Project-level deny rules for raw `git` and `gh`
+- Temporary read-only bash exceptions in local settings
+- Hooks retained as backstop
+
+### Phase 2 (future)
+
+- Evaluate replacing read-only bash exceptions with dedicated
+  tools or subagent patterns
+- Tighten the allowlist as more operations are mechanized
+- Each frequent prompt is a signal to build a new VRG tool
+
+### Phase 3 (future)
+
+- Ideal end state: `Bash(vrg *)` is the only allowlisted pattern
+- All operations flow through one command with validated
+  subcommands
+- No raw shell access without human approval
+
+## Related
+
+- [Identity Architecture](identity-architecture.md) — the
+  accounts that permissions protect
+- [Credential Management](credential-management.md) — how
+  `vrg-gh` selects credentials per-operation
+- [Account Setup](account-setup.md) — creating and configuring
+  accounts
+- [Permission model design spec][perm-spec] — full decision
+  rationale and alternatives considered
+
+[perm-spec]: https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/2026-05-14-permission-model-design.md

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -121,6 +121,11 @@ nav:
           - Code Review Guidelines: standards/ai-code-review-guidelines.md
           - Interaction Contract: standards/interaction-contract.md
           - Interaction Contract (Brief): standards/interaction-contract-brief.md
+  - Identity & Permissions:
+      - Identity Architecture: guides/identity-architecture.md
+      - Credential Management: guides/credential-management.md
+      - Permission Model: guides/permission-model.md
+      - Account Setup: guides/account-setup.md
   - Guides:
       - Git Workflow: guides/git-workflow.md
       - Consuming Repo Setup: guides/consuming-repo-setup.md


### PR DESCRIPTION
# Pull Request

## Summary

- Three new site documentation pages extracted from the internal design specs, covering the implemented identity, credential, and permission architecture. New Identity and Permissions nav section in mkdocs.yml groups these with the existing account setup guide.

## Issue Linkage

- Ref #815

## Notes

- -