### PR TITLE
Drop installation_id — dynamic token resolution

### DIFF
--- a/docs/plans/in-progress/2026-05-20-p2-vergil-vm-session-management.md
+++ b/docs/plans/in-progress/2026-05-20-p2-vergil-vm-session-management.md
@@ -72,25 +72,14 @@ limactl shell vergil-agent -- \
 [identities.vergil]
 vm_instance = "vergil-agent"
 auth_type = "app"
-app_id = 12345
-installation_id = 67890
-private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
-
-# Project workspace mappings — maps short names to paths
-# inside the VM. Paths mirror host paths under the mount.
-[identities.vergil.workspaces]
-vergil-tooling = "~/dev/projects/vergil-project/vergil-tooling"
-vergil-actions = "~/dev/projects/vergil-project/vergil-actions"
-vergil-docker  = "~/dev/projects/vergil-project/vergil-docker"
-vergil-vm      = "~/dev/projects/vergil-project/vergil-vm"
-diogenes-core  = "~/dev/projects/diogenes-project/diogenes-core"
+app_id = 3809631
+private_key_path = "~/.config/vergil/keys/wphillipmoore-vergil-agent.2026-05-22.private-key.pem"
 
 # Future: second identity
 # [identities.mimir]
 # vm_instance = "mimir-agent"
 # auth_type = "app"
 # app_id = ...
-# installation_id = ...
 # private_key_path = "~/.config/vergil/keys/mimir-agent.pem"
 ```
 
@@ -160,8 +149,7 @@ def config_file(tmp_path: Path) -> Path:
         vm_instance = "vergil-agent"
         auth_type = "app"
         app_id = 12345
-        installation_id = 67890
-        private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
+                private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
 
         [identities.vergil.workspaces]
         vergil-tooling = "~/dev/projects/vergil-project/vergil-tooling"
@@ -183,7 +171,7 @@ def test_identity_fields(config_file: Path) -> None:
     assert ident.vm_instance == "vergil-agent"
     assert ident.auth_type == "app"
     assert ident.app_id == "12345"
-    assert ident.installation_id == "67890"
+
     assert ident.workspaces["vergil-tooling"] == "~/dev/projects/vergil-project/vergil-tooling"
 
 
@@ -207,7 +195,6 @@ def test_resolve_project_ambiguous(tmp_path: Path) -> None:
         vm_instance = "vergil-agent"
         auth_type = "app"
         app_id = 11111
-        installation_id = 22222
         private_key_path = "~/.config/vergil/keys/vergil.pem"
         [identities.vergil.workspaces]
         shared-repo = "~/dev/shared-repo"
@@ -216,7 +203,6 @@ def test_resolve_project_ambiguous(tmp_path: Path) -> None:
         vm_instance = "mimir-agent"
         auth_type = "app"
         app_id = 33333
-        installation_id = 44444
         private_key_path = "~/.config/vergil/keys/mimir.pem"
         [identities.mimir.workspaces]
         shared-repo = "~/dev/shared-repo"
@@ -257,7 +243,7 @@ class Identity:
     vm_instance: str
     auth_type: str = "app"
     app_id: str = ""
-    installation_id: str = ""
+
     private_key_path: str = ""
     workspaces: dict[str, str] = field(default_factory=dict)
 
@@ -281,7 +267,7 @@ def load_config(path: Path) -> IdentityConfig:
             vm_instance=data["vm_instance"],
             auth_type=data.get("auth_type", "app"),
             app_id=str(data.get("app_id", "")),
-            installation_id=str(data.get("installation_id", "")),
+
             private_key_path=data.get("private_key_path", ""),
             workspaces=data.get("workspaces", {}),
         )
@@ -366,8 +352,7 @@ def config_dir(tmp_path: Path) -> Path:
         vm_instance = "vergil-agent"
         auth_type = "app"
         app_id = 12345
-        installation_id = 67890
-        private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
+                private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
 
         [identities.vergil.workspaces]
         vergil-tooling = "~/dev/projects/vergil-project/vergil-tooling"
@@ -703,5 +688,6 @@ vrg-session --shell --identity vergil
   detection (Plan 5), or wrapper simplification (#933 identity plan).
 - [x] **Identity schema consistency:** The `identities.toml` schema
   uses App credential fields (`auth_type`, `app_id`,
-  `installation_id`, `private_key_path`) consistent with Plan 3
-  and the single-account identity design (#933).
+  `private_key_path`) consistent with Plan 3 and the
+  single-account identity design (#933). Installation IDs are
+  resolved dynamically at runtime (Plan 5).

--- a/docs/plans/in-progress/2026-05-20-p3-vergil-vm-credential-provisioning.md
+++ b/docs/plans/in-progress/2026-05-20-p3-vergil-vm-credential-provisioning.md
@@ -10,11 +10,13 @@ credentials, GHCR auth) into the identity VM so the agent
 operates under its own App identity — never the human's.
 
 **Architecture:** A `vrg-vm-init` script runs on the host and
-injects GitHub App credentials (App ID, installation ID, private
-key) into the VM via `limactl shell`. Inside the VM, the tooling
-uses JWT → installation token exchange for all GitHub operations
-over HTTPS. No SSH keys are provisioned — the agent authenticates
-exclusively via App installation tokens.
+injects GitHub App credentials (App ID, private key) into the VM
+via `limactl shell`. Inside the VM, the tooling uses JWT →
+installation token exchange for all GitHub operations over HTTPS.
+Installation IDs are resolved dynamically at runtime by the
+wrapper scripts (`vrg-git`, `vrg-gh`) — not configured statically.
+No SSH keys are provisioned — the agent authenticates exclusively
+via App installation tokens.
 
 **Tech Stack:** Bash (provisioning scripts), Lima CLI, gh CLI,
 nerdctl, PyJWT
@@ -51,9 +53,15 @@ defines which credentials to provision)
 | Credential | Source | Storage inside VM | Purpose |
 |---|---|---|---|
 | App ID | `identities.toml` | `~/.config/vergil/app.env` | Identifies the GitHub App for JWT generation |
-| Installation ID | `identities.toml` | `~/.config/vergil/app.env` | Identifies the App's installation on a specific org |
 | Private key (.pem) | Host filesystem (path in `identities.toml`) | `~/.config/vergil/app.pem` | Signs JWTs for installation token exchange |
 | GHCR token | Derived from installation token | nerdctl login state | Pull vergil-docker images |
+
+Installation IDs are **not** stored in the VM or in
+`identities.toml`. The wrapper scripts (`vrg-git`, `vrg-gh`)
+resolve installation IDs dynamically at runtime via
+`GET /app/installations` using the App JWT, then cache the
+org → installation ID mapping for the session. This enables
+multi-org access from a single VM without per-org configuration.
 
 ### Injection Model
 
@@ -71,8 +79,7 @@ limactl shell vergil-agent -- bash -c \
 
 limactl shell vergil-agent -- bash -c \
   'cat > ~/.config/vergil/app.env && chmod 600 ~/.config/vergil/app.env' \
-  <<< "APP_ID=12345
-INSTALLATION_ID=67890"
+  <<< "APP_ID=3809631"
 ```
 
 ### The vrg-vm-init Script
