### PR TITLE
feat(vrg-vm): resolve VM template tag from vergil-vm config key

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -15,6 +15,7 @@ from vergil_tooling.lib.identity import (
     resolve_identity,
     resolve_identity_by_name,
     resolve_vergil_version,
+    resolve_vm_tag,
     resolve_workspace,
 )
 from vergil_tooling.lib.lima import (
@@ -42,7 +43,7 @@ def _resolve(args: argparse.Namespace) -> tuple[str, Identity, IdentityConfig]:
 def _cmd_create(args: argparse.Namespace) -> int:
     name, identity, config = _resolve(args)
     vergil_version = resolve_vergil_version(config, identity)
-    tag = args.tag if args.tag else vergil_version
+    tag = args.tag if args.tag else resolve_vm_tag(config, identity)
 
     status = vm_status(identity.vm_instance)
     if status:

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -16,6 +16,7 @@ class Identity:
     private_key_path: str = ""
     projects_dir: str = ""
     vergil: str = ""
+    vergil_vm: str = ""
 
 
 @dataclass
@@ -23,6 +24,7 @@ class IdentityConfig:
     identities: dict[str, Identity]
     default_identity: str | None = None
     vergil: str = ""
+    vergil_vm: str = ""
 
 
 def load_config(path: Path) -> IdentityConfig:
@@ -35,6 +37,7 @@ def load_config(path: Path) -> IdentityConfig:
 
     default_identity = raw.get("default_identity")
     vergil = raw.get("vergil", "")
+    vergil_vm = raw.get("vergil-vm", "")
 
     identities: dict[str, Identity] = {}
     for name, data in raw.get("identities", {}).items():
@@ -45,8 +48,14 @@ def load_config(path: Path) -> IdentityConfig:
             private_key_path=data.get("private_key_path", ""),
             projects_dir=data.get("projects_dir", ""),
             vergil=data.get("vergil", ""),
+            vergil_vm=data.get("vergil-vm", ""),
         )
-    return IdentityConfig(identities=identities, default_identity=default_identity, vergil=vergil)
+    return IdentityConfig(
+        identities=identities,
+        default_identity=default_identity,
+        vergil=vergil,
+        vergil_vm=vergil_vm,
+    )
 
 
 def default_config_path() -> Path:
@@ -116,6 +125,15 @@ def resolve_vergil_version(config: IdentityConfig, identity: Identity) -> str:
         return config.vergil
     print("ERROR: no 'vergil' version configured in identities.toml", file=sys.stderr)
     raise SystemExit(1)
+
+
+def resolve_vm_tag(config: IdentityConfig, identity: Identity) -> str:
+    """Return the VM template tag: identity vergil-vm, config vergil-vm, then vergil."""
+    if identity.vergil_vm:
+        return identity.vergil_vm
+    if config.vergil_vm:
+        return config.vergil_vm
+    return resolve_vergil_version(config, identity)
 
 
 _PROJECTS_PREFIX = "/projects"

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -16,6 +16,7 @@ from vergil_tooling.lib.identity import (
     resolve_identity,
     resolve_identity_by_name,
     resolve_vergil_version,
+    resolve_vm_tag,
     resolve_workspace,
 )
 
@@ -307,3 +308,51 @@ def test_resolve_vergil_version_missing() -> None:
     config = IdentityConfig(identities={"test": identity})
     with pytest.raises(SystemExit):
         resolve_vergil_version(config, identity)
+
+
+def test_vergil_vm_parsed_config_level(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        vergil = "v2.0"
+        vergil-vm = "v2.1"
+
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.vergil_vm == "v2.1"
+
+
+def test_vergil_vm_parsed_identity_level(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        vergil = "v2.0"
+
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        vergil-vm = "v2.1"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.identities["vergil"].vergil_vm == "v2.1"
+
+
+def test_resolve_vm_tag_from_identity() -> None:
+    identity = Identity(vm_instance="test", vergil_vm="v2.1")
+    config = IdentityConfig(identities={"test": identity}, vergil="v2.0", vergil_vm="v1.9")
+    assert resolve_vm_tag(config, identity) == "v2.1"
+
+
+def test_resolve_vm_tag_from_config() -> None:
+    identity = Identity(vm_instance="test")
+    config = IdentityConfig(identities={"test": identity}, vergil="v2.0", vergil_vm="v2.1")
+    assert resolve_vm_tag(config, identity) == "v2.1"
+
+
+def test_resolve_vm_tag_falls_back_to_vergil() -> None:
+    identity = Identity(vm_instance="test")
+    config = IdentityConfig(identities={"test": identity}, vergil="v2.0")
+    assert resolve_vm_tag(config, identity) == "v2.0"

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -152,6 +152,39 @@ class TestCreate:
         mock_fetch.assert_called_once_with("v2.2")
         mock_install.assert_called_once_with("vergil-agent", "v2.2")
 
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_create_uses_vergil_vm_for_tag(
+        self,
+        _status: MagicMock,
+        mock_fetch: MagicMock,
+        _create: MagicMock,
+        _inject: MagicMock,
+        mock_install: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        p = tmp_path / "identities.toml"
+        p.write_text(
+            textwrap.dedent("""\
+            vergil = "v2.0"
+            vergil-vm = "v2.1"
+
+            [identities.vergil]
+            vm_instance = "vergil-agent"
+            projects_dir = "/home/user/projects"
+        """)
+        )
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        main(["create", "--config", str(p)])
+        mock_fetch.assert_called_once_with("v2.1")
+        mock_install.assert_called_once_with("vergil-agent", "v2.0")
+
 
 class TestStart:
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")


### PR DESCRIPTION
# Pull Request

## Summary

- Add vergil-vm key support in identities.toml so the VM template version resolves without requiring --tag on every create

## Issue Linkage

- Ref #1040

## Notes

- -