### PR TITLE
feat(vrg-gh): escalate issue close to human credentials

### DIFF
--- a/docs/site/docs/guides/credential-management.md
+++ b/docs/site/docs/guides/credential-management.md
@@ -138,6 +138,9 @@ command and its context pass validation:
   merging to `main`, back-merge from `main` to `develop`).
 - **Approval:** Allowed under the human account only for release
   PRs authored by `vergil-release[bot]`.
+- **Issue close:** Allowed under the human account. The agent
+  account may lack the `CloseIssue` GraphQL permission as an
+  outside collaborator; escalating avoids this dependency.
 - **Other admin operations:** Denied entirely.
 
 Escalation requires both a permitted command and a validated

--- a/docs/site/docs/guides/permission-model.md
+++ b/docs/site/docs/guides/permission-model.md
@@ -87,7 +87,7 @@ second-level subcommands as a pair.
 |---|---|
 | `issue view` | Read-only |
 | `issue create` | Issue tracking |
-| `issue close` | Post-finalization closure |
+| `issue close` | Post-finalization closure (escalates to human credentials) |
 | `issue edit` | Updating metadata |
 | `issue list` | Read-only |
 | `issue comment` | Adding comments |

--- a/docs/specs/2026-05-14-credential-management-design.md
+++ b/docs/specs/2026-05-14-credential-management-design.md
@@ -197,6 +197,10 @@ credential gate checks both what command and what context:
   arbitrary feature branches is denied.
 - **Approval:** Allowed under the human account only for release
   PRs authored by the GitHub App (`vergil-release[bot]`).
+- **Issue close:** Allowed under the human account. The agent
+  account (outside collaborator) may lack the `CloseIssue`
+  GraphQL permission depending on org configuration. Escalating
+  to the human account avoids this dependency.
 - **Other admin operations:** Denied entirely through the wrapper.
 
 The specific per-command role mapping is an implementation detail

--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -43,6 +43,7 @@ _DENIED_TOP: dict[str, str] = {
 
 _ESCALATED_COMMANDS: set[tuple[str, str]] = {
     ("pr", "merge"),
+    ("issue", "close"),
 }
 
 

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -281,6 +281,24 @@ def test_default_uses_human_token_workaround() -> None:
 # -- credential selection: escalation for pr merge ---------------------------
 
 
+def test_issue_close_escalates_to_human() -> None:
+    with (
+        patch(
+            "vergil_tooling.bin.vrg_gh._discover_accounts",
+            return_value=("jdoe", "jdoe-vergil"),
+        ),
+        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="human-token\n")
+        from vergil_tooling.bin.vrg_gh import _get_token
+
+        token = _get_token(["issue", "close", "42"])
+    assert token == "human-token"  # noqa: S105
+    token_call = mock_run.call_args_list[-1]
+    assert "jdoe" in token_call[0][0]
+    assert "jdoe-vergil" not in token_call[0][0]
+
+
 def test_pr_merge_release_branch_escalates() -> None:
     with (
         patch(


### PR DESCRIPTION
# Pull Request

## Summary

- Add issue close to the credential escalation set so vrg-gh uses human credentials for the operation

## Issue Linkage

- Ref #796

## Notes

- The agent account (outside collaborator) lacks the CloseIssue GraphQL permission. Rather than granting additional GitHub permissions to the agent, this follows the existing credential escalation pattern: vrg-gh uses human credentials for issue close, the same way it already does for pr merge.

Currently a forward-looking change — the #799 workaround (all operations use human credentials while the -vergil account is flagged) means this takes effect when that workaround is reverted.

Changes:
- vrg_gh.py: add (issue, close) to _ESCALATED_COMMANDS
- test_vrg_gh.py: add test_issue_close_escalates_to_human
- credential management design spec: document issue close escalation
- credential management guide: document issue close escalation  
- permission model guide: annotate issue close row with escalation note