@@ -97,14 +104,12 @@ The init script reads credentials from `identities.toml`:
 [identities.vergil]
 vm_instance = "vergil-agent"
 auth_type = "app"
-app_id = 12345
-installation_id = 67890
-private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
+app_id = 3809631
+private_key_path = "~/.config/vergil/keys/wphillipmoore-vergil-agent.2026-05-22.private-key.pem"
 ```
 
 For automation, environment variable overrides are supported:
 - `VRG_APP_ID` — GitHub App ID
-- `VRG_INSTALLATION_ID` — Installation ID
 - `VRG_PRIVATE_KEY_PATH` — Path to private key file
 
 ### PAT Fallback Mode
@@ -280,7 +285,6 @@ credentials into the VM.
 #
 # Reads credentials from identities.toml or environment variables:
 #   VRG_APP_ID            — GitHub App ID
-#   VRG_INSTALLATION_ID   — Installation ID
 #   VRG_PRIVATE_KEY_PATH  — Path to App private key (.pem)
 #
 # Example:
@@ -297,14 +301,13 @@ echo ""
 # --- Read credentials from identities.toml or env vars ---
 
 APP_ID="${VRG_APP_ID:-}"
-INSTALLATION_ID="${VRG_INSTALLATION_ID:-}"
 PRIVATE_KEY_PATH="${VRG_PRIVATE_KEY_PATH:-}"
 
-if [ -z "$APP_ID" ] || [ -z "$INSTALLATION_ID" ] || [ -z "$PRIVATE_KEY_PATH" ]; then
+if [ -z "$APP_ID" ] || [ -z "$PRIVATE_KEY_PATH" ]; then
     echo "Reading credentials from identities.toml..."
     # TODO: parse identities.toml for the given identity
     # For now, require env vars
-    echo "ERROR: Set VRG_APP_ID, VRG_INSTALLATION_ID, and VRG_PRIVATE_KEY_PATH" >&2
+    echo "ERROR: Set VRG_APP_ID and VRG_PRIVATE_KEY_PATH" >&2
     exit 1
 fi
 
@@ -325,7 +328,6 @@ limactl shell "$INSTANCE" -- bash -c \
     'cat > ~/.config/vergil/app.env && chmod 600 ~/.config/vergil/app.env' \
     <<EOF
 APP_ID=$APP_ID
-INSTALLATION_ID=$INSTALLATION_ID
 EOF
 
 # --- Configure git for HTTPS ---
@@ -338,11 +340,12 @@ echo ""
 # --- GHCR Authentication ---
 
 echo "Configuring nerdctl GHCR authentication..."
-# Generate an installation token and use it for GHCR login
-# The token exchange uses the App credentials just injected
+# GHCR login uses a token from any installation (all share
+# the same packages:read scope). vrg-app-token resolves the
+# first available installation dynamically via the API.
 limactl shell "$INSTANCE" -- bash -c '
     source ~/.config/vergil/app.env
-    TOKEN=$(vrg-app-token --app-id "$APP_ID" --installation-id "$INSTALLATION_ID" --key ~/.config/vergil/app.pem)
+    TOKEN=$(vrg-app-token --app-id "$APP_ID" --key ~/.config/vergil/app.pem)
     echo "$TOKEN" | nerdctl login ghcr.io -u x-access-token --password-stdin
 '
 echo ""
@@ -350,9 +353,11 @@ echo ""
 # --- Git Identity ---
 
 echo "Configuring git identity..."
+# The App bot identity is derived from the App itself, not
+# from any particular installation.
 limactl shell "$INSTANCE" -- bash -c '
     source ~/.config/vergil/app.env
-    TOKEN=$(vrg-app-token --app-id "$APP_ID" --installation-id "$INSTALLATION_ID" --key ~/.config/vergil/app.pem)
+    TOKEN=$(vrg-app-token --app-id "$APP_ID" --key ~/.config/vergil/app.pem)
     GITHUB_USER=$(GH_TOKEN="$TOKEN" gh api user --jq ".login")
     GITHUB_EMAIL=$(GH_TOKEN="$TOKEN" gh api user --jq ".email // empty")
     if [ -z "$GITHUB_EMAIL" ]; then
@@ -395,9 +400,8 @@ cd ~/dev/projects/vergil-project/vergil-vm
 limactl start vergil-agent
 
 # Run credential init
-VRG_APP_ID=12345 \
-VRG_INSTALLATION_ID=67890 \
-VRG_PRIVATE_KEY_PATH=~/.config/vergil/keys/vergil-agent.pem \
+VRG_APP_ID=3809631 \
+VRG_PRIVATE_KEY_PATH=~/.config/vergil/keys/wphillipmoore-vergil-agent.2026-05-22.private-key.pem \
   ./scripts/vrg-vm-init.sh vergil vergil-agent
 ```
 
