### PR TITLE
fix(repo-config): update CLAUDE.md consumer template for vrg-container-run rename

### DIFF
--- a/src/vergil_tooling/data/claude_md_consumer.md
+++ b/src/vergil_tooling/data/claude_md_consumer.md
@@ -75,7 +75,7 @@ Rules for this session:
   read-only — all changes flow through your worktree on your
   feature branch.
 - When you need to run validation, run it from inside your worktree
-  (vrg-docker-run mounts the current directory).
+  (vrg-container-run mounts the current directory).
 ```
 
 All fields are required.
@@ -93,7 +93,7 @@ human who can run it directly via `! <command>` in the prompt.
 ## Validation
 
 ```bash
-vrg-docker-run -- vrg-validate
+vrg-container-run -- vrg-validate
 ```
 
 This is the **only** validation command. Do not run individual linters,


### PR DESCRIPTION
# Pull Request

## Summary

- Replace vrg-docker-run with vrg-container-run in the consumer template, fixing the audit check that blocks release preflight

## Issue Linkage

- Ref #1088

## Notes

- The vrg-docker-* to vrg-container-* rename (4e712baf) updated CLAUDE.md but missed the consumer template at src/vergil_tooling/data/claude_md_consumer.md. Two references to vrg-docker-run remained, causing the substring check in vrg-github-repo-config audit to fail with 'template not found'. This blocked release preflight. Other vrg-docker references in the repo are historical (changelogs, release notes, completed design specs) and correct as point-in-time records.