### PR TITLE
Replace stale st-* references with vrg-*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ MUST:
 ## Working Rules
 
 - This repository is a Python package providing shared tooling scripts.
-  Consumers resolve host-side `st-*` tools via `uv tool install` and
+  Consumers resolve host-side `vrg-*` tools via `uv tool install` and
   in-container tools via the dev container image's pre-bake (non-Python
   repos) or a `[tool.uv.sources]` dev dep (Python repos).
 - Test scripts with shellcheck before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Available skills:
 
 ### Environment Setup
 
-Host-side `st-*` tools are installed via `uv tool install` (see
+Host-side `vrg-*` tools are installed via `uv tool install` (see
 [Consumption Model](#consumption-model)). For developing
 vergil-tooling itself, there is also a **dev-tree override** using
 a local `.venv-host`:
@@ -196,7 +196,7 @@ vrg-docker-run -- uv run vrg-validate
 
 ### Python Package (`src/vergil_tooling/`)
 
-CLI tools installed as `st-*` console scripts:
+CLI tools installed as `vrg-*` console scripts:
 
 - **`vrg-commit`** — Construct standards-compliant conventional
   commits with co-author resolution
@@ -251,7 +251,7 @@ Consumed via `git config core.hooksPath .githooks`:
 | Target | Install mechanism | Who uses it |
 |---|---|---|
 | **Developer host** | `uv tool install` from git URL | Host-side commands: `vrg-docker-run`, `vrg-commit`, `vrg-submit-pr`, `vrg-prepare-release`, `vrg-finalize-repo` |
-| **Container runtime** (all languages) | `vrg-docker-run` cache-first install per `vergil.toml` | `st-*` inside the container for all consumers |
+| **Container runtime** (all languages) | `vrg-docker-run` cache-first install per `vergil.toml` | `vrg-*` inside the container for all consumers |
 
 **Host install** (canonical):
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Purpose
 
 Shared development tooling for all managed repositories. Structured as a
-Python package with CLI entry points (`st-*`), distributed as a
+Python package with CLI entry points (`vrg-*`), distributed as a
 host-level developer tool per
 [`docs/specs/host-level-tool.md`](docs/specs/host-level-tool.md).
 

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -13,7 +13,7 @@ The setup steps below wire up each one:
 | Surface | What it is | How you consume it |
 |---|---|---|
 | **Host tools** | `vrg-docker-run`, `vrg-commit`, `vrg-submit-pr`, and other host-side CLI tools. | `uv tool install` from the vergil-tooling git URL; scripts land in `~/.local/bin/`. |
-| **Dev container** | `ghcr.io/vergil-project/dev-<lang>:<version>` — pre-baked images with language runtimes, validators, and every other `st-*` tool installed. | Pulled automatically by `vrg-docker-run`; nothing to install manually. |
+| **Dev container** | `ghcr.io/vergil-project/dev-<lang>:<version>` — pre-baked images with language runtimes, validators, and every other `vrg-*` tool installed. | Pulled automatically by `vrg-docker-run`; nothing to install manually. |
 | **Claude Code plugin** | `vergil-claude-plugin` — hooks, skills, agents, and slash commands that enforce the workflow at the Claude-Code-tool level. | Declared in `.claude/settings.json`; Claude Code loads on session start. |
 
 Plus two layers that aren't installed as packages but are expected
@@ -63,7 +63,7 @@ live inside the container.
 uv tool install 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v1.4'
 ```
 
-This installs all `st-*` console scripts into `~/.local/bin/`,
+This installs all `vrg-*` console scripts into `~/.local/bin/`,
 which `uv`'s official installer already configures on `PATH`. No
 sibling checkout, no custom PATH entries, no venv bootstrapping.
 

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -5,7 +5,7 @@ repository. It covers the overall shape of the workflow, the two
 enforcement layers that back it up, and the per-change cycle you walk
 through from branching to finalization.
 
-For per-tool detail, each `st-*` command has its own reference page.
+For per-tool detail, each `vrg-*` command has its own reference page.
 For the rationale behind the worktree convention,
 see [the worktree convention spec][worktree-spec].
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -19,7 +19,7 @@ admits the commit.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_commit` |
+| Source | `vergil_tooling.bin.vrg_commit` |
 | Args | `--type` (required), `--scope`, `--message` (required), `--body`, `--agent` (required) |
 | Preconditions | Git repo, staged changes, not detached HEAD, not on protected branch, branch prefix matches branching model, issue number in branch name, not main worktree when `.worktrees/` present |
 | Failure mode | `SystemExit` with diagnostic on stderr for each check |
@@ -33,7 +33,7 @@ and opens a PR with a populated template body.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_submit_pr` |
+| Source | `vergil_tooling.bin.vrg_submit_pr` |
 | Args | `--issue` (required), `--summary` (required), `--linkage` (default: Fixes), `--notes`, `--title`, `--dry-run` |
 | Preconditions | Git repo, `gh` CLI on PATH |
 | Failure mode | Subprocess error from `git push` or `gh pr create` |
@@ -47,7 +47,7 @@ release-workflow PRs where the agent is both author and reviewer.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_merge_when_green` |
+| Source | `vergil_tooling.bin.vrg_merge_when_green` |
 | Args | `pr` (positional, required), `--strategy` (merge/squash/rebase), `--no-delete-branch` |
 | Preconditions | `gh` CLI on PATH, worktree-aware (skips `--delete-branch` in secondary worktrees) |
 | Failure mode | `subprocess.CalledProcessError` from `gh pr checks --fail-fast` on first red check |
@@ -63,7 +63,7 @@ Claude plugin, VERSION file) to find the version.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_prepare_release` |
+| Source | `vergil_tooling.bin.vrg_prepare_release` |
 | Args | `--issue` (required) |
 | Preconditions | On `develop` branch, clean working tree, local develop matches `origin/develop`, `gh` and `git-cliff` on PATH |
 | Failure mode | `SystemExit` with clear message for each precondition |
@@ -79,7 +79,7 @@ runs validation, and checks the Documentation workflow status.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_finalize_repo` |
+| Source | `vergil_tooling.bin.vrg_finalize_repo` |
 | Args | `--target-branch` (default: develop), `--dry-run` |
 | Preconditions | Git repo, worktree-aware (auto-switches to main worktree), `vrg-docker-run` on PATH |
 | Failure mode | Validation failures return exit 1; docs workflow failure is a soft warning (exit 0) |
@@ -94,7 +94,7 @@ and project (discover repos via a GitHub Project and sync each).
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_ensure_label` |
+| Source | `vergil_tooling.bin.vrg_ensure_label` |
 | Args | `--repo`, `--label`, `--color`, `--description`, `--sync`, `--owner`, `--project` |
 | Preconditions | `gh` CLI on PATH |
 | Failure mode | argparse validation for incompatible flag combinations; subprocess error from `gh` |
@@ -109,7 +109,7 @@ project language to select the Docker image; falls back to
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_docker_run` |
+| Source | `vergil_tooling.bin.vrg_docker_run` |
 | Args | `[--] <command> [args...]` (manual parsing, `--` separator) |
 | Preconditions | Git repo, `GH_TOKEN` set, Docker daemon running |
 | Failure mode | Explicit error message for missing `GH_TOKEN`; `assert_docker_available()` exits with message for Docker; `git.repo_root()` raises on non-git directory |
@@ -123,7 +123,7 @@ language and selects appropriate image and test command.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_docker_test` |
+| Source | `vergil_tooling.bin.vrg_docker_test` |
 | Args | None |
 | Preconditions | Git repo, Docker daemon running, language detection or `DOCKER_DEV_IMAGE` + `DOCKER_TEST_CMD` |
 | Failure mode | Explicit error for undetected language and unavailable Docker; `git.repo_root()` raises on non-git directory |
@@ -138,7 +138,7 @@ repos, wraps with `uv sync --group docs`.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_docker_docs` |
+| Source | `vergil_tooling.bin.vrg_docker_docs` |
 | Args | `<serve\|build> [mkdocs args...]` (manual parsing) |
 | Preconditions | Git repo, Docker daemon |
 | Failure mode | Usage message on missing/unknown subcommand |
@@ -153,7 +153,7 @@ between `BEGIN/END GENERATED MQSC METHODS` markers.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_generate_commands` |
+| Source | `vergil_tooling.bin.vrg_generate_commands` |
 | Args | `--language` (required), `--mapping-data` (required), `--target`, `--mapping-pages-dir`, `--check` |
 | Preconditions | `mapping-data.json` file exists at the given path |
 | Failure mode | Explicit error for missing mapping data file |
@@ -191,7 +191,7 @@ placeholder values.
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_repo_profile` |
+| Source | `vergil_tooling.bin.vrg_repo_profile` |
 | Args | None |
 | Preconditions | `docs/repository-standards.md` exists |
 | Failure mode | Exit 2 if profile file not found; exit 1 for missing or placeholder attributes |
@@ -209,7 +209,7 @@ and variants). Reads the GitHub event payload from
 
 | Attribute | Value |
 |---|---|
-| Source | `vergil_tooling.bin.st_pr_issue_linkage` |
+| Source | `vergil_tooling.bin.vrg_pr_issue_linkage` |
 | Args | None |
 | Preconditions | `GITHUB_EVENT_PATH` set and pointing to a valid JSON file |
 | Failure mode | Exit 2 for missing env var or file; exit 1 for auto-close keyword or missing linkage |
@@ -262,7 +262,7 @@ interface than argparse would provide. No alignment needed.
 - 0: success
 - 1: check failure, validation error, or precondition violation
 - 2: infrastructure error (used by `vrg-repo-profile`,
-  `st-markdown-standards`, `vrg-pr-issue-linkage`)
+  `vrg-pr-issue-linkage`)
 
 The 1-vs-2 distinction is not universal. Tools added before the
 convention was established use 1 for all errors.

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -2,7 +2,7 @@
 
 **Installed as:** `vrg-submit-pr` (Python console script)
 
