### PR TITLE
Pass app secrets to ops-github-config workflow

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -15,3 +15,6 @@ jobs:
     permissions:
       contents: read
       issues: write
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
# Pull Request

## Summary

- Forward APP_CLIENT_ID and APP_PRIVATE_KEY secrets to the ops-github-config reusable workflow, which now requires a GitHub App token for the Actions permissions API.

## Issue Linkage

- Ref #1002

## Notes

- -