### PR TITLE
fix(release): rationalize publish config and confirm-publish phase

### DIFF
--- a/docs/superpowers/plans/2026-05-21-rationalize-publish-config.md
+++ b/docs/superpowers/plans/2026-05-21-rationalize-publish-config.md
@@ -1,0 +1,73 @@
+# Rationalize [publish] Config and Fix confirm-publish Phase
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the `[publish]` config in `vergil.toml` and the `confirm_publish` release phase to match the actual CD workflow architecture (`cd.yml` calling reusable `cd-docs.yml` and `cd-release.yml`).
+
+**Architecture:** The old code watched two separate workflows (`publish.yml` and `Documentation`) that no longer exist. The new code watches a single "CD" workflow (`cd.yml`) and gates artifact verification on the `publish.release` and `publish.docs` booleans. The `docs_workflow` config field is removed since all repos use the same standardized CD workflow.
+
+**Tech Stack:** Python 3.14, pytest, `gh` CLI for GitHub API queries
+
+**Tracking issue:** #963
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/vergil_tooling/lib/config.py` | Modify | Remove `docs_workflow` field from `PublishConfig` |
+| `src/vergil_tooling/lib/release/context.py` | Modify | Replace per-workflow run fields with unified CD run fields |
+| `src/vergil_tooling/lib/release/confirm.py` | Rewrite | Watch single CD workflow, gate checks on publish booleans |
+| `src/vergil_tooling/lib/release/finalize.py` | Modify | Update summary to use new context fields |
+| `src/vergil_tooling/lib/release/orchestrator.py` | Modify | Update phase details to use new context fields |
+| `src/vergil_tooling/bin/vrg_finalize_repo.py` | Modify | Change workflow name from `"Documentation"` to `"CD"` |
+| `tests/vergil_tooling/test_config.py` | Modify | Remove `docs_workflow` tests |
+| `tests/vergil_tooling/test_release_confirm.py` | Rewrite | Test new CD workflow architecture |
+| `tests/vergil_tooling/test_release_finalize.py` | Modify | Update context field names in test setup |
+| `tests/vergil_tooling/test_release_orchestrator.py` | Modify | Update context field names and assertions |
+| `tests/vergil_tooling/test_vrg_finalize_repo.py` | Modify | Update workflow name in assertions |
+
+**Out of scope** (separate issues in consuming repos):
+- vergil-vm: set `release = false` (no release job in cd.yml)
+- vergil-claude-plugin: add `[publish]` section
+
+---
+
+## Task 1: Remove `docs_workflow` from `PublishConfig`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/config.py:57-62` (PublishConfig dataclass)
+- Modify: `src/vergil_tooling/lib/config.py:120-126` (parsing)
+- Modify: `tests/vergil_tooling/test_config.py:320-330` (test removal)
+
+## Task 2: Replace per-workflow context fields with unified CD fields
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/context.py:32-35`
+
+## Task 3: Rewrite `confirm.py` for CD workflow architecture
+
+**Files:**
+- Rewrite: `src/vergil_tooling/lib/release/confirm.py`
+- Rewrite: `tests/vergil_tooling/test_release_confirm.py`
+
+## Task 4: Update release summary in `finalize.py`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/finalize.py:40-57`
+- Modify: `tests/vergil_tooling/test_release_finalize.py:15-31`
+
+## Task 5: Update phase details in `orchestrator.py`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/orchestrator.py:64-72`
+- Modify: `tests/vergil_tooling/test_release_orchestrator.py:67-68,193-203`
+
+## Task 6: Fix `vrg_finalize_repo.py` workflow name
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_finalize_repo.py:21,91-146,289-301`
+- Modify: `tests/vergil_tooling/test_vrg_finalize_repo.py`
+
+## Task 7: Full validation

--- a/src/vergil_tooling/bin/vrg_finalize_repo.py
+++ b/src/vergil_tooling/bin/vrg_finalize_repo.py
@@ -2,9 +2,9 @@
 
 Switches to the target branch, fast-forward pulls, deletes merged local
 branches, and prunes stale remote-tracking references. After
-validation succeeds, also checks the most recent Documentation
-workflow run on the target branch and fails if it did not succeed
-(issue #303 — docs publish is async and used to fail silently).
+validation succeeds, also checks the most recent CD workflow run on the
+target branch and fails if it did not succeed (issue #303 — docs
+publish is async and used to fail silently).
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from pathlib import Path
 from vergil_tooling.lib import config, git
 from vergil_tooling.lib.docker_cache import clean_branch_images
 
-_DOCS_WORKFLOW_NAME = "Documentation"
+_CD_WORKFLOW_NAME = "CD"
 
 _ETERNAL_BY_MODEL: dict[str, list[str]] = {
     "docs-single-branch": ["develop"],
@@ -88,19 +88,18 @@ def _worktree_for_branch(branch: str, repo_root: Path) -> Path | None:
     return None
 
 
-def _check_docs_workflow_status(target_branch: str) -> str | None:
-    """Inspect the most recent Documentation workflow run on
-    ``target_branch`` and return a one-line message if it failed,
-    None if it succeeded, is in progress, or doesn't exist.
+def _check_cd_workflow_status(target_branch: str) -> str | None:
+    """Inspect the most recent CD workflow run on ``target_branch`` and
+    return a one-line message if it failed, None if it succeeded, is in
+    progress, or doesn't exist.
 
-    Docs publication is async relative to the merge that triggers it,
-    so a failure here doesn't block any PR — but it does mean the
-    site is stale until the next successful run. This check surfaces
-    such failures during finalize so they can be investigated
-    immediately. Issue #303.
+    The CD workflow is async relative to the merge that triggers it, so
+    a failure here doesn't block any PR — but it does mean the site or
+    release artifacts may be stale. This check surfaces such failures
+    during finalize so they can be investigated immediately. Issue #303.
 
     Returns None when:
-      - no Documentation workflow exists in the repo
+      - no CD workflow exists in the repo
       - the latest run succeeded or is still in progress
       - the JSON response is malformed (defensive)
     """
@@ -110,7 +109,7 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
             "run",
             "list",
             "--workflow",
-            _DOCS_WORKFLOW_NAME,
+            _CD_WORKFLOW_NAME,
             "--branch",
             target_branch,
             "--limit",
@@ -123,8 +122,6 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
         text=True,
     )
     if result.returncode != 0:
-        # gh failed (no workflow, no auth, network issue) — defensive
-        # silence rather than turning every finalize into a warning.
         return None
     stdout = result.stdout or ""
     try:
@@ -136,11 +133,10 @@ def _check_docs_workflow_status(target_branch: str) -> str | None:
     run = runs[0]
     conclusion = run.get("conclusion") or ""
     if conclusion in ("", "success", "skipped", "neutral"):
-        # "" means still in_progress / queued / not_completed.
         return None
     sha = (run.get("headSha") or "")[:7]
     return (
-        f"Documentation workflow run {run.get('databaseId')} on "
+        f"CD workflow run {run.get('databaseId')} on "
         f"{target_branch} ({sha}) ended with conclusion '{conclusion}'.\n"
         f"  {run.get('url') or ''}"
     )
@@ -271,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
     # block subsequent merges.
     docs_failure: str | None = None
     if not args.dry_run:
-        docs_failure = _check_docs_workflow_status(args.target_branch)
+        docs_failure = _check_cd_workflow_status(args.target_branch)
 
     print()
     print("Finalization complete.")
@@ -289,12 +285,12 @@ def main(argv: list[str] | None = None) -> int:
     if docs_failure is not None:
         print()
         print(
-            "ERROR: most recent Documentation workflow run did not succeed.",
+            "ERROR: most recent CD workflow run did not succeed.",
             file=sys.stderr,
         )
         print(f"  {docs_failure}", file=sys.stderr)
         print(
-            "  Docs publish is async — investigate before the next merge so",
+            "  CD workflow is async — investigate before the next merge so",
             file=sys.stderr,
         )
         print("  the site doesn't drift further from develop.", file=sys.stderr)

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -58,7 +58,6 @@ class PublishConfig:
     release: bool
     docs: bool
     consumer_refresh: str | None
-    docs_workflow: str
 
 
 @dataclass
@@ -122,7 +121,6 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         release=bool(publish_raw.get("release", False)),
         docs=bool(publish_raw.get("docs", True)),
         consumer_refresh=publish_raw.get("consumer-refresh"),
-        docs_workflow=str(publish_raw.get("docs-workflow", "Documentation")),
     )
 
     project = ProjectConfig(

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -1,4 +1,4 @@
-"""Phase 4: Watch workflows and verify publish artifacts."""
+"""Phase 4: Watch CD workflow and verify publish artifacts."""
 
 from __future__ import annotations
 
@@ -11,28 +11,30 @@ from vergil_tooling.lib.release.subprocess import watch_workflow
 if TYPE_CHECKING:
     from vergil_tooling.lib.release.context import ReleaseContext
 
+_CD_WORKFLOW = "cd.yml"
+
 
 def confirm_publish(ctx: ReleaseContext) -> None:
-    """Block on publish + docs workflows, then verify artifacts."""
+    """Watch the CD workflow on main and verify publish artifacts."""
     cfg = config.read_config(ctx.repo_root)
-    docs_workflow = cfg.publish.docs_workflow
 
-    _watch_workflow(ctx, "publish.yml", "publish")
-    _watch_workflow(ctx, docs_workflow, "docs")
-    _verify_artifacts(ctx)
+    if cfg.publish.release or cfg.publish.docs:
+        _watch_cd(ctx)
+
+    _verify_artifacts(ctx, release=cfg.publish.release)
 
     print(f"All artifacts confirmed for v{ctx.version}.")
 
 
-def _watch_workflow(ctx: ReleaseContext, workflow: str, label: str) -> None:
-    print(f"Waiting for {workflow} on main...")
+def _watch_cd(ctx: ReleaseContext) -> None:
+    print(f"Waiting for {_CD_WORKFLOW} on main...")
     run_id = github.read_output(
         "run",
         "list",
         "--repo",
         ctx.repo,
         "--workflow",
-        workflow,
+        _CD_WORKFLOW,
         "--branch",
         "main",
         "--limit",
@@ -45,8 +47,8 @@ def _watch_workflow(ctx: ReleaseContext, workflow: str, label: str) -> None:
     if not run_id:
         raise ReleaseError(
             phase="confirm-publish",
-            command=f"gh run list --workflow {workflow}",
-            message=f"No {workflow} run found on main.",
+            command=f"gh run list --workflow {_CD_WORKFLOW}",
+            message="No CD workflow run found on main.",
         )
 
     watch_workflow(ctx.repo, run_id, verbose=ctx.verbose)
@@ -63,27 +65,37 @@ def _watch_workflow(ctx: ReleaseContext, workflow: str, label: str) -> None:
         ".url",
     )
 
-    if label == "publish":
-        ctx.publish_run_id = run_id
-        ctx.publish_run_url = run_url
-    else:
-        ctx.docs_run_id = run_id
-        ctx.docs_run_url = run_url
-
-    print(f"  {workflow} succeeded: {run_url}")
+    ctx.cd_run_id = run_id
+    ctx.cd_run_url = run_url
+    print(f"  CD workflow succeeded: {run_url}")
 
 
-def _verify_artifacts(ctx: ReleaseContext) -> None:
+def _verify_artifacts(ctx: ReleaseContext, *, release: bool) -> None:
     git.run("fetch", "--tags", "--force", "origin")
 
-    tag = f"v{ctx.version}"
-    if not git.ref_exists(tag):
-        raise ReleaseError(
-            phase="confirm-publish",
-            command=f"git rev-parse {tag}",
-            message=f"Tag {tag} does not exist after publish.",
+    if release:
+        tag = f"v{ctx.version}"
+        if not git.ref_exists(tag):
+            raise ReleaseError(
+                phase="confirm-publish",
+                command=f"git rev-parse {tag}",
+                message=f"Tag {tag} does not exist after publish.",
+            )
+        ctx.tag = tag
+
+        release_url = github.read_output(
+            "release",
+            "view",
+            "--repo",
+            ctx.repo,
+            tag,
+            "--json",
+            "url",
+            "--jq",
+            ".url",
         )
-    ctx.tag = tag
+        ctx.release_url = release_url
+        print(f"  GitHub Release: {release_url}")
 
     develop_tag = f"develop-v{ctx.version}"
     if not git.ref_exists(develop_tag):
@@ -93,17 +105,3 @@ def _verify_artifacts(ctx: ReleaseContext) -> None:
             message=f"Develop boundary tag {develop_tag} does not exist.",
         )
     ctx.develop_tag = develop_tag
-
-    release_url = github.read_output(
-        "release",
-        "view",
-        "--repo",
-        ctx.repo,
-        tag,
-        "--json",
-        "url",
-        "--jq",
-        ".url",
-    )
-    ctx.release_url = release_url
-    print(f"  GitHub Release: {release_url}")

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -29,10 +29,8 @@ class ReleaseContext:
     bump_pr_url: str | None = None
     next_version: str | None = None
 
-    publish_run_id: str | None = None
-    publish_run_url: str | None = None
-    docs_run_id: str | None = None
-    docs_run_url: str | None = None
+    cd_run_id: str | None = None
+    cd_run_url: str | None = None
     tag: str | None = None
     develop_tag: str | None = None
     release_url: str | None = None

--- a/src/vergil_tooling/lib/release/finalize.py
+++ b/src/vergil_tooling/lib/release/finalize.py
@@ -46,12 +46,15 @@ def _build_summary(ctx: ReleaseContext) -> str:
         f"- Bump PR: {ctx.bump_pr_url}",
         "",
         "### Tags",
-        f"- Release tag: `{ctx.tag}`",
-        f"- Develop boundary tag: `{ctx.develop_tag}`",
-        "",
-        "### Artifacts",
-        f"- GitHub Release: {ctx.release_url}",
-        f"- publish.yml: {ctx.publish_run_url}",
-        f"- docs workflow: {ctx.docs_run_url}",
     ]
+    if ctx.tag:
+        lines.append(f"- Release tag: `{ctx.tag}`")
+    if ctx.develop_tag:
+        lines.append(f"- Develop boundary tag: `{ctx.develop_tag}`")
+    lines.append("")
+    lines.append("### Artifacts")
+    if ctx.release_url:
+        lines.append(f"- GitHub Release: {ctx.release_url}")
+    if ctx.cd_run_url:
+        lines.append(f"- CD workflow: {ctx.cd_run_url}")
     return "\n".join(lines)

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -66,10 +66,8 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
             lines.append(f"Tag: `{ctx.tag}`")
         if ctx.release_url:
             lines.append(f"Release: {ctx.release_url}")
-        if ctx.publish_run_url:
-            lines.append(f"publish.yml: {ctx.publish_run_url}")
-        if ctx.docs_run_url:
-            lines.append(f"docs workflow: {ctx.docs_run_url}")
+        if ctx.cd_run_url:
+            lines.append(f"CD workflow: {ctx.cd_run_url}")
     elif phase == "close-finalize":
         lines.append("Tracking issue closed. Repository finalized.")
     elif phase == "consumer-refresh":

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -315,16 +315,3 @@ def test_publish_consumer_refresh_default_none(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text(_VALID_TOML)
     cfg = read_config(tmp_path)
     assert cfg.publish.consumer_refresh is None
-
-
-def test_publish_docs_workflow(tmp_path: Path) -> None:
-    toml = _VALID_TOML + '\n[publish]\ndocs-workflow = "Pages"\n'
-    (tmp_path / "vergil.toml").write_text(toml)
-    cfg = read_config(tmp_path)
-    assert cfg.publish.docs_workflow == "Pages"
-
-
-def test_publish_docs_workflow_default(tmp_path: Path) -> None:
-    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
-    cfg = read_config(tmp_path)
-    assert cfg.publish.docs_workflow == "Documentation"

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -314,9 +314,7 @@ def _st_config(
         dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
-        publish=PublishConfig(
-            release=False, docs=True, consumer_refresh=None, docs_workflow="Documentation"
-        ),
+        publish=PublishConfig(release=False, docs=True, consumer_refresh=None),
     )
 
 
@@ -1328,9 +1326,7 @@ def test_compute_desired_state_publish_release_true() -> None:
         dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(),
-        publish=PublishConfig(
-            release=True, docs=True, consumer_refresh=None, docs_workflow="Documentation"
-        ),
+        publish=PublishConfig(release=True, docs=True, consumer_refresh=None),
     )
     state = compute_desired_state(config, visibility="public", is_org=True)
     assert state.publish.release is True

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -22,41 +22,110 @@ def _ctx() -> ReleaseContext:
     return ctx
 
 
-def test_confirm_publish_succeeds() -> None:
+def test_confirm_publish_release_and_docs() -> None:
+    """Both release and docs enabled — watches CD, verifies all artifacts."""
     ctx = _ctx()
     with (
         patch(
             _MOD + ".github.read_output",
             side_effect=[
-                "12345",  # publish run id
-                "https://github.com/o/r/actions/runs/12345",  # publish run url
-                "67890",  # docs run id
-                "https://github.com/o/r/actions/runs/67890",  # docs run url
-                "",  # tag check (no error)
-                "",  # develop tag check
+                "12345",  # CD run id
+                "https://github.com/o/r/actions/runs/12345",  # CD run url
                 "https://github.com/o/r/releases/tag/v2.1.0",  # release url
             ],
         ),
         patch(_MOD + ".watch_workflow"),
+        patch(_MOD + ".git.run"),
         patch(_MOD + ".git.ref_exists", return_value=True),
         patch(_MOD + ".config.read_config") as mock_config,
     ):
-        mock_config.return_value.publish.docs_workflow = "Documentation"
+        mock_config.return_value.publish.release = True
+        mock_config.return_value.publish.docs = True
         confirm_publish(ctx)
 
-    assert ctx.publish_run_id == "12345"
-    assert ctx.docs_run_id == "67890"
+    assert ctx.cd_run_id == "12345"
+    assert ctx.cd_run_url == "https://github.com/o/r/actions/runs/12345"
     assert ctx.tag == "v2.1.0"
+    assert ctx.develop_tag == "develop-v2.1.0"
+    assert ctx.release_url == "https://github.com/o/r/releases/tag/v2.1.0"
 
 
-def test_confirm_publish_fails_if_no_workflow_run() -> None:
+def test_confirm_publish_docs_only() -> None:
+    """release=false, docs=true — watches CD, verifies develop tag only."""
+    ctx = _ctx()
+    with (
+        patch(
+            _MOD + ".github.read_output",
+            side_effect=[
+                "12345",  # CD run id
+                "https://github.com/o/r/actions/runs/12345",  # CD run url
+            ],
+        ),
+        patch(_MOD + ".watch_workflow"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.ref_exists", return_value=True),
+        patch(_MOD + ".config.read_config") as mock_config,
+    ):
+        mock_config.return_value.publish.release = False
+        mock_config.return_value.publish.docs = True
+        confirm_publish(ctx)
+
+    assert ctx.cd_run_id == "12345"
+    assert ctx.develop_tag == "develop-v2.1.0"
+    assert ctx.tag is None
+    assert ctx.release_url is None
+
+
+def test_confirm_publish_skips_cd_when_nothing_published() -> None:
+    """release=false, docs=false — skips CD, still verifies develop tag."""
+    ctx = _ctx()
+    with (
+        patch(_MOD + ".github.read_output") as mock_gh,
+        patch(_MOD + ".watch_workflow") as mock_watch,
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.ref_exists", return_value=True),
+        patch(_MOD + ".config.read_config") as mock_config,
+    ):
+        mock_config.return_value.publish.release = False
+        mock_config.return_value.publish.docs = False
+        confirm_publish(ctx)
+
+    mock_gh.assert_not_called()
+    mock_watch.assert_not_called()
+    assert ctx.cd_run_id is None
+    assert ctx.develop_tag == "develop-v2.1.0"
+
+
+def test_confirm_publish_fails_if_no_cd_run() -> None:
     ctx = _ctx()
     with (
         patch(_MOD + ".github.read_output", return_value=""),
         patch(_MOD + ".config.read_config") as mock_config,
-        pytest.raises(ReleaseError, match="No publish.yml run"),
+        pytest.raises(ReleaseError, match="No CD workflow run found"),
     ):
-        mock_config.return_value.publish.docs_workflow = "Documentation"
+        mock_config.return_value.publish.release = True
+        mock_config.return_value.publish.docs = True
+        confirm_publish(ctx)
+
+
+def test_confirm_publish_fails_if_tag_missing() -> None:
+    ctx = _ctx()
+    with (
+        patch(
+            _MOD + ".github.read_output",
+            side_effect=[
+                "12345",
+                "https://github.com/o/r/actions/runs/12345",
+            ],
+        ),
+        patch(_MOD + ".watch_workflow"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.ref_exists", return_value=False),
+        patch(_MOD + ".config.read_config") as mock_config,
+        pytest.raises(ReleaseError, match="Tag.*does not exist"),
+    ):
+        mock_config.return_value.publish.release = True
+        mock_config.return_value.publish.docs = True
         confirm_publish(ctx)
 
 
@@ -69,8 +138,7 @@ def test_confirm_publish_fails_if_develop_tag_missing() -> None:
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "67890",
-                "https://github.com/o/r/actions/runs/67890",
+                "https://github.com/o/r/releases/tag/v2.1.0",
             ],
         ),
         patch(_MOD + ".watch_workflow"),
@@ -79,26 +147,6 @@ def test_confirm_publish_fails_if_develop_tag_missing() -> None:
         patch(_MOD + ".config.read_config") as mock_config,
         pytest.raises(ReleaseError, match="Develop boundary tag"),
     ):
-        mock_config.return_value.publish.docs_workflow = "Documentation"
-        confirm_publish(ctx)
-
-
-def test_confirm_publish_fails_if_tag_missing() -> None:
-    ctx = _ctx()
-    with (
-        patch(
-            _MOD + ".github.read_output",
-            side_effect=[
-                "12345",
-                "https://github.com/o/r/actions/runs/12345",
-                "67890",
-                "https://github.com/o/r/actions/runs/67890",
-            ],
-        ),
-        patch(_MOD + ".watch_workflow"),
-        patch(_MOD + ".git.ref_exists", return_value=False),
-        patch(_MOD + ".config.read_config") as mock_config,
-        pytest.raises(ReleaseError, match="Tag.*does not exist"),
-    ):
-        mock_config.return_value.publish.docs_workflow = "Documentation"
+        mock_config.return_value.publish.release = True
+        mock_config.return_value.publish.docs = True
         confirm_publish(ctx)

--- a/tests/vergil_tooling/test_release_finalize.py
+++ b/tests/vergil_tooling/test_release_finalize.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.lib.release.context import ReleaseContext, ReleaseError
-from vergil_tooling.lib.release.finalize import close_and_finalize
+from vergil_tooling.lib.release.finalize import _build_summary, close_and_finalize
 
 _MOD = "vergil_tooling.lib.release.finalize"
 
@@ -26,8 +26,7 @@ def _ctx() -> ReleaseContext:
     ctx.tag = "v2.1.0"
     ctx.develop_tag = "develop-v2.1.0"
     ctx.release_url = "https://github.com/owner/repo/releases/tag/v2.1.0"
-    ctx.publish_run_url = "https://github.com/owner/repo/actions/runs/123"
-    ctx.docs_run_url = "https://github.com/owner/repo/actions/runs/456"
+    ctx.cd_run_url = "https://github.com/owner/repo/actions/runs/123"
     return ctx
 
 
@@ -54,6 +53,19 @@ def test_close_and_finalize_prints_stdout() -> None:
         ),
     ):
         close_and_finalize(ctx)
+
+
+def test_build_summary_omits_none_fields() -> None:
+    ctx = _ctx()
+    ctx.tag = None
+    ctx.develop_tag = None
+    ctx.release_url = None
+    ctx.cd_run_url = None
+    summary = _build_summary(ctx)
+    assert "Release tag" not in summary
+    assert "Develop boundary tag" not in summary
+    assert "GitHub Release" not in summary
+    assert "CD workflow" not in summary
 
 
 def test_close_and_finalize_fails_on_finalize_error() -> None:

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -64,7 +64,7 @@ def test_phase_details_includes_ctx_fields() -> None:
 
     ctx.tag = "v2.1.0"
     ctx.release_url = "https://github.com/o/r/releases/tag/v2.1.0"
-    ctx.publish_run_url = "https://github.com/o/r/actions/runs/123"
+    ctx.cd_run_url = "https://github.com/o/r/actions/runs/123"
     details = _phase_details(ctx, "confirm-publish")
     assert "v2.1.0" in details
     assert "runs/123" in details
@@ -190,13 +190,12 @@ def test_phase_details_unknown_phase() -> None:
     assert details == ""
 
 
-def test_phase_details_confirm_docs_workflow() -> None:
+def test_phase_details_confirm_cd_workflow() -> None:
     from vergil_tooling.lib.release.orchestrator import _phase_details
 
     ctx = _ctx()
     ctx.tag = "v2.1.0"
     ctx.release_url = "https://github.com/o/r/releases/tag/v2.1.0"
-    ctx.publish_run_url = "https://github.com/o/r/actions/runs/123"
-    ctx.docs_run_url = "https://github.com/o/r/actions/runs/456"
+    ctx.cd_run_url = "https://github.com/o/r/actions/runs/123"
     details = _phase_details(ctx, "confirm-publish")
-    assert "docs workflow" in details
+    assert "CD workflow" in details

--- a/tests/vergil_tooling/test_vrg_finalize_repo.py
+++ b/tests/vergil_tooling/test_vrg_finalize_repo.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 import pytest
 
 from vergil_tooling.bin.vrg_finalize_repo import (
-    _check_docs_workflow_status,
+    _check_cd_workflow_status,
     _worktree_for_branch,
     _worktree_is_dirty,
     main,
@@ -105,7 +105,7 @@ def test_main_library_release(tmp_path: Path) -> None:
         patch(_MOD + ".git.read_output", return_value=""),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -121,7 +121,7 @@ def test_main_already_on_target(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -150,7 +150,7 @@ def test_main_no_profile(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -178,7 +178,7 @@ def test_main_application_promotion(tmp_path: Path) -> None:
         patch(_MOD + ".git.read_output", return_value=""),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -192,7 +192,7 @@ def test_main_docs_single_branch(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -206,7 +206,7 @@ def test_main_no_deleted_branches(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=["develop"]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -223,7 +223,7 @@ def test_main_validation_fails(tmp_path: Path) -> None:
             "vergil_tooling.bin.vrg_finalize_repo.subprocess.run",
             return_value=CompletedProcess(args=("vrg-validate",), returncode=1),
         ),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 1
@@ -237,7 +237,7 @@ def test_main_calls_docker_run(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()) as mock_sub,
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -255,7 +255,7 @@ def test_main_docker_run_uses_uv_for_python(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()) as mock_sub,
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0
@@ -263,7 +263,7 @@ def test_main_docker_run_uses_uv_for_python(tmp_path: Path) -> None:
     assert cmd == ("vrg-docker-run", "--", "uv", "run", "vrg-validate")
 
 
-# -- _check_docs_workflow_status (issue #303) --------------------------------
+# -- _check_cd_workflow_status (issue #303) --------------------------------
 
 
 def _gh_run_json(conclusion: str | None) -> str:
@@ -281,45 +281,45 @@ def _gh_run_json(conclusion: str | None) -> str:
     )
 
 
-def test_check_docs_workflow_returns_none_when_gh_fails() -> None:
+def test_check_cd_workflow_returns_none_when_gh_fails() -> None:
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=1, stdout="", stderr="oops"),
     ):
-        assert _check_docs_workflow_status("develop") is None
+        assert _check_cd_workflow_status("develop") is None
 
 
-def test_check_docs_workflow_returns_none_when_no_runs() -> None:
+def test_check_cd_workflow_returns_none_when_no_runs() -> None:
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout="[]"),
     ):
-        assert _check_docs_workflow_status("develop") is None
+        assert _check_cd_workflow_status("develop") is None
 
 
-def test_check_docs_workflow_returns_none_on_success() -> None:
+def test_check_cd_workflow_returns_none_on_success() -> None:
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("success")),
     ):
-        assert _check_docs_workflow_status("develop") is None
+        assert _check_cd_workflow_status("develop") is None
 
 
-def test_check_docs_workflow_returns_none_on_in_progress() -> None:
+def test_check_cd_workflow_returns_none_on_in_progress() -> None:
     # gh reports null conclusion (in_progress / queued).
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json(None)),
     ):
-        assert _check_docs_workflow_status("develop") is None
+        assert _check_cd_workflow_status("develop") is None
 
 
-def test_check_docs_workflow_returns_message_on_failure() -> None:
+def test_check_cd_workflow_returns_message_on_failure() -> None:
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout=_gh_run_json("failure")),
     ):
-        msg = _check_docs_workflow_status("develop")
+        msg = _check_cd_workflow_status("develop")
     assert msg is not None
     assert "12345" in msg
     assert "develop" in msg
@@ -328,21 +328,21 @@ def test_check_docs_workflow_returns_message_on_failure() -> None:
     assert "actions/runs/12345" in msg
 
 
-def test_check_docs_workflow_returns_none_on_malformed_json() -> None:
+def test_check_cd_workflow_returns_none_on_malformed_json() -> None:
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout="not json"),
     ):
-        assert _check_docs_workflow_status("develop") is None
+        assert _check_cd_workflow_status("develop") is None
 
 
-def test_check_docs_workflow_returns_none_on_empty_stdout() -> None:
+def test_check_cd_workflow_returns_none_on_empty_stdout() -> None:
     # Defensive: stdout missing entirely (None) shouldn't crash.
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout=None),
     ):
-        assert _check_docs_workflow_status("develop") is None
+        assert _check_cd_workflow_status("develop") is None
 
 
 def test_main_returns_one_on_docs_failure(
@@ -356,17 +356,16 @@ def test_main_returns_one_on_docs_failure(
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(
-            _MOD + "._check_docs_workflow_status",
+            _MOD + "._check_cd_workflow_status",
             return_value=(
-                "Documentation workflow run 999 on develop (deadbee) "
-                "ended with conclusion 'failure'."
+                "CD workflow run 999 on develop (deadbee) ended with conclusion 'failure'."
             ),
         ),
     ):
         result = main([])
     assert result == 1
     stderr = capsys.readouterr().err
-    assert "Documentation workflow" in stderr
+    assert "CD workflow" in stderr
 
 
 def test_main_skips_docs_check_on_dry_run(tmp_path: Path) -> None:
@@ -377,7 +376,7 @@ def test_main_skips_docs_check_on_dry_run(tmp_path: Path) -> None:
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.merged_branches", return_value=[]),
         patch(
-            _MOD + "._check_docs_workflow_status",
+            _MOD + "._check_cd_workflow_status",
             return_value="should not appear",
         ) as mock_check,
     ):
@@ -504,7 +503,7 @@ def test_main_removes_worktree_before_deleting_branch(tmp_path: Path) -> None:
         patch(_MOD + "._worktree_is_dirty", return_value=False),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
 
@@ -537,7 +536,7 @@ def test_main_skips_worktree_remove_when_branch_not_in_worktree(tmp_path: Path) 
         patch(_MOD + ".git.read_output", return_value=porcelain),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=0),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
 
@@ -572,7 +571,7 @@ def test_main_skips_dirty_worktree(tmp_path: Path, capsys: pytest.CaptureFixture
         patch(_MOD + ".git.read_output", return_value=porcelain),
         patch(_MOD + "._worktree_is_dirty", return_value=True),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
 
@@ -596,7 +595,7 @@ def test_main_cleans_docker_cache_on_branch_delete(
         patch(_MOD + ".git.read_output", return_value=""),
         patch(_MOD + ".subprocess.run", return_value=_validation_ok()),
         patch(_MOD + ".clean_branch_images", return_value=2) as mock_clean,
-        patch(_MOD + "._check_docs_workflow_status", return_value=None),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
     ):
         result = main([])
     assert result == 0

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -383,9 +383,7 @@ def _make_config() -> StConfig:
         dependencies={"vergil": "v2.0"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=CiConfig(versions=["3.14"], integration_tests=False),
-        publish=PublishConfig(
-            release=False, docs=True, consumer_refresh=None, docs_workflow="Documentation"
-        ),
+        publish=PublishConfig(release=False, docs=True, consumer_refresh=None),
     )
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Rationalize the [publish] config and fix the confirm-publish release phase to match the actual CD workflow architecture

## Issue Linkage

- Ref #963

## Notes

- Removes docs_workflow config field, rewrites confirm-publish to watch single CD workflow (cd.yml) instead of two non-existent workflows, gates artifact verification on publish.release/docs booleans, fixes vrg-finalize-repo workflow check, unifies context fields