### PR TITLE
Replace workspace registry with path-based resolution

### DIFF
--- a/src/vergil_tooling/bin/vrg_session.py
+++ b/src/vergil_tooling/bin/vrg_session.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from vergil_tooling.lib.identity import (
     default_config_path,
     load_config,
-    resolve_project,
+    resolve_identity,
+    resolve_workspace,
 )
 
 _default_config_path = default_config_path
@@ -43,9 +44,9 @@ def main(argv: list[str] | None = None) -> None:
         description="Launch a Claude Code session inside an identity VM",
     )
     parser.add_argument(
-        "project",
+        "workspace",
         nargs="?",
-        help="Project short name (from identities.toml workspaces)",
+        help="Workspace path (relative to /projects, or absolute)",
     )
     parser.add_argument(
         "--shell",
@@ -54,7 +55,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "--identity",
-        help="Identity name (default: resolved from project)",
+        help="Identity name (default: sole configured identity)",
     )
     parser.add_argument(
         "--config",
@@ -71,23 +72,20 @@ def main(argv: list[str] | None = None) -> None:
 
     config_path = args.config if args.config else _default_config_path()
     config = load_config(config_path)
+    identity = resolve_identity(config, args.identity)
 
-    if args.project:
-        identity, workspace = resolve_project(config, args.project)
-    elif args.identity:
-        if args.identity not in config.identities:
-            print(f"ERROR: identity '{args.identity}' not found", file=sys.stderr)
-            raise SystemExit(1)
-        identity = config.identities[args.identity]
-        workspace = None
-    else:
-        print("ERROR: provide a project name or --identity", file=sys.stderr)
+    workspace: str | None = None
+    if args.workspace:
+        workspace = resolve_workspace(args.workspace)
+
+    if not args.workspace and not args.identity and not args.shell:
+        print("ERROR: provide a workspace path or --identity", file=sys.stderr)
         raise SystemExit(1)
 
     cmd = build_command(
         vm_instance=identity.vm_instance,
         workspace=workspace,
-        shell_only=args.shell or not args.project,
+        shell_only=args.shell,
         claude_args=args.claude_args or None,
     )
 

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -15,12 +15,11 @@ class Identity:
     app_id: str = ""
     installation_id: str = ""
     private_key_path: str = ""
-    workspaces: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
 class IdentityConfig:
-    identities: dict[str, Identity] = field(default_factory=dict)
+    identities: dict[str, Identity]
 
 
 def load_config(path: Path) -> IdentityConfig:
@@ -39,7 +38,6 @@ def load_config(path: Path) -> IdentityConfig:
             app_id=str(data.get("app_id", "")),
             installation_id=str(data.get("installation_id", "")),
             private_key_path=data.get("private_key_path", ""),
-            workspaces=data.get("workspaces", {}),
         )
     return IdentityConfig(identities=identities)
 
@@ -48,24 +46,27 @@ def default_config_path() -> Path:
     return Path.home() / ".config" / "vergil" / "identities.toml"
 
 
-def resolve_project(config: IdentityConfig, project: str) -> tuple[Identity, str]:
-    matches: list[tuple[Identity, str]] = []
-    for ident in config.identities.values():
-        if project in ident.workspaces:
-            matches.append((ident, ident.workspaces[project]))
+def resolve_identity(config: IdentityConfig, name: str | None = None) -> Identity:
+    if name is not None:
+        if name not in config.identities:
+            print(f"ERROR: identity '{name}' not found", file=sys.stderr)
+            raise SystemExit(1)
+        return config.identities[name]
 
