### PR TITLE
fix(wait-until-green): exit non-zero when PR is blocked by branch protection

### DIFF
--- a/docs/specs/2026-05-19-wait-until-green-merge-state-design.md
+++ b/docs/specs/2026-05-19-wait-until-green-merge-state-design.md
@@ -1,0 +1,58 @@
+# vrg-wait-until-green: merge-state awareness
+
+**Issue:** [#806](https://github.com/vergil-project/vergil-tooling/issues/806)
+**Date:** 2026-05-19
+
+## Problem
+
+`vrg-wait-until-green` reports "All checks passed" and exits 0 when CI
+checks are green but the PR is blocked by branch protection (required
+reviews, merge restrictions, etc.). The break condition (`merge_state_status
+!= "BEHIND"`) treats BLOCKED, DIRTY, UNSTABLE, and UNKNOWN as success.
+
+## Design
+
+### Exit code semantics
+
+Exit 0 only for CLEAN. All other non-BEHIND states exit 1 with a message
+that acknowledges CI passed but explains why the PR is not mergeable.
+
+| `mergeStateStatus` | Exit | Message |
+|---|---|---|
+| CLEAN | 0 | "All checks passed." |
+| BLOCKED | 1 | "All checks passed, but PR is not mergeable (BLOCKED)." + review context |
+| DIRTY | 1 | "All checks passed, but PR is not mergeable (DIRTY)." |
+| UNSTABLE | 1 | "All checks passed, but PR is not mergeable (UNSTABLE)." |
+| UNKNOWN | 1 | "All checks passed, but PR is not mergeable (UNKNOWN)." |
+
+For BLOCKED, query `reviewDecision` to provide additional context. Only
+print the review line when `reviewDecision` is actionable
+(`REVIEW_REQUIRED` or `CHANGES_REQUESTED`). If `reviewDecision` is
+`APPROVED`, empty, or null, omit the review line — the blocker is
+something other than reviews (signed commits, deployment gates, etc.).
+In all BLOCKED cases, append a generic hint: "Check branch protection
+settings."
+
+### Changes
+
+**`src/vergil_tooling/lib/github.py`** — add `merge_status(pr) -> dict`
+helper that returns `{"mergeStateStatus": ..., "reviewDecision": ...}` from
+a single `gh pr view --json mergeStateStatus,reviewDecision` call.
+
+**`src/vergil_tooling/bin/vrg_wait_until_green.py`** — after the loop
+breaks, call `merge_status()` instead of printing success unconditionally.
+If CLEAN, print success and exit 0. Otherwise, print a diagnostic message
+and exit 1.
+
+**`tests/vergil_tooling/test_vrg_wait_until_green.py`** — update
+`test_main_succeeds_for_non_behind_states` so only CLEAN is success.
+Add tests for BLOCKED with/without review context. Add tests for DIRTY,
+UNSTABLE, UNKNOWN exiting non-zero.
+
+### Scope exclusions
+
+- `vrg-merge-when-green` shares the same loop but is not in scope. It will
+  fail at the merge step anyway if the PR is blocked. Can be addressed
+  separately.
+- No shared loop extraction. The duplication is small and a refactor is not
+  warranted by this bug fix.

--- a/docs/specs/2026-05-19-wait-until-green-merge-state-plan.md
+++ b/docs/specs/2026-05-19-wait-until-green-merge-state-plan.md
@@ -1,0 +1,318 @@
+# vrg-wait-until-green merge-state awareness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `vrg-wait-until-green` exit non-zero when CI checks pass but the PR is blocked by branch protection, instead of falsely reporting success.
+
+**Architecture:** Add a `merge_status()` helper to `github.py` that fetches `mergeStateStatus` and `reviewDecision` in one API call. Replace the unconditional "All checks passed" in `vrg_wait_until_green.py` with a post-loop merge-state check that exits 0 only for CLEAN.
+
+**Tech Stack:** Python 3.12+, `gh` CLI, `unittest.mock`
+
+---
+
+### Task 1: Add `merge_status()` helper to `github.py`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/github.py:267-277`
+- Test: `tests/vergil_tooling/test_github.py`
+
+- [ ] **Step 1: Write the failing test for `merge_status()`**
+
+Add this test after the existing `test_merge_state_status_returns_behind` test (line 123) in `tests/vergil_tooling/test_github.py`:
+
+```python
+def test_merge_status_returns_both_fields() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_json",
+        return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": "REVIEW_REQUIRED"},
+    ):
+        result = github.merge_status("https://github.com/pr/1")
+    assert result == {"mergeStateStatus": "BLOCKED", "reviewDecision": "REVIEW_REQUIRED"}
+
+
+def test_merge_status_with_empty_review_decision() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_json",
+        return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": ""},
+    ):
+        result = github.merge_status("https://github.com/pr/1")
+    assert result == {"mergeStateStatus": "BLOCKED", "reviewDecision": ""}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py::test_merge_status_returns_both_fields tests/vergil_tooling/test_github.py::test_merge_status_with_empty_review_decision -v`
+Expected: FAIL — `module 'vergil_tooling.lib.github' has no attribute 'merge_status'`
+
+- [ ] **Step 3: Implement `merge_status()` in `github.py`**
+
+Add after the existing `merge_state_status()` function (after line 277) in `src/vergil_tooling/lib/github.py`:
+
+```python
+def merge_status(pr: str) -> dict[str, str]:
+    """Return merge state and review decision for a PR.
+
+    Single API call returning ``{"mergeStateStatus": ..., "reviewDecision": ...}``.
+    """
+    result = read_json(
+        "pr",
+        "view",
+        pr,
+        "--json",
+        "mergeStateStatus,reviewDecision",
+    )
+    assert isinstance(result, dict)
+    state = str(result.get("mergeStateStatus", ""))
+    review = result.get("reviewDecision")
+    return {"mergeStateStatus": state, "reviewDecision": str(review) if review else ""}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_github.py::test_merge_status_returns_both_fields tests/vergil_tooling/test_github.py::test_merge_status_with_empty_review_decision -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-806-merge-state && vrg-commit -m "feat(github): add merge_status() helper for combined merge state and review decision query"
+```
+
+---
+
+### Task 2: Update `vrg_wait_until_green.py` to check merge state after loop
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_wait_until_green.py:40-52`
+- Test: `tests/vergil_tooling/test_vrg_wait_until_green.py`
+
+- [ ] **Step 1: Write the failing test — CLEAN still exits 0**
+
+Replace the existing `test_main_happy_path_not_behind` test in `tests/vergil_tooling/test_vrg_wait_until_green.py` to also mock `merge_status`:
+
+```python
+def test_main_happy_path_not_behind() -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 0
+    mock_wait.assert_called_once_with(_PR)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_wait_until_green.py::test_main_happy_path_not_behind -v`
+Expected: FAIL — `merge_status` not patched / not called in the code yet
+
+- [ ] **Step 3: Write the failing tests — non-CLEAN states exit 1**
+
+Replace the existing `test_main_succeeds_for_non_behind_states` with separate tests in `tests/vergil_tooling/test_vrg_wait_until_green.py`:
+
+```python
+def test_main_succeeds_only_for_clean() -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
+        patch(f"{_MOD}.github.update_branch") as mock_update,
+    ):
+        result = main([_PR])
+    assert result == 0
+    mock_update.assert_not_called()
+
+
+def test_main_fails_for_blocked_with_review_required(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BLOCKED"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": "REVIEW_REQUIRED"},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "BLOCKED" in err
+    assert "REVIEW_REQUIRED" in err
+    assert "branch protection" in err.lower()
+
+
+def test_main_fails_for_blocked_without_actionable_review(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BLOCKED"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": "APPROVED"},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "BLOCKED" in err
+    assert "APPROVED" not in err
+    assert "branch protection" in err.lower()
+
+
+def test_main_fails_for_dirty(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="DIRTY"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "DIRTY", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "DIRTY" in capsys.readouterr().err
+
+
+def test_main_fails_for_unstable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="UNSTABLE"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "UNSTABLE", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "UNSTABLE" in capsys.readouterr().err
+
+
+def test_main_fails_for_unknown(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="UNKNOWN"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "UNKNOWN", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "UNKNOWN" in capsys.readouterr().err
+```
+
+- [ ] **Step 4: Run the new tests to confirm they fail**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_wait_until_green.py -k "blocked or dirty or unstable or unknown or succeeds_only" -v`
+Expected: FAIL — the current code exits 0 for all non-BEHIND states
+
+- [ ] **Step 5: Implement the merge-state check in `vrg_wait_until_green.py`**
+
+Replace lines 40–52 (from `if github.merge_state_status` through `return 0`) in `src/vergil_tooling/bin/vrg_wait_until_green.py`:
+
+```python
+        if github.merge_state_status(args.pr) != "BEHIND":
+            break
+        updates += 1
+        if updates > _MAX_BRANCH_UPDATES:
+            print(
+                "Branch still behind after multiple updates — giving up.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Branch is behind base — updating and re-checking...")
+        github.update_branch(args.pr)
+    status = github.merge_status(args.pr)
+    if status["mergeStateStatus"] == "CLEAN":
+        print("All checks passed.")
+        return 0
+    state = status["mergeStateStatus"]
+    print(
+        f"All checks passed, but PR is not mergeable ({state}).",
+        file=sys.stderr,
+    )
+    if state == "BLOCKED":
+        review = status["reviewDecision"]
+        if review in ("REVIEW_REQUIRED", "CHANGES_REQUESTED"):
+            print(f"  Review status: {review}", file=sys.stderr)
+        print("  Check branch protection settings.", file=sys.stderr)
+    return 1
+```
+
+- [ ] **Step 6: Run all wait-until-green tests**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_wait_until_green.py -v`
+Expected: PASS for all tests
+
+- [ ] **Step 7: Update tests that now need `merge_status` mocked**
+
+The following existing tests call `main()` and reach the post-loop code, so they need `merge_status` patched:
+
+- `test_main_updates_branch_when_behind` — final loop iteration exits with CLEAN
+- `test_main_updates_branch_multiple_times` — final loop iteration exits with CLEAN
+
+Update both to add the `merge_status` mock:
+
+In `test_main_updates_branch_when_behind`, add inside the `with` block:
+```python
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
+```
+
+In `test_main_updates_branch_multiple_times`, add the same mock.
+
+- [ ] **Step 8: Run full test suite to verify everything passes**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run pytest tests/vergil_tooling/test_vrg_wait_until_green.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd .worktrees/issue-806-merge-state && vrg-commit -m "fix(wait-until-green): exit non-zero when PR is blocked by branch protection (#806)"
+```
+
+---
+
+### Task 3: Run full validation
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Run `vrg-validate`**
+
+Run: `cd .worktrees/issue-806-merge-state && vrg-docker-run -- uv run vrg-validate`
+Expected: All checks pass, 100% coverage maintained
+
+- [ ] **Step 2: Fix any issues**
+
+If linting, type checking, or coverage failures occur, fix them and re-run.
+
+- [ ] **Step 3: Commit fixes if any**
+
+```bash
+cd .worktrees/issue-806-merge-state && vrg-commit -m "style: fix lint/type issues from merge-state changes"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vergil-tooling"
-version = "2.0.21"
+version = "2.0.20"
 description = "VERGIL — Validation Engine for Repository Governance, Integration & Lifecycle"
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vergil-tooling"
-version = "2.0.20"
+version = "2.0.21"
 description = "VERGIL — Validation Engine for Repository Governance, Integration & Lifecycle"
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"

--- a/src/vergil_tooling/bin/vrg_wait_until_green.py
+++ b/src/vergil_tooling/bin/vrg_wait_until_green.py
@@ -48,8 +48,21 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         print("Branch is behind base — updating and re-checking...")
         github.update_branch(args.pr)
-    print("All checks passed.")
-    return 0
+    status = github.merge_status(args.pr)
+    if status["mergeStateStatus"] == "CLEAN":
+        print("All checks passed.")
+        return 0
+    state = status["mergeStateStatus"]
+    print(
+        f"All checks passed, but PR is not mergeable ({state}).",
+        file=sys.stderr,
+    )
+    if state == "BLOCKED":
+        review = status["reviewDecision"]
+        if review in ("REVIEW_REQUIRED", "CHANGES_REQUESTED"):
+            print(f"  Review status: {review}", file=sys.stderr)
+        print("  Check branch protection settings.", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -277,6 +277,24 @@ def merge_state_status(pr: str) -> str:
     )
 
 
+def merge_status(pr: str) -> dict[str, str]:
+    """Return merge state and review decision for a PR.
+
+    Single API call returning ``{"mergeStateStatus": ..., "reviewDecision": ...}``.
+    """
+    result = read_json(
+        "pr",
+        "view",
+        pr,
+        "--json",
+        "mergeStateStatus,reviewDecision",
+    )
+    assert isinstance(result, dict)
+    state = str(result.get("mergeStateStatus", ""))
+    review = result.get("reviewDecision")
+    return {"mergeStateStatus": state, "reviewDecision": str(review) if review else ""}
+
+
 def current_repo() -> str:
     """Return ``OWNER/REPO`` for the current directory's git remote."""
     return read_output("repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -289,7 +289,9 @@ def merge_status(pr: str) -> dict[str, str]:
         "--json",
         "mergeStateStatus,reviewDecision",
     )
-    assert isinstance(result, dict)
+    if not isinstance(result, dict):
+        msg = f"unexpected API response for pr view {pr}"
+        raise GitHubAPIError(1, f"gh pr view {pr}", msg)
     state = str(result.get("mergeStateStatus", ""))
     review = result.get("reviewDecision")
     return {"mergeStateStatus": state, "reviewDecision": str(review) if review else ""}

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -141,6 +141,14 @@ def test_merge_status_with_empty_review_decision() -> None:
     assert result == {"mergeStateStatus": "BLOCKED", "reviewDecision": ""}
 
 
+def test_merge_status_raises_on_non_dict_response() -> None:
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        pytest.raises(github.GitHubAPIError),
+    ):
+        github.merge_status("https://github.com/pr/1")
+
+
 def test_update_branch_calls_api() -> None:
     with patch(
         "vergil_tooling.lib.github.read_output",

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -123,6 +123,24 @@ def test_merge_state_status_returns_behind() -> None:
         assert github.merge_state_status("https://github.com/pr/1") == "BEHIND"
 
 
+def test_merge_status_returns_both_fields() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_json",
+        return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": "REVIEW_REQUIRED"},
+    ):
+        result = github.merge_status("https://github.com/pr/1")
+    assert result == {"mergeStateStatus": "BLOCKED", "reviewDecision": "REVIEW_REQUIRED"}
+
+
+def test_merge_status_with_empty_review_decision() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_json",
+        return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": ""},
+    ):
+        result = github.merge_status("https://github.com/pr/1")
+    assert result == {"mergeStateStatus": "BLOCKED", "reviewDecision": ""}
+
+
 def test_update_branch_calls_api() -> None:
     with patch(
         "vergil_tooling.lib.github.read_output",

--- a/tests/vergil_tooling/test_vrg_wait_until_green.py
+++ b/tests/vergil_tooling/test_vrg_wait_until_green.py
@@ -23,6 +23,10 @@ def test_main_happy_path_not_behind() -> None:
         patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
         patch(f"{_MOD}.github.wait_for_checks") as mock_wait,
         patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
     ):
         result = main([_PR])
     assert result == 0
@@ -48,6 +52,10 @@ def test_main_updates_branch_when_behind() -> None:
             side_effect=["BEHIND", "CLEAN"],
         ),
         patch(f"{_MOD}.github.update_branch") as mock_update,
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
     ):
         result = main([_PR])
     assert result == 0
@@ -64,6 +72,10 @@ def test_main_updates_branch_multiple_times() -> None:
             side_effect=["BEHIND", "BEHIND", "CLEAN"],
         ),
         patch(f"{_MOD}.github.update_branch") as mock_update,
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
     ):
         result = main([_PR])
     assert result == 0
@@ -83,17 +95,111 @@ def test_main_gives_up_after_max_updates() -> None:
     assert result == 1
 
 
-def test_main_succeeds_for_non_behind_states() -> None:
-    for status in ("CLEAN", "DIRTY", "BLOCKED", "UNSTABLE", "UNKNOWN"):
-        with (
-            patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
-            patch(f"{_MOD}.github.wait_for_checks"),
-            patch(f"{_MOD}.github.merge_state_status", return_value=status),
-            patch(f"{_MOD}.github.update_branch") as mock_update,
-        ):
-            result = main([_PR])
-        assert result == 0, f"Expected success for status {status}"
-        mock_update.assert_not_called()
+def test_main_succeeds_only_for_clean() -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "CLEAN", "reviewDecision": ""},
+        ),
+        patch(f"{_MOD}.github.update_branch") as mock_update,
+    ):
+        result = main([_PR])
+    assert result == 0
+    mock_update.assert_not_called()
+
+
+def test_main_fails_for_blocked_with_review_required(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BLOCKED"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": "REVIEW_REQUIRED"},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "BLOCKED" in err
+    assert "REVIEW_REQUIRED" in err
+    assert "branch protection" in err.lower()
+
+
+def test_main_fails_for_blocked_without_actionable_review(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="BLOCKED"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "BLOCKED", "reviewDecision": "APPROVED"},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "BLOCKED" in err
+    assert "APPROVED" not in err
+    assert "branch protection" in err.lower()
+
+
+def test_main_fails_for_dirty(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="DIRTY"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "DIRTY", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "DIRTY" in capsys.readouterr().err
+
+
+def test_main_fails_for_unstable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="UNSTABLE"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "UNSTABLE", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "UNSTABLE" in capsys.readouterr().err
+
+
+def test_main_fails_for_unknown(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.github.mergeable", return_value="MERGEABLE"),
+        patch(f"{_MOD}.github.wait_for_checks"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="UNKNOWN"),
+        patch(
+            f"{_MOD}.github.merge_status",
+            return_value={"mergeStateStatus": "UNKNOWN", "reviewDecision": ""},
+        ),
+    ):
+        result = main([_PR])
+    assert result == 1
+    assert "UNKNOWN" in capsys.readouterr().err
 
 
 def test_main_fails_fast_on_merge_conflicts(


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-wait-until-green now distinguishes CI-green from merge-ready, exiting non-zero when mergeStateStatus is not CLEAN

## Issue Linkage

- Ref #806

## Notes

- Adds a merge_status() helper to github.py that fetches mergeStateStatus and
reviewDecision in a single API call. After the CI-polling loop completes,
vrg-wait-until-green checks the merge state: exit 0 only for CLEAN, exit 1
for BLOCKED/DIRTY/UNSTABLE/UNKNOWN with a diagnostic message. For BLOCKED,
surfaces actionable review context (REVIEW_REQUIRED or CHANGES_REQUESTED)
and a generic branch-protection hint.

Key changes:
- src/vergil_tooling/lib/github.py: new merge_status() function
- src/vergil_tooling/bin/vrg_wait_until_green.py: post-loop merge-state check
- tests: 8 new tests replacing the old catch-all, 100% coverage maintained