### PR TITLE
refactor(github): dynamic per-org installation token resolution

### DIFF
--- a/docs/site/docs/guides/account-setup.md
+++ b/docs/site/docs/guides/account-setup.md
@@ -82,7 +82,12 @@ mv ~/Downloads/<app-name>.<date>.private-key.pem \
 Keep the original filename — it includes the creation date,
 which is useful metadata for key rotation.
 
-## Step 3: Install on your organizations
+## Step 3: Install on organizations and personal account
+
+The tooling resolves tokens dynamically based on the repository
+owner (org or user) parsed from the git remote URL. The App
+must be installed on every account that owns repositories the
+agent will operate on.
 
 1. From the App settings page, click **Install App** in the
    left sidebar
@@ -92,8 +97,14 @@ which is useful metadata for key rotation.
    select specific repos)
 4. Click **Install**
 
-Repeat for every organization. You can return to this page to
-add more organizations later.
+Repeat for every organization. If you also have personal
+repositories managed by the agent, install the App on your
+personal account the same way — it appears in the same list
+alongside your organizations. Without this installation, the
+tooling cannot acquire tokens for personal repos and will fall
+back to ambient `gh` auth.
+
+You can return to this page to add more accounts later.
 
 ## Step 4: Record the App ID
 
@@ -125,8 +136,9 @@ After completing all steps, verify:
 
 - [ ] Private key file exists in `~/.config/vergil/keys/`
 - [ ] `identities.toml` has the correct App ID and key path
-- [ ] The App is installed on all target organizations (check
-      Developer settings > GitHub Apps > your App > Install App)
+- [ ] The App is installed on all target organizations and your
+      personal account if needed (check Developer settings >
+      GitHub Apps > your App > Install App)
 - [ ] The App shows the correct repository permissions
       (Contents, PRs, Issues — all Read and write)
 

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -20,21 +20,21 @@ from vergil_tooling.lib import retry
 
 log = logging.getLogger(__name__)
 
-_cached_token: tuple[str, float] | None = None
+_token_cache: dict[str, tuple[str, float]] = {}
+_installation_cache: dict[str, str] | None = None
 
 
-def _load_app_config() -> tuple[str, str, Path] | None:
+def _load_app_config() -> tuple[str, Path] | None:
     """Read GitHub App credentials from env vars or ~/.config/vergil/.
 
-    Returns ``(app_id, installation_id, key_path)`` or ``None``
-    when App mode is not configured.
+    Returns ``(app_id, key_path)`` or ``None`` when App mode is
+    not configured.
     """
     app_id = os.environ.get("VRG_APP_ID", "")
-    installation_id = os.environ.get("VRG_INSTALLATION_ID", "")
     key_path_str = os.environ.get("VRG_PRIVATE_KEY_PATH", "")
 
-    if app_id and installation_id and key_path_str:
-        return app_id, installation_id, Path(key_path_str).expanduser()
+    if app_id and key_path_str:
+        return app_id, Path(key_path_str).expanduser()
 
     env_file = Path.home() / ".config" / "vergil" / "app.env"
     key_file = Path.home() / ".config" / "vergil" / "app.pem"
@@ -49,12 +49,63 @@ def _load_app_config() -> tuple[str, str, Path] | None:
             values[k.strip()] = v.strip()
 
     app_id = app_id or values.get("APP_ID", "")
-    installation_id = installation_id or values.get("INSTALLATION_ID", "")
 
-    if not app_id or not installation_id:
+    if not app_id:
         return None
 
