### PR TITLE
fix(ci): add container-suffix to audit and test workflow calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
+      container-suffix: python
 
   quality:
     uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
@@ -50,6 +51,7 @@ jobs:
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
+      container-suffix: python
 
   version:
     uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-suffix: python to the audit and test workflow calls that were relying on the reusable workflow fallback to inputs.language

## Issue Linkage

- Ref #961

## Notes

- Companion PR: vergil-project/vergil-actions#535 changes the fallback default from inputs.language to 'base'