### PR TITLE
chore(docs): replace stale st- prefix with vrg- in site docs

### DIFF
--- a/docs/git-hooks-and-validation.md
+++ b/docs/git-hooks-and-validation.md
@@ -41,7 +41,7 @@ entry points that share a common set of validators:
   [Validation Matrix](#validation-matrix) below.
 
 All hooks and validators are managed by vergil-tooling.
-Consuming repositories resolve host-side `st-*` tools via
+Consuming repositories resolve host-side `vrg-*` tools via
 `uv tool install` and in-container validators via the dev
 container image's pre-bake or a Python dev-dep declaration.
 

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -17,8 +17,8 @@ Install these on your host:
 - **macOS or Linux** (Bash)
 
 Everything else — language runtimes, linters, test frameworks, and
-most `st-*` tools — lives inside the dev container. The host-side
-`st-*` tools (`vrg-docker-run`, `vrg-commit`, `vrg-submit-pr`, etc.)
+most `vrg-*` tools — lives inside the dev container. The host-side
+`vrg-*` tools (`vrg-docker-run`, `vrg-commit`, `vrg-submit-pr`, etc.)
 are installed via `uv tool install`.
 
 ## 1. Install vergil-tooling on the host
@@ -27,7 +27,7 @@ are installed via `uv tool install`.
 uv tool install 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v1.4'
 ```
 
-This installs all `st-*` console scripts into `~/.local/bin/`,
+This installs all `vrg-*` console scripts into `~/.local/bin/`,
 which `uv`'s installer already puts on `PATH`.
 
 ```bash

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -11,7 +11,7 @@ commits, PRs, releases, and validation alongside bash validators and git hooks
 `vrg-commit`, `vrg-submit-pr`, `vrg-prepare-release`,
 `vrg-finalize-repo`, `vrg-validate`
 
-**Lint tools** (installed as `st-*`):
+**Lint tools** (installed as `vrg-*`):
 `vrg-repo-profile`, `vrg-pr-issue-linkage`, validation drivers
 
 **Git hooks** (`.githooks/`):
@@ -23,17 +23,17 @@ Env-var gate that admits `vrg-commit` and blocks raw `git commit`
 - **shellcheck clean** -- all shell scripts pass shellcheck
 - **No repo-specific logic** -- every script works in any consuming
   repository
-- **Host-level install** -- `uv tool install` puts `st-*` on PATH;
+- **Host-level install** -- `uv tool install` puts `vrg-*` on PATH;
   no sibling checkout required
 
 ## How It Works
 
 1. `vergil-tooling` is installed on the developer's host via
-   `uv tool install`, placing `st-*` scripts in `~/.local/bin/`.
+   `uv tool install`, placing `vrg-*` scripts in `~/.local/bin/`.
 2. `vrg-docker-run` bridges host commands into dev container images
    where language runtimes and validators live.
 3. Python consumers also declare `vergil-tooling` as a dev dep
-   via `[tool.uv.sources]` so `uv run st-*` inside the container
+   via `[tool.uv.sources]` so `uv run vrg-*` inside the container
    resolves the pinned version.
 4. Each repo checks in a `.githooks/pre-commit` env-var gate,
    enabled via `git config core.hooksPath .githooks`.

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -1,6 +1,6 @@
 # Script Reference
 
-Vergil-tooling provides Python CLI tools installed as `st-*` console
+Vergil-tooling provides Python CLI tools installed as `vrg-*` console
 scripts, plus git hooks. For the full audit of every tool's runtime
 preconditions, host-vs-container classification, and failure modes,
 see the [CLI Tools Overview](cli-tools-overview.md).


### PR DESCRIPTION
# Pull Request

## Summary

- Replace 9 stale st-* prefix references with vrg-* across 4 user-facing documentation files. Specs and plans left as-is (point-in-time historical records).

## Issue Linkage

- Ref #885

## Notes

- -