@@ -418,9 +422,10 @@ nerdctl pull ghcr.io/vergil-project/dev-python:latest  # Should work
 
 ## Self-Review Checklist
 
-- [x] **Spec coverage:** App ID, installation ID, private key,
-  GHCR auth, git identity, HTTPS configuration — all credential
-  types from the spec (#933) are covered.
+- [x] **Spec coverage:** App ID, private key, GHCR auth, git
+  identity, HTTPS configuration — all credential types from the
+  spec (#933) are covered. Installation IDs are resolved
+  dynamically at runtime (Plan 5), not provisioned statically.
 - [x] **No SSH:** SSH key injection, SSH config, known_hosts
   setup, and SSH verification are all removed. Git uses HTTPS
   with App installation tokens exclusively.

--- a/docs/plans/in-progress/2026-05-20-single-account-identity-tooling.md
+++ b/docs/plans/in-progress/2026-05-20-single-account-identity-tooling.md
@@ -28,6 +28,15 @@ harness.
 
 **Relationship to Plan 5:** This plan supersedes Tasks 3-4 of the
 vergil-tooling VM adaptations plan (`docs/plans/in-progress/2026-05-20-p5-vergil-tooling-vm-adaptations.md`).
+
+> **Update 2026-05-22:** `installation_id` has been removed from
+> `identities.toml` and the `Identity` dataclass (#1004).
+> Installation IDs are now resolved dynamically at runtime by the
+> wrapper scripts via `GET /app/installations`. The embedded code
+> snippets below still reference the static `installation_id` —
+> they reflect the design at the time of writing. The live code
+> in `github.py` will be updated to use dynamic resolution in
+> Plan 5.
 Plan 5 Tasks 1-2 (nerdctl runtime detection) remain
 independent.
 

--- a/docs/site/docs/guides/account-setup.md
+++ b/docs/site/docs/guides/account-setup.md
@@ -1,179 +1,137 @@
-# Account Setup
+# Identity Setup
 
-This guide walks through creating and configuring the GitHub
-accounts required by VERGIL tooling. Every contributor needs two
-accounts: their normal human account and a dedicated
-`<username>-vergil` account for AI agent operations.
+This guide walks through creating and configuring the GitHub App
+identity required by VERGIL tooling. Each contributor registers
+one GitHub App that acts as their agent identity across all
+managed organizations.
 
 For repo-level onboarding (installing tools, configuring hooks,
 CI), see [Consuming Repo Setup](consuming-repo-setup.md).
 
-## Why two accounts
+## Why a GitHub App
 
-VERGIL tooling enforces a hard separation between human and agent
-identity. The human account reviews, approves, and merges. The
-agent account does all development work — commits, PRs, branch
-operations. This separation is enforced by credential selection
-in `vrg-gh` and branch protection rules on every managed repo.
+VERGIL uses GitHub App installation tokens for agent
+authentication. Compared to the legacy multi-account model
+(deprecated), Apps provide:
 
-The `<username>-vergil` naming convention is load-bearing — the
-tooling discovers accounts by finding the one ending in `-vergil`
-in `gh auth status` and derives the human account name by
-stripping the suffix.
+- **No shadow-ban risk** — Apps are first-class GitHub citizens
+- **Short-lived tokens** — 1-hour installation tokens vs.
+  long-lived PATs
+- **Multi-org from one identity** — install the same App on
+  every org you manage
+- **Server-side merge control** — branch protection recognizes
+  the App identity
+- **Dynamic token resolution** — the tooling acquires tokens
+  on demand per-org, no static configuration needed
 
-## Step 1: Create the `-vergil` GitHub account
+## Prerequisites
 
-1. **Choose an email address.** Use a Gmail alias to route to your
-   existing inbox: `<your-email>+github-vergil@gmail.com`. This
-   avoids creating a separate email account while keeping the
-   GitHub accounts distinct.
+- A GitHub account that is an **owner** of the organizations
+  where the agent will operate
+- `~/.config/vergil/keys/` directory on your development machine
 
-2. **Sign up at github.com/signup.**
-   - Username: `<your-github-username>-vergil`
-   - Email: the alias from above
-   - Complete the CAPTCHA and email verification
+## Step 1: Register the GitHub App
 
-3. **Enable two-factor authentication.** Settings → Password and
-   authentication → Enable 2FA. Download and store the recovery
-   codes securely.
+1. Go to **github.com** > your profile icon > **Settings** >
+   **Developer settings** > **GitHub Apps** > **New GitHub App**
 
-4. **Set email preferences.** Settings → Emails:
-   - Check "Keep my email addresses private"
-   - Check "Block command line pushes that expose my email"
-   - Note the `noreply` email address (format:
-     `<id>+<username>-vergil@users.noreply.github.com`) — this
-     goes in `vergil.toml` co-author entries.
+2. Fill in the registration form:
 
-5. **Fill out the profile.** New accounts with empty profiles are
-   frequently shadow-banned by GitHub's automated systems. At
-   minimum set:
-   - Display name
-   - Bio (make it clear this is an AI agent identity linked to
-     your human account)
-   - Link to your human GitHub profile in the bio or website field
+   | Field | Value |
+   |---|---|
+   | **App name** | `<username>-vergil` |
+   | **Description** | AI agent identity for the Vergil project. Used by automated agents running inside isolated Lima VMs to manage repositories. Authenticates via installation tokens for GitHub API operations including commits, pull requests, and issue management. |
+   | **Homepage URL** | Your GitHub profile URL |
+   | **Webhook** | Uncheck "Active" (no webhook needed) |
 
-## Step 2: Generate a classic PAT
+3. Under **Repository permissions**, set:
 
-The agent account uses a classic Personal Access Token. From the
-`<username>-vergil` account:
+   | Permission | Access |
+   |---|---|
+   | **Contents** | Read and write |
+   | **Pull requests** | Read and write |
+   | **Issues** | Read and write |
 
-1. Settings → Developer settings → Personal access tokens →
-   Tokens (classic)
-2. Generate new token with scopes:
-   - `repo` (full repository access)
-   - `read:org` (org membership visibility)
-3. Set expiration (12 months recommended)
-4. Copy the token immediately — it is shown only once
+4. Under **Where can this GitHub App be installed?**, select
+   **Any account**.
 
-See the [credential management design][cred-spec] for the full
-rationale on classic PATs vs. fine-grained PATs.
+   !!! warning "Cannot change this later without extra steps"
+       If you select "Only on this account" during creation, the
+       App can only be installed on your personal account — not
+       on any organizations. To change it after creation: go to
+       the App settings > **Advanced** > under the **Danger
+       zone** section, click **Make public**. Once public and
+       installed on other accounts, this cannot be reverted.
 
-## Step 3: Log both accounts into `gh auth`
+5. Click **Create GitHub App**.
 
-Both accounts must be logged in on your development machine.
-The tooling uses `gh auth token -u <account>` to retrieve tokens
-per-subprocess — it never calls `gh auth switch`.
+## Step 2: Generate a private key
 
-```bash
-# Human account (if not already logged in)
-gh auth login -h github.com --web -p https
-
-# Agent account — log into the -vergil browser session first,
-# then authorize
-gh auth login -h github.com --web -p https
-```
-
-!!! warning "`gh auth login` has no `-u` flag"
-    You cannot specify which account to log in as. The `-u` flag
-    does not exist for `gh auth login`. Instead, make sure you
-    are logged into the correct GitHub account in your browser
-    before authorizing the OAuth flow.
-
-After both logins, switch back to your human account as the
-active default:
+1. On the App's settings page (you land here after creation),
+   scroll to **Private keys**
+2. Click **Generate a private key**
+3. Your browser downloads a `.pem` file (named with the App
+   name and date)
+4. Move it to your Vergil keys directory:
 
 ```bash
-gh auth switch -u <your-username>
+mv ~/Downloads/<app-name>.<date>.private-key.pem \
+   ~/.config/vergil/keys/
 ```
 
-Verify both are present:
+Keep the original filename — it includes the creation date,
+which is useful metadata for key rotation.
 
-```bash
-gh auth status
-# Should show both <username> and <username>-vergil
+## Step 3: Install on your organizations
 
-gh auth token -u <your-username>          # human PAT
-gh auth token -u <your-username>-vergil   # agent PAT
-```
+1. From the App settings page, click **Install App** in the
+   left sidebar
+2. Click **Install** next to each organization where the agent
+   should operate
+3. For each installation, choose **All repositories** (or
+   select specific repos)
+4. Click **Install**
 
-## Step 4: Update `vergil.toml`
+Repeat for every organization. You can return to this page to
+add more organizations later.
 
-Each repo's `vergil.toml` needs a co-author entry for your agent
-account. The noreply email comes from Step 1.4:
+## Step 4: Record the App ID
+
+The **App ID** is shown near the top of the App's **General**
+settings page (Developer settings > GitHub Apps > your App >
+Edit).
+
+You do not need to record installation IDs — the tooling
+resolves these dynamically at runtime via the GitHub API.
+
+## Step 5: Configure `identities.toml`
+
+Create or update `~/.config/vergil/identities.toml`:
 
 ```toml
-[project.co-authors]
-<username>-vergil = "Co-Authored-By: <username>-vergil <<id>+<username>-vergil@users.noreply.github.com>"
+[identities.vergil]
+vm_instance = "vergil-agent"
+auth_type = "app"
+app_id = <your-app-id>
+private_key_path = "~/.config/vergil/keys/<app-name>.<date>.private-key.pem"
 ```
 
-This is how `vrg-commit --agent <username>-vergil` resolves the
-co-author trailer.
-
-## Step 5: Request collaborator access
-
-The org owner invites `<username>-vergil` as an outside
-collaborator on each managed org:
-
-1. Navigate to the repo → Settings → Collaborators
-2. Click "Add people"
-3. Search for `<username>-vergil`, select it
-4. Set role to **Write**
-5. Send invitation
-
-Accept the invitation from the `-vergil` account (via email or
-the GitHub notifications page).
-
-One invitation per repo. The agent account is an outside
-collaborator by design — it does not become an org member.
-
-## Shadow-banning
-
-GitHub's automated systems frequently flag new accounts that have
-no activity, no profile content, or that were created in rapid
-succession. A shadow-banned account:
-
-- Returns 404 on its profile page
-- Can still authenticate and push code
-- Cannot be invited as a collaborator (invitation silently fails)
-
-**Prevention:**
-
-- Fill out the profile completely before doing anything else
-  (Step 1.5)
-- Enable 2FA immediately
-- Link to your human account in the bio
-- Make a small commit (even to a personal test repo) to establish
-  activity
-
-**Recovery:**
-
-If the account gets flagged, contact GitHub support at
-support.github.com/contact. Explain that this is a secondary
-account for AI-assisted development linked to your primary
-account. Response time varies but is typically 1-3 business days.
+The `private_key_path` is relative to your home directory (if
+it starts with `~`) or absolute.
 
 ## Verification checklist
 
-After completing all steps, verify the full chain:
+After completing all steps, verify:
 
-- [ ] `gh auth status` shows both accounts
-- [ ] `gh auth token -u <username>` returns a token
-- [ ] `gh auth token -u <username>-vergil` returns a token
-- [ ] `vrg-gh issue list` succeeds (tests credential selection)
-- [ ] `vrg-commit --help` succeeds (tests host tool install)
-- [ ] The `-vergil` account profile page loads (not 404)
-- [ ] The `-vergil` account has collaborator access on at least
-      one managed repo
+- [ ] Private key file exists in `~/.config/vergil/keys/`
+- [ ] `identities.toml` has the correct App ID and key path
+- [ ] The App is installed on all target organizations (check
+      Developer settings > GitHub Apps > your App > Install App)
+- [ ] The App shows the correct repository permissions
+      (Contents, PRs, Issues — all Read and write)
+
+Full end-to-end verification requires a running identity VM
+(see Plan 3: Credential Provisioning).
 
 ## Related
 
@@ -181,7 +139,7 @@ After completing all steps, verify the full chain:
   onboarding
 - [Git Workflow](git-workflow.md) — how the per-change cycle
   works
-- [Credential management design][cred-spec] — full rationale for
-  the two-account model
+- [Single-account identity design][identity-spec] — full
+  rationale for the GitHub App model
 
-[cred-spec]: https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/2026-05-14-credential-management-design.md
+[identity-spec]: https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/2026-05-20-single-account-identity-design.md

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -13,7 +13,6 @@ class Identity:
     vm_instance: str
     auth_type: str = "app"
     app_id: str = ""
-    installation_id: str = ""
     private_key_path: str = ""
 
 
@@ -36,7 +35,6 @@ def load_config(path: Path) -> IdentityConfig:
             vm_instance=data["vm_instance"],
             auth_type=data.get("auth_type", "app"),
             app_id=str(data.get("app_id", "")),
-            installation_id=str(data.get("installation_id", "")),
             private_key_path=data.get("private_key_path", ""),
         )
     return IdentityConfig(identities=identities)

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -27,7 +27,6 @@ def config_file(tmp_path: Path) -> Path:
         vm_instance = "vergil-agent"
         auth_type = "app"
         app_id = 12345
-        installation_id = 67890
         private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
     """)
     )
@@ -47,7 +46,6 @@ def test_identity_fields(config_file: Path) -> None:
     assert ident.vm_instance == "vergil-agent"
     assert ident.auth_type == "app"
     assert ident.app_id == "12345"
-    assert ident.installation_id == "67890"
 
 
 def test_missing_config_file(tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_vrg_session.py
+++ b/tests/vergil_tooling/test_vrg_session.py
@@ -21,7 +21,6 @@ def config_dir(tmp_path: Path) -> Path:
         vm_instance = "vergil-agent"
         auth_type = "app"
         app_id = 12345
-        installation_id = 67890
         private_key_path = "~/.config/vergil/keys/vergil-agent.pem"
     """)
     )


### PR DESCRIPTION
# Pull Request

## Summary

- Remove installation_id from Identity dataclass, identities.toml schema, and all plan documents. Rewrite account setup guide to document the GitHub App registration workflow. Installation IDs will be resolved dynamically at runtime (Plan 5).

## Issue Linkage

- Ref #1004

## Notes

- The existing github.py token exchange still uses a static installation_id from app.env. That will be replaced with dynamic per-org resolution when Plan 5 is implemented.