### PR TITLE
fix(repo-init): emit release job in CD workflow when publish_release is true

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -368,6 +368,15 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
 
 def render_cd_workflow(ctx: RepoInitContext) -> str:
     """Render .github/workflows/cd.yml."""
+    permissions = ["  contents: write\n"]
+    if ctx.publish_release:
+        permissions = [
+            "  attestations: write\n",
+            "  contents: write\n",
+            "  id-token: write\n",
+            "  pull-requests: write\n",
+        ]
+
     lines = [
         "name: CD\n",
         "\n",
@@ -377,7 +386,7 @@ def render_cd_workflow(ctx: RepoInitContext) -> str:
         "  workflow_dispatch:\n",
         "\n",
         "permissions:\n",
-        "  contents: write\n",
+        *permissions,
         "\n",
         "jobs:\n",
     ]
@@ -389,6 +398,22 @@ def render_cd_workflow(ctx: RepoInitContext) -> str:
                 "    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0\n",
                 "    permissions:\n",
                 "      contents: write\n",
+            ]
+        )
+
+    if ctx.publish_release:
+        suffix = _container_suffix(ctx.primary_language)
+        tag = _container_tag(ctx.primary_language, ctx.ci_versions)
+        lines.append("\n")
+        lines.extend(
+            [
+                "  release:\n",
+                "    if: github.ref == 'refs/heads/main'\n",
+                "    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0\n",
+                "    with:\n",
+                f"      language: {suffix}\n",
+                f'      container-tag: "{tag}"\n',
+                "    secrets: inherit\n",
             ]
         )
 
@@ -672,7 +697,7 @@ def step_ci_cd_workflows(ctx: RepoInitContext) -> None:
     ci_content = render_ci_workflow(ctx)
     (workflows_dir / "ci.yml").write_text(ci_content)
 
-    if ctx.publish_docs:
+    if ctx.publish_docs or ctx.publish_release:
         cd_content = render_cd_workflow(ctx)
         (workflows_dir / "cd.yml").write_text(cd_content)
 

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -295,12 +295,43 @@ class TestRenderCdWorkflow:
         content = render_cd_workflow(ctx)
         assert "cd-docs.yml@v2.0" in content
         assert "cd-release" not in content
+        assert "attestations: write" not in content
 
     def test_no_docs_job(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
         ctx.publish_docs = False
         content = render_cd_workflow(ctx)
         assert "cd-docs" not in content
+
+    def test_release_job(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.publish_docs = False
+        ctx.publish_release = True
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.12", "3.13", "3.14"]
+        content = render_cd_workflow(ctx)
+        assert "cd-release.yml@v2.0" in content
+        assert "if: github.ref == 'refs/heads/main'" in content
+        assert "language: python" in content
+        assert 'container-tag: "3.14"' in content
+        assert "secrets: inherit" in content
+        assert "attestations: write" in content
+        assert "id-token: write" in content
+        assert "pull-requests: write" in content
+        assert "cd-docs" not in content
+
+    def test_docs_and_release(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.publish_docs = True
+        ctx.publish_release = True
+        ctx.primary_language = "go"
+        ctx.ci_versions = ["1.22"]
+        content = render_cd_workflow(ctx)
+        assert "cd-docs.yml@v2.0" in content
+        assert "cd-release.yml@v2.0" in content
+        assert "language: go" in content
+        assert 'container-tag: "latest"' in content
+        assert "attestations: write" in content
 
 
 class TestRenderMkdocsYml:
@@ -626,7 +657,24 @@ class TestStepCiCdWorkflows:
         assert (tmp_path / ".github" / "workflows" / "ci.yml").exists()
         assert (tmp_path / ".github" / "workflows" / "cd.yml").exists()
 
-    def test_skips_cd_when_no_docs(self, tmp_path: Path) -> None:
+    def test_creates_cd_for_release_only(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.work_dir = tmp_path
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.14"]
+        ctx.release_model = "tagged-release"
+        ctx.publish_docs = False
+        ctx.publish_release = True
+
+        with patch("vergil_tooling.lib.repo_init.git.run"):
+            step_ci_cd_workflows(ctx)
+
+        assert (tmp_path / ".github" / "workflows" / "cd.yml").exists()
+        content = (tmp_path / ".github" / "workflows" / "cd.yml").read_text()
+        assert "cd-release.yml@v2.0" in content
+        assert "cd-docs" not in content
+
+    def test_skips_cd_when_no_docs_or_release(self, tmp_path: Path) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
         ctx.work_dir = tmp_path
         ctx.primary_language = "shell"


### PR DESCRIPTION
# Pull Request

## Summary

- render_cd_workflow now emits a release job calling cd-release.yml when publish_release is true, with correct permissions, language, container-tag, and secrets. step_ci_cd_workflows now writes cd.yml when publish_release or publish_docs.

## Issue Linkage

- Ref #973

## Notes

- -