### PR TITLE
fix(repo-init): skip CI jobs not required by CI gates ruleset

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -277,9 +277,16 @@ _CODEQL_LANGUAGES = frozenset(
 
 def render_ci_workflow(ctx: RepoInitContext) -> str:
     """Render .github/workflows/ci.yml."""
+    from vergil_tooling.lib.validate_commands import CheckKind, language_commands
+
     suffix = _container_suffix(ctx.primary_language)
     tag = _container_tag(ctx.primary_language, ctx.ci_versions)
     versions_json = json.dumps(ctx.ci_versions)
+
+    has_audit = len(language_commands(ctx.primary_language, CheckKind.AUDIT)) > 0
+    has_test = (
+        len(language_commands(ctx.primary_language, CheckKind.TEST)) > 0 or ctx.integration_tests
+    )
 
     lines = [
         "name: CI\n",
@@ -303,50 +310,62 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
         "  cancel-in-progress: true\n",
         "\n",
         "jobs:\n",
-        "  audit:\n",
-        "    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0\n",
-        "    with:\n",
-        f"      language: {ctx.primary_language}\n",
-        f"      versions: '{versions_json}'\n",
-        f"      container-tag: '{tag}'\n",
-        f"      container-suffix: {suffix}\n",
-        "\n",
-        "  quality:\n",
-        "    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0\n",
-        "    with:\n",
-        f"      language: {ctx.primary_language}\n",
-        f"      versions: '{versions_json}'\n",
-        f"      container-tag: '{tag}'\n",
-        f"      container-suffix: {suffix}\n",
-        "\n",
-        "  security:\n",
-        "    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0\n",
-        "    permissions:\n",
-        "      contents: read\n",
-        "      security-events: write\n",
-        "    with:\n",
-        f"      language: {ctx.primary_language}\n",
-        "      run-standards: ${{ inputs.run-release != 'false' }}\n",
-        "      run-security: ${{ inputs.run-security != 'false' }}\n",
-        f"      container-tag: '{tag}'\n",
-        f"      container-suffix: {suffix}\n",
     ]
 
-    if ctx.primary_language not in _CODEQL_LANGUAGES:
-        lines.append("      run-codeql: false\n")
+    if has_audit:
+        lines.extend(
+            [
+                "  audit:\n",
+                "    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0\n",
+                "    with:\n",
+                f"      language: {ctx.primary_language}\n",
+                f"      versions: '{versions_json}'\n",
+                f"      container-tag: '{tag}'\n",
+                f"      container-suffix: {suffix}\n",
+                "\n",
+            ]
+        )
 
     lines.extend(
         [
-            "\n",
-            "  test:\n",
-            "    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0\n",
+            "  quality:\n",
+            "    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0\n",
             "    with:\n",
             f"      language: {ctx.primary_language}\n",
             f"      versions: '{versions_json}'\n",
             f"      container-tag: '{tag}'\n",
             f"      container-suffix: {suffix}\n",
+            "\n",
+            "  security:\n",
+            "    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0\n",
+            "    permissions:\n",
+            "      contents: read\n",
+            "      security-events: write\n",
+            "    with:\n",
+            f"      language: {ctx.primary_language}\n",
+            "      run-standards: ${{ inputs.run-release != 'false' }}\n",
+            "      run-security: ${{ inputs.run-security != 'false' }}\n",
+            f"      container-tag: '{tag}'\n",
+            f"      container-suffix: {suffix}\n",
         ]
     )
+
+    if ctx.primary_language not in _CODEQL_LANGUAGES:
+        lines.append("      run-codeql: false\n")
+
+    if has_test:
+        lines.extend(
+            [
+                "\n",
+                "  test:\n",
+                "    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0\n",
+                "    with:\n",
+                f"      language: {ctx.primary_language}\n",
+                f"      versions: '{versions_json}'\n",
+                f"      container-tag: '{tag}'\n",
+                f"      container-suffix: {suffix}\n",
+            ]
+        )
 
     if ctx.release_model != "none":
         lines.extend(

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -255,6 +255,8 @@ class TestRenderCiWorkflow:
         ctx.release_model = "tagged-release"
         content = render_ci_workflow(ctx)
         assert "ci-quality.yml@v2.0" in content
+        assert "ci-audit.yml@v2.0" in content
+        assert "ci-test.yml@v2.0" in content
         assert "container-suffix: python" in content
         assert "ci-version-bump.yml@v2.0" in content
         assert "run-codeql: false" not in content
@@ -267,16 +269,39 @@ class TestRenderCiWorkflow:
         content = render_ci_workflow(ctx)
         assert "container-suffix: base" in content
         assert "run-codeql: false" in content
-        assert content.count("container-suffix: base") == 5
-        assert content.count("container-tag: 'latest'") == 5
+        assert "ci-audit.yml" not in content
+        assert "ci-test.yml" not in content
+        assert "ci-quality.yml@v2.0" in content
+        assert "ci-security.yml@v2.0" in content
+        assert "ci-version-bump.yml@v2.0" in content
+        assert content.count("container-suffix: base") == 3
+        assert content.count("container-tag: 'latest'") == 3
 
-    def test_codeql_disabled_for_claude_plugin(self) -> None:
+    def test_shell_no_release_minimal_jobs(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "shell"
+        ctx.ci_versions = ["latest"]
+        ctx.release_model = "none"
+        content = render_ci_workflow(ctx)
+        assert "ci-quality.yml@v2.0" in content
+        assert "ci-security.yml@v2.0" in content
+        assert "ci-audit.yml" not in content
+        assert "ci-test.yml" not in content
+        assert "version-bump" not in content
+        assert content.count("container-suffix: base") == 2
+        assert content.count("container-tag: 'latest'") == 2
+
+    def test_claude_plugin_skips_audit_and_test(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
         ctx.primary_language = "claude-plugin"
         ctx.ci_versions = ["latest"]
         ctx.release_model = "none"
         content = render_ci_workflow(ctx)
         assert "run-codeql: false" in content
+        assert "ci-audit.yml" not in content
+        assert "ci-test.yml" not in content
+        assert "ci-quality.yml@v2.0" in content
+        assert "ci-security.yml@v2.0" in content
 
     def test_no_version_bump_when_release_none(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
@@ -285,6 +310,15 @@ class TestRenderCiWorkflow:
         ctx.release_model = "none"
         content = render_ci_workflow(ctx)
         assert "version-bump" not in content
+
+    def test_integration_tests_emit_test_job_for_shell(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "shell"
+        ctx.ci_versions = ["latest"]
+        ctx.release_model = "none"
+        ctx.integration_tests = True
+        content = render_ci_workflow(ctx)
+        assert "ci-test.yml@v2.0" in content
 
 
 class TestRenderCdWorkflow:


### PR DESCRIPTION
# Pull Request

## Summary

- Align render_ci_workflow() with desired_ci_gates_ruleset() by consulting the language command registry before emitting audit and test jobs.

## Issue Linkage

- Ref #975

## Notes

- render_ci_workflow() unconditionally emitted audit and test jobs for all languages. Languages without command registry entries (shell, claude-plugin, none) ran these jobs even though the CI gates ruleset never required them — wasting compute and misleading maintainers.

The fix consults language_commands() from validate_commands.py (the same registry that desired_ci_gates_ruleset() already uses) to decide whether to emit each job. The audit job is only emitted when the language has AUDIT commands. The test job is only emitted when the language has TEST commands or when integration tests are enabled.

Follow-on issue #977 tracks adding an ongoing alignment audit between ci.yml jobs and CI gates rulesets.