### PR TITLE
chore(release): update next-cycle dependencies for v2.0.18

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15'",


### PR DESCRIPTION
# Pull Request

## Summary

- Refresh uv.lock after v2.0.18 release; all dev dependencies already at latest

## Issue Linkage

- Ref #855

## Notes

- -