### PR TITLE
feat(vrg-vm): inject Claude Code OAuth token during credential injection

### DIFF
--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -14,6 +14,7 @@ class Identity:
     auth_type: str = "app"
     app_id: str = ""
     private_key_path: str = ""
+    claude_token_path: str = ""
     projects_dir: str = ""
     vergil: str = ""
     vergil_vm: str = ""
@@ -46,6 +47,7 @@ def load_config(path: Path) -> IdentityConfig:
             auth_type=data.get("auth_type", "app"),
             app_id=str(data.get("app_id", "")),
             private_key_path=data.get("private_key_path", ""),
+            claude_token_path=data.get("claude_token_path", ""),
             projects_dir=data.get("projects_dir", ""),
             vergil=data.get("vergil", ""),
             vergil_vm=data.get("vergil-vm", ""),

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -157,7 +157,7 @@ def delete_vm(instance: str) -> None:
 
 
 def inject_credentials(instance: str, identity: Identity) -> None:
-    """Inject GitHub App credentials into a running VM."""
+    """Inject GitHub App and Claude Code credentials into a running VM."""
     key_path = Path(identity.private_key_path).expanduser()
     if not key_path.exists():
         print(f"ERROR: private key not found: {key_path}", file=sys.stderr)
@@ -189,6 +189,34 @@ def inject_credentials(instance: str, identity: Identity) -> None:
         "url.https://github.com/.insteadOf",
         "git@github.com:",
     )
+
+    if identity.claude_token_path:
+        _inject_claude_token(instance, identity.claude_token_path)
+
+
+_BASHRC_SOURCE_LINE = "[ -f ~/.config/vergil/claude.env ] && . ~/.config/vergil/claude.env"
+
+
+def _inject_claude_token(instance: str, token_path: str) -> None:
+    path = Path(token_path).expanduser()
+    if not path.exists():
+        print(f"ERROR: Claude token not found: {path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    token = path.read_text().strip()
+
+    print("  Injecting Claude Code token...")
+    shell_pipe(
+        instance,
+        "cat > ~/.config/vergil/claude.env && chmod 600 ~/.config/vergil/claude.env",
+        f"export CLAUDE_CODE_OAUTH_TOKEN={token}\n",
+    )
+
+    source_cmd = (
+        f'grep -qF "claude.env" ~/.bashrc 2>/dev/null'
+        f" || echo '{_BASHRC_SOURCE_LINE}' >> ~/.bashrc"
+    )
+    shell_run(instance, "bash", "-c", source_cmd)
 
 
 def install_tooling(instance: str, tag: str) -> None:

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -356,3 +356,22 @@ def test_resolve_vm_tag_falls_back_to_vergil() -> None:
     identity = Identity(vm_instance="test")
     config = IdentityConfig(identities={"test": identity}, vergil="v2.0")
     assert resolve_vm_tag(config, identity) == "v2.0"
+
+
+def test_claude_token_path_parsed(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        claude_token_path = "~/.config/vergil/keys/claude-oauth-token"
+    """)
+    )
+    cfg = load_config(p)
+    expected = "~/.config/vergil/keys/claude-oauth-token"
+    assert cfg.identities["vergil"].claude_token_path == expected
+
+
+def test_claude_token_path_defaults_empty(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    assert cfg.identities["vergil"].claude_token_path == ""

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -256,6 +256,71 @@ class TestInjectCredentials:
         assert "app.env" in env_call[0][1]
         assert "APP_ID=12345" in env_call[0][2]
 
+    @patch("vergil_tooling.lib.lima.shell_run")
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    def test_injects_claude_token(
+        self, mock_pipe: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        token_file = tmp_path / "claude-oauth-token"
+        token_file.write_text("test-oauth-token-abc123\n")
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            app_id="12345",
+            private_key_path=str(key_file),
+            claude_token_path=str(token_file),
+        )
+
+        inject_credentials("vergil-agent", identity)
+
+        assert mock_run.call_count == 3
+        bashrc_call = mock_run.call_args_list[2]
+        assert "claude.env" in " ".join(str(a) for a in bashrc_call[0])
+
+        assert mock_pipe.call_count == 3
+        claude_call = mock_pipe.call_args_list[2]
+        assert "claude.env" in claude_call[0][1]
+        assert "CLAUDE_CODE_OAUTH_TOKEN=test-oauth-token-abc123" in claude_call[0][2]
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    def test_skips_claude_token_when_not_configured(
+        self, mock_pipe: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            app_id="12345",
+            private_key_path=str(key_file),
+        )
+
+        inject_credentials("vergil-agent", identity)
+
+        assert mock_run.call_count == 2
+        assert mock_pipe.call_count == 2
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    def test_exits_if_claude_token_missing(
+        self, _mock_pipe: MagicMock, _mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        bad_path = "/nonexistent/claude-token"  # noqa: S105
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            app_id="12345",
+            private_key_path=str(key_file),
+            claude_token_path=bad_path,
+        )
+        with pytest.raises(SystemExit):
+            inject_credentials("vergil-agent", identity)
+
     def test_exits_if_key_missing(self) -> None:
         identity = Identity(
             vm_instance="vergil-agent",


### PR DESCRIPTION
# Pull Request

## Summary

- Extend inject_credentials to write CLAUDE_CODE_OAUTH_TOKEN env var into the VM, enabling Claude Code to authenticate using the Max subscription without interactive login

## Issue Linkage

- Ref #1064

## Notes

- Token path configured via claude_token_path in identities.toml. Env file sourced from .bashrc on login. Re-injected on every start, same lifecycle as GitHub App credentials.