### PR TITLE
fix(release): handle first release when no prior tags exist

### DIFF
--- a/src/vergil_tooling/lib/release/preflight.py
+++ b/src/vergil_tooling/lib/release/preflight.py
@@ -228,13 +228,16 @@ def _detect_version(repo_root: Path) -> str:
 
 
 def _check_version_not_tagged(version: str) -> None:
-    latest_tag = git.read_output(
-        "describe",
-        "--tags",
-        "--abbrev=0",
-        "--match",
-        "v*",
-    )
+    try:
+        latest_tag = git.read_output(
+            "describe",
+            "--tags",
+            "--abbrev=0",
+            "--match",
+            "v*",
+        )
+    except subprocess.CalledProcessError:
+        return
     if latest_tag == f"v{version}":
         raise ReleaseError(
             phase="preflight",

--- a/tests/vergil_tooling/test_release_preflight.py
+++ b/tests/vergil_tooling/test_release_preflight.py
@@ -95,6 +95,24 @@ def test_preflight_fails_if_version_matches_tag(_repo: Path) -> None:
         preflight(version_override=None, repo_root=_repo)
 
 
+def test_preflight_succeeds_with_no_prior_tags(_repo: Path) -> None:
+    import subprocess as _sp
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/git-cliff"),
+        patch(_MOD + ".github.read_output", return_value="owner/repo"),
+        patch(_MOD + "._check_branch_and_tree"),
+        patch(_MOD + "._audit_repo_config"),
+        patch(
+            _MOD + ".git.read_output",
+            side_effect=_sp.CalledProcessError(128, "git describe"),
+        ),
+        patch(_MOD + ".find_existing_tracking_issue", return_value=None),
+    ):
+        ctx = preflight(version_override=None, repo_root=_repo)
+    assert ctx.version == "2.1.0"
+
+
 def test_preflight_returns_context(_repo: Path) -> None:
     with (
         patch("shutil.which", return_value="/usr/bin/git-cliff"),


### PR DESCRIPTION
# Pull Request

## Summary

- Catch CalledProcessError from git describe --tags in _check_version_not_tagged so vrg-release works on repos with no prior tags (first release bootstrap).

## Issue Linkage

- Ref #1020

## Notes

- -