### PR TITLE
fix(vrg-vm): restore start_vm in create flow after provisioning

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -69,6 +69,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
         print(f"  Creating VM with projects mount: {identity.projects_dir}")
         create_vm(identity.vm_instance, template, identity.projects_dir)
 
+        print("  Starting VM...")
+        start_vm(identity.vm_instance)
+
         print("Injecting credentials...")
         inject_credentials(identity.vm_instance, identity)
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -39,6 +39,7 @@ class TestNoSubcommand:
 class TestCreate:
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -47,6 +48,7 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         mock_create: MagicMock,
+        mock_start: MagicMock,
         mock_inject: MagicMock,
         mock_install: MagicMock,
         config_file: Path,
@@ -61,6 +63,7 @@ class TestCreate:
 
         mock_fetch.assert_called_once_with("v2.0")
         mock_create.assert_called_once()
+        mock_start.assert_called_once()
         mock_inject.assert_called_once()
         mock_install.assert_called_once()
 
@@ -85,6 +88,7 @@ class TestCreate:
 
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -93,6 +97,7 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         _create: MagicMock,
+        _start: MagicMock,
         _inject: MagicMock,
         mock_install: MagicMock,
         config_file: Path,
@@ -121,6 +126,7 @@ class TestCreate:
 
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -129,6 +135,7 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         _create: MagicMock,
+        _start: MagicMock,
         _inject: MagicMock,
         mock_install: MagicMock,
         tmp_path: Path,
@@ -154,6 +161,7 @@ class TestCreate:
 
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.create_vm")
     @patch("vergil_tooling.bin.vrg_vm.fetch_template")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
@@ -162,6 +170,7 @@ class TestCreate:
         _status: MagicMock,
         mock_fetch: MagicMock,
         _create: MagicMock,
+        _start: MagicMock,
         _inject: MagicMock,
         mock_install: MagicMock,
         tmp_path: Path,


### PR DESCRIPTION
# Pull Request

## Summary

- limactl create --tty=false leaves the VM Stopped — start_vm is required before credential injection

## Issue Linkage

- Ref #1035

## Notes

- -