### PR TITLE
chore(plans): integrate vrg-github-repo-init and remove bespoke CI from vergil-vm plan

### DIFF
--- a/docs/plans/in-progress/2026-05-20-p1-vergil-vm-repository.md
+++ b/docs/plans/in-progress/2026-05-20-p1-vergil-vm-repository.md
@@ -40,30 +40,22 @@ software:
 
 ---
 
-## Prerequisites (Manual — Human)
+## Prerequisites (Interactive — Human with `vrg-github-repo-init`)
 
 Lima must be installed on the development machine, and the
-vergil-vm repository must be bootstrapped on GitHub before the
-agent can begin execution. The bootstrap follows the manual
-sequence documented in vergil-tooling#807 — a future `vrg-init`
-command will automate this, but for now it is a one-time manual
-process.
+vergil-vm repository must be bootstrapped using
+`vrg-github-repo-init`. This is the first real-world proof of
+concept for the initialization tool — it replaces the manual
+bootstrap sequence previously documented in vergil-tooling#807.
 
-**Wrapper restrictions:** Several bootstrap commands require
-raw `gh` or raw `git` because the wrappers block them:
-
-- **`vrg-gh`** restricts `repo` to `view` only. `repo create`,
-  `repo edit`, `api`, and `auth` are denied.
-- **`vrg-git`** denies `commit` (use vrg-commit — but vrg-commit
-  fails on an empty repo with no HEAD), `config` (except the
-  exact `config core.hooksPath .githooks`), and does not allow
-  `clone` (not in the subcommand allowlist).
-
-These commands must be run by the human directly (via
-`! <command>` in Claude Code, or from a separate terminal).
-Commands below are annotated with `# human: raw gh` or
-`# human: raw git` where this applies. Unmarked commands
-work through the normal wrappers.
+The init tool is an interactive 9-step wizard that handles:
+repo creation, clone, vergil.toml generation, scaffold files
+(.githooks/pre-commit, CLAUDE.md, .claude/settings.json,
+README.md, .gitignore, LICENSE), CI/CD workflows, branch
+structure (develop/main), and GitHub configuration (rulesets,
+labels, default branch). It commits each step with
+`chore(init): step N` messages and supports resumption if
+interrupted.
 
 ### 1. Install Lima
 
@@ -72,140 +64,63 @@ brew install lima
 limactl --version   # Confirm >= 2.0.0
 ```
 
-### 2. Create the GitHub repository
+### 2. Run `vrg-github-repo-init`
+
+Run from the vergil-tooling dev-tree override (since the
+tool's unreleased code is being tested):
 
 ```bash
-# human: raw gh — repo create is denied by vrg-gh
-gh repo create vergil-project/vergil-vm \
-  --public \
-  --description "Lima VM image definitions for Vergil identity VMs"
+cd ~/dev/projects/vergil-project/vergil-tooling
+UV_PROJECT_ENVIRONMENT=.venv-host uv run \
+  vrg-github-repo-init vergil-project/vergil-vm \
+  --visibility public
 ```
 
-### 3. Clone and create the initial commit
+The wizard prompts for configuration. Use these values to
+match the project requirements:
 
-The empty repo has no HEAD, so `vrg-commit` cannot be used for
-the first commit. Use raw `git` for the bootstrap only.
+| Prompt | Value |
+|---|---|
+| Description | `Lima VM image definitions for Vergil identity VMs` |
+| Repository type | `infrastructure` |
+| Primary language | `shell` |
+| Branching model | `library-release` |
+| Versioning scheme | `semver` |
+| Release model | `tagged-release` |
+| CI versions | `latest` |
+| Integration tests? | `no` |
+| Publish releases? | `yes` |
+| Publish docs? | `no` |
+| Vergil dependency version | `v2.1` |
+| License | `GPL-3.0` |
+
+The tool runs 9 steps automatically (create repo, clone,
+generate vergil.toml, scaffold files, CI/CD workflows, docs
+site, branch structure, GitHub config, GitHub Pages). Steps
+that don't apply (docs site, Pages) are skipped based on the
+configuration above.
+
+**What the init tool creates vs. what this plan replaces:**
+The init tool generates a baseline `.gitignore` and a standard
+CI workflow (`.github/workflows/ci.yml`). Task 1 extends the
+`.gitignore` with Lima-specific entries, and Task 5 replaces
+the standard CI workflow with a VM-specific version. Both
+tasks account for these init-generated files already existing.
+
+### 3. Create the VERSION file
+
+`vrg-github-repo-init` does not create a `VERSION` file.
+Create it after the wizard completes:
 
 ```bash