-**Source:** `src/vergil_tooling/bin/st_submit_pr.py`
+**Source:** `src/vergil_tooling/bin/vrg_submit_pr.py`
 
 Wrapper that creates standards-compliant pull requests with
 proper issue linkage.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -70,10 +70,10 @@ nav:
           - markdown-validation: reference/lint/markdown-standards.md
           - pr-issue-linkage: reference/lint/pr-issue-linkage.md
       - CLI Tools:
-          - st-commit: reference/dev/commit.md
-          - st-submit-pr: reference/dev/submit-pr.md
-          - st-prepare-release: reference/dev/prepare-release.md
-          - st-finalize-repo: reference/dev/finalize-repo.md
+          - vrg-commit: reference/dev/commit.md
+          - vrg-submit-pr: reference/dev/submit-pr.md
+          - vrg-prepare-release: reference/dev/prepare-release.md
+          - vrg-finalize-repo: reference/dev/finalize-repo.md
   - Standards:
       - Authoring:
           - Markdown Authoring: standards/markdown-authoring.md

--- a/docs/specs/worktree-convention.md
+++ b/docs/specs/worktree-convention.md
@@ -137,12 +137,12 @@ Rules for this session:
   read-only — all changes flow through your worktree on your
   feature branch.
 - When you need to run validation, run it from inside your worktree