-    return app_id, installation_id, key_file
+    return app_id, key_file
+
+
+def _detect_org() -> str | None:
+    """Detect the GitHub org from the current repo's git remote."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "remote", "get-url", "origin"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    url = result.stdout.strip()
+    # git@github.com:ORG/REPO.git or https://github.com/ORG/REPO.git
+    for prefix in ("git@github.com:", "https://github.com/"):
+        if url.startswith(prefix):
+            remainder = url[len(prefix) :]
+            org = remainder.split("/")[0]
+            if org:
+                return org
+    return None
+
+
+def _resolve_installations(jwt_token: str) -> dict[str, str]:
+    """Fetch all App installations and return an org → installation ID map."""
+    global _installation_cache  # noqa: PLW0603
+    if _installation_cache is not None:
+        return _installation_cache
+
+    result = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "gh",
+            "api",
+            "/app/installations",
+            "--jq",
+            r'.[] | "\(.account.login) \(.id)"',
+        ],
+        env={**os.environ, "GH_TOKEN": jwt_token},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    mapping: dict[str, str] = {}
+    for line in result.stdout.strip().splitlines():
+        parts = line.strip().split()
+        if len(parts) == 2:
+            mapping[parts[0]] = parts[1]
+
+    _installation_cache = mapping
+    return mapping
 
 
 def _generate_jwt(app_id: str, key_path: Path) -> str:
@@ -92,17 +143,22 @@ def _generate_jwt(app_id: str, key_path: Path) -> str:
     return f"{header}.{payload}.{signature}"
 
 
-def get_installation_token() -> str | None:
+def get_installation_token(org: str | None = None) -> str | None:
     """Return a GitHub App installation token, or ``None`` if not in App mode.
 
