### PR TITLE
fix(release-tooling): support all merge strategies and add --pr flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vergil-tooling"
-version = "2.0.20"
+version = "2.0.21"
 description = "VERGIL — Validation Engine for Repository Governance, Integration & Lifecycle"
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"

--- a/src/vergil_tooling/bin/vrg_resolve_tracking_issue.py
+++ b/src/vergil_tooling/bin/vrg_resolve_tracking_issue.py
@@ -1,9 +1,17 @@
-"""Extract the release tracking issue number from a merge commit.
+"""Extract the release tracking issue number from a PR on main.
 
-Given a merge commit on main (typically HEAD in a CD workflow), this
-tool extracts the PR number from the commit subject, reads the PR
-body via the GitHub API, and prints the tracking issue number found
-in the ``Ref #N`` linkage pattern.
+Given a commit (typically HEAD on main in a CD workflow), this tool
+determines the associated PR number, reads the PR body via the GitHub
+API, and prints the tracking issue number found in the ``Ref #N``
+linkage pattern.
+
+PR discovery uses three strategies in order:
+
+1. Merge-commit pattern: ``Merge pull request #N from ...``
+2. Squash-merge pattern: ``description (#N)``
+3. GitHub API fallback: ``repos/{owner}/{repo}/commits/{sha}/pulls``
+
+The ``--pr`` flag bypasses commit parsing entirely.
 
 Consumed by the ``version-bump-pr`` composite action in vergil-actions.
 """
@@ -11,14 +19,17 @@ Consumed by the ``version-bump-pr`` composite action in vergil-actions.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import re
 import subprocess
 import sys
+from typing import cast
 
 from vergil_tooling.lib import git, github
 from vergil_tooling.lib.linkage import extract_tracking_issue
 
 _MERGE_PR_RE = re.compile(r"^Merge pull request #(\d+) from ")
+_SQUASH_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -28,46 +39,52 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--commit",
         default="HEAD",
-        help="Merge commit to inspect (default: HEAD)",
+        help="Commit to inspect (default: HEAD)",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="PR number (bypasses commit parsing)",
     )
     return parser.parse_args(argv)
 
 
 def _extract_pr_number(subject: str) -> int | None:
     m = _MERGE_PR_RE.match(subject)
-    return int(m.group(1)) if m else None
+    if m:
+        return int(m.group(1))
+    m = _SQUASH_PR_RE.search(subject)
+    if m:
+        return int(m.group(1))
+    return None
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
+def _pr_from_api(commit: str) -> int | None:
+    repo = github.current_repo()
+    sha = git.read_output("rev-parse", commit)
+    result = github.read_json("api", f"repos/{repo}/commits/{sha}/pulls")
+    if not isinstance(result, list):
+        return None
+    prs = cast("list[dict[str, object]]", [p for p in result if isinstance(p, dict)])
+    for pr in prs:
+        if pr.get("merged_at"):
+            num = pr.get("number")
+            if isinstance(num, int):
+                return num
+    if prs:
+        num = prs[0].get("number")
+        if isinstance(num, int):
+            return num
+    return None
 
-    try:
-        subject = git.read_output("log", "-1", "--format=%s", args.commit)
-    except subprocess.CalledProcessError as exc:
-        print(
-            f"ERROR: failed to read commit {args.commit}: {exc}",
-            file=sys.stderr,
-        )
-        return 2
 
-    pr_num = _extract_pr_number(subject)
-    if pr_num is None:
-        print(
-            f"ERROR: commit {args.commit} is not a merge commit "
-            "(expected 'Merge pull request #N from ...' "
-            "— squash and rebase merges are not supported)",
-            file=sys.stderr,
-        )
-        return 1
-
+def _resolve_from_pr(pr_num: int) -> int:
     try:
         repo = github.current_repo()
         pr_data = github.read_json("api", f"repos/{repo}/pulls/{pr_num}")
     except subprocess.CalledProcessError as exc:
-        print(
-            f"ERROR: failed to fetch PR #{pr_num}: {exc}",
-            file=sys.stderr,
-        )
+        print(f"ERROR: failed to fetch PR #{pr_num}: {exc}", file=sys.stderr)
         return 2
 
     if not isinstance(pr_data, dict):
@@ -82,10 +99,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         issue_num = extract_tracking_issue(body)
     except ValueError as exc:
-        print(
-            f"ERROR: PR #{pr_num} body has {exc}",
-            file=sys.stderr,
-        )
+        print(f"ERROR: PR #{pr_num} body has {exc}", file=sys.stderr)
         return 1
 
     if issue_num is None:
@@ -97,6 +111,40 @@ def main(argv: list[str] | None = None) -> int:
 
     print(issue_num)
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.pr is not None:
+        return _resolve_from_pr(args.pr)
+
+    try:
+        subject = git.read_output("log", "-1", "--format=%s", args.commit)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"ERROR: failed to read commit {args.commit}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    pr_num = _extract_pr_number(subject)
+
+    if pr_num is None:
+        with contextlib.suppress(subprocess.CalledProcessError):
+            pr_num = _pr_from_api(args.commit)
+
+    if pr_num is None:
+        print(
+            f"ERROR: cannot determine PR for commit {args.commit}. "
+            f"Subject: {subject!r}. "
+            "Tried: merge-commit pattern, squash-merge pattern, GitHub API lookup. "
+            "Use --pr N to specify the PR number directly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return _resolve_from_pr(pr_num)
 
 
 if __name__ == "__main__":

--- a/tests/vergil_tooling/test_vrg_resolve_tracking_issue.py
+++ b/tests/vergil_tooling/test_vrg_resolve_tracking_issue.py
@@ -6,17 +6,27 @@ import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from vergil_tooling.bin.vrg_resolve_tracking_issue import main, parse_args
+from vergil_tooling.bin.vrg_resolve_tracking_issue import (
+    _extract_pr_number,
+    main,
+    parse_args,
+)
 
 if TYPE_CHECKING:
     import pytest
 
 _MOD = "vergil_tooling.bin.vrg_resolve_tracking_issue"
 
+_PR_BODY_WITH_REF = {"body": "## Summary\n\nRef #100\n"}
+
+
+# --- parse_args ---
+
 
 def test_parse_args_defaults() -> None:
     args = parse_args([])
     assert args.commit == "HEAD"
+    assert args.pr is None
 
 
 def test_parse_args_custom_commit() -> None:
@@ -24,17 +34,46 @@ def test_parse_args_custom_commit() -> None:
     assert args.commit == "abc123"
 
 
-def test_happy_path(capsys: pytest.CaptureFixture[str]) -> None:
+def test_parse_args_pr_flag() -> None:
+    args = parse_args(["--pr", "42"])
+    assert args.pr == 42
+
+
+# --- _extract_pr_number ---
+
+
+def test_extract_merge_commit() -> None:
+    assert _extract_pr_number("Merge pull request #42 from org/branch") == 42
+
+
+def test_extract_squash_merge() -> None:
+    assert _extract_pr_number("feat: add widget (#99)") == 99
+
+
+def test_extract_squash_merge_trailing_whitespace() -> None:
+    assert _extract_pr_number("fix: bug (#7) ") == 7
+
+
+def test_extract_no_match() -> None:
+    assert _extract_pr_number("chore: bump version to 2.0.21") is None
+
+
+def test_extract_merge_takes_priority_over_squash() -> None:
+    subject = "Merge pull request #10 from org/feat (#20)"
+    assert _extract_pr_number(subject) == 10
+
+
+# --- main: merge commit (existing happy path) ---
+
+
+def test_happy_path_merge_commit(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(
             f"{_MOD}.git.read_output",
             return_value="Merge pull request #42 from org/release/1.0.0",
         ),
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
-        patch(
-            f"{_MOD}.github.read_json",
-            return_value={"body": "## Summary\n\nRef #100\n"},
-        ),
+        patch(f"{_MOD}.github.read_json", return_value=_PR_BODY_WITH_REF),
     ):
         result = main([])
     assert result == 0
@@ -54,11 +93,139 @@ def test_commit_arg_forwarded() -> None:
     mock_git.assert_called_once_with("log", "-1", "--format=%s", "abc123")
 
 
-def test_not_a_merge_commit(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch(f"{_MOD}.git.read_output", return_value="feat: add widget"):
+# --- main: squash merge ---
+
+
+def test_happy_path_squash_merge(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.git.read_output", return_value="feat: add widget (#42)"),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.read_json", return_value=_PR_BODY_WITH_REF),
+    ):
+        result = main([])
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "100"
+
+
+# --- main: --pr flag ---
+
+
+def test_pr_flag_bypasses_commit_parsing(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.read_json", return_value=_PR_BODY_WITH_REF),
+    ):
+        result = main(["--pr", "42"])
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "100"
+
+
+# --- main: API fallback ---
+
+
+def test_api_fallback_when_no_pattern_matches(capsys: pytest.CaptureFixture[str]) -> None:
+    api_response = [{"number": 42, "merged_at": "2026-01-01T00:00:00Z"}]
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", "abc123sha"]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.github.read_json",
+            side_effect=[api_response, _PR_BODY_WITH_REF],
+        ),
+    ):
+        result = main([])
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "100"
+
+
+def test_api_fallback_prefers_merged_pr(capsys: pytest.CaptureFixture[str]) -> None:
+    api_response = [
+        {"number": 10, "merged_at": None},
+        {"number": 42, "merged_at": "2026-01-01T00:00:00Z"},
+    ]
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", "abc123sha"]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.github.read_json",
+            side_effect=[api_response, _PR_BODY_WITH_REF],
+        ),
+    ):
+        result = main([])
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "100"
+
+
+def test_api_fallback_uses_first_pr_if_none_merged(capsys: pytest.CaptureFixture[str]) -> None:
+    api_response = [{"number": 55, "merged_at": None}]
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", "abc123sha"]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.github.read_json",
+            side_effect=[api_response, _PR_BODY_WITH_REF],
+        ),
+    ):
+        result = main([])
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "100"
+
+
+def test_api_fallback_empty_list_reports_all_strategies(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", "abc123sha"]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.read_json", return_value=[]),
+    ):
         result = main([])
     assert result == 1
-    assert "not a merge commit" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "merge-commit pattern" in err
+    assert "squash-merge pattern" in err
+    assert "GitHub API lookup" in err
+    assert "--pr N" in err
+
+
+def test_api_fallback_non_list_response(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", "abc123sha"]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.read_json", return_value={"message": "not a list"}),
+    ):
+        result = main([])
+    assert result == 1
+    assert "cannot determine PR" in capsys.readouterr().err
+
+
+def test_api_fallback_non_int_number(capsys: pytest.CaptureFixture[str]) -> None:
+    api_response = [{"number": "not-an-int", "merged_at": "2026-01-01T00:00:00Z"}]
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", "abc123sha"]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.read_json", return_value=api_response),
+    ):
+        result = main([])
+    assert result == 1
+    assert "cannot determine PR" in capsys.readouterr().err
+
+
+def test_api_fallback_error_still_reports_strategies(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    api_err = subprocess.CalledProcessError(returncode=1, cmd=["gh"], stderr="fail")
+    with (
+        patch(f"{_MOD}.git.read_output", side_effect=["chore: bump version", api_err]),
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+    ):
+        result = main([])
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "cannot determine PR" in err
+
+
+# --- main: error paths ---
 
 
 def test_empty_pr_body(capsys: pytest.CaptureFixture[str]) -> None:
@@ -139,7 +306,6 @@ def test_gh_api_failure(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_integration_fixture_merge_commit(capsys: pytest.CaptureFixture[str]) -> None:
-    """Full main() with fixture data matching a real merge commit pattern."""
     commit_subject = "Merge pull request #856 from vergil-project/release/2.0.18"
     pr_body = (
         "## Release 2.0.18\n\n"
@@ -178,5 +344,16 @@ def test_git_failure(capsys: pytest.CaptureFixture[str]) -> None:
     err = subprocess.CalledProcessError(returncode=128, cmd=["git", "log"], stderr="bad revision")
     with patch(f"{_MOD}.git.read_output", side_effect=err):
         result = main([])
+    assert result == 2
+    assert "failed to" in capsys.readouterr().err.lower()
+
+
+def test_pr_flag_api_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    err = subprocess.CalledProcessError(returncode=1, cmd=["gh", "api"], stderr="Not Found")
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.read_json", side_effect=err),
+    ):
+        result = main(["--pr", "42"])
     assert result == 2
     assert "failed to" in capsys.readouterr().err.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -835,7 +835,7 @@ wheels = [
 
 [[package]]
 name = "vergil-tooling"
-version = "2.0.20"
+version = "2.0.21"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Pull Request

## Summary

- Support all merge strategies in vrg-resolve-tracking-issue and add --pr bypass flag

## Issue Linkage

- Ref #872

## Notes

- vrg-resolve-tracking-issue failed in the v2.0.20 CD release workflow because the version-bump-pr action calls it after HEAD has moved past the merge commit on main. The tool now uses three strategies to find the associated PR:

1. Merge-commit pattern (Merge pull request #N from ...)
2. Squash-merge pattern (description (#N))
3. GitHub API fallback (repos/{owner}/{repo}/commits/{sha}/pulls)

Additionally, a --pr flag allows callers to specify the PR number directly, bypassing commit parsing.

The companion fix in vergil-actions should update version-bump-pr to pass --commit origin/main or --pr N.