### PR TITLE
refactor(wrappers): remove flat-file audit logging from vrg-git and vrg-gh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,7 @@ All fields are required.
 
 Use `vrg-git` instead of `git` for all git operations. Use `vrg-gh`
 instead of `gh` for all GitHub CLI operations. These wrappers enforce
-subcommand allowlists, flag deny lists, credential selection, and
-audit logging.
+subcommand allowlists, flag deny lists, and credential selection.
 
 Raw `git` and `gh` are denied by the permission model. If a command
 is not available through the wrappers, explain the situation to the

--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -1,18 +1,14 @@
 """Safe gh wrapper for AI agent sessions.
 
-Enforces a two-level subcommand allowlist, flag deny lists, selects
-credentials based on command context, and logs every invocation to
-a JSON-lines audit file.
+Enforces a two-level subcommand allowlist, flag deny lists, and selects
+credentials based on command context.
 """
 
 from __future__ import annotations
 
-import datetime
-import json
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 from vergil_tooling.lib.github import _discover_accounts
 
@@ -47,22 +43,6 @@ _ESCALATED_COMMANDS: set[tuple[str, str]] = {
 }
 
 
-def _log_path() -> Path:
-    return Path.home() / ".local" / "share" / "vergil" / "vrg-gh.log"
-
-
-def _log(args: list[str], result: str) -> None:
-    path = _log_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    entry = {
-        "timestamp": datetime.datetime.now(tz=datetime.UTC).isoformat(),
-        "args": args,
-        "result": result,
-    }
-    with path.open("a") as f:
-        f.write(json.dumps(entry) + "\n")
-
-
 def _get_token(command: list[str]) -> str:  # noqa: ARG001
     # Workaround: always use human credentials while agent account is
     # flagged by GitHub (#799). Revert when the flag is lifted.
@@ -90,7 +70,6 @@ def main(argv: list[str] | None = None) -> int:
 
     if not argv:
         print("usage: vrg-gh <subcommand> <action> [args...]", file=sys.stderr)
-        _log([], "denied")
         return 2
 
     top = argv[0]
@@ -98,7 +77,6 @@ def main(argv: list[str] | None = None) -> int:
     if top in _DENIED_TOP:
         msg = _DENIED_TOP[top]
         print(f"vrg-gh: {top} is denied. {msg}", file=sys.stderr)
-        _log(argv, "denied")
         return 1
 
     if top not in _ALLOWED:
@@ -106,7 +84,6 @@ def main(argv: list[str] | None = None) -> int:
             f"vrg-gh: {top} is not recognized. Allowed: {', '.join(sorted(_ALLOWED))}",
             file=sys.stderr,
         )
-        _log(argv, "denied")
         return 1
 
     if len(argv) < 2:  # noqa: PLR2004
@@ -114,7 +91,6 @@ def main(argv: list[str] | None = None) -> int:
             f"vrg-gh: {top} requires a subcommand. Allowed: {', '.join(sorted(_ALLOWED[top]))}",
             file=sys.stderr,
         )
-        _log(argv, "denied")
         return 1
 
     sub = argv[1]
@@ -122,7 +98,6 @@ def main(argv: list[str] | None = None) -> int:
     if top in _DENIED_PAIRS and sub in _DENIED_PAIRS[top]:
         msg = _DENIED_PAIRS[top][sub]
         print(f"vrg-gh: {top} {sub} is denied. {msg}", file=sys.stderr)
-        _log(argv, "denied")
         return 1
 
     if sub not in _ALLOWED[top]:
@@ -130,7 +105,6 @@ def main(argv: list[str] | None = None) -> int:
             f"vrg-gh: {top} {sub} is not recognized. Allowed: {', '.join(sorted(_ALLOWED[top]))}",
             file=sys.stderr,
         )
-        _log(argv, "denied")
         return 1
 
     if top == "pr" and sub == "review" and "--approve" in argv:
@@ -138,14 +112,12 @@ def main(argv: list[str] | None = None) -> int:
             "vrg-gh: pr review --approve is denied. Agents cannot approve PRs.",
             file=sys.stderr,
         )
-        _log(argv, "denied")
         return 1
 
     if top == "pr" and sub == "merge":
         err = _validate_merge_context(argv)
         if err:
             print(f"vrg-gh: pr merge is denied. {err}", file=sys.stderr)
