### PR TITLE
fix(repo-init): emit run-codeql: false for unsupported languages

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -252,6 +252,22 @@ def _container_tag(language: str, versions: list[str]) -> str:
     return "latest"
 
 
+_CODEQL_LANGUAGES = frozenset(
+    {
+        "python",
+        "go",
+        "java",
+        "ruby",
+        "cpp",
+        "csharp",
+        "javascript",
+        "typescript",
+        "swift",
+        "kotlin",
+    }
+)
+
+
 def render_ci_workflow(ctx: RepoInitContext) -> str:
     """Render .github/workflows/ci.yml."""
     suffix = _container_suffix(ctx.primary_language)
@@ -305,13 +321,21 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
         "      run-security: ${{ inputs.run-security != 'false' }}\n",
         f"      container-tag: '{tag}'\n",
         f"      container-suffix: {suffix}\n",
-        "\n",
-        "  test:\n",
-        "    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0\n",
-        "    with:\n",
-        f"      language: {ctx.primary_language}\n",
-        f"      versions: '{versions_json}'\n",
     ]
+
+    if ctx.primary_language not in _CODEQL_LANGUAGES:
+        lines.append("      run-codeql: false\n")
+
+    lines.extend(
+        [
+            "\n",
+            "  test:\n",
+            "    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0\n",
+            "    with:\n",
+            f"      language: {ctx.primary_language}\n",
+            f"      versions: '{versions_json}'\n",
+        ]
+    )
 
     if ctx.release_model != "none":
         lines.extend(

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -256,6 +256,7 @@ class TestRenderCiWorkflow:
         assert "ci-quality.yml@v2.0" in content
         assert "container-suffix: python" in content
         assert "ci-version-bump.yml@v2.0" in content
+        assert "run-codeql: false" not in content
 
     def test_shell_workflow(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
@@ -264,6 +265,15 @@ class TestRenderCiWorkflow:
         ctx.release_model = "tagged-release"
         content = render_ci_workflow(ctx)
         assert "container-suffix: base" in content
+        assert "run-codeql: false" in content
+
+    def test_codeql_disabled_for_claude_plugin(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "claude-plugin"
+        ctx.ci_versions = ["latest"]
+        ctx.release_model = "none"
+        content = render_ci_workflow(ctx)
+        assert "run-codeql: false" in content
 
     def test_no_version_bump_when_release_none(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")


### PR DESCRIPTION
# Pull Request

## Summary

- render_ci_workflow now emits run-codeql: false in the security section for languages CodeQL does not support (shell, claude-plugin, none)

## Issue Linkage

- Ref #960

## Notes

- -