### PR TITLE
fix(vm): route credential mkdir through bash for tilde expansion

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -166,7 +166,7 @@ def inject_credentials(instance: str, identity: Identity) -> None:
     key_content = key_path.read_text()
 
     print("  Injecting App private key...")
-    shell_run(instance, "mkdir", "-p", "$HOME/.config/vergil")
+    shell_run(instance, "bash", "-c", "mkdir -p ~/.config/vergil")
     shell_pipe(
         instance,
         "cat > ~/.config/vergil/app.pem && chmod 600 ~/.config/vergil/app.pem",

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -241,7 +241,7 @@ class TestInjectCredentials:
 
         assert mock_run.call_count == 2
         mkdir_call = mock_run.call_args_list[0]
-        assert "mkdir" in mkdir_call[0]
+        assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
 
         git_call = mock_run.call_args_list[1]
         assert "git" in git_call[0]


### PR DESCRIPTION
# Pull Request

## Summary

- shell_run passes args directly without bash, so $HOME was not expanded in the mkdir call. Route through bash -c for consistent tilde expansion with the shell_pipe calls.

## Issue Linkage

- Ref #1025

## Notes

- -