### PR TITLE
fix(repo-init): chdir into cloned repo after step 2

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from dataclasses import dataclass, field
@@ -460,6 +461,7 @@ def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
 
     if (target / ".git").is_dir():
         ctx.work_dir = target
+        os.chdir(ctx.work_dir)
         print(f"Step 2: {target} already cloned, skipping.")
         return
 
@@ -474,6 +476,7 @@ def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
         check=True,
     )
     ctx.work_dir = target
+    os.chdir(ctx.work_dir)
     print(f"  Cloned to {target}.")
 
 

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -364,6 +364,7 @@ class TestStepClone:
                 side_effect=mock_subprocess_run,
             ),
             patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
+            patch("vergil_tooling.lib.repo_init.os.chdir"),
         ):
             step_clone(ctx, parent_dir=tmp_path)
 
@@ -375,7 +376,8 @@ class TestStepClone:
         (target / ".git").mkdir()
         ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
 
-        step_clone(ctx, parent_dir=tmp_path)
+        with patch("vergil_tooling.lib.repo_init.os.chdir"):
+            step_clone(ctx, parent_dir=tmp_path)
         assert ctx.work_dir == target
 
     def test_adopt_uses_cwd(self) -> None:
@@ -399,10 +401,42 @@ class TestStepClone:
             ),
             patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=tmp_path),
             patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
+            patch("vergil_tooling.lib.repo_init.os.chdir"),
         ):
             step_clone(ctx)
 
         assert ctx.work_dir == target
+
+    def test_clone_changes_cwd(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        target = tmp_path / "vergil-vm"
+
+        def mock_subprocess_run(cmd: Any, **kw: Any) -> None:
+            target.mkdir(exist_ok=True)
+            (target / ".git").mkdir()
+
+        with (
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=mock_subprocess_run,
+            ),
+            patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
+            patch("vergil_tooling.lib.repo_init.os.chdir") as mock_chdir,
+        ):
+            step_clone(ctx, parent_dir=tmp_path)
+
+        mock_chdir.assert_called_once_with(target)
+
+    def test_already_cloned_changes_cwd(self, tmp_path: Path) -> None:
+        target = tmp_path / "vergil-vm"
+        target.mkdir()
+        (target / ".git").mkdir()
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+
+        with patch("vergil_tooling.lib.repo_init.os.chdir") as mock_chdir:
+            step_clone(ctx, parent_dir=tmp_path)
+
+        mock_chdir.assert_called_once_with(target)
 
     def test_clone_aborted_by_user(self, tmp_path: Path) -> None:
         ctx = RepoInitContext(org="vergil-project", name="vergil-vm")


### PR DESCRIPTION
# Pull Request

## Summary

- Add os.chdir(ctx.work_dir) in step_clone so subsequent wizard steps find .git

## Issue Linkage

- Ref #952

## Notes

- Added two new tests asserting the CWD change; updated existing clone tests to mock os.chdir for test isolation.