-# human: raw git — clone is not in the vrg-git allowlist
-cd ~/dev/projects/vergil-project
-git clone git@github.com:vergil-project/vergil-vm.git
-cd vergil-vm
-
-# Create minimal initial files
+cd ~/dev/projects/vergil-project/vergil-vm
 echo "2.1.0" > VERSION
-cat > vergil.toml << 'EOF'
-[project]
-name = "vergil-vm"
-repository-type = "infrastructure"
-primary-language = "shell"
-versioning-scheme = "semver"
-branching-model = "library-release"
-release-model = "tagged-release"
-
-[ci]
-versions = ["latest"]
-
-[publish]
-release = true
-docs = false
-
-[dependencies]
-vergil = "v2.1"
-EOF
-
-cat > LICENSE << 'EOF'
-(GPL-3.0-or-later — copy from vergil-tooling/LICENSE)
-EOF
-
-# human: raw git — commit is denied by vrg-git, and vrg-commit
-# fails on an empty repo with no HEAD (#807)
-git add -A
-git commit -m "chore: initial repository scaffold"
-```
-
-### 4. Create branch structure
-
-GitHub repos default to `main`. Vergil convention uses
-`develop` as the default branch with `main` for releases.
-
-```bash
-# These work through vrg-git (branch, push are allowed;
-# -m and -u are not denied flags)
-vrg-git branch -m main develop
-vrg-git push -u origin develop
-
-vrg-git branch main
-vrg-git push -u origin main
-```
-
-### 5. Set default branch to develop
-
-```bash
-# human: raw gh — repo edit is denied by vrg-gh
-gh repo edit vergil-project/vergil-vm --default-branch develop
-```
-
-### 6. Apply GitHub repository configuration
-
-This must happen after both branches exist to avoid the
-chicken-and-egg problem (#807): rulesets require branches,
-and branches require commits.
-
-```bash
-# This is vrg-github-repo-config, not gh — no restriction
-vrg-github-repo-config apply --repo vergil-project/vergil-vm
-```
-
-If rulesets block the initial push, temporarily disable them
-via the GitHub web UI, push, then re-enable. This is the
-known bootstrapping workaround until `vrg-init` exists.
-
-### 7. Set up hooks and development environment
-
-```bash
-mkdir -p .githooks
-# Copy .githooks/pre-commit from any existing Vergil repo
-cp ../vergil-tooling/.githooks/pre-commit .githooks/pre-commit
-
-# vrg-git allows the exact command: config core.hooksPath .githooks
-vrg-git config core.hooksPath .githooks
-
-# Verify vrg-commit works (normal workflow from here on)
-vrg-commit --type chore --scope repo --message "enable pre-commit hook" \
-  --body "Copied from vergil-tooling"
+vrg-commit --type chore --scope repo --message "add VERSION file" \
+  --body "Initial version for vergil-vm"
 vrg-git push
 ```
 
-### 8. Create CLAUDE.md
-
-The `vrg-github-repo-config audit` command checks that
-`CLAUDE.md` exists and contains the **exact** consumer template
-from `vergil_tooling/data/claude_md_consumer.md` as a substring
-(case-sensitive, whitespace-exact). The template includes four
-mandatory sections: Memory management, Parallel AI agent
-development (with structure, rules, and agent prompt contract),
-Shell command policy, and Validation.
-
-Start with the verbatim template, then add a project-specific
-header above it (`# CLAUDE.md`, project overview, etc.).
-Additional sections can appear before or after the template,
-but the template text must not be modified.
-
-```bash
-# Copy the consumer template as the base
-cp ../vergil-tooling/src/vergil_tooling/data/claude_md_consumer.md CLAUDE.md
-
-# Prepend the project header (edit the file to add above the template):
-#   # CLAUDE.md
-#   ## Project Overview
-#   vergil-vm provides Lima VM image definitions ...
-
-# Verify audit compliance
-vrg-github-repo-config audit --repo vergil-project/vergil-vm
-```
-
-### 9. Verify the repo is ready
+### 4. Verify the repo is ready
 
 ```bash
 vrg-github-repo-config audit --repo vergil-project/vergil-vm
@@ -227,12 +142,15 @@ development workflow. The agent can create worktrees, use
 
 | File | Action | Responsibility |
 |---|---|---|
-| `VERSION` | Prerequisite | Semver version (2.1.0) — created during bootstrap |
-| `vergil.toml` | Prerequisite | Project metadata — created during bootstrap |
-| `LICENSE` | Prerequisite | GPL-3.0-or-later — created during bootstrap |
-| `.githooks/pre-commit` | Prerequisite | Commit gate — created during bootstrap |
-| `CLAUDE.md` | Prerequisite | Agent instructions — created during bootstrap |
-| `.gitignore` | Create | Ignore build artifacts |
+| `vergil.toml` | Init wizard | Project metadata — created by `vrg-github-repo-init` step 3 |
+| `LICENSE` | Init wizard | GPL-3.0-or-later — created by `vrg-github-repo-init` step 4 |
+| `.githooks/pre-commit` | Init wizard | Commit gate — created by `vrg-github-repo-init` step 4 |
+| `CLAUDE.md` | Init wizard | Agent instructions — created by `vrg-github-repo-init` step 4 |
+| `.claude/settings.json` | Init wizard | Claude Code settings — created by `vrg-github-repo-init` step 4 |
+| `README.md` | Init wizard | Project README — created by `vrg-github-repo-init` step 4 |
+| `.gitignore` | Init wizard + Extend | Baseline from init; Lima-specific entries added in Task 1 |
+| `.github/workflows/ci.yml` | Init wizard + Replace | Standard CI from init; replaced with VM-specific version in Task 5 |
+| `VERSION` | Prerequisite step 3 | Semver version (2.1.0) — created manually after init wizard |
 | `templates/agent.yaml` | Create | Lima VM template with all provisioning |
 | `tests/run-tests.sh` | Create | Test runner (shells into VM, runs each test) |
 | `tests/test_base.sh` | Create | Verify OS, user, shell, sudo |
@@ -240,21 +158,25 @@ development workflow. The agent can create worktrees, use
 | `tests/test_containerd.sh` | Create | Verify containerd running, nerdctl works |
 | `tests/test_vergil.sh` | Create | Verify vergil-tooling installable via uv |
 | `build.sh` | Create | Create VM, run provisioning, run tests, clean up |
-| `.github/workflows/ci.yml` | Create | shellcheck, yamllint, template validation |
 
 ---
 
 ### Task 1: Directory Structure and Remaining Scaffold
 
-The prerequisite bootstrap created `VERSION`, `vergil.toml`,
-`LICENSE`, `.githooks/pre-commit`, and `CLAUDE.md`. This task
-creates the remaining directory structure and configuration
-that the bootstrap did not cover.
+The `vrg-github-repo-init` wizard created `VERSION`,
+`vergil.toml`, `LICENSE`, `.githooks/pre-commit`, `CLAUDE.md`,
+`.claude/settings.json`, `README.md`, `.gitignore`, and
+`.github/workflows/ci.yml`. This task extends the baseline
+`.gitignore` with Lima-specific entries and creates the
+remaining directory structure.
 
 **Files:**
-- Create: `.gitignore`
+- Extend: `.gitignore` (add Lima-specific entries)
 
-- [ ] **Step 1: Create .gitignore**
+- [ ] **Step 1: Extend .gitignore with Lima-specific entries**
+
+The init tool created a baseline `.gitignore` (editors, OS,
+Vergil entries). Append Lima build artifact patterns:
 
 ```gitignore
 # Lima build artifacts
