### PR TITLE
fix(repo-init): emit container-suffix and container-tag for all CI jobs

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -301,6 +301,8 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
         "    with:\n",
         f"      language: {ctx.primary_language}\n",
         f"      versions: '{versions_json}'\n",
+        f"      container-tag: '{tag}'\n",
+        f"      container-suffix: {suffix}\n",
         "\n",
         "  quality:\n",
         "    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0\n",
@@ -334,6 +336,8 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
             "    with:\n",
             f"      language: {ctx.primary_language}\n",
             f"      versions: '{versions_json}'\n",
+            f"      container-tag: '{tag}'\n",
+            f"      container-suffix: {suffix}\n",
         ]
     )
 

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -266,6 +266,8 @@ class TestRenderCiWorkflow:
         content = render_ci_workflow(ctx)
         assert "container-suffix: base" in content
         assert "run-codeql: false" in content
+        assert content.count("container-suffix: base") == 5
+        assert content.count("container-tag: 'latest'") == 5
 
     def test_codeql_disabled_for_claude_plugin(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-suffix and container-tag to audit and test jobs in render_ci_workflow so shell repos pull prod-base instead of the nonexistent prod-shell

## Issue Linkage

- Ref #961

## Notes

- -