### PR TITLE
feat(co-authors): replace static config with dynamic GitHub API resolution

### DIFF
--- a/docs/superpowers/plans/2026-05-18-co-author-auto-discovery.md
+++ b/docs/superpowers/plans/2026-05-18-co-author-auto-discovery.md
@@ -622,3 +622,21 @@ If fixes were needed:
 vrg-git add -u
 vrg-commit --type fix --scope co-authors --message "address validation findings from co-author auto-discovery" --agent wphillipmoore-vergil
 ```
+
+---
+
+### Task 6: Cross-repo rollout
+
+Post-merge operational steps. These use existing workflows, not new code.
+
+- [ ] **Step 1: Land the PR**
+
+Submit the PR via `vrg-submit-pr` and wait for CI. Merge once approved.
+
+- [ ] **Step 2: Publish a new vergil-tooling release**
+
+Use `/vergil:publish` to drive the release workflow. The new version includes `resolve_co_author_trailer()` and the deprecated `--agent` flag.
+
+- [ ] **Step 3: Clean up consuming repos**
+
+In each consuming repo, delete the `[project.co-authors]` section from `vergil.toml`. This is optional and can happen at each repo's own pace — leftover sections are silently ignored by the updated parser.

--- a/docs/superpowers/plans/2026-05-18-co-author-auto-discovery.md
+++ b/docs/superpowers/plans/2026-05-18-co-author-auto-discovery.md
@@ -1,0 +1,624 @@
+# Co-Author Auto-Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace static `[project.co-authors]` config in `vergil.toml` with dynamic co-author trailer resolution via the GitHub API.
+
+**Architecture:** New `resolve_co_author_trailer()` function in `lib/github.py` discovers the agent account from `gh auth status` (existing `_discover_accounts()`), queries `/users/<agent>` to get the numeric GitHub user ID, and constructs the `Co-Authored-By` trailer. `vrg-commit` calls this function instead of reading from `vergil.toml`. The `--agent` flag is deprecated (accepted with warning, value ignored). The `[project.co-authors]` section and all co-author parsing in `config.py` are removed.
+
+**Tech Stack:** Python 3.12+, `gh` CLI, GitHub REST API (`/users/<username>`), pytest
+
+---
+
+### Task 1: Add `resolve_co_author_trailer()` to `lib/github.py`
+
+**Files:**
+- Test: `tests/vergil_tooling/test_github.py`
+- Modify: `src/vergil_tooling/lib/github.py:44` (after `_discover_accounts()`)
+
+- [ ] **Step 1: Write the failing test for happy path**
+
+Add to `tests/vergil_tooling/test_github.py` at the end of the file, inside a new test class:
+
+```python
+class TestResolveCoAuthorTrailer:
+    def test_constructs_trailer_from_api(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                return_value=("jdoe", "jdoe-vergil"),
+            ),
+            patch(
+                "vergil_tooling.lib.github.read_json",
+                return_value={"id": 12345, "login": "jdoe-vergil"},
+            ),
+        ):
+            trailer = github.resolve_co_author_trailer()
+        assert trailer == "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py::TestResolveCoAuthorTrailer::test_constructs_trailer_from_api -v`
+Expected: FAIL with `AttributeError: module 'vergil_tooling.lib.github' has no attribute 'resolve_co_author_trailer'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/vergil_tooling/lib/github.py` after `_discover_accounts()` (after line 44):
+
+```python
+def resolve_co_author_trailer() -> str:
+    """Discover the agent account and return its ``Co-Authored-By`` trailer.
+
+    Queries the GitHub API for the agent's numeric user ID to construct
+    the noreply email that GitHub uses for commit attribution.
+    """
+    _human, agent = _discover_accounts()
+    data = read_json("api", f"users/{agent}")
+    uid = data["id"]  # type: ignore[index]
+    return f"Co-Authored-By: {agent} <{uid}+{agent}@users.noreply.github.com>"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py::TestResolveCoAuthorTrailer::test_constructs_trailer_from_api -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for API 404 (flagged account)**
+
+Add to the `TestResolveCoAuthorTrailer` class:
+
+```python
+    def test_api_404_raises_github_api_error(self) -> None:
+        err = github.GitHubAPIError(
+            1, ["gh"], output='{"message": "Not Found"}', stderr="HTTP 404"
+        )
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                return_value=("jdoe", "jdoe-vergil"),
+            ),
+            patch(
+                "vergil_tooling.lib.github.read_json",
+                side_effect=err,
+            ),
+            pytest.raises(github.GitHubAPIError, match="404"),
+        ):
+            github.resolve_co_author_trailer()
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+This test passes without code changes — `read_json` already raises `GitHubAPIError` for non-retryable errors, and `resolve_co_author_trailer` doesn't catch it.
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py::TestResolveCoAuthorTrailer::test_api_404_raises_github_api_error -v`
+Expected: PASS
+
+- [ ] **Step 7: Write failing test for discovery failure**
+
+Add to the `TestResolveCoAuthorTrailer` class:
+
+```python
+    def test_discovery_failure_propagates(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                side_effect=SystemExit(1),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            github.resolve_co_author_trailer()
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py::TestResolveCoAuthorTrailer::test_discovery_failure_propagates -v`
+Expected: PASS
+
+- [ ] **Step 9: Run all github tests**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py -v`
+Expected: All tests pass (existing + 3 new)
+
+- [ ] **Step 10: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/github.py tests/vergil_tooling/test_github.py
+vrg-commit --type feat --scope github --message "add resolve_co_author_trailer for dynamic co-author discovery" --agent wphillipmoore-vergil
+```
+
+---
+
+### Task 2: Deduplicate `_discover_accounts()` in `vrg_gh.py`
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_gh.py:1-83`
+- Modify: `tests/vergil_tooling/test_vrg_gh.py:174-258`
+
+- [ ] **Step 1: Replace local `_discover_accounts()` with import**
+
+In `src/vergil_tooling/bin/vrg_gh.py`, delete lines 64-83 (the local `_discover_accounts()` function). Then update the imports — add at the top of the file after the existing imports:
+
+```python
+from vergil_tooling.lib.github import _discover_accounts
+```
+
+Remove `import re` from the imports (line 13) since it's only used by the deleted function.
+
+The `_get_token` function on line 86 (which will shift up after the deletion) already calls `_discover_accounts()` — it will now resolve to the imported version.
+
+- [ ] **Step 2: Update test patches to target the new import path**
+
+In `tests/vergil_tooling/test_vrg_gh.py`, the four `_discover_accounts` tests (lines 174-258) import and patch `vergil_tooling.bin.vrg_gh._discover_accounts`. Since `vrg_gh.py` now imports it from `lib.github`, the tests need to patch `vergil_tooling.bin.vrg_gh._discover_accounts` (which still works because the import binds the name in the `vrg_gh` module namespace). No changes needed to the test patches — they already target the right module-level name.
+
+However, the tests that do `from vergil_tooling.bin.vrg_gh import _discover_accounts` (lines 175, 199, 225, 249) should be updated to import from the canonical location:
+
+Replace all four occurrences of:
+```python
+    from vergil_tooling.bin.vrg_gh import _discover_accounts
+```
+with:
+```python
+    from vergil_tooling.lib.github import _discover_accounts
+```
+
+And update the four corresponding `patch` targets from:
+```python
+        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+```
+to:
+```python
+        patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
+```
+
+- [ ] **Step 3: Run vrg_gh tests**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_gh.py -v`
+Expected: All tests pass
+
+- [ ] **Step 4: Run github tests to confirm no regressions**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py -v`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_gh.py tests/vergil_tooling/test_vrg_gh.py
+vrg-commit --type refactor --scope vrg-gh --message "replace local _discover_accounts with import from lib/github" --agent wphillipmoore-vergil
+```
+
+---
+
+### Task 3: Update `vrg-commit` to use dynamic resolution
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_commit.py:1-226`
+- Modify: `tests/vergil_tooling/test_vrg_commit.py:1-473`
+
+- [ ] **Step 1: Write failing test for auto-discovery path (no --agent)**
+
+Add to `tests/vergil_tooling/test_vrg_commit.py`:
+
+```python
+def test_main_auto_discovery(tmp_path: Path) -> None:
+    commit_file_content = ""
+
+    def capture_run(*args: str) -> None:
+        nonlocal commit_file_content
+        if args[0] == "commit" and args[1] == "--file":
+            commit_file_content = Path(args[2]).read_text(encoding="utf-8")
+
+    with (
+        _commit_environment(tmp_path),
+        patch("vergil_tooling.bin.vrg_commit.git.run", side_effect=capture_run),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>",
+        ),
+    ):
+        result = main(
+            ["--type", "feat", "--scope", "core", "--message", "add feature"]
+        )
+    assert result == 0
+    assert commit_file_content.startswith("feat(core): add feature\n")
+    assert "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>" in commit_file_content
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_commit.py::test_main_auto_discovery -v`
+Expected: FAIL — `--agent` is still required by argparse
+
+- [ ] **Step 3: Write failing test for deprecated --agent flag**
+
+Add to `tests/vergil_tooling/test_vrg_commit.py`:
+
+```python
+def test_main_agent_flag_prints_deprecation_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with (
+        _commit_environment(tmp_path),
+        patch("vergil_tooling.bin.vrg_commit.git.run"),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>",
+        ),
+    ):
+        result = main(
+            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "ignored"]
+        )
+    assert result == 0
+    err = capsys.readouterr().err
+    assert "deprecated" in err.lower()
+```
+
+- [ ] **Step 4: Implement the changes to `vrg_commit.py`**
+
+In `src/vergil_tooling/bin/vrg_commit.py`:
+
+**a)** Add import — change line 19 from:
+```python
+from vergil_tooling.lib import config, git
+```
+to:
+```python
+from vergil_tooling.lib import config, git, github
+```
+
+**b)** Update the `--agent` argument (line 78-80) — change from:
+```python
+    parser.add_argument(
+        "--agent", required=True, help="AI agent identity (key in [project.co-authors])"
+    )
+```
+to:
+```python
+    parser.add_argument(
+        "--agent",
+        required=False,
+        default=None,
+        help="Deprecated. Co-author identity is now auto-discovered.",
+    )
+```
+
+**c)** Update the module docstring (line 3) — change from:
+```python
+"""Commit wrapper that constructs standards-compliant commit messages.
+
+Resolves Co-Authored-By identities from vergil.toml.
+```
+to:
+```python
+"""Commit wrapper that constructs standards-compliant commit messages.
+
+Resolves Co-Authored-By identities dynamically via the GitHub API.
+```
+
+**d)** Replace the co-author lookup block (lines 192-198) — change from:
+```python
+    if st_config is None or args.agent not in st_config.project.co_authors:
+        print(
+            f"ERROR: no co-author identity for agent '{args.agent}' in {config.CONFIG_FILE}.",
+            file=sys.stderr,
+        )
+        return 1
+    identity = st_config.project.co_authors[args.agent]
+```
+to:
+```python
+    if args.agent is not None:
+        print(
+            "WARNING: --agent is deprecated and will be removed in a future release. "
+            "Co-author identity is now auto-discovered from gh auth status.",
+            file=sys.stderr,
+        )
+
+    try:
+        identity = github.resolve_co_author_trailer()
+    except (SystemExit, github.GitHubAPIError) as exc:
+        print(f"ERROR: failed to resolve co-author identity: {exc}", file=sys.stderr)
+        return 1
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_commit.py::test_main_auto_discovery tests/vergil_tooling/test_vrg_commit.py::test_main_agent_flag_prints_deprecation_warning -v`
+Expected: PASS
+
+- [ ] **Step 6: Update existing tests to mock `resolve_co_author_trailer`**
+
+The existing tests that pass `--agent agent` and expect the co-author trailer from `vergil.toml` now need to mock `resolve_co_author_trailer()` instead.
+
+**Update `_commit_environment`** — add a default mock for `resolve_co_author_trailer`. Change the context manager (lines 37-74) to add one more `patch`:
+
+```python
+@contextlib.contextmanager
+def _commit_environment(
+    tmp_path: Path,
+    *,
+    branch: str = "feature/42-test",
+    is_main_worktree: bool = False,
+    branching_model: str = "library-release",
+    has_staged: bool = True,
+    write_config: bool = True,
+) -> Iterator[None]:
+    if write_config:
+        (tmp_path / "vergil.toml").write_text(
+            _TEST_TOML_TEMPLATE.format(branching_model=branching_model)
+        )
+
+    with (
+        patch("vergil_tooling.bin.vrg_commit.git.current_branch", return_value=branch),
+        patch("vergil_tooling.bin.vrg_commit.git.repo_root", return_value=tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_commit.git.is_main_worktree",
+            return_value=is_main_worktree,
+        ),
+        patch(
+            "vergil_tooling.bin.vrg_commit.git.has_staged_changes",
+            return_value=has_staged,
+        ),
+        patch("vergil_tooling.bin.vrg_commit.git.run"),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: test-agent <test-agent@test.com>",
+        ),
+    ):
+        yield
+```
+
+**Remove co-author lines from `_TEST_TOML_TEMPLATE`** (lines 18-34) — change from:
+```python
+_TEST_TOML_TEMPLATE = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "{branching_model}"
+release-model = "tagged-release"
+primary-language = "python"
+
+[project.co-authors]
+agent = "Co-Authored-By: test-agent <test-agent@test.com>"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["3.14"]
+"""
+```
+to:
+```python
+_TEST_TOML_TEMPLATE = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "{branching_model}"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["3.14"]
+"""
+```
+
+**Update `_DEFAULT_ARGS`** (line 232) — remove `--agent` since it's no longer required:
+```python
+_DEFAULT_ARGS = ["--type", "feat", "--scope", "core", "--message", "test"]
+```
+
+**Update `test_main_missing_config`** (lines 204-212) — this test currently expects exit code 1 when `vergil.toml` is missing because the co-author lookup fails. Now the missing-config path still reads branching_model as `""` (fallback), but `resolve_co_author_trailer()` is mocked. The test needs to mock the resolver too:
+
+```python
+def test_main_missing_config(tmp_path: Path) -> None:
+    with (
+        patch("vergil_tooling.bin.vrg_commit.git.current_branch", return_value="feature/42-test"),
+        patch("vergil_tooling.bin.vrg_commit.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_commit.git.is_main_worktree", return_value=False),
+        patch("vergil_tooling.bin.vrg_commit.git.has_staged_changes", return_value=True),
+        patch("vergil_tooling.bin.vrg_commit.git.run"),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: test-agent <test-agent@test.com>",
+        ),
+    ):
+        result = main(_DEFAULT_ARGS)
+    assert result == 0
+```
+
+**Delete `test_main_unknown_agent`** (lines 215-220) — this test is no longer applicable. The `--agent` value is ignored; there is no "unknown agent" case.
+
+- [ ] **Step 7: Run all vrg_commit tests**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_commit.py -v`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_commit.py tests/vergil_tooling/test_vrg_commit.py
+vrg-commit --type feat --scope vrg-commit --message "replace config-based co-author lookup with dynamic API resolution" --agent wphillipmoore-vergil
+```
+
+---
+
+### Task 4: Remove co-author config from `config.py` and `vergil.toml`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/config.py:16,47,98-104,151-158`
+- Modify: `vergil.toml:8-9`
+- Modify: `tests/vergil_tooling/test_config.py:67-80,85-95,123-130,140-148`
+
+- [ ] **Step 1: Write failing test for backward compatibility**
+
+Add to `tests/vergil_tooling/test_config.py`:
+
+```python
+def test_read_config_ignores_leftover_co_authors(tmp_path: Path) -> None:
+    toml = _VALID_TOML + ""
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert not hasattr(cfg.project, "co_authors")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_config.py::test_read_config_ignores_leftover_co_authors -v`
+Expected: FAIL — `ProjectConfig` still has `co_authors` attribute
+
+- [ ] **Step 3: Remove co-author code from `config.py`**
+
+In `src/vergil_tooling/lib/config.py`:
+
+**a)** Delete the `_COAUTHOR_RE` regex (line 16):
+```python
+_COAUTHOR_RE = re.compile(r"^Co-Authored-By:\s+.+\s+<.+>$")
+```
+
+**b)** Remove `import re` from line 6, since it's no longer used.
+
+**c)** Remove `co_authors` from `ProjectConfig` (line 47):
+```python
+    co_authors: dict[str, str]
+```
+
+**d)** Delete the co-author validation block (lines 98-104):
+```python
+    co_authors: dict[str, str] = {}
+    co_authors_raw = project_raw.get("co-authors", {})
+    for name, trailer in co_authors_raw.items():
+        if not _COAUTHOR_RE.match(trailer):
+            msg = f"{CONFIG_FILE}: malformed co-author trailer for '{name}': {trailer!r}"
+            raise ConfigError(msg)
+        co_authors[name] = trailer
+```
+
+**e)** Remove `co_authors=co_authors` from the `ProjectConfig` constructor call (around line 157 after deletions above):
+Change from:
+```python
+    project = ProjectConfig(
+        repository_type=project_raw["repository-type"],
+        versioning_scheme=project_raw["versioning-scheme"],
+        branching_model=project_raw["branching-model"],
+        release_model=project_raw["release-model"],
+        primary_language=project_raw["primary-language"],
+        co_authors=co_authors,
+    )
+```
+to:
+```python
+    project = ProjectConfig(
+        repository_type=project_raw["repository-type"],
+        versioning_scheme=project_raw["versioning-scheme"],
+        branching_model=project_raw["branching-model"],
+        release_model=project_raw["release-model"],
+        primary_language=project_raw["primary-language"],
+    )
+```
+
+- [ ] **Step 4: Run the backward compatibility test**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_config.py::test_read_config_ignores_leftover_co_authors -v`
+Expected: PASS
+
+- [ ] **Step 5: Update test fixtures and assertions**
+
+In `tests/vergil_tooling/test_config.py`:
+
+**a)** Remove co-author lines from `_BASE_TOML` (lines 67-80) — change from:
+```python
+_BASE_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[project.co-authors]
+agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"
+
+[dependencies]
+vergil = "v2.0"
+"""
+```
+to:
+```python
+_BASE_TOML = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "python"
+
+[dependencies]
+vergil = "v2.0"
+"""
+```
+
+**b)** Remove co-author assertions from `test_read_config_valid` (lines 93-94):
+```python
+    assert "agent" in cfg.project.co_authors
+    assert "user-agent" in cfg.project.co_authors["agent"]
+```
+
+**c)** Delete `test_read_config_malformed_co_author` entirely (lines 123-130).
+
+**d)** Delete `test_read_config_no_co_authors` entirely (lines 140-148).
+
+**e)** Update the `test_read_config_ignores_leftover_co_authors` test written in Step 1. The `_VALID_TOML` fixture no longer has co-authors, so we need to add them explicitly:
+
+```python
+def test_read_config_ignores_leftover_co_authors(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '\n[project.co-authors]\nagent = "Co-Authored-By: x <1+x@users.noreply.github.com>"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert not hasattr(cfg.project, "co_authors")
+```
+
+- [ ] **Step 6: Remove `[project.co-authors]` from `vergil.toml`**
+
+In `vergil.toml`, delete lines 8-9:
+```toml
+[project.co-authors]
+wphillipmoore-vergil = "Co-Authored-By: wphillipmoore-vergil <285019742+wphillipmoore-vergil@users.noreply.github.com>"
+```
+
+- [ ] **Step 7: Run all config tests**
+
+Run: `vrg-docker-run -- uv run pytest tests/vergil_tooling/test_config.py -v`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/config.py vergil.toml tests/vergil_tooling/test_config.py
+vrg-commit --type refactor --scope config --message "remove co-author config from vergil.toml and config.py" --agent wphillipmoore-vergil
+```
+
+---
+
+### Task 5: Full validation
+
+- [ ] **Step 1: Run the full validation pipeline**
+
+Run: `vrg-docker-run -- uv run vrg-validate`
+Expected: All checks pass (lint, typecheck, tests, audit)
+
+- [ ] **Step 2: Fix any validation failures**
+
+Address any issues found by the full pipeline (type errors, lint warnings, etc.)
+
+- [ ] **Step 3: Commit any fixes**
+
+If fixes were needed:
+```bash
+vrg-git add -u
+vrg-commit --type fix --scope co-authors --message "address validation findings from co-author auto-discovery" --agent wphillipmoore-vergil
+```

--- a/docs/superpowers/specs/2026-05-18-co-author-auto-discovery-design.md
+++ b/docs/superpowers/specs/2026-05-18-co-author-auto-discovery-design.md
@@ -1,0 +1,163 @@
+# Co-Author Auto-Discovery Design
+
+**Issue:** #725
+**Date:** 2026-05-18
+**Status:** Draft
+
+## Problem
+
+`[project.co-authors]` in `vergil.toml` hardcodes a single agent
+identity (GitHub user ID + noreply email) at the repository level.
+This blocks multi-contributor workflows — each developer has their
+own AI agent account, and a repo-level config can only represent one.
+Every consuming repo must carry this mapping, creating per-repo
+maintenance for something that belongs to the developer, not the
+repository.
+
+## Solution
+
+Replace the static `[project.co-authors]` config with dynamic
+resolution at commit time. The agent account is discovered from
+`gh auth status` (existing convention), and the GitHub API provides
+the numeric user ID needed to construct the noreply email for the
+`Co-Authored-By` trailer.
+
+## Design
+
+### Identity Resolution
+
+New function in `src/vergil_tooling/lib/github.py`:
+
+```
+resolve_co_author_trailer() -> str
+```
+
+Steps:
+
+1. Call `_discover_accounts()` to get the agent account name
+   (e.g., `wphillipmoore-vergil`). This function already exists in
+   `lib/github.py` and parses `gh auth status` for the single
+   `-vergil` suffixed account.
+2. Call `gh api /users/<agent>` via the existing `read_json()` helper
+   to fetch the agent's GitHub profile.
+3. Extract the `id` field (numeric GitHub user ID).
+4. Construct and return:
+   `Co-Authored-By: <agent> <<id>+<agent>@users.noreply.github.com>`
+
+Error handling: `_discover_accounts()` already hard-errors if zero or
+multiple `-vergil` accounts are found. `read_json()` already retries
+transient GitHub API errors (502/503/504/429) with exponential
+backoff. Persistent API failures surface as `GitHubAPIError`.
+
+### Changes to `vrg-commit`
+
+**Remove config-based co-author lookup.** The block that reads
+`args.agent` from `st_config.project.co_authors` (lines 192-198 of
+`vrg_commit.py`) is replaced with a single call to
+`resolve_co_author_trailer()`.
+
+**Deprecate `--agent` flag.** The flag remains in the argparse
+definition but becomes optional with no default. When passed,
+`vrg-commit` prints a deprecation warning to stderr and ignores the
+value:
+
+```
+WARNING: --agent is deprecated and will be removed in a future
+release. Co-author identity is now auto-discovered from
+gh auth status.
+```
+
+The flag will be removed in a subsequent release once no consuming
+scripts or agent sessions pass it.
+
+**Commit flow after the change:**
+
+1. Parse args (`--agent` accepted but ignored with warning).
+2. Read `vergil.toml` for branching model and other config.
+3. Validate commit context (branch checks, detached HEAD, etc.).
+4. Call `resolve_co_author_trailer()` — discovers agent, queries API,
+   returns trailer string.
+5. Build commit message with trailer appended.
+6. Execute `git commit --file`.
+
+### Changes to `vergil.toml` and `config.py`
+
+**`vergil.toml`:** Delete the `[project.co-authors]` section.
+
+**`src/vergil_tooling/lib/config.py`:**
+
+- Delete the `_COAUTHOR_RE` regex.
+- Remove the `co_authors` field from `ProjectConfig`.
+- Delete the co-author validation block in `_parse_raw_config()`.
+- Remove the `co_authors` kwarg from the `ProjectConfig` constructor
+  call.
+
+Leftover `[project.co-authors]` sections in consuming repos are
+harmless — the parser will ignore unknown keys under `[project]`.
+This avoids coordination pressure during rollout.
+
+### Deduplicate `_discover_accounts()`
+
+`vrg_gh.py` has a duplicate of `_discover_accounts()` that
+predates the `lib/github.py` version. The duplicate is removed and
+`vrg_gh.py` imports from the lib.
+
+### Test Changes
+
+**`test_config.py`:**
+
+- Remove co-author entries from TOML test fixtures.
+- Remove `test_read_config_malformed_co_author`.
+- Update `test_read_config_valid` to not assert on `co_authors`.
+- Add a test confirming that a `[project.co-authors]` section in
+  TOML is silently ignored (backward compatibility).
+
+**`test_vrg_commit.py`:**
+
+- Remove co-author entries from TOML test fixtures.
+- Update tests that assert on agent resolution behavior to mock
+  `resolve_co_author_trailer()` instead.
+- Add a test: passing `--agent` prints deprecation warning and
+  succeeds.
+- Add a test: omitting `--agent` succeeds (auto-discovery path).
+
+**`test_github.py` (new tests):**
+
+- Test `resolve_co_author_trailer()` with a mocked `gh api` response
+  returning a known numeric ID.
+- Test that `_discover_accounts()` failure propagates cleanly.
+- Test that a `gh api` failure (non-transient) raises
+  `GitHubAPIError`.
+
+### Cross-Repo Rollout
+
+1. Land the vergil-tooling PR.
+2. Publish a new vergil-tooling release.
+3. Clean up consuming repos' `vergil.toml` files at their own pace —
+   leftover `[project.co-authors]` sections are inert.
+
+## Rejected Alternatives
+
+### Convention-Based Derivation (No API Call)
+
+Construct the noreply email without the numeric ID prefix. GitHub
+requires the numeric ID for reliable commit attribution — without it,
+commits may not link to the agent account. Attribution is the purpose
+of the trailer, so this defeats the goal.
+
+### API Call + Local Cache
+
+Cache the resolved trailer in `~/.config/vergil/co-authors.toml`
+after the first API call. Adds cache file management, cache
+invalidation logic, and extra code paths. The network dependency
+already exists (`gh auth` is required for commits), so offline
+capability provides no practical benefit. The complexity is not
+justified.
+
+### Per-User Config File
+
+Store agent identity in `~/.config/vergil/agents.toml` or similar.
+Requires manual setup per developer, config file maintenance, and
+diverges from the convention-based approach the tooling already uses
+for account discovery. Adds configuration surface area that
+auto-discovery eliminates entirely.

--- a/docs/superpowers/specs/2026-05-18-co-author-auto-discovery-design.md
+++ b/docs/superpowers/specs/2026-05-18-co-author-auto-discovery-design.md
@@ -49,6 +49,19 @@ multiple `-vergil` accounts are found. `read_json()` already retries
 transient GitHub API errors (502/503/504/429) with exponential
 backoff. Persistent API failures surface as `GitHubAPIError`.
 
+If `gh api /users/<agent>` returns 404, `vrg-commit` prints a clear
+error explaining the agent account may be flagged or suspended by
+GitHub. This is a known scenario — GitHub has previously flagged
+newly created bot-style accounts, making them invisible to the
+public user API even though they appear in `gh auth status`.
+
+The `/users/<name>` endpoint is public and does not require
+authentication, but the call routes through `read_json()` →
+`_run_with_retry()`, which injects `GH_TOKEN` for the human
+account. This coupling is accepted — if `gh auth` is broken,
+nothing else in `vrg-commit` works either, and the retry
+machinery is useful for transient GitHub errors.
+
 ### Changes to `vrg-commit`
 
 **Remove config-based co-author lookup.** The block that reads
@@ -98,9 +111,12 @@ This avoids coordination pressure during rollout.
 
 ### Deduplicate `_discover_accounts()`
 
-`vrg_gh.py` has a duplicate of `_discover_accounts()` that
-predates the `lib/github.py` version. The duplicate is removed and
-`vrg_gh.py` imports from the lib.
+`vrg_gh.py` has its own copy of `_discover_accounts()` that
+predates the `lib/github.py` version (added in the credential
+injection work, commit `cc5ec16`). The two copies differ only in
+error message prefix. The `vrg_gh.py` copy is removed and
+`vrg_gh.py` imports `_discover_accounts` from `lib/github.py`
+directly. The error prefix becomes `"vergil-tooling:"` everywhere.
 
 ### Test Changes
 

--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -1,6 +1,6 @@
 """Commit wrapper that constructs standards-compliant commit messages.
 
-Resolves Co-Authored-By identities from vergil.toml.
+Resolves Co-Authored-By identities dynamically via the GitHub API.
 Performs branch / context validation (formerly in
 `vergil_tooling.bin.pre_commit_hook`, removed under the host-level-tool
 spec — see docs/specs/host-level-tool.md). Sets VRG_COMMIT_CONTEXT=1
@@ -16,7 +16,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from vergil_tooling.lib import config, git
+from vergil_tooling.lib import config, git, github
 
 ALLOWED_TYPES = (
     "feat",
@@ -76,7 +76,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--message", required=True, help="Commit description")
     parser.add_argument("--body", default="", help="Detailed commit body")
     parser.add_argument(
-        "--agent", required=True, help="AI agent identity (key in [project.co-authors])"
+        "--agent",
+        required=False,
+        default=None,
+        help="Deprecated. Co-author identity is now auto-discovered.",
     )
     return parser.parse_args(argv)
 
@@ -189,13 +192,18 @@ def main(argv: list[str] | None = None) -> int:
             "Issues must remain open until post-merge workflows succeed.",
         )
 
-    if st_config is None or args.agent not in st_config.project.co_authors:
+    if args.agent is not None:
         print(
-            f"ERROR: no co-author identity for agent '{args.agent}' in {config.CONFIG_FILE}.",
+            "WARNING: --agent is deprecated and will be removed in a future release. "
+            "Co-author identity is now auto-discovered from gh auth status.",
             file=sys.stderr,
         )
+
+    try:
+        identity = github.resolve_co_author_trailer()
+    except (SystemExit, github.GitHubAPIError) as exc:
+        print(f"ERROR: failed to resolve co-author identity: {exc}", file=sys.stderr)
         return 1
-    identity = st_config.project.co_authors[args.agent]
 
     if not git.has_staged_changes():
         print(

--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import datetime
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
+
+from vergil_tooling.lib.github import _discover_accounts
 
 _ALLOWED: dict[str, set[str]] = {
     "issue": {"view", "create", "close", "edit", "list", "comment"},
@@ -59,28 +60,6 @@ def _log(args: list[str], result: str) -> None:
     }
     with path.open("a") as f:
         f.write(json.dumps(entry) + "\n")
-
-
-def _discover_accounts() -> tuple[str, str]:
-    result = subprocess.run(  # noqa: S603
-        ["gh", "auth", "status"],  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    output = result.stdout or result.stderr
-    accounts = list(dict.fromkeys(re.findall(r"Logged in to github\.com account (\S+)", output)))
-    vergil = [a for a in accounts if a.endswith("-vergil")]
-    if len(vergil) != 1:
-        print(
-            "vrg-gh: cannot discover -vergil account in gh auth status. "
-            f"Expected exactly one, found: {vergil}",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    agent = vergil[0]
-    human = agent.removesuffix("-vergil")
-    return human, agent
 
 
 def _get_token(command: list[str]) -> str:  # noqa: ARG001

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import re
 import tomllib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -12,8 +11,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 CONFIG_FILE = "vergil.toml"
-
-_COAUTHOR_RE = re.compile(r"^Co-Authored-By:\s+.+\s+<.+>$")
 
 _ENUMS: dict[str, set[str]] = {
     "repository-type": {"library", "application", "infrastructure", "tooling", "documentation"},
@@ -44,7 +41,6 @@ class ProjectConfig:
     branching_model: str
     release_model: str
     primary_language: str
-    co_authors: dict[str, str]
 
 
 @dataclass
@@ -94,14 +90,6 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
             allowed = ", ".join(sorted(_ENUMS[field]))
             msg = f"{CONFIG_FILE}: invalid {field} '{value}' (allowed: {allowed})"
             raise ConfigError(msg)
-
-    co_authors: dict[str, str] = {}
-    co_authors_raw = project_raw.get("co-authors", {})
-    for name, trailer in co_authors_raw.items():
-        if not _COAUTHOR_RE.match(trailer):
-            msg = f"{CONFIG_FILE}: malformed co-author trailer for '{name}': {trailer!r}"
-            raise ConfigError(msg)
-        co_authors[name] = trailer
 
     deps = raw.get("dependencies", {})
     if "vergil" not in deps:
@@ -154,7 +142,6 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         branching_model=project_raw["branching-model"],
         release_model=project_raw["release-model"],
         primary_language=project_raw["primary-language"],
-        co_authors=co_authors,
     )
     return StConfig(
         project=project,

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -52,7 +52,10 @@ def resolve_co_author_trailer() -> str:
     """
     _human, agent = _discover_accounts()
     data = read_json("api", f"users/{agent}")
-    uid = data["id"]  # type: ignore[index]
+    if not isinstance(data, dict):
+        msg = f"unexpected API response for users/{agent}"
+        raise GitHubAPIError(1, f"gh api users/{agent}", msg)
+    uid = data["id"]
     return f"Co-Authored-By: {agent} <{uid}+{agent}@users.noreply.github.com>"
 
 

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -44,6 +44,18 @@ def _discover_accounts() -> tuple[str, str]:
     return human, agent
 
 
+def resolve_co_author_trailer() -> str:
+    """Discover the agent account and return its ``Co-Authored-By`` trailer.
+
+    Queries the GitHub API for the agent's numeric user ID to construct
+    the noreply email that GitHub uses for commit attribution.
+    """
+    _human, agent = _discover_accounts()
+    data = read_json("api", f"users/{agent}")
+    uid = data["id"]  # type: ignore[index]
+    return f"Co-Authored-By: {agent} <{uid}+{agent}@users.noreply.github.com>"
+
+
 @functools.lru_cache(maxsize=1)
 def _human_token() -> str:
     """Return the human account's token (cached for the process lifetime)."""

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -123,8 +123,10 @@ def test_read_config_missing_dependencies_key(tmp_path: Path) -> None:
 
 
 def test_read_config_ignores_leftover_co_authors(tmp_path: Path) -> None:
-    toml = _VALID_TOML + '\n[project.co-authors]\nagent = "Co-Authored-By: x <1+x@users.noreply.github.com>"\n'
-    (tmp_path / "vergil.toml").write_text(toml)
+    co_authors = (
+        '\n[project.co-authors]\nagent = "Co-Authored-By: x <1+x@users.noreply.github.com>"\n'
+    )
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML + co_authors)
     cfg = read_config(tmp_path)
     assert not hasattr(cfg.project, "co_authors")
 

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -72,9 +72,6 @@ branching-model = "library-release"
 release-model = "tagged-release"
 primary-language = "python"
 