@@ -263,14 +185,6 @@ that the bootstrap did not cover.
 *.img
 *.iso
 
-# macOS
-.DS_Store
-
-# Editor
-*.swp
-*.swo
-*~
-
 # Build output
 /build/
 ```
@@ -278,14 +192,16 @@ that the bootstrap did not cover.
 - [ ] **Step 2: Create directory structure**
 
 ```bash
-mkdir -p templates tests .github/workflows
+mkdir -p templates tests
 ```
+
+(`.github/workflows/` already exists from the init scaffold.)
 
 - [ ] **Step 3: Commit**
 
 ```bash
-vrg-commit --type chore --scope vm --message "directory structure and gitignore" \
-  --body "templates/, tests/, .github/workflows/, .gitignore"
+vrg-commit --type chore --scope vm --message "directory structure and Lima-specific gitignore" \
+  --body "templates/, tests/, Lima build artifact patterns in .gitignore"
 ```
 
 ---
@@ -717,10 +633,14 @@ yamllint for the Lima template. Running an actual VM in CI
 requires QEMU on the GitHub Actions runner, which is deferred
 to Plan 6 (Distribution).
 
-**Files:**
-- Create: `.github/workflows/ci.yml`
+The init tool generated a standard CI workflow. This task
+replaces it with a VM-specific version that runs shellcheck
+and yamllint instead of the standard language-based checks.
 
-- [ ] **Step 1: Write the CI workflow**
+**Files:**
+- Replace: `.github/workflows/ci.yml` (overwrite init-generated version)
+
+- [ ] **Step 1: Replace the CI workflow with VM-specific version**
 
 ```yaml
 # .github/workflows/ci.yml

