### PR TITLE
fix(github): hardcode co-author noreply ID while agent account is shadow-banned

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -47,16 +47,25 @@ def _discover_accounts() -> tuple[str, str]:
 def resolve_co_author_trailer() -> str:
     """Discover the agent account and return its ``Co-Authored-By`` trailer.
 
-    Queries the GitHub API for the agent's numeric user ID to construct
-    the noreply email that GitHub uses for commit attribution.
+    Workaround: hardcode the noreply trailer while the agent account is
+    flagged by GitHub (#799). The API lookup (gh api users/{agent}) fails
+    for shadow-banned accounts. Revert to the API-based approach when
+    GitHub support unflags the account.
     """
     _human, agent = _discover_accounts()
+    # Workaround (#799/#839): skip API lookup, use known noreply ID.
+    known_noreply: dict[str, int] = {
+        "wphillipmoore-vergil": 285019742,
+    }
+    uid = known_noreply.get(agent)
+    if uid is not None:
+        return f"Co-Authored-By: {agent} <{uid}+{agent}@users.noreply.github.com>"
     data = read_json("api", f"users/{agent}")
     if not isinstance(data, dict):
         msg = f"unexpected API response for users/{agent}"
         raise GitHubAPIError(1, f"gh api users/{agent}", msg)
-    uid = data["id"]
-    return f"Co-Authored-By: {agent} <{uid}+{agent}@users.noreply.github.com>"
+    api_uid = data["id"]
+    return f"Co-Authored-By: {agent} <{api_uid}+{agent}@users.noreply.github.com>"
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -605,7 +605,22 @@ class TestGhEnv:
 
 
 class TestResolveCoAuthorTrailer:
-    def test_constructs_trailer_from_api(self) -> None:
+    def test_known_agent_skips_api(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.github._discover_accounts",
+                return_value=("wphillipmoore", "wphillipmoore-vergil"),
+            ),
+            patch("vergil_tooling.lib.github.read_json") as mock_api,
+        ):
+            trailer = github.resolve_co_author_trailer()
+        mock_api.assert_not_called()
+        assert trailer == (
+            "Co-Authored-By: wphillipmoore-vergil "
+            "<285019742+wphillipmoore-vergil@users.noreply.github.com>"
+        )
+
+    def test_unknown_agent_falls_back_to_api(self) -> None:
         with (
             patch(
                 "vergil_tooling.lib.github._discover_accounts",


### PR DESCRIPTION
# Pull Request

## Summary

- Skip gh api users/ lookup for known agent accounts with hardcoded noreply IDs

## Issue Linkage

- Ref #839

## Notes

- Temporary workaround matching the _get_token pattern from #812. Falls back to API for unknown agents. Revert when GitHub unflags the account (#799).