### PR TITLE
fix(vrg-vm): remove redundant start_vm from create flow

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -68,9 +68,6 @@ def _cmd_create(args: argparse.Namespace) -> int:
         print(f"  Creating VM with projects mount: {identity.projects_dir}")
         create_vm(identity.vm_instance, template, identity.projects_dir)
 
-        print("  Starting VM...")
-        start_vm(identity.vm_instance)
-
         print("Injecting credentials...")
         inject_credentials(identity.vm_instance, identity)
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -39,7 +39,6 @@ class TestNoSubcommand:
 class TestCreate:
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
-    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -48,7 +47,6 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         mock_create: MagicMock,
-        mock_start: MagicMock,
         mock_inject: MagicMock,
         mock_install: MagicMock,
         config_file: Path,
@@ -63,7 +61,6 @@ class TestCreate:
 
         mock_fetch.assert_called_once_with("v2.0")
         mock_create.assert_called_once()
-        mock_start.assert_called_once()
         mock_inject.assert_called_once()
         mock_install.assert_called_once()
 
@@ -88,7 +85,6 @@ class TestCreate:
 
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
-    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -97,7 +93,6 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         _create: MagicMock,
-        _start: MagicMock,
         _inject: MagicMock,
         mock_install: MagicMock,
         config_file: Path,
@@ -126,7 +121,6 @@ class TestCreate:
 
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
-    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -135,7 +129,6 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         _create: MagicMock,
-        _start: MagicMock,
         _inject: MagicMock,
         mock_install: MagicMock,
         tmp_path: Path,


### PR DESCRIPTION
# Pull Request

## Summary

- Remove redundant start_vm call from _cmd_create — limactl create --tty=false already starts the VM, so the explicit start races and fails

## Issue Linkage

- Ref #1035

## Notes

- -