--- a/docs/plans/in-progress/2026-05-20-p1-vergil-vm-repository.md
+++ b/docs/plans/in-progress/2026-05-20-p1-vergil-vm-repository.md
@@ -31,7 +31,7 @@ software:
 
 | Plan | Scope | Deliverable |
 |---|---|---|
-| **1. Repository + Working VM** (this plan) | vergil-vm repo, Lima template, provisioning, build, test, CI | `limactl start` produces a working identity VM |
+| **1. Repository + Working VM** (this plan) | vergil-vm repo, Lima template, provisioning, build, test | `limactl start` produces a working identity VM |
 | 2. Session Management | vrg-session command, identities.toml, API key forwarding | `vrg-session <project>` launches Claude Code in VM |
 | 3. Credential Provisioning | GitHub App credentials (App ID, private key, installation token exchange), GHCR auth | VM boots with agent identity credentials |
 | ~~4. Egress Filtering~~ | ~~HAProxy, pf, iptables, allowlists~~ | Deferred to v2.2 (#901) |
@@ -100,12 +100,12 @@ site, branch structure, GitHub config, GitHub Pages). Steps
 that don't apply (docs site, Pages) are skipped based on the
 configuration above.
 
-**What the init tool creates vs. what this plan replaces:**
+**What the init tool creates vs. what this plan extends:**
 The init tool generates a baseline `.gitignore` and a standard
 CI workflow (`.github/workflows/ci.yml`). Task 1 extends the
-`.gitignore` with Lima-specific entries, and Task 5 replaces
-the standard CI workflow with a VM-specific version. Both
-tasks account for these init-generated files already existing.
+`.gitignore` with Lima-specific entries. The CI workflow is
+used as-is — `vrg-validate` already runs shellcheck and
+yamllint as common checks for shell-language repos.
 
 ### 3. Create the VERSION file
 