-    Reads App credentials from ``~/.config/vergil/`` (or env var
-    overrides), generates a JWT, and exchanges it for a 1-hour
-    installation token via the GitHub API. Tokens are cached for
-    55 minutes.
+    Resolves the installation ID dynamically by calling
+    ``GET /app/installations`` and matching the org. If *org* is
+    ``None``, detects it from the current repo's git remote.
+    Tokens are cached per-org for 55 minutes.
     """
-    global _cached_token  # noqa: PLW0603
-    if _cached_token is not None:
-        token, expiry = _cached_token
+    if org is None:
+        org = _detect_org()
+    if org is None:
+        return None
+
+    cached = _token_cache.get(org)
+    if cached is not None:
+        token, expiry = cached
         if time.time() < expiry:
             return token
 
@@ -110,8 +166,13 @@ def get_installation_token() -> str | None:
     if config is None:
         return None
 
-    app_id, installation_id, key_path = config
+    app_id, key_path = config
     jwt_token = _generate_jwt(app_id, key_path)
+
+    installations = _resolve_installations(jwt_token)
+    installation_id = installations.get(org)
+    if not installation_id:
+        return None
 
     result = subprocess.run(  # noqa: S603
         [  # noqa: S607
@@ -130,7 +191,7 @@ def get_installation_token() -> str | None:
     )
 
     token = result.stdout.strip()
-    _cached_token = (token, time.time() + 3300)
+    _token_cache[org] = (token, time.time() + 3300)
     return token
 
 

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -20,7 +20,8 @@ _real_gh_env = github._gh_env
 @pytest.fixture(autouse=True)
 def _no_credential_injection(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("vergil_tooling.lib.github._gh_env", lambda: None)
-    github._cached_token = None
+    github._token_cache.clear()
+    github._installation_cache = None
 
 
 def _completed(
@@ -547,7 +548,6 @@ class TestLoadAppConfig:
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         assert github._load_app_config() is None
 
@@ -558,31 +558,28 @@ class TestLoadAppConfig:
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         config_dir = tmp_path / ".config" / "vergil"
         config_dir.mkdir(parents=True)
-        (config_dir / "app.env").write_text("APP_ID=12345\nINSTALLATION_ID=67890\n")
+        (config_dir / "app.env").write_text("APP_ID=12345\n")
         (config_dir / "app.pem").write_text("fake-key\n")
         result = github._load_app_config()
         assert result is not None
-        app_id, installation_id, key_path = result
+        app_id, key_path = result
         assert app_id == "12345"
-        assert installation_id == "67890"
         assert key_path == config_dir / "app.pem"
 
-    def test_returns_none_when_missing_installation_id(
+    def test_returns_none_when_missing_app_id(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         config_dir = tmp_path / ".config" / "vergil"
         config_dir.mkdir(parents=True)
-        (config_dir / "app.env").write_text("APP_ID=12345\n")
+        (config_dir / "app.env").write_text("# no app id\n")
         (config_dir / "app.pem").write_text("fake-key\n")
         assert github._load_app_config() is None
 
@@ -595,13 +592,11 @@ class TestLoadAppConfig:
         key_file = tmp_path / "override.pem"
         key_file.write_text("override-key\n")
         monkeypatch.setenv("VRG_APP_ID", "99999")
-        monkeypatch.setenv("VRG_INSTALLATION_ID", "88888")
         monkeypatch.setenv("VRG_PRIVATE_KEY_PATH", str(key_file))
         result = github._load_app_config()
         assert result is not None
-        app_id, installation_id, key_path = result
+        app_id, key_path = result
         assert app_id == "99999"
-        assert installation_id == "88888"
         assert key_path == key_file
 
     def test_ignores_comments_in_env_file(
@@ -611,13 +606,10 @@ class TestLoadAppConfig:
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         config_dir = tmp_path / ".config" / "vergil"
         config_dir.mkdir(parents=True)
-        (config_dir / "app.env").write_text(
-            "# GitHub App credentials\nAPP_ID=12345\nINSTALLATION_ID=67890\n"
-        )
+        (config_dir / "app.env").write_text("# GitHub App credentials\nAPP_ID=12345\n")
         (config_dir / "app.pem").write_text("fake-key\n")
         result = github._load_app_config()
         assert result is not None
@@ -681,6 +673,59 @@ class TestGenerateJwt:
         assert "exp" in payload
 
 
+class TestDetectOrg:
+    def test_parses_ssh_remote(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout="git@github.com:vergil-project/vergil-tooling.git\n"
+            )
+            assert github._detect_org() == "vergil-project"
+
+    def test_parses_https_remote(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout="https://github.com/vergil-project/vergil-tooling.git\n"
+            )
+            assert github._detect_org() == "vergil-project"
+
+    def test_returns_none_on_git_failure(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+            assert github._detect_org() is None
+
+    def test_returns_none_for_unrecognized_url(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="https://gitlab.com/org/repo.git\n")
+            assert github._detect_org() is None
+
+    def test_returns_none_for_empty_org(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="git@github.com:/repo.git\n")
+            assert github._detect_org() is None
+
+
+class TestResolveInstallations:
+    def test_returns_org_to_id_mapping(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="vergil-project 111\nwphillipmoore 222\n")
+            result = github._resolve_installations("fake-jwt")
+        assert result == {"vergil-project": "111", "wphillipmoore": "222"}
+
+    def test_caches_result(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="org1 100\n")
+            first = github._resolve_installations("jwt1")
+            second = github._resolve_installations("jwt2")
+        assert first is second
+        assert mock_run.call_count == 1
+
+    def test_skips_malformed_lines(self) -> None:
+        with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="good-org 100\nbad line here\n\n")
+            result = github._resolve_installations("jwt")
+        assert result == {"good-org": "100"}
+
+
 class TestGetInstallationToken:
     def test_returns_none_when_no_app_config(
         self,
@@ -689,10 +734,19 @@ class TestGetInstallationToken:
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
-        github._cached_token = None
-        assert github.get_installation_token() is None
+        assert github.get_installation_token(org="some-org") is None
+
+    def test_returns_none_when_no_org_detected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+        monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
+        with patch("vergil_tooling.lib.github._detect_org", return_value=None):
+            assert github.get_installation_token() is None
 
     def test_exchanges_jwt_for_installation_token(
         self,
@@ -701,47 +755,69 @@ class TestGetInstallationToken:
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         config_dir = tmp_path / ".config" / "vergil"
         config_dir.mkdir(parents=True)
-        (config_dir / "app.env").write_text("APP_ID=12345\nINSTALLATION_ID=67890\n")
+        (config_dir / "app.env").write_text("APP_ID=12345\n")
         (config_dir / "app.pem").write_text("fake-key\n")
-        github._cached_token = None
         with (
+            patch("vergil_tooling.lib.github._generate_jwt", return_value="fake-jwt"),
             patch(
-                "vergil_tooling.lib.github._generate_jwt",
-                return_value="fake-jwt",
+                "vergil_tooling.lib.github._resolve_installations",
+                return_value={"test-org": "67890"},
             ),
             patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
         ):
             mock_run.return_value = _completed(stdout="ghs_install_token_abc\n")
-            token = github.get_installation_token()
+            token = github.get_installation_token(org="test-org")
         assert token == "ghs_install_token_abc"  # noqa: S105
         call_args = mock_run.call_args[0][0]
         assert "/app/installations/67890/access_tokens" in " ".join(call_args)
 
-    def test_caches_token(
+    def test_returns_none_when_org_not_in_installations(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         config_dir = tmp_path / ".config" / "vergil"
         config_dir.mkdir(parents=True)
-        (config_dir / "app.env").write_text("APP_ID=12345\nINSTALLATION_ID=67890\n")
+        (config_dir / "app.env").write_text("APP_ID=12345\n")
         (config_dir / "app.pem").write_text("fake-key\n")
-        github._cached_token = None
         with (
             patch("vergil_tooling.lib.github._generate_jwt", return_value="jwt"),
+            patch(
+                "vergil_tooling.lib.github._resolve_installations",
+                return_value={"other-org": "111"},
+            ),
+        ):
+            assert github.get_installation_token(org="missing-org") is None
+
+    def test_caches_token_per_org(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+        monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
+        config_dir = tmp_path / ".config" / "vergil"
+        config_dir.mkdir(parents=True)
+        (config_dir / "app.env").write_text("APP_ID=12345\n")
+        (config_dir / "app.pem").write_text("fake-key\n")
+        with (
+            patch("vergil_tooling.lib.github._generate_jwt", return_value="jwt"),
+            patch(
+                "vergil_tooling.lib.github._resolve_installations",
+                return_value={"test-org": "67890"},
+            ),
             patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
         ):
             mock_run.return_value = _completed(stdout="ghs_token\n")
-            first = github.get_installation_token()
-            second = github.get_installation_token()
+            first = github.get_installation_token(org="test-org")
+            second = github.get_installation_token(org="test-org")
         assert first == second == "ghs_token"
         assert mock_run.call_count == 1
 
@@ -752,17 +828,20 @@ class TestGetInstallationToken:
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
-        monkeypatch.delenv("VRG_INSTALLATION_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
         config_dir = tmp_path / ".config" / "vergil"
         config_dir.mkdir(parents=True)
-        (config_dir / "app.env").write_text("APP_ID=12345\nINSTALLATION_ID=67890\n")
+        (config_dir / "app.env").write_text("APP_ID=12345\n")
         (config_dir / "app.pem").write_text("fake-key\n")
-        github._cached_token = ("old_token", 0.0)
+        github._token_cache["test-org"] = ("old_token", 0.0)
         with (
             patch("vergil_tooling.lib.github._generate_jwt", return_value="jwt"),
+            patch(
+                "vergil_tooling.lib.github._resolve_installations",
+                return_value={"test-org": "67890"},
+            ),
             patch("vergil_tooling.lib.github.subprocess.run") as mock_run,
         ):
             mock_run.return_value = _completed(stdout="new_token\n")
-            token = github.get_installation_token()
+            token = github.get_installation_token(org="test-org")
         assert token == "new_token"  # noqa: S105


### PR DESCRIPTION
# Pull Request

## Summary

- Replace static installation_id lookup with dynamic per-org token resolution via _detect_org, _resolve_installations, and per-org token caching in get_installation_token

## Issue Linkage

- Ref #1006

## Notes

- -