### PR TITLE
fix(release): use contains instead of startswith for CD job name matching

### DIFF
--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -112,7 +112,7 @@ def _verify_jobs(
             "--json",
             "jobs",
             "--jq",
-            f'.jobs[] | select(.name | startswith("{job_name}")) | .conclusion',
+            f'.jobs[] | select(.name | contains("{job_name}")) | .conclusion',
         )
         if not conclusion:
             raise ReleaseError(


### PR DESCRIPTION
# Pull Request

## Summary

- Fix confirm phase failing on repos where CD jobs are nested under a different caller workflow name

## Issue Linkage

- Ref #1125

## Notes

- -