### PR TITLE
refactor(gh): extract shared retry module and wire into vrg-gh

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 
+from vergil_tooling.lib import retry
 from vergil_tooling.lib.github import _discover_accounts
 
 _ALLOWED: dict[str, set[str]] = {
@@ -122,9 +123,22 @@ def main(argv: list[str] | None = None) -> int:
 
     token = _get_token(argv)
     env = {**os.environ, "GH_TOKEN": token}
-    result = subprocess.run(  # noqa: S603
-        ["gh", *argv],  # noqa: S607
-        env=env,
-        check=False,
-    )
-    return result.returncode
+    try:
+        result = retry.run_with_retry(
+            ["gh", *argv],  # noqa: S607
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.stdout:
+            sys.stdout.write(exc.stdout)
+        if exc.stderr:
+            sys.stderr.write(exc.stderr)
+        return exc.returncode
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    return 0

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -11,12 +11,13 @@ import functools
 import json
 import logging
 import os
-import random
 import re
 import subprocess
 import sys
 import time
 from typing import Any
+
+from vergil_tooling.lib import retry
 
 log = logging.getLogger(__name__)
 
@@ -109,48 +110,19 @@ _NO_CHECKS_PHRASE = "no checks reported"
 _POLL_INTERVAL_SECS = 5
 _POLL_TIMEOUT_SECS = 60
 
-_MAX_RETRIES = 4
-_BASE_DELAY_SECS = 2.0
-_MAX_DELAY_SECS = 60.0
-_RETRYABLE_PATTERNS = (
-    "http 502",
-    "http 503",
-    "http 504",
-    "http 429",
-    "timed out",
-    "connection reset",
-)
-
-
-def _is_retryable(exc: subprocess.CalledProcessError) -> bool:
-    detail = ((exc.stderr or "") + (exc.stdout or "")).lower()
-    return any(p in detail for p in _RETRYABLE_PATTERNS)
-
 
 def _run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
     if "env" not in kwargs:
         env = _gh_env()
         if env is not None:
             kwargs["env"] = env
-    for attempt in range(_MAX_RETRIES + 1):
-        try:
-            return subprocess.run(*args, **kwargs)  # noqa: S603
-        except subprocess.CalledProcessError as exc:
-            if attempt == _MAX_RETRIES or not _is_retryable(exc):
-                detail = ((exc.stderr or "") + (exc.stdout or "")).strip()
-                if detail:
-                    raise GitHubAPIError(exc.returncode, exc.cmd, exc.stdout, exc.stderr) from exc
-                raise
-            delay = min(_BASE_DELAY_SECS * (2**attempt), _MAX_DELAY_SECS)
-            delay *= 0.5 + random.random()  # noqa: S311
-            log.warning(
-                "GitHub API error (attempt %d/%d), retrying in %.1fs",
-                attempt + 1,
-                _MAX_RETRIES + 1,
-                delay,
-            )
-            time.sleep(delay)
-    raise AssertionError("unreachable")  # pragma: no cover
+    try:
+        return retry.run_with_retry(*args, **kwargs)
+    except subprocess.CalledProcessError as exc:
+        detail = ((exc.stderr or "") + (exc.stdout or "")).strip()
+        if detail:
+            raise GitHubAPIError(exc.returncode, exc.cmd, exc.stdout, exc.stderr) from exc
+        raise
 
 
 def run(*args: str) -> None:

--- a/src/vergil_tooling/lib/retry.py
+++ b/src/vergil_tooling/lib/retry.py
@@ -1,0 +1,63 @@
+"""Retry logic for transient GitHub API errors.
+
+Shared by ``github.py`` (library wrappers) and ``vrg_gh.py`` (CLI wrapper)
+so both paths handle HTTP 502/503/504/429 and network timeouts identically.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import subprocess
+import time
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+MAX_RETRIES = 4
+BASE_DELAY_SECS = 2.0
+MAX_DELAY_SECS = 60.0
+_RETRYABLE_PATTERNS = (
+    "http 502",
+    "http 503",
+    "http 504",
+    "http 429",
+    "timed out",
+    "connection reset",
+)
+
+
+def is_retryable(exc: subprocess.CalledProcessError) -> bool:
+    """Return True if the error looks like a transient GitHub API failure."""
+    detail = ((exc.stderr or "") + (exc.stdout or "")).lower()
+    return any(p in detail for p in _RETRYABLE_PATTERNS)
+
+
+def compute_delay(attempt: int) -> float:
+    """Return a jittered exponential backoff delay for the given attempt."""
+    delay: float = min(BASE_DELAY_SECS * (2**attempt), MAX_DELAY_SECS)
+    jitter: float = 0.5 + random.random()  # noqa: S311
+    return delay * jitter
+
+
+def run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    """Run ``subprocess.run`` with retry on transient GitHub API errors.
+
+    Requires ``check=True`` and ``capture_output=True`` (or equivalent)
+    so that ``CalledProcessError`` carries stderr/stdout for detection.
+    """
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            return subprocess.run(*args, **kwargs)  # noqa: S603
+        except subprocess.CalledProcessError as exc:
+            if attempt == MAX_RETRIES or not is_retryable(exc):
+                raise
+            delay = compute_delay(attempt)
+            log.warning(
+                "GitHub API error (attempt %d/%d), retrying in %.1fs",
+                attempt + 1,
+                MAX_RETRIES + 1,
+                delay,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -26,7 +26,7 @@ def _completed(
 
 
 def test_run_delegates_to_subprocess() -> None:
-    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed()
         github.run("pr", "list")
     mock_run.assert_called_once_with(
@@ -35,7 +35,7 @@ def test_run_delegates_to_subprocess() -> None:
 
 
 def test_run_prints_captured_output(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed(stdout="PR merged\n", stderr="warning\n")
         github.run("pr", "merge")
     captured = capsys.readouterr()
@@ -44,7 +44,7 @@ def test_run_prints_captured_output(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_read_output_returns_stripped_stdout() -> None:
-    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed(stdout="  result\n")
         assert github.read_output("pr", "view") == "result"
     mock_run.assert_called_once_with(
@@ -224,7 +224,7 @@ def test_list_project_repos_empty() -> None:
 def test_read_json_returns_parsed_dict() -> None:
     payload = {"name": "test", "value": 42}
     cp = _completed(stdout=json.dumps(payload) + "\n")
-    with patch("vergil_tooling.lib.github.subprocess.run", return_value=cp):
+    with patch("vergil_tooling.lib.retry.subprocess.run", return_value=cp):
         result = github.read_json("api", "repos/o/r")
     assert result == payload
 
@@ -232,7 +232,7 @@ def test_read_json_returns_parsed_dict() -> None:
 def test_read_json_returns_parsed_list() -> None:
     payload = [{"id": 1}, {"id": 2}]
     cp = _completed(stdout=json.dumps(payload) + "\n")
-    with patch("vergil_tooling.lib.github.subprocess.run", return_value=cp):
+    with patch("vergil_tooling.lib.retry.subprocess.run", return_value=cp):
         result = github.read_json("api", "repos/o/r/rulesets")
     assert result == payload
 
@@ -256,7 +256,7 @@ def test_checks_registered_returns_true_when_checks_exist() -> None:
 
 
 def test_write_json_sends_body_via_stdin() -> None:
-    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed()
         github.write_json("PATCH", "repos/o/r", {"key": "value"})
     mock_run.assert_called_once_with(
@@ -269,7 +269,7 @@ def test_write_json_sends_body_via_stdin() -> None:
 
 
 def test_write_json_put_method() -> None:
-    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed()
         github.write_json("PUT", "repos/o/r/actions/permissions", {"allowed_actions": "all"})
     call_args = mock_run.call_args
@@ -279,7 +279,7 @@ def test_write_json_put_method() -> None:
 
 
 def test_delete_calls_gh_api() -> None:
-    with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed()
         github.delete("repos/o/r/vulnerability-alerts")
     mock_run.assert_called_once_with(
@@ -346,34 +346,9 @@ def _api_error(
     return exc
 
 
-class TestIsRetryable:
-    @pytest.mark.parametrize(
-        "stderr",
-        [
-            "HTTP 502 Bad Gateway",
-            "HTTP 503 Service Unavailable",
-            "HTTP 504 Gateway Timeout",
-            "HTTP 429 rate limit exceeded",
-            "request timed out",
-            "connection reset by peer",
-        ],
-    )
-    def test_retryable_errors(self, stderr: str) -> None:
-        assert github._is_retryable(_api_error(stderr=stderr)) is True
-
-    def test_retryable_error_in_stdout(self) -> None:
-        assert github._is_retryable(_api_error(stdout="HTTP 504")) is True
-
-    def test_non_retryable_error(self) -> None:
-        assert github._is_retryable(_api_error(stderr="HTTP 404 Not Found")) is False
-
-    def test_empty_output(self) -> None:
-        assert github._is_retryable(_api_error()) is False
-
-
 class TestRunWithRetry:
     def test_succeeds_on_first_attempt(self) -> None:
-        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+        with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
             mock_run.return_value = _completed(stdout="ok")
             result = github._run_with_retry(("gh", "pr", "view"), check=True)
         assert result.stdout == "ok"
@@ -383,11 +358,11 @@ class TestRunWithRetry:
         err = _api_error(stderr="HTTP 504 Gateway Timeout")
         with (
             patch(
-                "vergil_tooling.lib.github.subprocess.run",
+                "vergil_tooling.lib.retry.subprocess.run",
                 side_effect=[err, err, _completed(stdout="ok")],
             ) as mock_run,
-            patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
         ):
             result = github._run_with_retry(("gh", "pr", "view"), check=True)
         assert result.stdout == "ok"
@@ -397,12 +372,9 @@ class TestRunWithRetry:
     def test_raises_after_max_retries(self) -> None:
         err = _api_error(stderr="HTTP 504 Gateway Timeout")
         with (
-            patch(
-                "vergil_tooling.lib.github.subprocess.run",
-                side_effect=err,
-            ),
-            patch("vergil_tooling.lib.github.time.sleep"),
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
             pytest.raises(github.GitHubAPIError, match="Gateway Timeout"),
         ):
             github._run_with_retry(("gh", "pr", "view"), check=True)
@@ -410,8 +382,8 @@ class TestRunWithRetry:
     def test_raises_immediately_on_non_retryable_error(self) -> None:
         err = _api_error(stderr="HTTP 404 Not Found")
         with (
-            patch("vergil_tooling.lib.github.subprocess.run", side_effect=err),
-            patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
             pytest.raises(github.GitHubAPIError, match="404 Not Found"),
         ):
             github._run_with_retry(("gh", "pr", "view"), check=True)
@@ -422,7 +394,7 @@ class TestRunWithRetry:
         err.stderr = ""
         err.stdout = ""
         with (
-            patch("vergil_tooling.lib.github.subprocess.run", side_effect=err),
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
             pytest.raises(subprocess.CalledProcessError) as exc_info,
         ):
             github._run_with_retry(("gh", "pr", "view"), check=True)
@@ -432,11 +404,11 @@ class TestRunWithRetry:
         err = _api_error(stderr="HTTP 504 Gateway Timeout")
         with (
             patch(
-                "vergil_tooling.lib.github.subprocess.run",
+                "vergil_tooling.lib.retry.subprocess.run",
                 side_effect=[err, err, err, _completed()],
             ),
-            patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
         ):
             github._run_with_retry(("gh", "pr", "view"), check=True)
         delays = [c.args[0] for c in mock_sleep.call_args_list]
@@ -448,11 +420,11 @@ class TestRetryIntegration:
         err = _api_error(stderr="HTTP 504 Gateway Timeout")
         with (
             patch(
-                "vergil_tooling.lib.github.subprocess.run",
+                "vergil_tooling.lib.retry.subprocess.run",
                 side_effect=[err, _completed()],
             ) as mock_run,
-            patch("vergil_tooling.lib.github.time.sleep"),
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
         ):
             github.run("pr", "list")
         assert mock_run.call_count == 2
@@ -461,11 +433,11 @@ class TestRetryIntegration:
         err = _api_error(stderr="HTTP 502 Bad Gateway")
         with (
             patch(
-                "vergil_tooling.lib.github.subprocess.run",
+                "vergil_tooling.lib.retry.subprocess.run",
                 side_effect=[err, _completed(stdout="result\n")],
             ) as mock_run,
-            patch("vergil_tooling.lib.github.time.sleep"),
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
         ):
             assert github.read_output("pr", "view") == "result"
         assert mock_run.call_count == 2
@@ -474,11 +446,11 @@ class TestRetryIntegration:
         err = _api_error(stderr="HTTP 503 Service Unavailable")
         with (
             patch(
-                "vergil_tooling.lib.github.subprocess.run",
+                "vergil_tooling.lib.retry.subprocess.run",
                 side_effect=[err, _completed()],
             ) as mock_run,
-            patch("vergil_tooling.lib.github.time.sleep"),
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
         ):
             github.write_json("PATCH", "repos/o/r", {"key": "val"})
         assert mock_run.call_count == 2
@@ -487,11 +459,11 @@ class TestRetryIntegration:
         err = _api_error(stderr="HTTP 429 rate limit exceeded")
         with (
             patch(
-                "vergil_tooling.lib.github.subprocess.run",
+                "vergil_tooling.lib.retry.subprocess.run",
                 side_effect=[err, _completed()],
             ) as mock_run,
-            patch("vergil_tooling.lib.github.time.sleep"),
-            patch("vergil_tooling.lib.github.random.random", return_value=0.5),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
         ):
             github.delete("repos/o/r/vulnerability-alerts")
         assert mock_run.call_count == 2
@@ -567,7 +539,7 @@ class TestCredentialInjection:
         fake_env = {"GH_TOKEN": "test-token", "PATH": "/usr/bin"}
         with (
             patch("vergil_tooling.lib.github._gh_env", return_value=fake_env),
-            patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
         ):
             mock_run.return_value = _completed()
             github._run_with_retry(("gh", "pr", "list"), check=True)
@@ -575,7 +547,7 @@ class TestCredentialInjection:
         assert kwargs["env"] is fake_env
 
     def test_run_with_retry_skips_env_when_none(self) -> None:
-        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+        with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
             mock_run.return_value = _completed()
             github._run_with_retry(("gh", "pr", "list"), check=True)
         _, kwargs = mock_run.call_args
@@ -585,7 +557,7 @@ class TestCredentialInjection:
         caller_env = {"GH_TOKEN": "caller-token"}
         with (
             patch("vergil_tooling.lib.github._gh_env", return_value={"GH_TOKEN": "other"}),
-            patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
         ):
             mock_run.return_value = _completed()
             github._run_with_retry(("gh", "pr", "list"), check=True, env=caller_env)

--- a/tests/vergil_tooling/test_retry.py
+++ b/tests/vergil_tooling/test_retry.py
@@ -1,0 +1,129 @@
+"""Tests for vergil_tooling.lib.retry."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from vergil_tooling.lib import retry
+
+
+def _api_error(
+    returncode: int = 1, stderr: str = "", stdout: str = ""
+) -> subprocess.CalledProcessError:
+    exc = subprocess.CalledProcessError(returncode=returncode, cmd=["gh"])
+    exc.stderr = stderr
+    exc.stdout = stdout
+    return exc
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestIsRetryable:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "HTTP 502 Bad Gateway",
+            "HTTP 503 Service Unavailable",
+            "HTTP 504 Gateway Timeout",
+            "HTTP 429 rate limit exceeded",
+            "request timed out",
+            "connection reset by peer",
+        ],
+    )
+    def test_retryable_errors(self, stderr: str) -> None:
+        assert retry.is_retryable(_api_error(stderr=stderr)) is True
+
+    def test_retryable_error_in_stdout(self) -> None:
+        assert retry.is_retryable(_api_error(stdout="HTTP 504")) is True
+
+    def test_non_retryable_error(self) -> None:
+        assert retry.is_retryable(_api_error(stderr="HTTP 404 Not Found")) is False
+
+    def test_empty_output(self) -> None:
+        assert retry.is_retryable(_api_error()) is False
+
+
+class TestComputeDelay:
+    def test_increases_with_attempt(self) -> None:
+        with patch("vergil_tooling.lib.retry.random.random", return_value=0.5):
+            delays = [retry.compute_delay(i) for i in range(4)]
+        assert delays[0] < delays[1] < delays[2] < delays[3]
+
+    def test_capped_at_max(self) -> None:
+        with patch("vergil_tooling.lib.retry.random.random", return_value=0.5):
+            delay = retry.compute_delay(100)
+        assert delay <= retry.MAX_DELAY_SECS * 1.5
+
+    def test_jitter_range(self) -> None:
+        with patch("vergil_tooling.lib.retry.random.random", return_value=0.0):
+            low = retry.compute_delay(0)
+        with patch("vergil_tooling.lib.retry.random.random", return_value=1.0):
+            high = retry.compute_delay(0)
+        assert low < high
+        assert low == retry.BASE_DELAY_SECS * 0.5
+        assert high == retry.BASE_DELAY_SECS * 1.5
+
+
+class TestRunWithRetry:
+    def test_succeeds_on_first_attempt(self) -> None:
+        with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="ok")
+            result = retry.run_with_retry(("gh", "pr", "view"), check=True)
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 1
+
+    def test_retries_on_504_then_succeeds(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch(
+                "vergil_tooling.lib.retry.subprocess.run",
+                side_effect=[err, err, _completed(stdout="ok")],
+            ) as mock_run,
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
+        ):
+            result = retry.run_with_retry(("gh", "pr", "view"), check=True)
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_raises_after_max_retries(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
+            pytest.raises(subprocess.CalledProcessError, match=""),
+        ):
+            retry.run_with_retry(("gh", "pr", "view"), check=True)
+
+    def test_raises_immediately_on_non_retryable(self) -> None:
+        err = _api_error(stderr="HTTP 404 Not Found")
+        with (
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            retry.run_with_retry(("gh", "pr", "view"), check=True)
+        mock_sleep.assert_not_called()
+
+    def test_backoff_delay_increases(self) -> None:
+        err = _api_error(stderr="HTTP 504 Gateway Timeout")
+        with (
+            patch(
+                "vergil_tooling.lib.retry.subprocess.run",
+                side_effect=[err, err, err, _completed()],
+            ),
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
+        ):
+            retry.run_with_retry(("gh", "pr", "view"), check=True)
+        delays = [c.args[0] for c in mock_sleep.call_args_list]
+        assert delays[0] < delays[1] < delays[2]

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_gh import main
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
 
 # -- no arguments / missing subcommand ----------------------------------------
 
@@ -54,9 +62,9 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
 def test_allowed_pair_passes(top: str, sub: str) -> None:
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
     ):
