### PR TITLE
fix(release): route wait_for_checks and watch_workflow through GitHub retry wrapper

### DIFF
--- a/src/vergil_tooling/lib/release/subprocess.py
+++ b/src/vergil_tooling/lib/release/subprocess.py
@@ -6,10 +6,28 @@ import subprocess as _subprocess
 import sys
 import time
 
-from vergil_tooling.lib.github import _checks_registered, _gh_env
+from vergil_tooling.lib.github import _checks_registered, _run_with_retry
 
 _POLL_INTERVAL_SECS = 5
 _POLL_TIMEOUT_SECS = 60
+
+
+def _run_verbose(cmd: tuple[str, ...], *, verbose: bool) -> None:
+    """Run *cmd* through the GitHub retry wrapper, printing output if verbose."""
+    try:
+        result = _run_with_retry(cmd, capture_output=True, text=True, check=True)
+    except _subprocess.CalledProcessError as exc:
+        if verbose:
+            if exc.stdout:
+                print(exc.stdout, end="")
+            if exc.stderr:
+                print(exc.stderr, end="", file=sys.stderr)
+        raise
+    if verbose:
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
 
 
 def wait_for_checks(pr: str, *, verbose: bool) -> None:
@@ -20,49 +38,15 @@ def wait_for_checks(pr: str, *, verbose: bool) -> None:
             break
         time.sleep(_POLL_INTERVAL_SECS)
 
-    env = _gh_env()
-    result = _subprocess.run(  # noqa: S603
+    _run_verbose(
         ("gh", "pr", "checks", pr, "--watch", "--fail-fast"),  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
+        verbose=verbose,
     )
-    if verbose:
-        if result.stdout:
-            print(result.stdout, end="")
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr)
-
-    if result.returncode != 0:
-        raise _subprocess.CalledProcessError(
-            result.returncode,
-            result.args,
-            output=result.stdout,
-            stderr=result.stderr,
-        )
 
 
 def watch_workflow(repo: str, run_id: str, *, verbose: bool) -> None:
     """Block until a workflow run completes. Verbose controls output."""
-    env = _gh_env()
-    result = _subprocess.run(  # noqa: S603
+    _run_verbose(
         ("gh", "run", "watch", "--repo", repo, "--exit-status", run_id),  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
+        verbose=verbose,
     )
-    if verbose:
-        if result.stdout:
-            print(result.stdout, end="")
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr)
-
-    if result.returncode != 0:
-        raise _subprocess.CalledProcessError(
-            result.returncode,
-            result.args,
-            output=result.stdout,
-            stderr=result.stderr,
-        )

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -18,11 +18,16 @@ def _completed(
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
+def _cpe(stdout: str = "", stderr: str = "") -> subprocess.CalledProcessError:
+    exc = subprocess.CalledProcessError(1, ["gh"], output=stdout, stderr=stderr)
+    return exc
+
+
 class TestWaitForChecks:
     def test_verbose_prints_output(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._subprocess.run", return_value=_completed(stdout="all passed\n")),
+            patch(_MOD + "._run_with_retry", return_value=_completed(stdout="all passed\n")),
         ):
             wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
         captured = capsys.readouterr()
@@ -31,7 +36,7 @@ class TestWaitForChecks:
     def test_quiet_suppresses_output(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._subprocess.run", return_value=_completed(stdout="all passed\n")),
+            patch(_MOD + "._run_with_retry", return_value=_completed(stdout="all passed\n")),
         ):
             wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
         captured = capsys.readouterr()
@@ -40,10 +45,7 @@ class TestWaitForChecks:
     def test_failure_raises_with_output(self) -> None:
         with (
             patch(_MOD + "._checks_registered", return_value=True),
-            patch(
-                _MOD + "._subprocess.run",
-                return_value=_completed(returncode=1, stdout="fail", stderr="err"),
-            ),
+            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
             pytest.raises(subprocess.CalledProcessError) as exc_info,
         ):
             wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
@@ -54,8 +56,8 @@ class TestWaitForChecks:
         with (
             patch(_MOD + "._checks_registered", return_value=True),
             patch(
-                _MOD + "._subprocess.run",
-                return_value=_completed(returncode=1, stdout="check output\n", stderr="error\n"),
+                _MOD + "._run_with_retry",
+                side_effect=_cpe(stdout="check output\n", stderr="error\n"),
             ),
             pytest.raises(subprocess.CalledProcessError),
         ):
@@ -64,21 +66,43 @@ class TestWaitForChecks:
         assert "check output" in captured.out
         assert "error" in captured.err
 
+    def test_verbose_failure_no_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch(_MOD + "._checks_registered", return_value=True),
+            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="fail\n", stderr="")),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
+        captured = capsys.readouterr()
+        assert "fail" in captured.out
+        assert captured.err == ""
+
     def test_verbose_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._subprocess.run", return_value=_completed(stdout="", stderr="warn\n")),