-    if not matches:
-        print(
-            f"ERROR: project '{project}' not found in any identity",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
+    if len(config.identities) == 1:
+        return next(iter(config.identities.values()))
 
-    if len(matches) > 1:
-        print(
-            f"ERROR: project '{project}' found in multiple identities — ambiguous",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
+    print(
+        "ERROR: multiple identities configured — use --identity to select one",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
-    return matches[0]
+
+_PROJECTS_PREFIX = "/projects"
+
+
+def resolve_workspace(path: str) -> str:
+    if path.startswith("/"):
+        return path
+    return f"{_PROJECTS_PREFIX}/{path}"

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -13,7 +13,8 @@ from vergil_tooling.lib.identity import (
     IdentityConfig,
     default_config_path,
     load_config,
-    resolve_project,
+    resolve_identity,
+    resolve_workspace,
 )
 
 
@@ -28,10 +29,6 @@ def config_file(tmp_path: Path) -> Path:
         app_id = 12345
         installation_id = 67890
         private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
-
-        [identities.vergil.workspaces]
-        vergil-tooling = "/projects/vergil-project/vergil-tooling"
-        diogenes-core = "/projects/diogenes-project/diogenes-core"
     """)
     )
     return p
@@ -51,48 +48,6 @@ def test_identity_fields(config_file: Path) -> None:
     assert ident.auth_type == "app"
     assert ident.app_id == "12345"
     assert ident.installation_id == "67890"
-    assert ident.workspaces["vergil-tooling"] == "/projects/vergil-project/vergil-tooling"
-
-
-def test_resolve_project_found(config_file: Path) -> None:
-    cfg = load_config(config_file)
-    ident, workspace = resolve_project(cfg, "vergil-tooling")
-    assert ident.vm_instance == "vergil-agent"
-    assert workspace == "/projects/vergil-project/vergil-tooling"
-
-
-def test_resolve_project_not_found(config_file: Path) -> None:
-    cfg = load_config(config_file)
-    with pytest.raises(SystemExit):
-        resolve_project(cfg, "nonexistent-project")
-
-
-def test_resolve_project_ambiguous(tmp_path: Path) -> None:
-    p = tmp_path / "identities.toml"
-    p.write_text(
-        textwrap.dedent("""\
-        [identities.vergil]
-        vm_instance = "vergil-agent"
-        auth_type = "app"
-        app_id = 11111
-        installation_id = 22222
-        private_key_path = "~/.config/vergil/keys/vergil.pem"
-        [identities.vergil.workspaces]
-        shared-repo = "/projects/shared-repo"
-
-        [identities.mimir]
-        vm_instance = "mimir-agent"
-        auth_type = "app"
-        app_id = 33333
-        installation_id = 44444
-        private_key_path = "~/.config/vergil/keys/mimir.pem"
-        [identities.mimir.workspaces]
-        shared-repo = "/projects/shared-repo"
-    """)
-    )
-    cfg = load_config(p)
-    with pytest.raises(SystemExit):
-        resolve_project(cfg, "shared-repo")
 
 
 def test_missing_config_file(tmp_path: Path) -> None:
@@ -104,3 +59,47 @@ def test_default_config_path() -> None:
     result = default_config_path()
     assert result.name == "identities.toml"
     assert result.parent.name == "vergil"
+
+
+def test_resolve_identity_sole(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    ident = resolve_identity(cfg)
+    assert ident.vm_instance == "vergil-agent"
+
+
+def test_resolve_identity_by_name(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    ident = resolve_identity(cfg, "vergil")
+    assert ident.vm_instance == "vergil-agent"
+
+
+def test_resolve_identity_not_found(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    with pytest.raises(SystemExit):
+        resolve_identity(cfg, "nonexistent")
+
+
+def test_resolve_identity_ambiguous(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+
+        [identities.mimir]
+        vm_instance = "mimir-agent"
+    """)
+    )
+    cfg = load_config(p)
+    with pytest.raises(SystemExit):
+        resolve_identity(cfg)
+
+
+def test_resolve_workspace_relative() -> None:
+    assert resolve_workspace("vergil-project/vergil-tooling") == (
+        "/projects/vergil-project/vergil-tooling"
+    )
+
+
+def test_resolve_workspace_absolute() -> None:
+    assert resolve_workspace("/custom/path") == "/custom/path"

--- a/tests/vergil_tooling/test_vrg_session.py
+++ b/tests/vergil_tooling/test_vrg_session.py
@@ -23,9 +23,6 @@ def config_dir(tmp_path: Path) -> Path:
         app_id = 12345
         installation_id = 67890
         private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
-
-        [identities.vergil.workspaces]
-        vergil-tooling = "/projects/vergil-project/vergil-tooling"
     """)
     )
     return tmp_path
@@ -112,7 +109,7 @@ def test_build_command_claude_args_ignored_in_shell_mode() -> None:
     ]
 
 
-def test_no_project_or_identity(config_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_no_workspace_or_identity(config_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "vergil_tooling.bin.vrg_session._default_config_path",
         lambda: config_dir / ".config" / "vergil" / "identities.toml",
@@ -130,7 +127,7 @@ def test_identity_not_found(config_dir: Path, monkeypatch: pytest.MonkeyPatch) -
         main(["--shell", "--identity", "nonexistent"])
 
 
-def test_main_identity_only(
+def test_main_shell_with_identity(
     config_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -150,7 +147,7 @@ def test_main_identity_only(
     assert execed[0][1] == ["limactl", "shell", "--start", "vergil-agent"]
 
 
-def test_main_launches_session(
+def test_main_relative_path(
     config_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -165,7 +162,7 @@ def test_main_launches_session(
         lambda prog, args: execed.append((prog, args)),
     )
 
-    main(["vergil-tooling"])
+    main(["vergil-project/vergil-tooling"])
     assert len(execed) == 1
     assert execed[0][1] == [
         "limactl",
@@ -174,6 +171,35 @@ def test_main_launches_session(
         "vergil-agent",
         "--workdir",
         "/projects/vergil-project/vergil-tooling",
+        "--",
+        "claude",
+    ]
+
+
+def test_main_absolute_path(
+    config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_session._default_config_path",
+        lambda: config_dir / ".config" / "vergil" / "identities.toml",
+    )
+
+    execed: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_session.os.execvp",
+        lambda prog, args: execed.append((prog, args)),
+    )
+
+    main(["/custom/absolute/path"])
+    assert len(execed) == 1
+    assert execed[0][1] == [
+        "limactl",
+        "shell",
+        "--start",
+        "vergil-agent",
+        "--workdir",
+        "/custom/absolute/path",
         "--",
         "claude",
     ]
@@ -194,7 +220,7 @@ def test_main_passes_claude_args(
         lambda prog, args: execed.append((prog, args)),
     )
 
-    main(["vergil-tooling", "--", "--model", "claude-opus-4-6"])
+    main(["vergil-project/vergil-tooling", "--", "--model", "claude-opus-4-6"])
     assert len(execed) == 1
     assert execed[0][1] == [
         "limactl",
@@ -221,7 +247,7 @@ def test_main_explicit_config(
     )
 
     cfg = str(config_dir / ".config" / "vergil" / "identities.toml")
-    main(["--config", cfg, "vergil-tooling"])
+    main(["--config", cfg, "vergil-project/vergil-tooling"])
     assert len(execed) == 1
     assert execed[0][1] == [
         "limactl",
@@ -232,4 +258,51 @@ def test_main_explicit_config(
         "/projects/vergil-project/vergil-tooling",
         "--",
         "claude",
+    ]
+
+
+def test_main_shell_default_identity(
+    config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_session._default_config_path",
+        lambda: config_dir / ".config" / "vergil" / "identities.toml",
+    )
+
+    execed: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_session.os.execvp",
+        lambda prog, args: execed.append((prog, args)),
+    )
+
+    main(["--shell"])
+    assert len(execed) == 1
+    assert execed[0][1] == ["limactl", "shell", "--start", "vergil-agent"]
+
+
+def test_main_shell_with_workspace(
+    config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_session._default_config_path",
+        lambda: config_dir / ".config" / "vergil" / "identities.toml",
+    )
+
+    execed: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_session.os.execvp",
+        lambda prog, args: execed.append((prog, args)),
+    )
+
+    main(["--shell", "vergil-project/vergil-tooling"])
+    assert len(execed) == 1
+    assert execed[0][1] == [
+        "limactl",
+        "shell",
+        "--start",
+        "vergil-agent",
+        "--workdir",
+        "/projects/vergil-project/vergil-tooling",
     ]


### PR DESCRIPTION
# Pull Request

## Summary

- Drop workspaces section from identities.toml. The workspace argument is now a path — relative paths are prepended with /projects (the fixed VM mount point), absolute paths pass through. Default to the sole configured identity when only one exists. No registry to maintain when adding new repos.

## Issue Linkage

- Ref #992

## Notes

- -