### PR TITLE
chore(ci): temporarily point vergil-actions refs to @develop

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,13 +13,13 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@develop
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@develop
     with:
       language: python
       container-tag: "3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@develop
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
@@ -28,7 +28,7 @@ jobs:
       container-suffix: python
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@develop
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
@@ -36,7 +36,7 @@ jobs:
       container-suffix: python
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@develop
     permissions:
       contents: read
       security-events: write
@@ -48,7 +48,7 @@ jobs:
       container-suffix: python
 
   test:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@develop
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
@@ -56,7 +56,7 @@ jobs:
       container-suffix: python
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@develop
     with:
       language: python
       run-release: ${{ inputs.run-release != 'false' }}

--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   github-config:
-    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@develop
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
# Pull Request

## Summary

- Point vergil-actions workflow refs to @develop to avoid duplicate version-bump PRs

## Issue Linkage

- Ref #1101

## Notes

- Change all vergil-actions workflow references from `@v2.0` to `@develop`
across ci.yml, cd.yml, and ops.yml.

This is a temporary measure to avoid duplicate version-bump PRs until
vergil-actions is released with a new version tag. The change will be
reverted after that release.