-            _log(argv, "denied")
             return 1
 
     token = _get_token(argv)
@@ -155,5 +127,4 @@ def main(argv: list[str] | None = None) -> int:
         env=env,
         check=False,
     )
-    _log(argv, "allowed")
     return result.returncode

--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -1,16 +1,12 @@
 """Safe git wrapper for AI agent sessions.
 
-Enforces a subcommand allowlist, flag deny lists, and logs every
-invocation to a JSON-lines audit file.
+Enforces a subcommand allowlist and flag deny lists.
 """
 
 from __future__ import annotations
 
-import datetime
-import json
 import subprocess
 import sys
-from pathlib import Path
 
 _ALLOWED_SIMPLE: set[str] = {
     "status",
@@ -95,22 +91,6 @@ def _is_upstream_gone(branch_name: str) -> bool:
     return False
 
 
-def _log_path() -> Path:
-    return Path.home() / ".local" / "share" / "vergil" / "vrg-git.log"
-
-
-def _log(args: list[str], result: str) -> None:
-    path = _log_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    entry = {
-        "timestamp": datetime.datetime.now(tz=datetime.UTC).isoformat(),
-        "args": args,
-        "result": result,
-    }
-    with path.open("a") as f:
-        f.write(json.dumps(entry) + "\n")
-
-
 def _check_denied_flags(subcmd: str, args: list[str]) -> str | None:
     denied_flags = _FLAG_DENY.get(subcmd, set())
     if not denied_flags:
@@ -159,20 +139,17 @@ def main(argv: list[str] | None = None) -> int:
 
     if not argv:
         print("usage: vrg-git <subcommand> [args...]", file=sys.stderr)
-        _log([], "denied")
         return 2
 
     subcmd = argv[0]
 
     if tuple(argv) in _ALLOWED_EXACT:
         result = subprocess.run(["git", *argv], check=False)  # noqa: S603, S607
-        _log(argv, "allowed")
         return result.returncode
 
     if subcmd in _DENIED:
         msg = _DENIED[subcmd]
         print(f"vrg-git: {subcmd} is denied. {msg}", file=sys.stderr)
-        _log(argv, "denied")
         return 1
 
     if subcmd in _ALLOWED_COMPOUND:
@@ -184,17 +161,14 @@ def main(argv: list[str] | None = None) -> int:
                 f"Allowed: {', '.join(sorted(allowed_subs))}",
                 file=sys.stderr,
             )
-            _log(argv, "denied")
             return 1
 
         flag_err = _check_denied_flags(subcmd, argv[1:])
         if flag_err:
             print(f"vrg-git: {flag_err}", file=sys.stderr)
-            _log(argv, "denied")
             return 1
 
         result = subprocess.run(["git", *argv], check=False)  # noqa: S603, S607
-        _log(argv, "allowed")
         return result.returncode
 
     if subcmd not in _ALLOWED_SIMPLE:
@@ -203,15 +177,12 @@ def main(argv: list[str] | None = None) -> int:
             f"Allowed: {', '.join(sorted(_ALLOWED_SIMPLE | set(_ALLOWED_COMPOUND)))}",
             file=sys.stderr,
         )
-        _log(argv, "denied")
         return 1
 
     flag_err = _check_denied_flags(subcmd, argv[1:])
     if flag_err:
         print(f"vrg-git: {flag_err}", file=sys.stderr)
-        _log(argv, "denied")
         return 1
 
     result = subprocess.run(["git", *argv], check=False)  # noqa: S603, S607
-    _log(argv, "allowed")
     return result.returncode

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-import json
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_gh import main
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 # -- no arguments / missing subcommand ----------------------------------------
 
@@ -348,47 +342,6 @@ def test_gh_token_injected_into_env() -> None:
         main(["issue", "list"])
     _, kwargs = mock_run.call_args
     assert kwargs["env"]["GH_TOKEN"] == "injected-token"  # noqa: S105