-  (st-docker-run mounts the current directory).
+  (vrg-docker-run mounts the current directory).
 ```
 
 All fields are required. The template is intended as a copy-paste
 starting point; an operator launching multiple parallel agents fills
-in the placeholders for each one. A future `st-worktree-prompt` helper
+in the placeholders for each one. A future `vrg-worktree-prompt` helper
 could emit this text given `<issue-number>` and `<slug>` — see
 [Enforcement and follow-up work](#enforcement-and-follow-up-work).
 
@@ -171,18 +171,18 @@ where neither is viable.
 
 ### Cleanup
 
-Post-merge cleanup in this fleet runs through `st-finalize-repo`.
+Post-merge cleanup in this fleet runs through `vrg-finalize-repo`.
 Worktree removal should live there too — the canonical flow becomes:
 
 ```bash
 cd ~/dev/github/<project>
-st-finalize-repo                               # handles branch delete,
+vrg-finalize-repo                              # handles branch delete,
                                                # remote prune, and
                                                # worktree removal for
                                                # the finalized branch
 ```
 
-Extending `st-finalize-repo` to be worktree-aware is tracked as
+Extending `vrg-finalize-repo` to be worktree-aware is tracked as
 follow-up work (see
 [Enforcement and follow-up work](#enforcement-and-follow-up-work)).
 Until that lands, the interim procedure is raw git:
@@ -196,7 +196,7 @@ git fetch --prune                        # drop deleted remote tracking refs
 
 If the worktree directory lingers after a crash or force-removed
 branch, `git worktree prune` cleans up stale metadata. A separate
-`st-worktree-prune` for abandoned branches that never merged is not
+`vrg-worktree-prune` for abandoned branches that never merged is not
 part of this spec — add it only if the abandoned-branch case proves
 to need tooling in practice.
 
@@ -208,7 +208,7 @@ to need tooling in practice.
 | Edit at the main tree root | Rule 3 ignored, or a human edit slipped in | Standing "no direct commits to develop" policy forbids this at the commit level; same git hook catches it |
 | Memory silo from starting session in the wrong directory | Session started inside `.worktrees/<name>/` instead of the root | Documentation + muscle memory; a `claude` wrapper script could refuse to launch unless CWD is a project root |
 | Agent writes to a sibling worktree or the main tree (intentional or mis-prompted) | Prompt contract ignored or misread | Git hook (same backstop) catches any such write that actually gets committed; see [Trust model](#trust-model) for the limits of isolation |
-| Stale worktrees accumulate after branch land | Author forgets the cleanup step | `st-finalize-repo` will remove the worktree as part of its post-merge flow once extended |
+| Stale worktrees accumulate after branch land | Author forgets the cleanup step | `vrg-finalize-repo` will remove the worktree as part of its post-merge flow once extended |
 | Worktree branch gets into weird state on rebase of main | Shared history diverges during long-lived worktree | Normal git hygiene: rebase the worktree's branch onto updated `develop` periodically; no special convention needed |
 
 ### Trust model
@@ -323,10 +323,10 @@ tracked separately):
     `.worktrees/*` is non-empty (or, more simply, refuses all commits
     from the project root, since rule 3 says the main tree is
     read-only).
-- **`st-finalize-repo` extension.** Worktree removal when finalizing
+- **`vrg-finalize-repo` extension.** Worktree removal when finalizing
   the branch for that worktree. Covers the cleanup failure mode
   structurally.
-- **`st-worktree-prompt` helper.** Emits the canonical prompt
+- **`vrg-worktree-prompt` helper.** Emits the canonical prompt
   template given an issue number and slug, so operators don't
   hand-author the prompt each time.
 - **Claude Code plugin.** Hooks at session start (or on work-item
@@ -341,7 +341,7 @@ them. They raise the floor on consistency; they do not gate adoption.
 ## Out of scope
 
 - **Automated worktree provisioning for the initial adoption** (e.g.,
-  `st-worktree-add <issue-number>`). Tracked as follow-up.
+  `vrg-worktree-add <issue-number>`). Tracked as follow-up.
 - **Devcontainer integration.** Worktrees and devcontainers are
   orthogonal; a worktree can run inside or outside a devcontainer.
   This spec does not prescribe.

--- a/src/vergil_tooling/lib/docker.py
+++ b/src/vergil_tooling/lib/docker.py
@@ -1,4 +1,4 @@
-"""Shared Docker container logic for st-docker-* commands."""
+"""Shared Docker container logic for vrg-docker-* commands."""
 
 from __future__ import annotations
 

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # Env-var contract with `.githooks/pre-commit`. Any internal caller
 # that runs `git commit` via this helper is by definition an
-# st-* tool invocation — admit it via the gate. See
+# vrg-* tool invocation — admit it via the gate. See
 # docs/specs/host-level-tool.md "Git hooks".
 _GATE_ENV_VAR = "VRG_COMMIT_CONTEXT"
 _GATE_ENABLED_VALUE = "1"


### PR DESCRIPTION
# Pull Request

## Summary

- Replace stale st-* references with vrg-* across docs, source docstrings, and the worktree convention spec

## Issue Linkage

- Ref #816

## Notes

- 11 files updated. Historical files (changelog, release notes, completed plans, pre-rename specs) intentionally left unchanged.