### PR TITLE
feat(repo-config): add core.hooksPath audit check

### DIFF
--- a/docs/specs/2026-05-19-hooks-path-audit-check-design.md
+++ b/docs/specs/2026-05-19-hooks-path-audit-check-design.md
@@ -34,8 +34,12 @@ result = subprocess.run(
     ["git", "config", "core.hooksPath"],
     capture_output=True,
     text=True,
+    cwd=repo_root,
 )
 ```
+
+The `cwd=repo_root` ensures the query reads the correct repo's
+local config, not wherever the calling process happens to be.
 
 Compare `result.stdout.strip()` against `.githooks`. Emit a
 `DiffItem` when the value doesn't match:

--- a/docs/specs/2026-05-19-hooks-path-audit-check-plan.md
+++ b/docs/specs/2026-05-19-hooks-path-audit-check-plan.md
@@ -1,0 +1,271 @@
+# core.hooksPath Audit Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the repo audit tool to verify that `core.hooksPath` is configured to `.githooks` in local git config.
+
+**Architecture:** Add a `subprocess.run(["git", "config", "core.hooksPath"], ...)` call inside the existing `_check_githooks()` function in `repo_config.py`. The check fires only when `.githooks/pre-commit` already exists on disk. Non-zero exit codes or wrong values produce a `DiffItem` with field `local.git_config.hooks_path`.
+
+**Tech Stack:** Python 3.12+, subprocess (stdlib), pytest
+
+---
+
+## File Map
+
+- **Modify:** `src/vergil_tooling/lib/repo_config.py` — add `subprocess` import and extend `_check_githooks()`
+- **Modify:** `tests/vergil_tooling/test_repo_config.py` — add three new tests in `TestGithooks`, update `_write_compliant_repo()` and `TestIntegration`
+
+---
+
+### Task 1: Test — hooks_path not configured
+
+Add a test for the case where `.githooks/pre-commit` exists but no git repo is initialized (so `git config core.hooksPath` fails).
+
+**Files:**
+- Modify: `tests/vergil_tooling/test_repo_config.py` (inside `TestGithooks`, after line 76)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test method to the `TestGithooks` class, after the existing `test_present` method:
+
+```python
+def test_hooks_path_not_configured(self, tmp_path: Path) -> None:
+    (tmp_path / ".githooks").mkdir()
+    (tmp_path / ".githooks" / "pre-commit").write_text("#!/bin/sh\n")
+    diff = audit_local_config(tmp_path)
+    fields = {i.field for i in diff.items}
+    assert "local.git_config.hooks_path" in fields
+    match = next(i for i in diff.items if i.field == "local.git_config.hooks_path")
+    assert match.actual == "not configured"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py::TestGithooks::test_hooks_path_not_configured -v`
+
+Expected: FAIL — `local.git_config.hooks_path` is not in the diff because the check doesn't exist yet.
+
+- [ ] **Step 3: Implement the check**
+
+In `src/vergil_tooling/lib/repo_config.py`, add `subprocess` to the imports:
+
+```python
+import subprocess
+```
+
+Then extend `_check_githooks()` — the current function returns early when the file is missing. After the early return (when the file *does* exist), add the `core.hooksPath` check:
+
+```python
+def _check_githooks(repo_root: Path, items: list[DiffItem]) -> None:
+    hook_path = repo_root / ".githooks" / "pre-commit"
+    if not hook_path.is_file():
+        items.append(
+            DiffItem(
+                field="local.githooks_pre_commit",
+                expected="present",
+                actual="missing",
+            )
+        )
+        return
+
+    result = subprocess.run(
+        ["git", "config", "core.hooksPath"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    actual = result.stdout.strip()
+    if actual != ".githooks":
+        items.append(
+            DiffItem(
+                field="local.git_config.hooks_path",
+                expected=".githooks",
+                actual=actual or "not configured",
+            )
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py::TestGithooks::test_hooks_path_not_configured -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-commit --type feat --scope repo-config --message "add core.hooksPath audit check (#825)"
+```
+
+---
+
+### Task 2: Test — hooks_path wrong value
+
+Add a test for the case where `core.hooksPath` is configured but set to the wrong value.
+
+**Files:**
+- Modify: `tests/vergil_tooling/test_repo_config.py` (inside `TestGithooks`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test method to `TestGithooks`, after `test_hooks_path_not_configured`:
+
+```python
+def test_hooks_path_wrong_value(self, tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", "wrong/path"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    (tmp_path / ".githooks").mkdir()
+    (tmp_path / ".githooks" / "pre-commit").write_text("#!/bin/sh\n")
+    diff = audit_local_config(tmp_path)
+    fields = {i.field for i in diff.items}
+    assert "local.git_config.hooks_path" in fields
+    match = next(i for i in diff.items if i.field == "local.git_config.hooks_path")
+    assert match.actual == "wrong/path"
+```
+
+This test also needs `subprocess` imported at the top of the test file. Add to the imports:
+
+```python
+import subprocess
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+This test should pass immediately because the implementation from Task 1 already handles wrong values.
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py::TestGithooks::test_hooks_path_wrong_value -v`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+vrg-commit --type test --scope repo-config --message "add test for wrong core.hooksPath value"
+```
+
+---
+
+### Task 3: Test — hooks_path correctly configured
+
+Add a test for the happy path where `core.hooksPath` is set to `.githooks`.
+
+**Files:**
+- Modify: `tests/vergil_tooling/test_repo_config.py` (inside `TestGithooks`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test method to `TestGithooks`, after `test_hooks_path_wrong_value`:
+
+```python
+def test_hooks_path_configured(self, tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", ".githooks"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    (tmp_path / ".githooks").mkdir()
+    (tmp_path / ".githooks" / "pre-commit").write_text("#!/bin/sh\n")
+    diff = audit_local_config(tmp_path)
+    fields = {i.field for i in diff.items}
+    assert "local.git_config.hooks_path" not in fields
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+This should also pass immediately — the implementation already handles the matching case.
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py::TestGithooks::test_hooks_path_configured -v`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+vrg-commit --type test --scope repo-config --message "add test for correctly configured core.hooksPath"
+```
+
+---
+
+### Task 4: Update integration test
+
+The existing `_write_compliant_repo()` helper scaffolds a fully compliant repo, but it doesn't `git init` or set `core.hooksPath`. The new check will cause `test_compliant_repo` to fail. Fix by initializing a git repo and setting the config.
+
+**Files:**
+- Modify: `tests/vergil_tooling/test_repo_config.py` (`_write_compliant_repo()` at line 262, and `TestIntegration` at line 272)
+
+- [ ] **Step 1: Run the existing integration test to confirm it fails**
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py::TestIntegration::test_compliant_repo -v`
+
+Expected: FAIL — `local.git_config.hooks_path` will appear in the diff because `_write_compliant_repo()` doesn't set up git.
+
+- [ ] **Step 2: Update `_write_compliant_repo()` to initialize git**
+
+Replace the `_write_compliant_repo` function (line 262) with:
+
+```python
+def _write_compliant_repo(root: Path) -> None:
+    """Scaffold a fully compliant repo structure."""
+    subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", ".githooks"],
+        cwd=root,
+        capture_output=True,
+        check=True,
+    )
+    (root / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML)
+    (root / ".githooks").mkdir()
+    (root / ".githooks" / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+    (root / "CLAUDE.md").write_text("# CLAUDE.md\n\n" + _TEMPLATE_TEXT + "\n")
+    (root / ".claude").mkdir()
+    (root / ".claude" / "settings.json").write_text(json.dumps(_MINIMAL_SETTINGS))
+```
+
+- [ ] **Step 3: Update `test_empty_directory_reports_all_missing`**
+
+The empty-directory test (line 273) should also verify the new field is *not* reported for an empty directory — because `.githooks/pre-commit` doesn't exist, the conditional check should not fire. The existing assertions already cover this implicitly (the test checks for specific fields, not that no others appear), but add an explicit assertion to document the conditional behavior:
+
+After the existing assertions in `test_empty_directory_reports_all_missing`, add:
+
+```python
+assert "local.git_config.hooks_path" not in fields
+```
+
+- [ ] **Step 4: Run the full integration test class**
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py::TestIntegration -v`
+
+Expected: PASS — both `test_empty_directory_reports_all_missing` and `test_compliant_repo` pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-commit --type test --scope repo-config --message "update integration tests for core.hooksPath check"
+```
+
+---
+
+### Task 5: Full validation
+
+Run the complete validation pipeline to confirm nothing is broken.
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Run all repo_config tests**
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_repo_config.py -v`
+
+Expected: All tests pass, including the three new ones and the updated integration tests.
+
+- [ ] **Step 2: Run full validation**
+
+Run: `cd .worktrees/issue-825-hooks-path-audit && vrg-docker-run -- uv run vrg-validate`
+
+Expected: All checks pass (lint, typecheck, tests, audit).

--- a/docs/superpowers/specs/2026-05-19-hooks-path-audit-check-design.md
+++ b/docs/superpowers/specs/2026-05-19-hooks-path-audit-check-design.md
@@ -1,0 +1,110 @@
+# Design: Audit check for `core.hooksPath` configuration
+
+**Issue:** [#825](https://github.com/vergil-project/vergil-tooling/issues/825)
+**Date:** 2026-05-19
+**Scope:** Audit check only. The init-tool requirement (setting
+`core.hooksPath` during repo bootstrap) is tracked under
+[#807](https://github.com/vergil-project/vergil-tooling/issues/807).
+
+## Problem
+
+The repo audit tool checks whether `.githooks/pre-commit` exists on
+disk but has no way to verify that `core.hooksPath` is configured in
+local git config. Without that setting, git ignores the hook file
+entirely — the pre-commit gate is present but inactive.
+
+Discovered during the-infrastructure-mindset conversion (#823).
+
+## Design
+
+### Where the check lives
+
+Extend `_check_githooks()` in `src/vergil_tooling/lib/repo_config.py`.
+The check fires conditionally: only when `.githooks/pre-commit`
+exists on disk. If the hook file is missing, that diagnostic is
+sufficient — reporting "hooksPath not configured" on top of
+"hook file missing" is redundant noise.
+
+### How the check works
+
+After confirming `.githooks/pre-commit` exists, run:
+
+```python
+result = subprocess.run(
+    ["git", "config", "core.hooksPath"],
+    capture_output=True,
+    text=True,
+)
+```
+
+Compare `result.stdout.strip()` against `.githooks`. Emit a
+`DiffItem` when the value doesn't match:
+
+```python
+DiffItem(
+    field="local.git_config.hooks_path",
+    expected=".githooks",
+    actual=<stdout.strip() or "not configured">,
+)
+```
+
+Failure modes:
+- **Key unset** (rc=1, empty stdout): actual = `"not configured"`.
+- **Key set to wrong value**: actual = the wrong value.
+- **Not a git repo** (rc=128 or similar): treated the same as
+  unset. The audit tool runs from CWD which is expected to be a
+  git repo, but the check degrades gracefully.
+- **`git` not installed** (`FileNotFoundError`): propagates. A
+  genuine environment problem for any user of this tooling.
+
+### Field name
+
+`local.git_config.hooks_path` — establishes a `local.git_config.*`
+namespace for potential future git config checks without building
+any infrastructure for that now.
+
+### What doesn't change
+
+- **CLI layer** (`vrg_github_repo_config.py`): no changes.
+  `audit_local_config()` is called the same way.
+- **Data model** (`ConfigDiff`, `DiffItem`): unchanged. The
+  existing structure handles this naturally.
+- **`--repo` skip logic**: already prevents local checks from
+  running when CWD doesn't match the target repo.
+
+## Testing
+
+### New tests in `TestGithooks`
+
+1. **`test_hooks_path_not_configured`** — `.githooks/pre-commit`
+   exists, no git repo initialized (or key unset). Expects
+   `local.git_config.hooks_path` in the diff with
+   actual=`"not configured"`.
+
+2. **`test_hooks_path_wrong_value`** — `.githooks/pre-commit`
+   exists inside a `git init`'d repo with
+   `core.hooksPath` set to `wrong/path`. Expects
+   `local.git_config.hooks_path` in the diff with the wrong value.
+
+3. **`test_hooks_path_configured`** — `.githooks/pre-commit` exists
+   inside a `git init`'d repo with `core.hooksPath` set to
+   `.githooks`. Expects no `local.git_config.hooks_path` in the
+   diff.
+
+### Integration test update
+
+`_write_compliant_repo()` must be updated to `git init` the
+`tmp_path` and set `core.hooksPath` to `.githooks`. Without this,
+the existing `test_compliant_repo` test would fail because the new
+check fires on the scaffolded repo.
+
+## Implementation notes
+
+This is the first `subprocess` call in `repo_config.py` — the
+module was previously pure filesystem. `subprocess` is stdlib and
+the call is a simple read-only query, so this is a minimal change
+in character.
+
+Raw `git config` (not `vrg-git`) is correct here: this is a
+host-side audit tool reading local config, not an agent-context
+operation that needs wrapper enforcement.

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.resources
 import json
+import subprocess
 from typing import TYPE_CHECKING, Any
 
 from vergil_tooling.lib.config import ConfigError, read_config
@@ -97,6 +98,23 @@ def _check_githooks(repo_root: Path, items: list[DiffItem]) -> None:
                 field="local.githooks_pre_commit",
                 expected="present",
                 actual="missing",
+            )
+        )
+        return
+
+    result = subprocess.run(
+        ["git", "config", "core.hooksPath"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    actual = result.stdout.strip()
+    if actual != ".githooks":
+        items.append(
+            DiffItem(
+                field="local.git_config.hooks_path",
+                expected=".githooks",
+                actual=actual or "not configured",
             )
         )
 

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -102,8 +102,8 @@ def _check_githooks(repo_root: Path, items: list[DiffItem]) -> None:
         )
         return
 
-    result = subprocess.run(
-        ["git", "config", "core.hooksPath"],
+    result = subprocess.run(  # noqa: S603
+        ["git", "config", "core.hooksPath"],  # noqa: S607
         capture_output=True,
         text=True,
         cwd=repo_root,

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -86,9 +86,9 @@ class TestGithooks:
         assert match.actual == "not configured"
 
     def test_hooks_path_wrong_value(self, tmp_path: Path) -> None:
-        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "config", "core.hooksPath", "wrong/path"],
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)  # noqa: S603, S607
+        subprocess.run(  # noqa: S603
+            ["git", "config", "core.hooksPath", "wrong/path"],  # noqa: S607
             cwd=tmp_path,
             capture_output=True,
             check=True,
@@ -102,9 +102,9 @@ class TestGithooks:
         assert match.actual == "wrong/path"
 
     def test_hooks_path_configured(self, tmp_path: Path) -> None:
-        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "config", "core.hooksPath", ".githooks"],
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)  # noqa: S603, S607
+        subprocess.run(  # noqa: S603
+            ["git", "config", "core.hooksPath", ".githooks"],  # noqa: S607
             cwd=tmp_path,
             capture_output=True,
             check=True,
@@ -301,9 +301,9 @@ class TestClaudeSettings:
 
 def _write_compliant_repo(root: Path) -> None:
     """Scaffold a fully compliant repo structure."""
-    subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)
-    subprocess.run(
-        ["git", "config", "core.hooksPath", ".githooks"],
+    subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)  # noqa: S603, S607
+    subprocess.run(  # noqa: S603
+        ["git", "config", "core.hooksPath", ".githooks"],  # noqa: S607
         cwd=root,
         capture_output=True,
         check=True,

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -301,6 +301,13 @@ class TestClaudeSettings:
 
 def _write_compliant_repo(root: Path) -> None:
     """Scaffold a fully compliant repo structure."""
+    subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", ".githooks"],
+        cwd=root,
+        capture_output=True,
+        check=True,
+    )
     (root / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML)
     (root / ".githooks").mkdir()
     (root / ".githooks" / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
@@ -318,6 +325,7 @@ class TestIntegration:
         assert "local.githooks_pre_commit" in fields
         assert "local.claude_md" in fields
         assert "local.claude_settings" in fields
+        assert "local.git_config.hooks_path" not in fields
 
     def test_compliant_repo(self, tmp_path: Path) -> None:
         _write_compliant_repo(tmp_path)

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from vergil_tooling.lib.repo_config import audit_local_config
@@ -83,6 +84,22 @@ class TestGithooks:
         assert "local.git_config.hooks_path" in fields
         match = next(i for i in diff.items if i.field == "local.git_config.hooks_path")
         assert match.actual == "not configured"
+
+    def test_hooks_path_wrong_value(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "core.hooksPath", "wrong/path"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+        (tmp_path / ".githooks").mkdir()
+        (tmp_path / ".githooks" / "pre-commit").write_text("#!/bin/sh\n")
+        diff = audit_local_config(tmp_path)
+        fields = {i.field for i in diff.items}
+        assert "local.git_config.hooks_path" in fields
+        match = next(i for i in diff.items if i.field == "local.git_config.hooks_path")
+        assert match.actual == "wrong/path"
 
 
 class TestClaudeMd:

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -101,6 +101,20 @@ class TestGithooks:
         match = next(i for i in diff.items if i.field == "local.git_config.hooks_path")
         assert match.actual == "wrong/path"
 
+    def test_hooks_path_configured(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "core.hooksPath", ".githooks"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+        (tmp_path / ".githooks").mkdir()
+        (tmp_path / ".githooks" / "pre-commit").write_text("#!/bin/sh\n")
+        diff = audit_local_config(tmp_path)
+        fields = {i.field for i in diff.items}
+        assert "local.git_config.hooks_path" not in fields
+
 
 class TestClaudeMd:
     def test_missing_file(self, tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -75,6 +75,15 @@ class TestGithooks:
         fields = {i.field for i in diff.items}
         assert "local.githooks_pre_commit" not in fields
 
+    def test_hooks_path_not_configured(self, tmp_path: Path) -> None:
+        (tmp_path / ".githooks").mkdir()
+        (tmp_path / ".githooks" / "pre-commit").write_text("#!/bin/sh\n")
+        diff = audit_local_config(tmp_path)
+        fields = {i.field for i in diff.items}
+        assert "local.git_config.hooks_path" in fields
+        match = next(i for i in diff.items if i.field == "local.git_config.hooks_path")
+        assert match.actual == "not configured"
+
 
 class TestClaudeMd:
     def test_missing_file(self, tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add core.hooksPath audit check to repo config tool

## Issue Linkage

- Ref #825

## Notes

- Extends the repo audit tool (`vrg-github-repo-config audit`) to verify that
`core.hooksPath` is configured to `.githooks` in local git config. Without
this setting, the `.githooks/pre-commit` file exists on disk but git ignores
it entirely — the pre-commit gate is present but inactive.

The check fires conditionally: only when `.githooks/pre-commit` already exists.
If the hook file is missing, that diagnostic is sufficient.

The init-tool requirement (setting `core.hooksPath` during repo bootstrap) is
tracked separately under #807.

### Changes

- `src/vergil_tooling/lib/repo_config.py`: Added `subprocess` import and
  extended `_check_githooks()` to query `git config core.hooksPath` after
  confirming the hook file exists. Emits field `local.git_config.hooks_path`
  when the value doesn't match `.githooks`.
- `tests/vergil_tooling/test_repo_config.py`: Three new tests in
  `TestGithooks` (not configured, wrong value, correctly configured) and
  updated integration test helper `_write_compliant_repo()` to `git init`
  and set `core.hooksPath`.