### PR TITLE
fix(922): remove stale audit-logging reference from CLAUDE.md consumer template

### DIFF
--- a/src/vergil_tooling/data/claude_md_consumer.md
+++ b/src/vergil_tooling/data/claude_md_consumer.md
@@ -84,8 +84,7 @@ All fields are required.
 
 Use `vrg-git` instead of `git` for all git operations. Use `vrg-gh`
 instead of `gh` for all GitHub CLI operations. These wrappers enforce
-subcommand allowlists, flag deny lists, credential selection, and
-audit logging.
+subcommand allowlists, flag deny lists, and credential selection.
 
 Raw `git` and `gh` are denied by the permission model. If a command
 is not available through the wrappers, explain the situation to the


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the audit-logging mention from claude_md_consumer.md template — audit logging was removed from vrg-git/vrg-gh in PR #913, making the template text diverge from the repo's actual CLAUDE.md and causing the local audit check to fail.

## Issue Linkage

- Ref #922

## Notes

- The consumer template mentioned 'credential selection, and audit logging' but PR #913 removed audit logging. The repo CLAUDE.md correctly says 'and credential selection' without the audit logging clause. This one-word divergence caused the substring match in the audit to fail, blocking publish preflight.