### PR TITLE
feat(session): identity config parser for VM session management

### DIFF
--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -1,0 +1,71 @@
+"""Parse identity VM configuration from ``identities.toml``."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Identity:
+    vm_instance: str
+    auth_type: str = "app"
+    app_id: str = ""
+    installation_id: str = ""
+    private_key_path: str = ""
+    workspaces: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class IdentityConfig:
+    identities: dict[str, Identity] = field(default_factory=dict)
+
+
+def load_config(path: Path) -> IdentityConfig:
+    if not path.exists():
+        print(f"ERROR: identity config not found: {path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+
+    identities: dict[str, Identity] = {}
+    for name, data in raw.get("identities", {}).items():
+        identities[name] = Identity(
+            vm_instance=data["vm_instance"],
+            auth_type=data.get("auth_type", "app"),
+            app_id=str(data.get("app_id", "")),
+            installation_id=str(data.get("installation_id", "")),
+            private_key_path=data.get("private_key_path", ""),
+            workspaces=data.get("workspaces", {}),
+        )
+    return IdentityConfig(identities=identities)
+
+
+def default_config_path() -> Path:
+    return Path.home() / ".config" / "vergil" / "identities.toml"
+
+
+def resolve_project(config: IdentityConfig, project: str) -> tuple[Identity, str]:
+    matches: list[tuple[Identity, str]] = []
+    for ident in config.identities.values():
+        if project in ident.workspaces:
+            matches.append((ident, ident.workspaces[project]))
+
+    if not matches:
+        print(
+            f"ERROR: project '{project}' not found in any identity",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    if len(matches) > 1:
+        print(
+            f"ERROR: project '{project}' found in multiple identities — ambiguous",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    return matches[0]

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from vergil_tooling.lib.identity import (
+    Identity,
+    IdentityConfig,
+    default_config_path,
+    load_config,
+    resolve_project,
+)
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Path:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        auth_type = "app"
+        app_id = 12345
+        installation_id = 67890
+        private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
+
+        [identities.vergil.workspaces]
+        vergil-tooling = "/projects/vergil-project/vergil-tooling"
+        diogenes-core = "/projects/diogenes-project/diogenes-core"
+    """)
+    )
+    return p
+
+
+def test_load_config(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    assert isinstance(cfg, IdentityConfig)
+    assert "vergil" in cfg.identities
+
+
+def test_identity_fields(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    ident = cfg.identities["vergil"]
+    assert isinstance(ident, Identity)
+    assert ident.vm_instance == "vergil-agent"
+    assert ident.auth_type == "app"
+    assert ident.app_id == "12345"
+    assert ident.installation_id == "67890"
+    assert ident.workspaces["vergil-tooling"] == "/projects/vergil-project/vergil-tooling"
+
+
+def test_resolve_project_found(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    ident, workspace = resolve_project(cfg, "vergil-tooling")
+    assert ident.vm_instance == "vergil-agent"
+    assert workspace == "/projects/vergil-project/vergil-tooling"
+
+
+def test_resolve_project_not_found(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    with pytest.raises(SystemExit):
+        resolve_project(cfg, "nonexistent-project")
+
+
+def test_resolve_project_ambiguous(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        auth_type = "app"
+        app_id = 11111
+        installation_id = 22222
+        private_key_path = "~/.config/vergil/keys/vergil.pem"
+        [identities.vergil.workspaces]
+        shared-repo = "/projects/shared-repo"
+
+        [identities.mimir]
+        vm_instance = "mimir-agent"
+        auth_type = "app"
+        app_id = 33333
+        installation_id = 44444
+        private_key_path = "~/.config/vergil/keys/mimir.pem"
+        [identities.mimir.workspaces]
+        shared-repo = "/projects/shared-repo"
+    """)
+    )
+    cfg = load_config(p)
+    with pytest.raises(SystemExit):
+        resolve_project(cfg, "shared-repo")
+
+
+def test_missing_config_file(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        load_config(tmp_path / "nonexistent.toml")
+
+
+def test_default_config_path() -> None:
+    result = default_config_path()
+    assert result.name == "identities.toml"
+    assert result.parent.name == "vergil"


### PR DESCRIPTION
# Pull Request

## Summary

- Identity configuration parser that reads identities.toml and resolves project short names to identity VMs and workspace paths using the /projects mount convention.

## Issue Linkage

- Ref #984

## Notes

- 7 tests, 100% coverage. Workspace paths use /projects (vergil-vm#19).