-        mock_run.return_value.returncode = 0
+        mock_run.return_value = _completed()
         rc = main([top, sub])
     assert rc == 0
     args = mock_run.call_args[0][0]
@@ -130,9 +138,9 @@ def test_auth_denied(capsys: pytest.CaptureFixture[str]) -> None:
 def test_pr_review_comment_allowed() -> None:
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
     ):
-        mock_run.return_value.returncode = 0
+        mock_run.return_value = _completed()
         rc = main(["pr", "review", "--comment", "-b", "looks good"])
     assert rc == 0
 
@@ -140,9 +148,9 @@ def test_pr_review_comment_allowed() -> None:
 def test_pr_review_no_flags_allowed() -> None:
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
     ):
-        mock_run.return_value.returncode = 0
+        mock_run.return_value = _completed()
         rc = main(["pr", "review"])
     assert rc == 0
 
@@ -315,9 +323,9 @@ def test_pr_merge_release_branch_escalates() -> None:
 def test_pr_merge_allowed_with_valid_context() -> None:
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="human-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
     ):
-        mock_run.return_value.returncode = 0
+        mock_run.return_value = _completed()
         rc = main(["pr", "merge", "42"])
     assert rc == 0
 
@@ -336,9 +344,9 @@ def test_pr_merge_denied_without_args(
 def test_gh_token_injected_into_env() -> None:
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="injected-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
     ):
