### PR TITLE
feat(926): confirm clone location before cloning in repo init wizard

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -463,6 +463,11 @@ def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
         print(f"Step 2: {target} already cloned, skipping.")
         return
 
+    resolved = target.resolve()
+    if not prompt_yes_no(f"Step 2: Clone to {resolved}?", default=True):
+        print("Aborted. Re-run from the directory where you want the clone.")
+        raise SystemExit(1)
+
     print(f"Step 2: Cloning {ctx.repo}...")
     subprocess.run(  # noqa: S603
         ("git", "clone", f"git@github.com:{ctx.repo}.git", str(target)),  # noqa: S607

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -5,6 +5,8 @@ import tomllib
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
+import pytest
+
 from vergil_tooling.lib.config import _parse_raw_config
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
@@ -356,7 +358,13 @@ class TestStepClone:
             target.mkdir(exist_ok=True)
             (target / ".git").mkdir()
 
-        with patch("vergil_tooling.lib.repo_init.subprocess.run", side_effect=mock_subprocess_run):
+        with (
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=mock_subprocess_run,
+            ),
+            patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
+        ):
             step_clone(ctx, parent_dir=tmp_path)
 
         assert ctx.work_dir == target
@@ -385,12 +393,25 @@ class TestStepClone:
             (target / ".git").mkdir()
 
         with (
-            patch("vergil_tooling.lib.repo_init.subprocess.run", side_effect=mock_subprocess_run),
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=mock_subprocess_run,
+            ),
             patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=tmp_path),
+            patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
         ):
             step_clone(ctx)
 
         assert ctx.work_dir == target
+
+    def test_clone_aborted_by_user(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+
+        with (
+            patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=False),
+            pytest.raises(SystemExit),
+        ):
+            step_clone(ctx, parent_dir=tmp_path)
 
 
 class TestStepGenerateConfig:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a confirmation prompt showing the resolved clone target path before cloning, so users can abort if they ran the tool from the wrong directory.

## Issue Linkage

- Ref #926

## Notes

- Shows the resolved absolute path and asks for confirmation with a Y/n prompt before cloning. If the user declines, prints guidance to re-run from the correct directory and exits with code 1. Adopt mode and already-cloned paths are unaffected.