@@ -149,7 +149,7 @@ development workflow. The agent can create worktrees, use
 | `.claude/settings.json` | Init wizard | Claude Code settings — created by `vrg-github-repo-init` step 4 |
 | `README.md` | Init wizard | Project README — created by `vrg-github-repo-init` step 4 |
 | `.gitignore` | Init wizard + Extend | Baseline from init; Lima-specific entries added in Task 1 |
-| `.github/workflows/ci.yml` | Init wizard + Replace | Standard CI from init; replaced with VM-specific version in Task 5 |
+| `.github/workflows/ci.yml` | Init wizard | Standard CI from init; used as-is (vrg-validate covers shellcheck + yamllint) |
 | `VERSION` | Prerequisite step 3 | Semver version (2.1.0) — created manually after init wizard |
 | `templates/agent.yaml` | Create | Lima VM template with all provisioning |
 | `tests/run-tests.sh` | Create | Test runner (shells into VM, runs each test) |
@@ -626,62 +626,7 @@ vrg-commit --type feat --scope vm --message "build script for VM creation and te
 
 ---
 
-### Task 5: CI Workflow
-
-Static analysis only — shellcheck for all bash scripts and
-yamllint for the Lima template. Running an actual VM in CI
-requires QEMU on the GitHub Actions runner, which is deferred
-to Plan 6 (Distribution).
-
-The init tool generated a standard CI workflow. This task
-replaces it with a VM-specific version that runs shellcheck
-and yamllint instead of the standard language-based checks.
-
-**Files:**
-- Replace: `.github/workflows/ci.yml` (overwrite init-generated version)
-
-- [ ] **Step 1: Replace the CI workflow with VM-specific version**
-
-```yaml
-# .github/workflows/ci.yml
-name: CI
-
-on:
-  pull_request:
-    branches: [develop, main]
-
-permissions:
-  contents: read
-
-jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: shellcheck
-      run: |
-        sudo apt-get update && sudo apt-get install -y shellcheck
-        find . -name '*.sh' -not -path './.git/*' \
-          -exec shellcheck --severity=warning {} +
-
-    - name: yamllint
-      run: |
-        pip install yamllint
-        yamllint --strict templates/
-```
-
-- [ ] **Step 2: Commit**
-
-```bash
-vrg-commit --type ci --scope vm --message "CI workflow for static analysis" \
-  --body "shellcheck for bash scripts, yamllint for Lima templates"
-```
-
----
-
-### Task 6: Manual Validation
+### Task 5: Manual Validation
 
 This task is not automated — it requires a human or agent
 with Lima installed on macOS to run the build and verify the


### PR DESCRIPTION
# Pull Request

## Summary

- Update Plan 1 prerequisites to use vrg-github-repo-init wizard instead of manual 9-step bootstrap, and delete Task 5 (bespoke CI) since vrg-validate already covers shellcheck and yamllint for shell-language repos.

## Issue Linkage

- Ref #903

## Notes

- Two changes to the vergil-vm implementation plan:

1. **Prerequisites**: Replace the 9-step manual bootstrap (raw git/gh commands)
   with the interactive `vrg-github-repo-init` wizard. Includes a reference table
   of wizard prompt values. Adds a post-init step for the VERSION file (not
   created by the init tool).

2. **Remove bespoke CI (Task 5)**: The plan proposed a custom CI workflow running
   shellcheck and yamllint directly. This is redundant — `vrg-validate` already
   runs both as common checks for any `primary-language = "shell"` repo, and the
   init-generated CI workflow invokes `vrg-validate` through `vrg-docker-run`.
   No Vergil-managed repo should have a bespoke CI workflow. Task 5 deleted,
   Task 6 renumbered to Task 5.

File map and cross-references updated throughout.