-        mock_run.return_value.returncode = 0
+        mock_run.return_value = _completed()
         main(["issue", "list"])
     _, kwargs = mock_run.call_args
     assert kwargs["env"]["GH_TOKEN"] == "injected-token"  # noqa: S105
@@ -350,19 +358,115 @@ def test_gh_token_injected_into_env() -> None:
 def test_subprocess_uses_shell_false() -> None:
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
     ):
-        mock_run.return_value.returncode = 0
+        mock_run.return_value = _completed()
         main(["issue", "list"])
     _, kwargs = mock_run.call_args
     assert kwargs.get("shell") is not True
 
 
 def test_returns_subprocess_exit_code() -> None:
+    err = subprocess.CalledProcessError(128, ["gh", "issue", "list"])
+    err.stdout = ""
+    err.stderr = "fatal\n"
     with (
         patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
-        patch("vergil_tooling.bin.vrg_gh.subprocess.run") as mock_run,
+        patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
     ):
-        mock_run.return_value.returncode = 128
         rc = main(["issue", "list"])
     assert rc == 128
+
+
+def test_stdout_and_stderr_replayed_on_success(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = _completed(stdout="output\n", stderr="warning\n")
+        main(["issue", "list"])
+    captured = capsys.readouterr()
+    assert "output" in captured.out
+    assert "warning" in captured.err
+
+
+def test_stdout_and_stderr_replayed_on_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    err = subprocess.CalledProcessError(1, ["gh"])
+    err.stdout = "partial\n"
+    err.stderr = "HTTP 404 Not Found\n"
+    with (
+        patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
+        patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+    ):
+        rc = main(["issue", "view", "42"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "partial" in captured.out
+    assert "404" in captured.err
+
+
+def test_failure_with_no_output(capsys: pytest.CaptureFixture[str]) -> None:
+    err = subprocess.CalledProcessError(1, ["gh"])
+    err.stdout = ""
+    err.stderr = ""
+    with (
+        patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
+        patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+    ):
+        rc = main(["issue", "view", "42"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+# -- retry behaviour ----------------------------------------------------------
+
+
+def _api_error(
+    returncode: int = 1, stderr: str = "", stdout: str = ""
+) -> subprocess.CalledProcessError:
+    exc = subprocess.CalledProcessError(returncode=returncode, cmd=["gh"])
+    exc.stderr = stderr
+    exc.stdout = stdout
+    return exc
+
+
+class TestVrgGhRetry:
+    def test_retries_on_502_then_succeeds(self) -> None:
+        err = _api_error(stderr="HTTP 502 Bad Gateway")
+        with (
+            patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
+            patch(
+                "vergil_tooling.lib.retry.subprocess.run",
+                side_effect=[err, _completed(stdout="ok\n")],
+            ) as mock_run,
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
+        ):
+            rc = main(["issue", "list"])
+        assert rc == 0
+        assert mock_run.call_count == 2
+
+    def test_gives_up_after_max_retries(self) -> None:
+        err = _api_error(stderr="HTTP 503 Service Unavailable")
+        with (
+            patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+            patch("vergil_tooling.lib.retry.time.sleep"),
+            patch("vergil_tooling.lib.retry.random.random", return_value=0.5),
+        ):
+            rc = main(["issue", "list"])
+        assert rc == 1
+
+    def test_no_retry_on_non_transient_error(self) -> None:
+        err = _api_error(stderr="HTTP 404 Not Found")
+        with (
+            patch("vergil_tooling.bin.vrg_gh._get_token", return_value="fake-token"),
+            patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err) as mock_run,
+            patch("vergil_tooling.lib.retry.time.sleep") as mock_sleep,
+        ):
+            rc = main(["issue", "view", "42"])
+        assert rc == 1
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- Extract transient-error retry logic from github.py into shared lib/retry.py and wire it into vrg-gh CLI wrapper so both paths handle HTTP 502/503/504/429 and network timeouts identically.

## Issue Linkage

- Ref #955

## Notes

- -