-
-
-# -- invocation logging -------------------------------------------------------
-
-
-def test_allowed_invocation_logged(tmp_path: Path) -> None:
-    log_file = tmp_path / "vrg-gh.log"
-    with (
-        patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
-        patch("vergil_tooling.bin.vrg_gh._log_path", return_value=log_file),
-    ):
-        mock_run.return_value.returncode = 0
-        main(["issue", "list"])
-    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
-    assert len(entries) == 1
-    assert entries[0]["args"] == ["issue", "list"]
-    assert entries[0]["result"] == "allowed"
-    assert "timestamp" in entries[0]
-
-
-def test_denied_invocation_logged(tmp_path: Path) -> None:
-    log_file = tmp_path / "vrg-gh.log"
-    with patch("vergil_tooling.bin.vrg_gh._log_path", return_value=log_file):
-        main(["api", "repos/owner/repo"])
-    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
-    assert len(entries) == 1
-    assert entries[0]["args"] == ["api", "repos/owner/repo"]
-    assert entries[0]["result"] == "denied"
-
-
-def test_log_directory_created(tmp_path: Path) -> None:
-    log_file = tmp_path / "subdir" / "vrg-gh.log"
-    with (
-        patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
-        patch("vergil_tooling.bin.vrg_gh._log_path", return_value=log_file),
-    ):
-        mock_run.return_value.returncode = 0
-        main(["issue", "list"])
-    assert log_file.exists()
 
 
 # -- subprocess passthrough ---------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -2,18 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import subprocess
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_git import main
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 # -- no arguments -------------------------------------------------------------
 
@@ -158,19 +152,6 @@ def test_exact_match_denies_other_config(capsys: pytest.CaptureFixture[str]) -> 
 def test_exact_match_denies_bare_config(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["config"]) != 0
     assert "denied" in capsys.readouterr().err.lower()
-
-
-def test_exact_match_logged(tmp_path: Path) -> None:
-    log_file = tmp_path / "vrg-git.log"
-    with (
-        patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
-        patch("vergil_tooling.bin.vrg_git._log_path", return_value=log_file),
-    ):
-        mock_run.return_value.returncode = 0
-        main(["config", "core.hooksPath", ".githooks"])
-    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
-    assert len(entries) == 1
-    assert entries[0]["result"] == "allowed"
 
 
 # -- helper: _is_protected_branch --------------------------------------------
@@ -427,45 +408,6 @@ def test_rebase_normal_allowed() -> None:
         mock_run.return_value.returncode = 0
         rc = main(["rebase", "main"])
     assert rc == 0
-
-
-# -- invocation logging -------------------------------------------------------
-
-
-def test_allowed_invocation_logged(tmp_path: Path) -> None:
-    log_file = tmp_path / "vrg-git.log"
-    with (
-        patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
-        patch("vergil_tooling.bin.vrg_git._log_path", return_value=log_file),
-    ):
-        mock_run.return_value.returncode = 0
-        main(["status"])
-    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
-    assert len(entries) == 1
-    assert entries[0]["args"] == ["status"]
-    assert entries[0]["result"] == "allowed"
-    assert "timestamp" in entries[0]
-
-
-def test_denied_invocation_logged(tmp_path: Path) -> None:
-    log_file = tmp_path / "vrg-git.log"
-    with patch("vergil_tooling.bin.vrg_git._log_path", return_value=log_file):
-        main(["commit"])
-    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
-    assert len(entries) == 1
-    assert entries[0]["args"] == ["commit"]
-    assert entries[0]["result"] == "denied"
-
-
-def test_log_directory_created(tmp_path: Path) -> None:
-    log_file = tmp_path / "subdir" / "vrg-git.log"
-    with (
-        patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
-        patch("vergil_tooling.bin.vrg_git._log_path", return_value=log_file),
-    ):
-        mock_run.return_value.returncode = 0
-        main(["status"])
-    assert log_file.exists()
 
 
 # -- subprocess passthrough ----------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Remove unbounded flat-file audit logging from vrg-git and vrg-gh, eliminating the only host-OS-specific data directory in the codebase

## Issue Linkage

- Ref #902

## Notes

- Drops `_log_path()`, `_log()`, all `_log()` call sites, and unused imports
(`datetime`, `json`, `Path`) from both `vrg_git.py` and `vrg_gh.py`.

Removes 7 logging-specific tests across both test files. Updates CLAUDE.md
shell command policy to no longer mention audit logging.

The flat-file JSON-lines logs at `~/.local/share/vergil/` grew without bound
(no rotation, no size cap) and duplicated information already available through
git history and shell command output. Removing them entirely simplifies the
platform abstraction story for multi-platform host support (#909).

This is a pure deletion -- 168 lines removed, 4 lines changed (docstrings and
CLAUDE.md). All 1080 tests pass with 100% coverage maintained.