### PR TITLE
fix(vrg-vm): replace --workdir with bash -c cd wrapper in session

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -175,11 +176,11 @@ def _cmd_session(args: argparse.Namespace) -> int:
     cmd = ["limactl", "shell", "--start", identity.vm_instance]
 
     if workspace:
-        cmd.extend(["--workdir", workspace])
-
-    if args.cmd:
-        cmd.append("--")
-        cmd.extend(args.cmd)
+        if args.cmd:
+            inner = f"cd {shlex.quote(workspace)} && exec {shlex.join(args.cmd)}"
+        else:
+            inner = f"cd {shlex.quote(workspace)} && exec bash --login"
+        cmd.extend(["bash", "-c", inner])
 
     os.execvp(cmd[0], cmd)  # noqa: S606, S607
     return 0  # unreachable, keeps mypy happy

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -297,13 +297,35 @@ class TestSession:
     def test_session_with_workspace(self, mock_exec: MagicMock, config_file: Path) -> None:
         main(["session", "--config", str(config_file), "vergil-tooling"])
         cmd = mock_exec.call_args[0][1]
-        assert "--workdir" in cmd
-        idx = cmd.index("--workdir")
-        assert cmd[idx + 1] == "/projects/vergil-tooling"
+        assert "bash" in cmd
+        assert "-c" in cmd
+        inner = cmd[cmd.index("-c") + 1]
+        assert "cd /projects/vergil-tooling" in inner
+        assert "exec bash --login" in inner
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
     def test_session_with_command(self, mock_exec: MagicMock, config_file: Path) -> None:
         main(["session", "--config", str(config_file), "vergil-tooling", "claude"])
         cmd = mock_exec.call_args[0][1]
-        assert "--" in cmd
-        assert "claude" in cmd
+        assert "bash" in cmd
+        assert "-c" in cmd
+        inner = cmd[cmd.index("-c") + 1]
+        assert "cd /projects/vergil-tooling" in inner
+        assert "exec claude" in inner
+
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    def test_session_command_with_flags(self, mock_exec: MagicMock, config_file: Path) -> None:
+        main(
+            [
+                "session",
+                "--config",
+                str(config_file),
+                "vergil-tooling",
+                "claude",
+                "--model",
+                "opus",
+            ]
+        )
+        cmd = mock_exec.call_args[0][1]
+        inner = cmd[cmd.index("-c") + 1]
+        assert "exec claude --model opus" in inner


### PR DESCRIPTION
# Pull Request

## Summary

- limactl shell --workdir breaks command passthrough — replace with bash -c wrapping for reliable workspace + command handling

## Issue Linkage

- Ref #1050

## Notes

- -