+            patch(_MOD + "._run_with_retry", return_value=_completed(stdout="", stderr="warn\n")),
         ):
             wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
         captured = capsys.readouterr()
         assert captured.out == ""
         assert "warn" in captured.err
 
+    def test_verbose_failure_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch(_MOD + "._checks_registered", return_value=True),
+            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="", stderr="error\n")),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "error" in captured.err
+
     def test_polls_until_checks_registered(self) -> None:
         registered_calls = iter([False, False, True])
         with (
             patch(_MOD + "._checks_registered", side_effect=registered_calls),
-            patch(_MOD + "._subprocess.run", return_value=_completed()),
+            patch(_MOD + "._run_with_retry", return_value=_completed()),
             patch(_MOD + ".time.sleep"),
             patch(_MOD + ".time.monotonic", side_effect=[0, 1, 2, 3]),
         ):
@@ -87,7 +111,7 @@ class TestWaitForChecks:
     def test_polls_timeout_falls_through(self) -> None:
         with (
             patch(_MOD + "._checks_registered", return_value=False),
-            patch(_MOD + "._subprocess.run", return_value=_completed()),
+            patch(_MOD + "._run_with_retry", return_value=_completed()),
             patch(_MOD + ".time.sleep"),
             patch(_MOD + ".time.monotonic", side_effect=[0, 100]),
         ):
@@ -96,23 +120,20 @@ class TestWaitForChecks:
 
 class TestWatchWorkflow:
     def test_verbose_prints_output(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with patch(_MOD + "._subprocess.run", return_value=_completed(stdout="workflow done\n")):
+        with patch(_MOD + "._run_with_retry", return_value=_completed(stdout="workflow done\n")):
             watch_workflow("owner/repo", "12345", verbose=True)
         captured = capsys.readouterr()
         assert "workflow done" in captured.out
 
     def test_quiet_suppresses_output(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with patch(_MOD + "._subprocess.run", return_value=_completed(stdout="workflow done\n")):
+        with patch(_MOD + "._run_with_retry", return_value=_completed(stdout="workflow done\n")):
             watch_workflow("owner/repo", "12345", verbose=False)
         captured = capsys.readouterr()
         assert captured.out == ""
 
     def test_failure_raises_with_output(self) -> None:
         with (
-            patch(
-                _MOD + "._subprocess.run",
-                return_value=_completed(returncode=1, stdout="fail", stderr="err"),
-            ),
+            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
             pytest.raises(subprocess.CalledProcessError) as exc_info,
         ):
             watch_workflow("owner/repo", "12345", verbose=False)
@@ -120,7 +141,7 @@ class TestWatchWorkflow:
         assert exc_info.value.stderr == "err"
 
     def test_verbose_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with patch(_MOD + "._subprocess.run", return_value=_completed(stdout="", stderr="warn\n")):
+        with patch(_MOD + "._run_with_retry", return_value=_completed(stdout="", stderr="warn\n")):
             watch_workflow("owner/repo", "12345", verbose=True)
         captured = capsys.readouterr()
         assert captured.out == ""
@@ -129,12 +150,22 @@ class TestWatchWorkflow:
     def test_verbose_failure_prints_then_raises(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch(
-                _MOD + "._subprocess.run",
-                return_value=_completed(returncode=1, stdout="run log\n", stderr="error\n"),
+                _MOD + "._run_with_retry",
+                side_effect=_cpe(stdout="run log\n", stderr="error\n"),
             ),
             pytest.raises(subprocess.CalledProcessError),
         ):
             watch_workflow("owner/repo", "12345", verbose=True)
         captured = capsys.readouterr()
         assert "run log" in captured.out
+        assert "error" in captured.err
+
+    def test_verbose_failure_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="", stderr="error\n")),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            watch_workflow("owner/repo", "12345", verbose=True)
+        captured = capsys.readouterr()
+        assert captured.out == ""
         assert "error" in captured.err


### PR DESCRIPTION
# Pull Request

## Summary

- Route release subprocess wrappers through github._run_with_retry to handle transient 502/503/504 errors

## Issue Linkage

- Ref #958

## Notes

- `release/subprocess.py` called `subprocess.run` directly, bypassing the transient-error retry logic in `github._run_with_retry()`. When `gh pr checks --watch` or `gh run watch` hit a GitHub 502/503/504, the release pipeline failed immediately with no retry.

**Fix:** Extracted a shared `_run_verbose()` helper that routes all calls through `_run_with_retry` while preserving the verbose output control. Both `wait_for_checks()` and `watch_workflow()` now get automatic retry on transient GitHub API errors.

Observed in production during vergil-actions v2.0.10 release (merge-bump phase hit a 502).