### PR TITLE
fix(plans): correct vergil.toml example in VM repository plan

### DIFF
--- a/docs/plans/2026-05-20-vergil-vm-repository.md
+++ b/docs/plans/2026-05-20-vergil-vm-repository.md
@@ -98,18 +98,20 @@ cat > vergil.toml << 'EOF'
 [project]
 name = "vergil-vm"
 repository-type = "infrastructure"
-primary-language = "bash"
+primary-language = "shell"
 versioning-scheme = "semver"
+branching-model = "library-release"
 release-model = "tagged-release"
 
 [ci]
-versions = []
+versions = ["latest"]
 
 [publish]
-publish-packages = false
+release = true
+docs = false
 
 [dependencies]
-vergil-tooling = "v2.1"
+vergil = "v2.1"
 EOF
 
 cat > LICENSE << 'EOF'


### PR DESCRIPTION
# Pull Request

## Summary

- Fix five config schema discrepancies in the vergil-vm plan's vergil.toml example

## Issue Linkage

- Ref #910

## Notes

- The vergil-vm repository plan contained a vergil.toml example that would fail validation if used as-is during bootstrap. Fixed: primary-language bash→shell, publish-packages→release/docs, added missing branching-model, ci.versions []→["latest"], dependency key vergil-tooling→vergil.