### PR TITLE
fix(vrg-vm): write onboarding-complete flag for Claude Code TUI

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -226,6 +226,13 @@ def _inject_claude_token(instance: str, token_path: str) -> None:
         credentials + "\n",
     )
 
+    onboarding = json.dumps({"hasCompletedOnboarding": True})
+    shell_pipe(
+        instance,
+        "cat > ~/.claude.json",
+        onboarding + "\n",
+    )
+
 
 def install_tooling(instance: str, tag: str) -> None:
     """Install vergil-tooling inside the VM."""

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -282,7 +282,7 @@ class TestInjectCredentials:
         assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
         assert ".claude" in " ".join(str(a) for a in mkdir_call[0])
 
-        assert mock_pipe.call_count == 4
+        assert mock_pipe.call_count == 5
         claude_call = mock_pipe.call_args_list[2]
         assert "claude.env" in claude_call[0][1]
         assert "CLAUDE_CODE_OAUTH_TOKEN=test-oauth-token-abc123" in claude_call[0][2]
@@ -290,6 +290,9 @@ class TestInjectCredentials:
         assert ".credentials.json" in creds_call[0][1]
         assert "claudeAiOauth" in creds_call[0][2]
         assert "test-oauth-token-abc123" in creds_call[0][2]
+        onboarding_call = mock_pipe.call_args_list[4]
+        assert ".claude.json" in onboarding_call[0][1]
+        assert "hasCompletedOnboarding" in onboarding_call[0][2]
 
     @patch("vergil_tooling.lib.lima.shell_run")
     @patch("vergil_tooling.lib.lima.shell_pipe")


### PR DESCRIPTION
# Pull Request

## Summary

- Write ~/.claude.json with hasCompletedOnboarding during token injection so the interactive TUI skips the login selection screen

## Issue Linkage

- Ref #1064

## Notes

- Known Claude Code bug: the TUI checks ~/.claude.json (not ~/.claude/) for onboarding state and ignores env vars and credentials files without it. Issues anthropics/claude-code#4714, #27900, #28438, #32463.