### PR TITLE
chore(release): next-cycle dependency update for v2.0.20

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15'",


### PR DESCRIPTION
# Pull Request

## Summary

- Refresh dev dependency lock for v2.0.20 development cycle

## Issue Linkage

- Ref #864

## Notes

- Next-cycle dependency update for v2.0.20 development cycle.

Categories updated:
- Python dev dependencies: uv lock --upgrade (lock revision refresh, no version changes)
- GitHub Actions: already on floating v2.0 tag, no changes needed
- No Dockerfiles in this repository

Validation: 1039 tests pass, 100% coverage, all lints clean.