### PR TITLE
fix(vrg-vm): source credential env in session bash -c wrapper

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -177,10 +177,11 @@ def _cmd_session(args: argparse.Namespace) -> int:
     cmd = ["limactl", "shell", "--start", f"--workdir={workdir}", identity.vm_instance]
 
     if workspace:
+        source = ". ~/.config/vergil/claude.env 2>/dev/null;"
         if args.cmd:
-            inner = f"cd {shlex.quote(workspace)} && exec {shlex.join(args.cmd)}"
+            inner = f"{source} cd {shlex.quote(workspace)} && exec {shlex.join(args.cmd)}"
         else:
-            inner = f"cd {shlex.quote(workspace)} && exec bash --login"
+            inner = f"{source} cd {shlex.quote(workspace)} && exec bash --login"
         cmd.extend(["bash", "-c", inner])
 
     os.execvp(cmd[0], cmd)  # noqa: S606, S607

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -302,6 +302,7 @@ class TestSession:
         assert "bash" in cmd
         assert "-c" in cmd
         inner = cmd[cmd.index("-c") + 1]
+        assert "claude.env" in inner
         assert "cd /projects/vergil-tooling" in inner
         assert "exec bash --login" in inner
 
@@ -312,6 +313,7 @@ class TestSession:
         assert "bash" in cmd
         assert "-c" in cmd
         inner = cmd[cmd.index("-c") + 1]
+        assert "claude.env" in inner
         assert "cd /projects/vergil-tooling" in inner
         assert "exec claude" in inner
 
@@ -330,4 +332,5 @@ class TestSession:
         )
         cmd = mock_exec.call_args[0][1]
         inner = cmd[cmd.index("-c") + 1]
+        assert "claude.env" in inner
         assert "exec claude --model opus" in inner


### PR DESCRIPTION
# Pull Request

## Summary

- Explicitly source ~/.config/vergil/claude.env before cd/exec in the session command so CLAUDE_CODE_OAUTH_TOKEN is available to non-interactive shells

## Issue Linkage

- Ref #1064

## Notes

- bash -c is non-interactive and skips .bashrc. The env file must be sourced explicitly for injected credentials to reach processes like claude.