-[project.co-authors]
-agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"
-
 [dependencies]
 vergil = "v2.0"
 """
@@ -90,8 +87,6 @@ def test_read_config_valid(tmp_path: Path) -> None:
     assert cfg.project.branching_model == "library-release"
     assert cfg.project.release_model == "tagged-release"
     assert cfg.project.primary_language == "python"
-    assert "agent" in cfg.project.co_authors
-    assert "user-agent" in cfg.project.co_authors["agent"]
     assert cfg.dependencies["vergil"] == "v2.0"
 
 
@@ -120,16 +115,6 @@ def test_read_config_invalid_enum(tmp_path: Path) -> None:
         read_config(tmp_path)
 
 
-def test_read_config_malformed_co_author(tmp_path: Path) -> None:
-    toml = _VALID_TOML.replace(
-        'agent = "Co-Authored-By: user-agent <111+user-agent@users.noreply.github.com>"',
-        'agent = "not a valid trailer"',
-    )
-    (tmp_path / "vergil.toml").write_text(toml)
-    with pytest.raises(ConfigError, match="co-author.*agent"):
-        read_config(tmp_path)
-
-
 def test_read_config_missing_dependencies_key(tmp_path: Path) -> None:
     toml = _VALID_TOML.replace('vergil = "v2.0"', 'other = "v1.0"')
     (tmp_path / "vergil.toml").write_text(toml)
@@ -137,15 +122,11 @@ def test_read_config_missing_dependencies_key(tmp_path: Path) -> None:
         read_config(tmp_path)
 
 
-def test_read_config_no_co_authors(tmp_path: Path) -> None:
-    lines = [
-        ln
-        for ln in _VALID_TOML.splitlines(keepends=True)
-        if "co-authors" not in ln.lower() and "agent" not in ln
-    ]
-    (tmp_path / "vergil.toml").write_text("".join(lines))
+def test_read_config_ignores_leftover_co_authors(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '\n[project.co-authors]\nagent = "Co-Authored-By: x <1+x@users.noreply.github.com>"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
     cfg = read_config(tmp_path)
-    assert cfg.project.co_authors == {}
+    assert not hasattr(cfg.project, "co_authors")
 
 
 # -- [markdownlint] section ---------------------------------------------------

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -599,3 +599,49 @@ class TestGhEnv:
             side_effect=SystemExit(1),
         ):
             assert github._gh_env() is None
+
+
+# --- resolve_co_author_trailer ---
+
+
+class TestResolveCoAuthorTrailer:
+    def test_constructs_trailer_from_api(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                return_value=("jdoe", "jdoe-vergil"),
+            ),
+            patch(
+                "vergil_tooling.lib.github.read_json",
+                return_value={"id": 12345, "login": "jdoe-vergil"},
+            ),
+        ):
+            trailer = github.resolve_co_author_trailer()
+        assert trailer == "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>"
+
+    def test_api_404_raises_github_api_error(self) -> None:
+        err = github.GitHubAPIError(
+            1, ["gh"], output='{"message": "Not Found"}', stderr="HTTP 404"
+        )
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                return_value=("jdoe", "jdoe-vergil"),
+            ),
+            patch(
+                "vergil_tooling.lib.github.read_json",
+                side_effect=err,
+            ),
+            pytest.raises(github.GitHubAPIError, match="404"),
+        ):
+            github.resolve_co_author_trailer()
+
+    def test_discovery_failure_propagates(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                side_effect=SystemExit(1),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            github.resolve_co_author_trailer()

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -620,9 +620,7 @@ class TestResolveCoAuthorTrailer:
         assert trailer == "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>"
 
     def test_api_404_raises_github_api_error(self) -> None:
-        err = github.GitHubAPIError(
-            1, ["gh"], output='{"message": "Not Found"}', stderr="HTTP 404"
-        )
+        err = github.GitHubAPIError(1, ["gh"], output='{"message": "Not Found"}', stderr="HTTP 404")
         with (
             patch(
                 "vergil_tooling.lib.github._discover_accounts",
@@ -633,6 +631,20 @@ class TestResolveCoAuthorTrailer:
                 side_effect=err,
             ),
             pytest.raises(github.GitHubAPIError, match="404"),
+        ):
+            github.resolve_co_author_trailer()
+
+    def test_non_dict_response_raises(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                return_value=("jdoe", "jdoe-vergil"),
+            ),
+            patch(
+                "vergil_tooling.lib.github.read_json",
+                return_value=[{"id": 1}],
+            ),
+            pytest.raises(github.GitHubAPIError),
         ):
             github.resolve_co_author_trailer()
 

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -170,7 +170,6 @@ def _project(
         branching_model="library-release",
         release_model=release_model,
         primary_language=language,
-        co_authors={},
     )
 
 

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -23,9 +23,6 @@ branching-model = "{branching_model}"
 release-model = "tagged-release"
 primary-language = "python"
 
-[project.co-authors]
-agent = "Co-Authored-By: test-agent <test-agent@test.com>"
-
 [dependencies]
 vergil = "v2.0"
 
@@ -70,6 +67,10 @@ def _commit_environment(
             return_value=has_staged,
         ),
         patch("vergil_tooling.bin.vrg_commit.git.run"),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: test-agent <test-agent@test.com>",
+        ),
     ):
         yield
 
@@ -207,17 +208,62 @@ def test_main_missing_config(tmp_path: Path) -> None:
         patch("vergil_tooling.bin.vrg_commit.git.repo_root", return_value=tmp_path),
         patch("vergil_tooling.bin.vrg_commit.git.is_main_worktree", return_value=False),
         patch("vergil_tooling.bin.vrg_commit.git.has_staged_changes", return_value=True),
+        patch("vergil_tooling.bin.vrg_commit.git.run"),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: test-agent <test-agent@test.com>",
+        ),
     ):
         result = main(_DEFAULT_ARGS)
-    assert result == 1
+    assert result == 0
 
 
-def test_main_unknown_agent(tmp_path: Path) -> None:
-    with _commit_environment(tmp_path):
+# --------------------------------------------------------------------------
+# Co-author auto-discovery
+# --------------------------------------------------------------------------
+
+
+def test_main_auto_discovery(tmp_path: Path) -> None:
+    commit_file_content = ""
+
+    def capture_run(*args: str) -> None:
+        nonlocal commit_file_content
+        if args[0] == "commit" and args[1] == "--file":
+            commit_file_content = Path(args[2]).read_text(encoding="utf-8")
+
+    with (
+        _commit_environment(tmp_path),
+        patch("vergil_tooling.bin.vrg_commit.git.run", side_effect=capture_run),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>",
+        ),
+    ):
         result = main(
-            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "nonexistent"]
+            ["--type", "feat", "--scope", "core", "--message", "add feature"]
         )
-    assert result == 1
+    assert result == 0
+    assert commit_file_content.startswith("feat(core): add feature\n")
+    assert "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>" in commit_file_content
+
+
+def test_main_agent_flag_prints_deprecation_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with (
+        _commit_environment(tmp_path),
+        patch("vergil_tooling.bin.vrg_commit.git.run"),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            return_value="Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>",
+        ),
+    ):
+        result = main(
+            ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "ignored"]
+        )
+    assert result == 0
+    err = capsys.readouterr().err
+    assert "deprecated" in err.lower()
 
 
 # --------------------------------------------------------------------------
@@ -229,7 +275,7 @@ def test_main_unknown_agent(tmp_path: Path) -> None:
 # Reference: docs/specs/host-level-tool.md "Migration / vergil-tooling
 # itself" step 1; docs/plans/host-level-tool-plan.md Task 1.1.
 
-_DEFAULT_ARGS = ["--type", "feat", "--scope", "core", "--message", "test", "--agent", "agent"]
+_DEFAULT_ARGS = ["--type", "feat", "--scope", "core", "--message", "test"]
 
 
 # Check 1: detached HEAD

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -239,12 +239,11 @@ def test_main_auto_discovery(tmp_path: Path) -> None:
             return_value="Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>",
         ),
     ):
-        result = main(
-            ["--type", "feat", "--scope", "core", "--message", "add feature"]
-        )
+        result = main(["--type", "feat", "--scope", "core", "--message", "add feature"])
     assert result == 0
     assert commit_file_content.startswith("feat(core): add feature\n")
-    assert "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>" in commit_file_content
+    expected = "Co-Authored-By: jdoe-vergil <12345+jdoe-vergil@users.noreply.github.com>"
+    assert expected in commit_file_content
 
 
 def test_main_agent_flag_prints_deprecation_warning(
@@ -264,6 +263,23 @@ def test_main_agent_flag_prints_deprecation_warning(
     assert result == 0
     err = capsys.readouterr().err
     assert "deprecated" in err.lower()
+
+
+def test_main_resolve_failure_returns_1(tmp_path: Path) -> None:
+    with (
+        patch(
+            "vergil_tooling.bin.vrg_commit.git.current_branch",
+            return_value="feature/42-test",
+        ),
+        patch("vergil_tooling.bin.vrg_commit.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_commit.git.is_main_worktree", return_value=False),
+        patch(
+            "vergil_tooling.bin.vrg_commit.github.resolve_co_author_trailer",
+            side_effect=SystemExit(1),
+        ),
+    ):
+        result = main(_DEFAULT_ARGS)
+    assert result == 1
 
 
 # --------------------------------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -172,9 +172,9 @@ github.com
 
 
 def test_discover_accounts() -> None:
-    from vergil_tooling.bin.vrg_gh import _discover_accounts
+    from vergil_tooling.lib.github import _discover_accounts
 
-    with patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=_AUTH_STATUS_TWO_ACCOUNTS,
@@ -196,9 +196,9 @@ github.com
 
 
 def test_discover_accounts_deduplicates() -> None:
-    from vergil_tooling.bin.vrg_gh import _discover_accounts
+    from vergil_tooling.lib.github import _discover_accounts
 
-    with patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=_AUTH_STATUS_DUPLICATE_HUMAN,
@@ -222,9 +222,9 @@ github.com
 
 
 def test_discover_accounts_ignores_other_accounts() -> None:
-    from vergil_tooling.bin.vrg_gh import _discover_accounts
+    from vergil_tooling.lib.github import _discover_accounts
 
-    with patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=_AUTH_STATUS_MANY_ACCOUNTS,
@@ -244,10 +244,10 @@ github.com
 def test_discover_accounts_missing_vergil(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    from vergil_tooling.bin.vrg_gh import _discover_accounts
+    from vergil_tooling.lib.github import _discover_accounts
 
     with (
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
         pytest.raises(SystemExit),
     ):
         mock_run.return_value = MagicMock(

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -318,7 +318,6 @@ def _make_config() -> StConfig:
             branching_model="library-release",
             release_model="tagged-release",
             primary_language="python",
-            co_authors={},
         ),
         dependencies={"vergil": "v2.0"},
         markdownlint=MarkdownlintConfig(ignore=[]),

--- a/tests/vergil_tooling/test_vrg_repo_profile.py
+++ b/tests/vergil_tooling/test_vrg_repo_profile.py
@@ -20,9 +20,6 @@ branching-model = "library-release"
 release-model = "tagged-release"
 primary-language = "python"
 
-[project.co-authors]
-claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>"
-
 [dependencies]
 vergil = "v2.0"
 
@@ -59,16 +56,6 @@ def test_missing_field(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_invalid_enum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     toml = _VALID_TOML.replace('"library"', '"banana"')
-    _write_toml(tmp_path, toml)
-    assert main() == 1
-
-
-def test_malformed_co_author(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    toml = _VALID_TOML.replace(
-        'claude = "Co-Authored-By: user-claude <111+user-claude@users.noreply.github.com>"',
-        'claude = "not a trailer"',
-    )
     _write_toml(tmp_path, toml)
     assert main() == 1
 

--- a/vergil.toml
+++ b/vergil.toml
@@ -5,6 +5,9 @@ branching-model = "library-release"
 release-model = "tagged-release"
 primary-language = "python"
 
+[project.co-authors]
+wphillipmoore-vergil = "Co-Authored-By: wphillipmoore-vergil <285019742+wphillipmoore-vergil@users.noreply.github.com>"
+
 [publish]
 release = true
 docs = true

--- a/vergil.toml
+++ b/vergil.toml
@@ -5,9 +5,6 @@ branching-model = "library-release"
 release-model = "tagged-release"
 primary-language = "python"
 
-[project.co-authors]
-wphillipmoore-vergil = "Co-Authored-By: wphillipmoore-vergil <285019742+wphillipmoore-vergil@users.noreply.github.com>"
-
 [publish]
 release = true
 docs = true


### PR DESCRIPTION
# Pull Request

## Summary

- Replace [project.co-authors] config with runtime GitHub API resolution via gh auth status and /users/<agent> endpoint

## Issue Linkage

- Ref #725

## Notes

- ### What changed

- **`lib/github.py`**: Added `resolve_co_author_trailer()` — discovers the
  `-vergil` agent account from `gh auth status`, queries the GitHub API for
  its numeric user ID, and constructs the `Co-Authored-By` trailer dynamically.
- **`bin/vrg_commit.py`**: Replaced config-based co-author lookup with
  `github.resolve_co_author_trailer()`. Made `--agent` optional with a
  deprecation warning (value ignored).
- **`bin/vrg_gh.py`**: Removed local `_discover_accounts()` duplicate; now
  imports from `lib/github`.
- **`lib/config.py`**: Removed `co_authors` field from `ProjectConfig` and all
  co-author validation. Leftover `[project.co-authors]` sections in
  `vergil.toml` are silently ignored for backward compatibility.
- **`vergil.toml`**: Retained `[project.co-authors]` for bootstrapping — the
  host-installed `vrg-commit` still reads it until this release is published.
  Removal deferred to post-publish cleanup.

### Design decisions

- **Runtime resolution over static config**: eliminates per-repo maintenance of
  numeric GitHub user IDs and `Co-Authored-By` trailers.
- **`gh auth status` discovery**: reuses the existing multi-account convention
  (`-vergil` suffix) without requiring new configuration.
- **Deprecate `--agent`, don't remove**: avoids breaking callers that still pass
  the flag (including the currently-installed `vrg-commit`).
- **`[project.co-authors]` kept temporarily**: the bootstrapping problem — the
  host-installed `vrg-commit` predates this change — requires the section to
  remain until the new version is published and installed.

### Post-merge rollout

After this PR merges and a release is published:
1. Update host installs to the new version.
2. Remove `[project.co-authors]` from `vergil.toml` in all repos.
3. In a future release, remove the `--agent` flag entirely.