### PR TITLE
feat(vm): derive tooling and template version from identities.toml vergil key

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -9,10 +9,12 @@ from pathlib import Path
 
 from vergil_tooling.lib.identity import (
     Identity,
+    IdentityConfig,
     default_config_path,
     load_config,
     resolve_identity,
     resolve_identity_by_name,
+    resolve_vergil_version,
     resolve_workspace,
 )
 from vergil_tooling.lib.lima import (
@@ -27,21 +29,20 @@ from vergil_tooling.lib.lima import (
     vm_status,
 )
 
-_DEFAULT_TAG = "v2.0"
-
 _default_config_path = default_config_path
 
 
-def _resolve(args: argparse.Namespace) -> tuple[str, Identity]:
+def _resolve(args: argparse.Namespace) -> tuple[str, Identity, IdentityConfig]:
     config_path = args.config if args.config else _default_config_path()
     config = load_config(config_path)
     name, identity = resolve_identity_by_name(config, args.identity)
-    return name, identity
+    return name, identity, config
 
 
 def _cmd_create(args: argparse.Namespace) -> int:
-    name, identity = _resolve(args)
-    tag = args.tag
+    name, identity, config = _resolve(args)
+    vergil_version = resolve_vergil_version(config, identity)
+    tag = args.tag if args.tag else vergil_version
 
     status = vm_status(identity.vm_instance)
     if status:
@@ -73,7 +74,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
         print("Injecting credentials...")
         inject_credentials(identity.vm_instance, identity)
 
-        install_tooling(identity.vm_instance, tag)
+        install_tooling(identity.vm_instance, vergil_version)
     finally:
         template.unlink(missing_ok=True)
 
@@ -82,7 +83,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
 
 
 def _cmd_start(args: argparse.Namespace) -> int:
-    name, identity = _resolve(args)
+    name, identity, _config = _resolve(args)
 
     status = vm_status(identity.vm_instance)
     if not status:
@@ -103,7 +104,7 @@ def _cmd_start(args: argparse.Namespace) -> int:
 
 
 def _cmd_stop(args: argparse.Namespace) -> int:
-    name, identity = _resolve(args)
+    name, identity, _config = _resolve(args)
 
     print(f"Stopping VM '{identity.vm_instance}' (identity: {name})...")
     stop_vm(identity.vm_instance)
@@ -113,7 +114,7 @@ def _cmd_stop(args: argparse.Namespace) -> int:
 
 
 def _cmd_restart(args: argparse.Namespace) -> int:
-    name, identity = _resolve(args)
+    name, identity, _config = _resolve(args)
 
     print(f"Restarting VM '{identity.vm_instance}' (identity: {name})...")
     stop_vm(identity.vm_instance)
@@ -127,7 +128,7 @@ def _cmd_restart(args: argparse.Namespace) -> int:
 
 
 def _cmd_destroy(args: argparse.Namespace) -> int:
-    name, identity = _resolve(args)
+    name, identity, _config = _resolve(args)
 
     status = vm_status(identity.vm_instance)
     if not status:
@@ -198,7 +199,7 @@ def main(argv: list[str] | None = None) -> int:
     p_create = sub.add_parser("create", help="Create and provision a new VM")
     _add_identity_args(p_create)
     p_create.add_argument(
-        "--tag", default=_DEFAULT_TAG, help="Template version tag (default: v2.0)"
+        "--tag", default="", help="VM template version tag (default: vergil version from config)"
     )
 
     p_start = sub.add_parser("start", help="Start VM and inject credentials")

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -15,12 +15,14 @@ class Identity:
     app_id: str = ""
     private_key_path: str = ""
     projects_dir: str = ""
+    vergil: str = ""
 
 
 @dataclass
 class IdentityConfig:
     identities: dict[str, Identity]
     default_identity: str | None = None
+    vergil: str = ""
 
 
 def load_config(path: Path) -> IdentityConfig:
@@ -32,6 +34,7 @@ def load_config(path: Path) -> IdentityConfig:
         raw = tomllib.load(f)
 
     default_identity = raw.get("default_identity")
+    vergil = raw.get("vergil", "")
 
     identities: dict[str, Identity] = {}
     for name, data in raw.get("identities", {}).items():
@@ -41,8 +44,9 @@ def load_config(path: Path) -> IdentityConfig:
             app_id=str(data.get("app_id", "")),
             private_key_path=data.get("private_key_path", ""),
             projects_dir=data.get("projects_dir", ""),
+            vergil=data.get("vergil", ""),
         )
-    return IdentityConfig(identities=identities, default_identity=default_identity)
+    return IdentityConfig(identities=identities, default_identity=default_identity, vergil=vergil)
 
 
 def default_config_path() -> Path:
@@ -101,6 +105,16 @@ def resolve_identity_by_name(
         "ERROR: multiple identities configured — use --identity to select one",
         file=sys.stderr,
     )
+    raise SystemExit(1)
+
+
+def resolve_vergil_version(config: IdentityConfig, identity: Identity) -> str:
+    """Return the vergil ecosystem version: identity-level, then config-level."""
+    if identity.vergil:
+        return identity.vergil
+    if config.vergil:
+        return config.vergil
+    print("ERROR: no 'vergil' version configured in identities.toml", file=sys.stderr)
     raise SystemExit(1)
 
 

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -15,6 +15,7 @@ from vergil_tooling.lib.identity import (
     load_config,
     resolve_identity,
     resolve_identity_by_name,
+    resolve_vergil_version,
     resolve_workspace,
 )
 
@@ -258,3 +259,51 @@ def test_resolve_identity_by_name_ambiguous(tmp_path: Path) -> None:
     cfg = load_config(p)
     with pytest.raises(SystemExit):
         resolve_identity_by_name(cfg)
+
+
+def test_vergil_version_parsed(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        vergil = "v2.0"
+
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.vergil == "v2.0"
+
+
+def test_vergil_version_per_identity(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        vergil = "v2.0"
+
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        vergil = "v2.2"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.identities["vergil"].vergil == "v2.2"
+
+
+def test_resolve_vergil_version_from_config() -> None:
+    identity = Identity(vm_instance="test")
+    config = IdentityConfig(identities={"test": identity}, vergil="v2.0")
+    assert resolve_vergil_version(config, identity) == "v2.0"
+
+
+def test_resolve_vergil_version_identity_overrides() -> None:
+    identity = Identity(vm_instance="test", vergil="v2.2")
+    config = IdentityConfig(identities={"test": identity}, vergil="v2.0")
+    assert resolve_vergil_version(config, identity) == "v2.2"
+
+
+def test_resolve_vergil_version_missing() -> None:
+    identity = Identity(vm_instance="test")
+    config = IdentityConfig(identities={"test": identity})
+    with pytest.raises(SystemExit):
+        resolve_vergil_version(config, identity)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -18,6 +18,7 @@ def config_file(tmp_path: Path) -> Path:
     p.write_text(
         textwrap.dedent("""\
         default_identity = "vergil"
+        vergil = "v2.0"
 
         [identities.vergil]
         vm_instance = "vergil-agent"
@@ -76,6 +77,8 @@ class TestCreate:
         p = tmp_path / "identities.toml"
         p.write_text(
             textwrap.dedent("""\
+            vergil = "v2.0"
+
             [identities.vergil]
             vm_instance = "vergil-agent"
         """)
@@ -96,7 +99,7 @@ class TestCreate:
         _create: MagicMock,
         _start: MagicMock,
         _inject: MagicMock,
-        _install: MagicMock,
+        mock_install: MagicMock,
         config_file: Path,
         tmp_path: Path,
     ) -> None:
@@ -106,6 +109,55 @@ class TestCreate:
 
         main(["create", "--config", str(config_file), "--tag", "v3.0"])
         mock_fetch.assert_called_once_with("v3.0")
+        mock_install.assert_called_once_with("vergil-agent", "v2.0")
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_create_fails_without_vergil_version(self, _status: MagicMock, tmp_path: Path) -> None:
+        p = tmp_path / "identities.toml"
+        p.write_text(
+            textwrap.dedent("""\
+            [identities.vergil]
+            vm_instance = "vergil-agent"
+            projects_dir = "/home/user/projects"
+        """)
+        )
+        with pytest.raises(SystemExit):
+            main(["create", "--config", str(p)])
+
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_create_uses_identity_vergil_override(
+        self,
+        _status: MagicMock,
+        mock_fetch: MagicMock,
+        _create: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        mock_install: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        p = tmp_path / "identities.toml"
+        p.write_text(
+            textwrap.dedent("""\
+            vergil = "v2.0"
+
+            [identities.vergil]
+            vm_instance = "vergil-agent"
+            projects_dir = "/home/user/projects"
+            vergil = "v2.2"
+        """)
+        )
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        main(["create", "--config", str(p)])
+        mock_fetch.assert_called_once_with("v2.2")
+        mock_install.assert_called_once_with("vergil-agent", "v2.2")
 
 
 class TestStart:


### PR DESCRIPTION
# Pull Request

## Summary

- Add vergil key to identities.toml as the ecosystem version. Resolves per-identity override then top-level default. The --tag CLI flag overrides only the VM template version; tooling always installs at the resolved vergil version.

## Issue Linkage

- Ref #1030

## Notes

- -