### PR TITLE
fix(vrg-vm): write .credentials.json for Claude Code interactive TUI auth

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -218,6 +218,14 @@ def _inject_claude_token(instance: str, token_path: str) -> None:
     )
     shell_run(instance, "bash", "-c", source_cmd)
 
+    credentials = json.dumps({"claudeAiOauth": {"accessToken": token}})
+    shell_run(instance, "bash", "-c", "mkdir -p ~/.claude")
+    shell_pipe(
+        instance,
+        "cat > ~/.claude/.credentials.json && chmod 600 ~/.claude/.credentials.json",
+        credentials + "\n",
+    )
+
 
 def install_tooling(instance: str, tag: str) -> None:
     """Install vergil-tooling inside the VM."""

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -275,14 +275,21 @@ class TestInjectCredentials:
 
         inject_credentials("vergil-agent", identity)
 
-        assert mock_run.call_count == 3
+        assert mock_run.call_count == 4
         bashrc_call = mock_run.call_args_list[2]
         assert "claude.env" in " ".join(str(a) for a in bashrc_call[0])
+        mkdir_call = mock_run.call_args_list[3]
+        assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
+        assert ".claude" in " ".join(str(a) for a in mkdir_call[0])
 
-        assert mock_pipe.call_count == 3
+        assert mock_pipe.call_count == 4
         claude_call = mock_pipe.call_args_list[2]
         assert "claude.env" in claude_call[0][1]
         assert "CLAUDE_CODE_OAUTH_TOKEN=test-oauth-token-abc123" in claude_call[0][2]
+        creds_call = mock_pipe.call_args_list[3]
+        assert ".credentials.json" in creds_call[0][1]
+        assert "claudeAiOauth" in creds_call[0][2]
+        assert "test-oauth-token-abc123" in creds_call[0][2]
 
     @patch("vergil_tooling.lib.lima.shell_run")
     @patch("vergil_tooling.lib.lima.shell_pipe")


### PR DESCRIPTION
# Pull Request

## Summary

- Write ~/.claude/.credentials.json during token injection so the interactive TUI recognizes stored auth instead of showing the login prompt

## Issue Linkage

- Ref #1064

## Notes

- The TUI checks for the credentials file before falling through to CLAUDE_CODE_OAUTH_TOKEN. Both mechanisms are now populated during injection.