### PR TITLE
feat(vm): stateless VM lifecycle — staleness enforcement, auto-update, rebuild

### DIFF
--- a/docs/plans/in-progress/2026-05-24-stateless-vm-lifecycle.md
+++ b/docs/plans/in-progress/2026-05-24-stateless-vm-lifecycle.md
@@ -1,0 +1,919 @@
+# Stateless VM Lifecycle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make identity VMs dataless and stateless — selective
+host mounts for Claude Code data, staleness enforcement with hard
+block, auto-update on every entry point, and a `rebuild` command.
+
+**Architecture:** All persistent data lives on the macOS host via
+virtiofs mounts (`~/.claude/projects/`, `~/.claude/skills/`) and
+file copies (`CLAUDE.md`, `settings.json`). VM staleness is
+checked against Lima directory metadata on the host. vergil-tooling
+is auto-updated on `start` and `session` with graceful fallback
+on network failure.
+
+**Tech Stack:** Python, Lima, argparse, pytest
+
+**Specs:**
+- `docs/specs/2026-05-24-stateless-vm-lifecycle-design.md` (#907)
+
+**Repository:** vergil-tooling (all changes are host-side
+orchestration in `vrg-vm`)
+
+**Note on Lima template mounts:** The `~/.claude/projects/` and
+`~/.claude/skills/` mounts need to be added to the Lima template
+in the vergil-vm repository. That template does not live in this
+repo. This plan covers the vergil-tooling side (host-side
+orchestration). The vergil-vm template changes are tracked
+separately.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/vergil_tooling/lib/lima.py` | Modify | Add `vm_age_days()`, `copy_claude_config()`, graceful `try_update_tooling()` |
+| `src/vergil_tooling/bin/vrg_vm.py` | Modify | Add `rebuild` subcommand, staleness check, `--allow-stale-vm`, auto-update in `start` |
+| `tests/vergil_tooling/test_lima.py` | Modify | Tests for `vm_age_days()`, `copy_claude_config()`, `try_update_tooling()` |
+| `tests/vergil_tooling/test_vrg_vm.py` | Modify | Tests for `rebuild`, staleness enforcement, `--allow-stale-vm` |
+
+---
+
+### Task 1: VM Age Detection
+
+Read the VM creation timestamp from Lima's instance directory
+metadata on the host. No data is stored inside the VM.
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py`
+- Modify: `tests/vergil_tooling/test_lima.py`
+
+- [ ] **Step 1: Write the failing test for `vm_age_days`**
+
+```python
+class TestVmAgeDays:
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_age_in_days(self, mock: MagicMock, tmp_path: Path) -> None:
+        vm_dir = tmp_path / "vergil-agent"
+        vm_dir.mkdir()
+
+        mock.return_value = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"name": "vergil-agent", "dir": str(vm_dir)}) + "\n"
+        )
+
+        age = vm_age_days("vergil-agent")
+        assert age is not None
+        assert age >= 0
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_none_when_vm_not_found(self, mock: MagicMock) -> None:
+        mock.return_value = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"name": "other-vm", "dir": "/tmp/other"}) + "\n"
+        )
+        assert vm_age_days("vergil-agent") is None
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_none_on_error(self, mock: MagicMock) -> None:
+        mock.side_effect = subprocess.CalledProcessError(1, "limactl")
+        assert vm_age_days("vergil-agent") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_lima.py::TestVmAgeDays -v`
+Expected: FAIL with `ImportError` (function not defined)
+
+- [ ] **Step 3: Implement `vm_age_days`**
+
+Add to `src/vergil_tooling/lib/lima.py`:
+
+```python
+import time
+
+def vm_age_days(instance: str) -> float | None:
+    """Return VM age in fractional days, or None if not found."""
+    try:
+        result = _limactl("list", "--json")
+    except subprocess.CalledProcessError:
+        return None
+    for line in result.stdout.strip().splitlines():
+        entry = json.loads(line)
+        if entry.get("name") == instance:
+            vm_dir = entry.get("dir", "")
+            if not vm_dir:
+                return None
+            dir_path = Path(vm_dir)
+            if not dir_path.exists():
+                return None
+            created = dir_path.stat().st_birthtime
+            return (time.time() - created) / 86400
+    return None
+```
+
+Update imports: add `time` to the import list.
+
+- [ ] **Step 4: Export `vm_age_days` from the module**
+
+Add `vm_age_days` to the imports in
+`src/vergil_tooling/bin/vrg_vm.py` and to the test import in
+`tests/vergil_tooling/test_lima.py`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_lima.py::TestVmAgeDays -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```
+vrg-commit --type feat --scope vm \
+  --message "vm_age_days reads VM creation time from Lima metadata" \
+  --body "Returns fractional days since VM creation using the Lima instance directory birth time. Ref #907"
+```
+
+---
+
+### Task 2: Copy Claude Config Files
+
+Copy `~/.claude/CLAUDE.md` and `~/.claude/settings.json` from the
+host into the VM. Lima mounts directories, not files, so these
+individual files must be copied.
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py`
+- Modify: `tests/vergil_tooling/test_lima.py`
+
+- [ ] **Step 1: Write the failing test for `copy_claude_config`**
+
+```python
+class TestCopyClaudeConfig:
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_copies_existing_files(
+        self, mock_run: MagicMock, mock_pipe: MagicMock, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "CLAUDE.md").write_text("# My prefs\n")
+        (claude_dir / "settings.json").write_text('{"key": "val"}\n')
+
+        copy_claude_config("vergil-agent", claude_dir)
+
+        assert mock_run.call_count == 1
+        mkdir_call = mock_run.call_args_list[0]
+        assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
+        assert ".claude" in " ".join(str(a) for a in mkdir_call[0])
+
+        assert mock_pipe.call_count == 2
+        md_call = mock_pipe.call_args_list[0]
+        assert "CLAUDE.md" in md_call[0][1]
+        assert "# My prefs" in md_call[0][2]
+        settings_call = mock_pipe.call_args_list[1]
+        assert "settings.json" in settings_call[0][1]
+        assert '"key"' in settings_call[0][2]
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_skips_missing_files(
+        self, mock_run: MagicMock, mock_pipe: MagicMock, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+
+        copy_claude_config("vergil-agent", claude_dir)
+
+        mock_run.assert_called_once()
+        mock_pipe.assert_not_called()
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_skips_if_claude_dir_missing(
+        self, mock_run: MagicMock, mock_pipe: MagicMock, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+
+        copy_claude_config("vergil-agent", claude_dir)
+
+        mock_run.assert_not_called()
+        mock_pipe.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_lima.py::TestCopyClaudeConfig -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Implement `copy_claude_config`**
+
+Add to `src/vergil_tooling/lib/lima.py`:
+
+```python
+_CLAUDE_CONFIG_FILES = ("CLAUDE.md", "settings.json")
+
+
+def copy_claude_config(instance: str, claude_dir: Path) -> None:
+    """Copy CLAUDE.md and settings.json from host into the VM."""
+    if not claude_dir.is_dir():
+        return
+    shell_run(instance, "bash", "-c", "mkdir -p ~/.claude")
+    for filename in _CLAUDE_CONFIG_FILES:
+        source = claude_dir / filename
+        if source.exists():
+            content = source.read_text()
+            shell_pipe(
+                instance,
+                f"cat > ~/.claude/{filename}",
+                content,
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_lima.py::TestCopyClaudeConfig -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+vrg-commit --type feat --scope vm \
+  --message "copy_claude_config copies CLAUDE.md and settings.json into VM" \
+  --body "One-way host-to-VM copy for files that cannot be mounted (Lima mounts directories only). Ref #907"
+```
+
+---
+
+### Task 3: Graceful Tooling Update
+
+Wrap `update_tooling` with a version that catches network failures
+and warns instead of aborting. Used by `start` and `session`.
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py`
+- Modify: `tests/vergil_tooling/test_lima.py`
+
+- [ ] **Step 1: Write the failing test for `try_update_tooling`**
+
+```python
+class TestTryUpdateTooling:
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_returns_true_on_success(self, mock_update: MagicMock) -> None:
+        result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        assert result is True
+        mock_update.assert_called_once_with("vergil-agent", None, fallback_tag="v2.0")
+
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_returns_false_on_subprocess_error(
+        self, mock_update: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_update.side_effect = subprocess.CalledProcessError(1, "uv")
+        result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_returns_false_on_system_exit(
+        self, mock_update: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_update.side_effect = SystemExit(1)
+        result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_passes_explicit_tag(self, mock_update: MagicMock) -> None:
+        try_update_tooling("vergil-agent", tag="v2.1", fallback_tag="v2.0")
+        mock_update.assert_called_once_with("vergil-agent", "v2.1", fallback_tag="v2.0")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_lima.py::TestTryUpdateTooling -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Implement `try_update_tooling`**
+
+Add to `src/vergil_tooling/lib/lima.py`:
+
+```python
+def try_update_tooling(
+    instance: str,
+    tag: str | None = None,
+    *,
+    fallback_tag: str = "",
+) -> bool:
+    """Update vergil-tooling, returning False on failure instead of aborting."""
+    try:
+        update_tooling(instance, tag, fallback_tag=fallback_tag)
+        return True
+    except (subprocess.CalledProcessError, SystemExit):
+        print(
+            "WARNING: vergil-tooling update failed — continuing with installed version",
+            file=sys.stderr,
+        )
+        return False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_lima.py::TestTryUpdateTooling -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+vrg-commit --type feat --scope vm \
+  --message "try_update_tooling wraps update with graceful fallback" \
+  --body "Returns False and warns on failure instead of aborting. Used by start and session to avoid blocking on network errors. Ref #907"
+```
+
+---
+
+### Task 4: Staleness Enforcement in `vrg-vm start`
+
+Add staleness check and `--allow-stale-vm` flag to `start`.
+Also add auto-update and Claude config copy.
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py`
+- Modify: `tests/vergil_tooling/test_vrg_vm.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+_DEFAULT_STALENESS_DAYS = 3
+
+
+class TestStartStaleness:
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_rejects_stale_vm(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        result = main(["start", "--config", str(config_file)])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "5 days old" in captured.err or "5.0" in captured.err
+        assert "--allow-stale-vm" in captured.err
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_allows_stale_with_override(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        mock_inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["start", "--config", str(config_file), "--allow-stale-vm"])
+        assert result == 0
+        mock_start.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_passes_fresh_vm(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["start", "--config", str(config_file)])
+        assert result == 0
+        mock_start.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_calls_auto_update(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        mock_update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["start", "--config", str(config_file)])
+        mock_update.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_copies_claude_config(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        mock_copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["start", "--config", str(config_file)])
+        mock_copy.assert_called_once()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestStartStaleness -v`
+Expected: FAIL
+
+- [ ] **Step 3: Update imports in `vrg_vm.py`**
+
+Add to the `lima` import block:
+
+```python
+from vergil_tooling.lib.lima import (
+    copy_claude_config,
+    create_vm,
+    delete_vm,
+    fetch_template,
+    inject_credentials,
+    install_tooling,
+    list_vms,
+    start_vm,
+    stop_vm,
+    try_update_tooling,
+    update_tooling,
+    vm_age_days,
+    vm_status,
+)
+```
+
+- [ ] **Step 4: Add `--allow-stale-vm` to `start` parser**
+
+In the `main` function, after the `p_start` parser is created:
+
+```python
+p_start = sub.add_parser("start", help="Start VM and inject credentials")
+_add_identity_args(p_start)
+p_start.add_argument(
+    "--allow-stale-vm",
+    action="store_true",
+    help="Start even if the VM exceeds the staleness threshold",
+)
+```
+
+- [ ] **Step 5: Add staleness constant**
+
+At the top of `vrg_vm.py`, after imports:
+
+```python
+_DEFAULT_STALENESS_DAYS = 3
+```
+
+- [ ] **Step 6: Rewrite `_cmd_start`**
+
+```python
+def _cmd_start(args: argparse.Namespace) -> int:
+    name, identity, config = _resolve(args)
+
+    status = vm_status(identity.vm_instance)
+    if not status:
+        print(
+            f"ERROR: VM '{identity.vm_instance}' does not exist — run 'vrg-vm create' first",
+            file=sys.stderr,
+        )
+        return 1
+
+    allow_stale = getattr(args, "allow_stale_vm", False)
+    if not allow_stale:
+        age = vm_age_days(identity.vm_instance)
+        if age is not None and age > _DEFAULT_STALENESS_DAYS:
+            print(
+                f"ERROR: VM '{identity.vm_instance}' is {age:.0f} days old"
+                f" (threshold: {_DEFAULT_STALENESS_DAYS} days).\n"
+                f"Rebuild with: vrg-vm rebuild --identity {name}\n"
+                f"Override with: vrg-vm start --allow-stale-vm --identity {name}",
+                file=sys.stderr,
+            )
+            return 1
+
+    print(f"Starting VM '{identity.vm_instance}' (identity: {name})...")
+    start_vm(identity.vm_instance)
+
+    print("Injecting credentials...")
+    inject_credentials(identity.vm_instance, identity)
+
+    claude_dir = Path.home() / ".claude"
+    print("Copying Claude Code config...")
+    copy_claude_config(identity.vm_instance, claude_dir)
+
+    fallback = resolve_vergil_version(config, identity)
+    print("Updating vergil-tooling...")
+    try_update_tooling(identity.vm_instance, fallback_tag=fallback)
+
+    print(f"VM '{identity.vm_instance}' is running.")
+    return 0
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestStartStaleness -v`
+Expected: PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -v`
+Expected: ALL PASS (existing `TestStart` tests may need the new
+mocked dependencies added — update them to patch the new functions)
+
+- [ ] **Step 9: Commit**
+
+```
+vrg-commit --type feat --scope vm \
+  --message "staleness enforcement and auto-update in vrg-vm start" \
+  --body "Refuses to start VMs older than 3 days unless --allow-stale-vm is passed. Auto-updates vergil-tooling and copies Claude config on start. Ref #907"
+```
+
+---
+
+### Task 5: Staleness Enforcement in `vrg-vm session`
+
+Add staleness check and `--allow-stale-vm` to `session`.
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py`
+- Modify: `tests/vergil_tooling/test_vrg_vm.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestSessionStaleness:
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    def test_session_rejects_stale_vm(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _update: MagicMock,
+        _exec: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        result = main(["session", "--config", str(config_file)])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "--allow-stale-vm" in captured.err
+
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    def test_session_allows_stale_with_override(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _update: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["session", "--config", str(config_file), "--allow-stale-vm"])
+        mock_exec.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    def test_session_passes_fresh_vm(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _update: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["session", "--config", str(config_file)])
+        mock_exec.assert_called_once()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestSessionStaleness -v`
+Expected: FAIL
+
+- [ ] **Step 3: Add `--allow-stale-vm` to `session` parser**
+
+```python
+p_session = sub.add_parser("session", help="Shell into a VM")
+_add_identity_args(p_session)
+p_session.add_argument(
+    "--allow-stale-vm",
+    action="store_true",
+    help="Connect even if the VM exceeds the staleness threshold",
+)
+```
+
+- [ ] **Step 4: Add staleness check to `_cmd_session`**
+
+Insert at the beginning of `_cmd_session`, after resolving
+the identity:
+
+```python
+def _cmd_session(args: argparse.Namespace) -> int:
+    config_path = args.config if args.config else _default_config_path()
+    config = load_config(config_path)
+    identity = resolve_identity(config, args.identity)
+
+    allow_stale = getattr(args, "allow_stale_vm", False)
+    if not allow_stale:
+        age = vm_age_days(identity.vm_instance)
+        if age is not None and age > _DEFAULT_STALENESS_DAYS:
+            name = args.identity or config.default_identity or "default"
+            print(
+                f"ERROR: VM '{identity.vm_instance}' is {age:.0f} days old"
+                f" (threshold: {_DEFAULT_STALENESS_DAYS} days).\n"
+                f"Rebuild with: vrg-vm rebuild --identity {name}\n"
+                f"Override with: vrg-vm session --allow-stale-vm --identity {name}",
+                file=sys.stderr,
+            )
+            return 1
+
+    fallback = resolve_vergil_version(config, identity)
+    try_update_tooling(identity.vm_instance, fallback_tag=fallback)
+
+    claude_dir = Path.home() / ".claude"
+    copy_claude_config(identity.vm_instance, claude_dir)
+
+    # ... rest of session logic unchanged
+```
+
+Note: replace the existing `update_tooling` call with
+`try_update_tooling` and add the `copy_claude_config` call.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestSessionStaleness -v`
+Expected: PASS
+
+- [ ] **Step 6: Update existing session tests**
+
+The existing `TestSession` tests need to mock the new
+dependencies (`vm_age_days`, `copy_claude_config`,
+`try_update_tooling`). Update each test to add these patches.
+Replace `update_tooling` patches with `try_update_tooling`.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```
+vrg-commit --type feat --scope vm \
+  --message "staleness enforcement in vrg-vm session" \
+  --body "Session refuses to connect to VMs older than 3 days unless --allow-stale-vm is passed. Also copies Claude config and uses graceful tooling update. Ref #907"
+```
+
+---
+
+### Task 6: Rebuild Command
+
+Add `vrg-vm rebuild` as a single command that destroys and
+recreates a VM.
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py`
+- Modify: `tests/vergil_tooling/test_vrg_vm.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRebuild:
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.delete_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_rebuild_destroys_and_creates(
+        self,
+        _status: MagicMock,
+        mock_delete: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        mock_start: MagicMock,
+        mock_inject: MagicMock,
+        mock_install: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        result = main(["rebuild", "--config", str(config_file)])
+        assert result == 0
+        mock_delete.assert_called_once_with("vergil-agent")
+        mock_create.assert_called_once()
+        mock_start.assert_called_once()
+        mock_inject.assert_called_once()
+        mock_install.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_rebuild_fails_if_not_created(
+        self, _status: MagicMock, config_file: Path
+    ) -> None:
+        result = main(["rebuild", "--config", str(config_file)])
+        assert result == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestRebuild -v`
+Expected: FAIL
+
+- [ ] **Step 3: Add `rebuild` subcommand parser**
+
+In `main`, add after the `destroy` parser:
+
+```python
+p_rebuild = sub.add_parser("rebuild", help="Destroy and recreate VM (stateless rebuild)")
+_add_identity_args(p_rebuild)
+p_rebuild.add_argument(
+    "--tag", default="", help="VM template version tag (default: vergil version from config)"
+)
+```
+
+Add to the dispatch dict:
+
+```python
+"rebuild": _cmd_rebuild,
+```
+
+- [ ] **Step 4: Implement `_cmd_rebuild`**
+
+```python
+def _cmd_rebuild(args: argparse.Namespace) -> int:
+    name, identity, config = _resolve(args)
+
+    status = vm_status(identity.vm_instance)
+    if not status:
+        print(
+            f"ERROR: VM '{identity.vm_instance}' does not exist — run 'vrg-vm create' first",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not identity.projects_dir:
+        print(
+            f"ERROR: identity '{name}' has no projects_dir configured",
+            file=sys.stderr,
+        )
+        return 1
+
+    vergil_version = resolve_vergil_version(config, identity)
+    tag = args.tag if args.tag else resolve_vm_tag(config, identity)
+
+    print(f"Rebuilding VM '{identity.vm_instance}' (identity: {name})...")
+
+    print("  Destroying old VM...")
+    delete_vm(identity.vm_instance)
+
+    print(f"  Fetching template ({tag})...")
+    template = fetch_template(tag)
+
+    try:
+        print(f"  Creating VM with projects mount: {identity.projects_dir}")
+        create_vm(identity.vm_instance, template, identity.projects_dir)
+
+        print("  Starting VM...")
+        start_vm(identity.vm_instance)
+
+        print("  Injecting credentials...")
+        inject_credentials(identity.vm_instance, identity)
+
+        install_tooling(identity.vm_instance, vergil_version)
+
+        claude_dir = Path.home() / ".claude"
+        print("  Copying Claude Code config...")
+        copy_claude_config(identity.vm_instance, claude_dir)
+    finally:
+        template.unlink(missing_ok=True)
+
+    print(f"\nVM '{identity.vm_instance}' rebuilt and ready.")
+    return 0
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestRebuild -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `vrg-container-run -- uv run vrg-validate`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```
+vrg-commit --type feat --scope vm \
+  --message "vrg-vm rebuild command for stateless VM lifecycle" \
+  --body "Destroys and recreates the VM in one step. Safe because VMs are stateless — all persistent data lives on host mounts. Ref #907"
+```
+
+---
+
+### Task 7: Update Existing Tests
+
+The existing `TestStart` and `TestSession` tests need to be
+updated to account for the new dependencies (`vm_age_days`,
+`copy_claude_config`, `try_update_tooling`).
+
+**Files:**
+- Modify: `tests/vergil_tooling/test_vrg_vm.py`
+
+- [ ] **Step 1: Update `TestStart` tests**
+
+Add patches for `vm_age_days` (returning `1.0`),
+`copy_claude_config`, and `try_update_tooling` to the existing
+start tests. The existing `test_start_and_inject` test should
+verify that all three new functions are called.
+
+- [ ] **Step 2: Update `TestSession` tests**
+
+Replace `update_tooling` patches with `try_update_tooling`.
+Add `vm_age_days` (returning `1.0`) and `copy_claude_config`
+patches to all session tests.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `vrg-container-run -- uv run vrg-validate`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```
+vrg-commit --type test --scope vm \
+  --message "update existing VM tests for stateless lifecycle changes" \
+  --body "Adds mocks for vm_age_days, copy_claude_config, and try_update_tooling to existing start and session tests. Ref #907"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage:** All spec requirements are covered:
+  - Selective mounts → noted as vergil-vm template work (out of scope for this plan)
+  - Copied files (CLAUDE.md, settings.json) → Task 2
+  - Auto-update on start and session → Tasks 4, 5
+  - Graceful fallback → Task 3
+  - Staleness enforcement → Tasks 4, 5
+  - `--allow-stale-vm` override → Tasks 4, 5
+  - `vrg-vm rebuild` → Task 6
+  - VM age from Lima metadata → Task 1
+- [x] **Placeholder scan:** No TBDs, TODOs, or vague steps. All code shown.
+- [x] **Type consistency:** `vm_age_days` returns `float | None`,
+  `try_update_tooling` returns `bool`, `copy_claude_config` takes
+  `Path` — consistent across all tasks.
+- [x] **Scope boundaries:** Lima template changes (mounts) are
+  explicitly noted as vergil-vm work, not included here.

--- a/docs/specs/2026-05-24-stateless-vm-lifecycle-design.md
+++ b/docs/specs/2026-05-24-stateless-vm-lifecycle-design.md
@@ -1,0 +1,343 @@
+# Stateless VM Lifecycle Design
+
+**Issue:** #907
+**Date:** 2026-05-24
+**Status:** Draft
+**Supersedes:** Distribution and Dynamic Tooling Management sections
+of #894 (`2026-05-20-vergil-vm-image-management-design.md`)
+**Related:** #892 (identity VM isolation), #894 (VM image
+management), mempalace (transcript mining)
+
+## Problem
+
+The identity VM isolation design (#892) and the VM image management
+design (#894) assumed that VMs would be long-lived and that keeping
+them current required two mechanisms: centrally published pre-built
+images for onboarding, and a dynamic in-place update system for OS
+packages and tooling.
+
+Both assumptions are wrong for this system:
+
+1. **Published images are over-engineering.** Docker images already
+   solve the "works on my machine" problem for development — the
+   entire build/test/validate toolchain lives in vergil-docker
+   containers consumed via `vrg-container-run`. The VM's role is
+   narrower: an isolation boundary that runs a container runtime
+   and a handful of CLI tools. A provisioning script that installs
+   five tools on a stock Ubuntu image does not produce meaningful
+   variance across machines. Publishing pre-built images adds a
+   CD pipeline, registry management, and multi-arch build
+   complexity for a problem that doesn't exist.
+
+2. **In-place OS updates are the wrong model.** VMs should be
+   rebuilt frequently, not patched in place. Frequent rebuilds
+   keep the environment fresh (latest OS packages, latest tool
+   versions), keep agent contexts from accumulating drift, and
+   align with the principle that VMs are disposable compute —
+   not persistent workstations.
+
+The key insight: **VMs must be dataless and stateless.** All
+persistent data lives on the macOS host, accessed via mounts.
+The VM is a disposable shell. Rebuilding it loses nothing.
+
+This design replaces the distribution and dynamic tooling
+management sections of #894 with a simpler model: local builds,
+frequent rebuilds, and targeted in-place updates for
+vergil-tooling only.
+
+## Core Principle: Dataless, Stateless VMs
+
+The identity VM contains no state that survives a rebuild. All
+persistent data lives on the macOS host, accessed via virtiofs
+mounts and file copies at VM startup.
+
+### Mounts
+
+| Mount | Default host path | VM path | Configurable? |
+|---|---|---|---|
+| Workspace | `~/dev` | Host-path-preserving | Yes |
+| Claude projects | `~/.claude/projects` | `~/.claude/projects` (native) | No |
+| Claude skills | `~/.claude/skills` | `~/.claude/skills` (native) | No |
+
+**Workspace mount:** Host-path-preserving — if the host path is
+`/Users/pmoore/dev`, the VM mount point is `/Users/pmoore/dev`.
+This ensures Claude Code derives identical project memory keys
+regardless of whether a session runs on the host or in the VM.
+The workspace mount path is configurable per identity (via
+`identities.toml`), since developers organize their source trees
+differently. One developer may mount `~/dev`, another
+`~/dev/projects`, another `~` entirely. The mount must be
+host-path-preserving regardless of which directory is chosen.
+
+**Claude projects mount:** The host's `~/.claude/projects/`
+directory is mounted at the VM's native `~/.claude/projects/`.
+This contains session transcripts and memory files — the data
+that mempalace mines and that provides continuity across
+sessions.
+
+**Claude skills mount:** The host's `~/.claude/skills/` directory
+is mounted at the VM's native `~/.claude/skills/`. User-defined
+skills are shared across host and VM sessions.
+
+Only specific subdirectories are mounted, not all of `~/.claude/`.
+This is deliberate: Claude Code credentials (`.credentials.json`)
+are injected per-identity by `vrg-vm` and must remain VM-local.
+Mounting all of `~/.claude/` would cause per-identity credential
+files to bleed onto the host or collide between VMs.
+
+### Copied on VM Start
+
+Individual files that cannot be mounted (Lima mounts directories,
+not files) are copied from the host into the VM at startup,
+during the credential injection phase:
+
+| File | Purpose |
+|---|---|
+| `~/.claude/CLAUDE.md` | User's global preferences and behavioral guidance |
+| `~/.claude/settings.json` | User's global Claude Code settings |
+
+These are one-way copies (host → VM). Changes made inside the
+VM are not persisted — the host copy is authoritative.
+
+### VM-Local (Not Shared)
+
+Everything else in the VM's `~/.claude/` directory is local to
+that VM instance and destroyed on rebuild:
+
+| Path | Why VM-local |
+|---|---|
+| `.credentials.json` | Per-identity Claude Code OAuth token, injected by `vrg-vm` |
+| `plugins/` | Plugin cache, re-fetched automatically |
+| `cache/`, `debug/`, `downloads/` | Ephemeral working state |
+| `history.jsonl` | Per-environment command history |
+| `sessions/`, `session-env/` | Per-instance session state |
+| `statsig/`, `telemetry/` | Analytics, per-instance |
+
+### Why This Works
+
+Claude Code derives project memory keys from the working
+directory path, not from where `~/.claude` lives. Because repos
+are mounted at host-preserving paths, the derived key (e.g.,
+`-Users-pmoore-dev-projects-vergil-project-vergil-tooling`) is
+identical whether the session runs on the host or in the VM.
+Both environments read and write the same physical files in
+`~/.claude/projects/` through different mount points.
+
+**Mempalace integration:** Mempalace mines `~/.claude/projects/`
+on the host. It is unaware of VMs. Sessions that ran inside VMs
+produce transcripts in the same location as host sessions —
+mempalace sees them all. No special configuration, no
+VM-awareness in mempalace.
+
+**Concurrent access:** Running Claude Code on the host and inside
+a VM simultaneously is safe — the same pattern as running
+multiple Claude Code instances in separate terminal windows
+today.
+
+### Consequence
+
+Rebuilding a VM loses nothing of value. Session transcripts and
+memory files persist on the host via the `projects/` mount.
+User preferences are re-copied on next start. Credentials are
+re-injected. No backup, no migration, no data export. Destroy
+and recreate.
+
+## Update Strategy: Two Tiers
+
+The VM has exactly two categories of software with different
+update mechanisms.
+
+### Tier 1: vergil-tooling (In-Place, Aggressive)
+
+vergil-tooling is the sole component updated in place. It
+releases frequently and a bug fix mid-session should not require
+a full VM rebuild.
+
+**Mechanism:**
+
+All update orchestration runs on the host via `vrg-vm`. Nothing
+inside the VM drives updates — the VM is a passive target.
+
+- `vrg-vm update` reinstalls vergil-tooling inside the VM via
+  `uv tool install --reinstall`, executed through `limactl shell`.
+- The version target is read from `identities.toml` on the host
+  (the `vergil` key at identity or config level). No version
+  configuration is stored inside the VM.
+- Both `vrg-vm start` and `vrg-vm session` auto-update
+  vergil-tooling — ensures the VM is current on every entry
+  point. The cost is low and eliminates stale-tooling scenarios.
+  If the update fails (network unavailable, GitHub unreachable),
+  the command warns and continues with the installed version.
+- The user can run `vrg-vm update` explicitly at any time to
+  pick up a new release mid-session.
+- A marker file inside the VM (`~/.config/vergil/tooling-tag`)
+  records which tag was last installed. This is ephemeral state —
+  destroyed on rebuild, used only by the update mechanism to
+  detect the current version.
+
+**Scope constraint:** `vrg-vm update` updates vergil-tooling and
+nothing else. It does not touch OS packages, git, gh, uv,
+containerd, nerdctl, or any other software in the VM.
+
+### Tier 2: Everything Else (Rebuild From Scratch)
+
+OS packages, git, gh, uv, containerd, nerdctl, developer
+convenience tools — all installed by the provisioning script at
+VM creation time. No in-place update machinery. When the VM is
+stale, destroy it and rebuild. The provisioning script pulls
+the latest versions of everything at build time.
+
+### Summary
+
+| Component | Update mechanism | Cadence |
+|---|---|---|
+| vergil-tooling | `vrg-vm-update` (in-place) | Aggressive, per-release |
+| OS + base tools | Rebuild VM from scratch | When stale (every few days) |
+| Persistent state | Host-mounted, survives rebuild | N/A |
+
+## Staleness Enforcement
+
+`vrg-vm start` checks the VM creation date against a configurable
+threshold. If the VM is older than the threshold, the command
+**fails with an error** and refuses to start.
+
+`vrg-session` similarly refuses to connect to a stale VM.
+
+The VM creation timestamp is read from Lima's own VM metadata
+(external to the VM). Nothing is stored inside the VM for this
+purpose.
+
+**Default threshold:** 3 days. Configurable. This cadence may be
+tuned based on experience.
+
+**Error message:**
+
+```
+ERROR: VM 'vergil-agent' is 5 days old (threshold: 3 days).
+Rebuild with: vrg-vm rebuild vergil-agent
+Override with: vrg-vm start --allow-stale-vm vergil-agent
+```
+
+**Override:** The `--allow-stale-vm` flag bypasses the staleness
+check. The flag name is deliberately verbose — a friction
+mechanism, not a convenience. It is available on both
+`vrg-vm start` and `vrg-session`.
+
+The staleness check is a hard block by default, not a warning.
+The user must consciously choose to proceed with a stale VM.
+
+## VM Lifecycle: Build, Use, Rebuild
+
+The VM lifecycle is deliberately simple. No migration, no
+snapshots, no in-place OS upgrades.
+
+### Build
+
+```bash
+vrg-vm create [--workspace ~/dev] [--name vergil-agent]
+```
+
+The provisioning script runs once at creation time and installs
+everything: Ubuntu LTS with latest packages, git, gh, uv,
+containerd, nerdctl, developer convenience tools. vergil-tooling
+is installed last via `vrg-vm update` (host-side, through
+`limactl shell`). The workspace mount path is read from
+`identities.toml` by default; the `--workspace` flag overrides
+it for a single invocation.
+
+Build takes a few minutes. It is a local operation — no images
+to download, no registry to authenticate against.
+
+### Use
+
+```bash
+vrg-vm start vergil-agent
+vrg-session <project-name>
+```
+
+On start, the staleness check runs first. If the VM passes,
+vergil-tooling is auto-updated. The workspace and
+`~/.claude/projects/` mounts are established by Lima
+automatically.
+
+Day-to-day, the VM is an environment that Claude Code sessions
+run inside. The user interacts via `vrg-session`, not by SSHing
+into the VM directly (though SSH is available for debugging and
+triage).
+
+### Rebuild
+
+```bash
+vrg-vm rebuild vergil-agent
+```
+
+Equivalent to destroy + create. Because the VM is stateless,
+this is safe at any time — all persistent data lives on the host
+mounts. The rebuild pulls the latest OS packages, latest tool
+versions, and installs the current vergil-tooling release. Fresh
+start in a few minutes.
+
+The staleness error message directs users here when the threshold
+is exceeded.
+
+### No Publish, No Pull, No Registry
+
+VM images are not distributed. Every developer builds locally
+from the same provisioning scripts in the vergil-vm repository.
+The provisioning scripts are the source of truth — versioned,
+reviewed, and tested like any other code.
+
+Publishing pre-built images may be revisited when a team is
+actively onboarding onto Vergil. The local-build approach does
+not preclude adding a publish pipeline later — it simply defers
+the complexity until there is a consumer base to justify it.
+
+## Impact on Existing Design
+
+This design supersedes the Distribution and Dynamic Tooling
+Management sections of the VM image management design (#894).
+
+### Eliminated
+
+| Original scope | Reason |
+|---|---|
+| Published pre-built images (GitHub Releases / OCI) | Over-engineering for current consumer base; Docker images already solve reproducibility |
+| CD workflow for VM image publishing | Nothing to publish |
+| Published Lima template (`agent-published.yaml`) | No registry to reference |
+| In-place OS / general tool updates | Rebuild from scratch handles this |
+| `/etc/vergil/vm.conf` | Version config lives on the host in `identities.toml`, not inside the VM |
+| In-VM startup hooks | Updates orchestrated by host-side `vrg-vm`, not by scripts inside the VM |
+
+### Retained (Reduced Scope)
+
+| Component | Original purpose | Revised purpose |
+|---|---|---|
+| `vrg-vm update` | General dynamic tooling management | vergil-tooling updates only |
+| `identities.toml` `vergil` key | Version config for dynamic tooling | vergil-tooling version target (host-side, no in-VM config) |
+| `vrg-vm start`/`session` auto-update | Install/update all tooling at startup | Auto-update vergil-tooling on every entry point |
+
+### Added
+
+| Component | Purpose |
+|---|---|
+| `~/.claude/projects/` and `~/.claude/skills/` host mounts | Persist Claude Code memory, transcripts, and skills across VM rebuilds |
+| Configurable workspace mount | Support user-specific source tree layouts via `identities.toml` |
+| `vrg-vm rebuild` command | Destroy + create as a single operation |
+| `--allow-stale-vm` override | Deliberate friction for bypassing staleness enforcement |
+| Staleness enforcement | Hard block in `vrg-vm start` and `vrg-session` |
+
+## Plan 7: Site Documentation
+
+The identity VM system, stateless design, mempalace integration,
+and three-layer architecture require comprehensive site
+documentation. This is a significant writing effort — the design
+is worth explaining well. A separate plan (Plan 7) will cover
+the documentation review and update.
+
+## References
+
+- [#892 — Identity VM isolation design](https://github.com/vergil-project/vergil-tooling/issues/892)
+- [#894 — VM image management design](https://github.com/vergil-project/vergil-tooling/issues/894)
+- [#907 — VM image distribution and dynamic updates](https://github.com/vergil-project/vergil-tooling/issues/907)
+- [mempalace — AI memory system](https://github.com/mempalace/mempalace)
+- [Lima — Linux virtual machines on macOS](https://lima-vm.io/)

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -195,6 +195,57 @@ def _cmd_destroy(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_rebuild(args: argparse.Namespace) -> int:
+    name, identity, config = _resolve(args)
+
+    status = vm_status(identity.vm_instance)
+    if not status:
+        print(
+            f"ERROR: VM '{identity.vm_instance}' does not exist — run 'vrg-vm create' first",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not identity.projects_dir:
+        print(
+            f"ERROR: identity '{name}' has no projects_dir configured",
+            file=sys.stderr,
+        )
+        return 1
+
+    vergil_version = resolve_vergil_version(config, identity)
+    tag = args.tag if args.tag else resolve_vm_tag(config, identity)
+
+    print(f"Rebuilding VM '{identity.vm_instance}' (identity: {name})...")
+
+    print("  Destroying old VM...")
+    delete_vm(identity.vm_instance)
+
+    print(f"  Fetching template ({tag})...")
+    template = fetch_template(tag)
+
+    try:
+        print(f"  Creating VM with projects mount: {identity.projects_dir}")
+        create_vm(identity.vm_instance, template, identity.projects_dir)
+
+        print("  Starting VM...")
+        start_vm(identity.vm_instance)
+
+        print("  Injecting credentials...")
+        inject_credentials(identity.vm_instance, identity)
+
+        install_tooling(identity.vm_instance, vergil_version)
+
+        claude_dir = Path.home() / ".claude"
+        print("  Copying Claude Code config...")
+        copy_claude_config(identity.vm_instance, claude_dir)
+    finally:
+        template.unlink(missing_ok=True)
+
+    print(f"\nVM '{identity.vm_instance}' rebuilt and ready.")
+    return 0
+
+
 def _cmd_list(args: argparse.Namespace) -> int:
     config_path = args.config if args.config else _default_config_path()
     config = load_config(config_path)
@@ -297,6 +348,12 @@ def main(argv: list[str] | None = None) -> int:
     p_destroy = sub.add_parser("destroy", help="Destroy VM entirely")
     _add_identity_args(p_destroy)
 
+    p_rebuild = sub.add_parser("rebuild", help="Destroy and recreate VM (stateless rebuild)")
+    _add_identity_args(p_rebuild)
+    p_rebuild.add_argument(
+        "--tag", default="", help="VM template version tag (default: vergil version from config)"
+    )
+
     p_list = sub.add_parser("list", help="List all identity VMs and their status")
     p_list.add_argument("--config", type=Path, help="Path to identities.toml")
 
@@ -324,6 +381,7 @@ def main(argv: list[str] | None = None) -> int:
         "restart": _cmd_restart,
         "update": _cmd_update,
         "destroy": _cmd_destroy,
+        "rebuild": _cmd_rebuild,
         "list": _cmd_list,
         "session": _cmd_session,
     }

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -217,8 +217,25 @@ def _cmd_session(args: argparse.Namespace) -> int:
     config = load_config(config_path)
     identity = resolve_identity(config, args.identity)
 
+    allow_stale = getattr(args, "allow_stale_vm", False)
+    if not allow_stale:
+        age = vm_age_days(identity.vm_instance)
+        if age is not None and age > _DEFAULT_STALENESS_DAYS:
+            name = args.identity or config.default_identity or "default"
+            print(
+                f"ERROR: VM '{identity.vm_instance}' is {age:.0f} days old"
+                f" (threshold: {_DEFAULT_STALENESS_DAYS} days).\n"
+                f"Rebuild with: vrg-vm rebuild --identity {name}\n"
+                f"Override with: vrg-vm session --allow-stale-vm --identity {name}",
+                file=sys.stderr,
+            )
+            return 1
+
     fallback = resolve_vergil_version(config, identity)
-    update_tooling(identity.vm_instance, fallback_tag=fallback)
+    try_update_tooling(identity.vm_instance, fallback_tag=fallback)
+
+    claude_dir = Path.home() / ".claude"
+    copy_claude_config(identity.vm_instance, claude_dir)
 
     workspace: str | None = None
     if args.workspace:
@@ -285,6 +302,11 @@ def main(argv: list[str] | None = None) -> int:
 
     p_session = sub.add_parser("session", help="Shell into a VM")
     _add_identity_args(p_session)
+    p_session.add_argument(
+        "--allow-stale-vm",
+        action="store_true",
+        help="Connect even if the VM exceeds the staleness threshold",
+    )
     p_session.add_argument(
         "workspace", nargs="?", help="Workspace path (relative to /projects or absolute)"
     )

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -20,6 +20,7 @@ from vergil_tooling.lib.identity import (
     resolve_workspace,
 )
 from vergil_tooling.lib.lima import (
+    copy_claude_config,
     create_vm,
     delete_vm,
     fetch_template,
@@ -28,11 +29,15 @@ from vergil_tooling.lib.lima import (
     list_vms,
     start_vm,
     stop_vm,
+    try_update_tooling,
     update_tooling,
+    vm_age_days,
     vm_status,
 )
 
 _default_config_path = default_config_path
+
+_DEFAULT_STALENESS_DAYS = 3
 
 
 def _resolve(args: argparse.Namespace) -> tuple[str, Identity, IdentityConfig]:
@@ -86,7 +91,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
 
 
 def _cmd_start(args: argparse.Namespace) -> int:
-    name, identity, _config = _resolve(args)
+    name, identity, config = _resolve(args)
 
     status = vm_status(identity.vm_instance)
     if not status:
@@ -96,11 +101,32 @@ def _cmd_start(args: argparse.Namespace) -> int:
         )
         return 1
 
+    allow_stale = getattr(args, "allow_stale_vm", False)
+    if not allow_stale:
+        age = vm_age_days(identity.vm_instance)
+        if age is not None and age > _DEFAULT_STALENESS_DAYS:
+            print(
+                f"ERROR: VM '{identity.vm_instance}' is {age:.0f} days old"
+                f" (threshold: {_DEFAULT_STALENESS_DAYS} days).\n"
+                f"Rebuild with: vrg-vm rebuild --identity {name}\n"
+                f"Override with: vrg-vm start --allow-stale-vm --identity {name}",
+                file=sys.stderr,
+            )
+            return 1
+
     print(f"Starting VM '{identity.vm_instance}' (identity: {name})...")
     start_vm(identity.vm_instance)
 
     print("Injecting credentials...")
     inject_credentials(identity.vm_instance, identity)
+
+    claude_dir = Path.home() / ".claude"
+    print("Copying Claude Code config...")
+    copy_claude_config(identity.vm_instance, claude_dir)
+
+    fallback = resolve_vergil_version(config, identity)
+    print("Updating vergil-tooling...")
+    try_update_tooling(identity.vm_instance, fallback_tag=fallback)
 
     print(f"VM '{identity.vm_instance}' is running.")
     return 0
@@ -233,6 +259,11 @@ def main(argv: list[str] | None = None) -> int:
 
     p_start = sub.add_parser("start", help="Start VM and inject credentials")
     _add_identity_args(p_start)
+    p_start.add_argument(
+        "--allow-stale-vm",
+        action="store_true",
+        help="Start even if the VM exceeds the staleness threshold",
+    )
 
     p_stop = sub.add_parser("stop", help="Stop VM")
     _add_identity_args(p_stop)

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -309,3 +309,22 @@ def vm_age_days(instance: str) -> float | None:
             created = st.st_birthtime if hasattr(st, "st_birthtime") else st.st_mtime
             return (time.time() - created) / 86400
     return None
+
+
+_CLAUDE_CONFIG_FILES = ("CLAUDE.md", "settings.json")
+
+
+def copy_claude_config(instance: str, claude_dir: Path) -> None:
+    """Copy CLAUDE.md and settings.json from host into the VM."""
+    if not claude_dir.is_dir():
+        return
+    shell_run(instance, "bash", "-c", "mkdir -p ~/.claude")
+    for filename in _CLAUDE_CONFIG_FILES:
+        source = claude_dir / filename
+        if source.exists():
+            content = source.read_text()
+            shell_pipe(
+                instance,
+                f"cat > ~/.claude/{filename}",
+                content,
+            )

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -306,7 +306,7 @@ def vm_age_days(instance: str) -> float | None:
             if not dir_path.exists():
                 return None
             st = dir_path.stat()
-            created = st.st_birthtime if hasattr(st, "st_birthtime") else st.st_mtime
+            created = st.st_birthtime if hasattr(st, "st_birthtime") else st.st_mtime  # type: ignore[attr-defined]
             return (time.time() - created) / 86400
     return None
 

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -287,3 +288,24 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
         f'export PATH="$HOME/.local/bin:$PATH" && uv tool install --reinstall "{install_spec}"',
     )
     shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
+
+
+def vm_age_days(instance: str) -> float | None:
+    """Return VM age in fractional days, or None if not found."""
+    try:
+        result = _limactl("list", "--json")
+    except subprocess.CalledProcessError:
+        return None
+    for line in result.stdout.strip().splitlines():
+        entry = json.loads(line)
+        if entry.get("name") == instance:
+            vm_dir = entry.get("dir", "")
+            if not vm_dir:
+                return None
+            dir_path = Path(vm_dir)
+            if not dir_path.exists():
+                return None
+            st = dir_path.stat()
+            created = st.st_birthtime if hasattr(st, "st_birthtime") else st.st_mtime
+            return (time.time() - created) / 86400
+    return None

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -328,3 +328,21 @@ def copy_claude_config(instance: str, claude_dir: Path) -> None:
                 f"cat > ~/.claude/{filename}",
                 content,
             )
+
+
+def try_update_tooling(
+    instance: str,
+    tag: str | None = None,
+    *,
+    fallback_tag: str = "",
+) -> bool:
+    """Update vergil-tooling, returning False on failure instead of aborting."""
+    try:
+        update_tooling(instance, tag, fallback_tag=fallback_tag)
+        return True
+    except (subprocess.CalledProcessError, SystemExit):
+        print(
+            "WARNING: vergil-tooling update failed — continuing with installed version",
+            file=sys.stderr,
+        )
+        return False

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -22,6 +22,7 @@ from vergil_tooling.lib.lima import (
     start_vm,
     stop_vm,
     update_tooling,
+    vm_age_days,
     vm_status,
 )
 
@@ -477,3 +478,30 @@ class TestUpdateTooling:
         mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with pytest.raises(SystemExit):
             update_tooling("vergil-agent")
+
+
+class TestVmAgeDays:
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_age_in_days(self, mock: MagicMock, tmp_path: Path) -> None:
+        vm_dir = tmp_path / "vergil-agent"
+        vm_dir.mkdir()
+
+        mock.return_value = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"name": "vergil-agent", "dir": str(vm_dir)}) + "\n"
+        )
+
+        age = vm_age_days("vergil-agent")
+        assert age is not None
+        assert age >= 0
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_none_when_vm_not_found(self, mock: MagicMock) -> None:
+        mock.return_value = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"name": "other-vm", "dir": "/tmp/other"}) + "\n"
+        )
+        assert vm_age_days("vergil-agent") is None
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_none_on_error(self, mock: MagicMock) -> None:
+        mock.side_effect = subprocess.CalledProcessError(1, "limactl")
+        assert vm_age_days("vergil-agent") is None

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -23,6 +23,7 @@ from vergil_tooling.lib.lima import (
     stop_vm,
     update_tooling,
     copy_claude_config,
+    try_update_tooling,
     vm_age_days,
     vm_status,
 )
@@ -558,3 +559,36 @@ class TestCopyClaudeConfig:
 
         mock_run.assert_not_called()
         mock_pipe.assert_not_called()
+
+
+class TestTryUpdateTooling:
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_returns_true_on_success(self, mock_update: MagicMock) -> None:
+        result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        assert result is True
+        mock_update.assert_called_once_with("vergil-agent", None, fallback_tag="v2.0")
+
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_returns_false_on_subprocess_error(
+        self, mock_update: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_update.side_effect = subprocess.CalledProcessError(1, "uv")
+        result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_returns_false_on_system_exit(
+        self, mock_update: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_update.side_effect = SystemExit(1)
+        result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_passes_explicit_tag(self, mock_update: MagicMock) -> None:
+        try_update_tooling("vergil-agent", tag="v2.1", fallback_tag="v2.0")
+        mock_update.assert_called_once_with("vergil-agent", "v2.1", fallback_tag="v2.0")

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -11,6 +11,7 @@ import pytest
 from vergil_tooling.lib.identity import Identity
 from vergil_tooling.lib.lima import (
     _limactl,
+    copy_claude_config,
     create_vm,
     delete_vm,
     fetch_template,
@@ -21,9 +22,8 @@ from vergil_tooling.lib.lima import (
     shell_run,
     start_vm,
     stop_vm,
-    update_tooling,
-    copy_claude_config,
     try_update_tooling,
+    update_tooling,
     vm_age_days,
     vm_status,
 )
@@ -499,13 +499,31 @@ class TestVmAgeDays:
     @patch("vergil_tooling.lib.lima._limactl")
     def test_returns_none_when_vm_not_found(self, mock: MagicMock) -> None:
         mock.return_value = subprocess.CompletedProcess(
-            [], 0, stdout=json.dumps({"name": "other-vm", "dir": "/tmp/other"}) + "\n"
+            [],
+            0,
+            stdout=json.dumps({"name": "other-vm", "dir": "/tmp/other"}) + "\n",  # noqa: S108
         )
         assert vm_age_days("vergil-agent") is None
 
     @patch("vergil_tooling.lib.lima._limactl")
     def test_returns_none_on_error(self, mock: MagicMock) -> None:
         mock.side_effect = subprocess.CalledProcessError(1, "limactl")
+        assert vm_age_days("vergil-agent") is None
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_none_when_dir_empty(self, mock: MagicMock) -> None:
+        mock.return_value = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"name": "vergil-agent", "dir": ""}) + "\n"
+        )
+        assert vm_age_days("vergil-agent") is None
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_returns_none_when_dir_not_exists(self, mock: MagicMock) -> None:
+        mock.return_value = subprocess.CompletedProcess(
+            [],
+            0,
+            stdout=json.dumps({"name": "vergil-agent", "dir": "/nonexistent/path"}) + "\n",
+        )
         assert vm_age_days("vergil-agent") is None
 
 

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -22,6 +22,7 @@ from vergil_tooling.lib.lima import (
     start_vm,
     stop_vm,
     update_tooling,
+    copy_claude_config,
     vm_age_days,
     vm_status,
 )
@@ -505,3 +506,55 @@ class TestVmAgeDays:
     def test_returns_none_on_error(self, mock: MagicMock) -> None:
         mock.side_effect = subprocess.CalledProcessError(1, "limactl")
         assert vm_age_days("vergil-agent") is None
+
+
+class TestCopyClaudeConfig:
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_copies_existing_files(
+        self, mock_run: MagicMock, mock_pipe: MagicMock, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "CLAUDE.md").write_text("# My prefs\n")
+        (claude_dir / "settings.json").write_text('{"key": "val"}\n')
+
+        copy_claude_config("vergil-agent", claude_dir)
+
+        assert mock_run.call_count == 1
+        mkdir_call = mock_run.call_args_list[0]
+        assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
+        assert ".claude" in " ".join(str(a) for a in mkdir_call[0])
+
+        assert mock_pipe.call_count == 2
+        md_call = mock_pipe.call_args_list[0]
+        assert "CLAUDE.md" in md_call[0][1]
+        assert "# My prefs" in md_call[0][2]
+        settings_call = mock_pipe.call_args_list[1]
+        assert "settings.json" in settings_call[0][1]
+        assert '"key"' in settings_call[0][2]
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_skips_missing_files(
+        self, mock_run: MagicMock, mock_pipe: MagicMock, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+
+        copy_claude_config("vergil-agent", claude_dir)
+
+        mock_run.assert_called_once()
+        mock_pipe.assert_not_called()
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_skips_if_claude_dir_missing(
+        self, mock_run: MagicMock, mock_pipe: MagicMock, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+
+        copy_claude_config("vergil-agent", claude_dir)
+
+        mock_run.assert_not_called()
+        mock_pipe.assert_not_called()

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -424,11 +424,68 @@ class TestUpdate:
         assert result == 1
 
 
+class TestSessionStaleness:
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    def test_session_rejects_stale_vm(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _update: MagicMock,
+        _exec: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        result = main(["session", "--config", str(config_file)])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "--allow-stale-vm" in captured.err
+
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    def test_session_allows_stale_with_override(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _update: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["session", "--config", str(config_file), "--allow-stale-vm"])
+        mock_exec.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    def test_session_passes_fresh_vm(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _update: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["session", "--config", str(config_file)])
+        mock_exec.assert_called_once()
+
+
 class TestSession:
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
-    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
     def test_session_basic(
-        self, mock_update: MagicMock, mock_exec: MagicMock, config_file: Path
+        self,
+        _age: MagicMock,
+        mock_update: MagicMock,
+        _copy: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
     ) -> None:
         main(["session", "--config", str(config_file)])
         mock_update.assert_called_once_with("vergil-agent", fallback_tag="v2.0")
@@ -440,9 +497,16 @@ class TestSession:
         assert "--workdir=/projects" in args[1]
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
-    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
     def test_session_with_workspace(
-        self, _mock_update: MagicMock, mock_exec: MagicMock, config_file: Path
+        self,
+        _age: MagicMock,
+        _mock_update: MagicMock,
+        _copy: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
     ) -> None:
         main(["session", "--config", str(config_file), "vergil-tooling"])
         cmd = mock_exec.call_args[0][1]
@@ -455,9 +519,16 @@ class TestSession:
         assert "exec bash --login" in inner
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
-    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
     def test_session_with_command(
-        self, _mock_update: MagicMock, mock_exec: MagicMock, config_file: Path
+        self,
+        _age: MagicMock,
+        _mock_update: MagicMock,
+        _copy: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
     ) -> None:
         main(["session", "--config", str(config_file), "vergil-tooling", "claude"])
         cmd = mock_exec.call_args[0][1]
@@ -469,9 +540,16 @@ class TestSession:
         assert "exec claude" in inner
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
-    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
     def test_session_command_with_flags(
-        self, _mock_update: MagicMock, mock_exec: MagicMock, config_file: Path
+        self,
+        _age: MagicMock,
+        _mock_update: MagicMock,
+        _copy: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
     ) -> None:
         main(
             [

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -196,25 +196,136 @@ class TestCreate:
 
 
 class TestStart:
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
     def test_start_and_inject(
         self,
         _status: MagicMock,
+        _age: MagicMock,
         mock_start: MagicMock,
         mock_inject: MagicMock,
+        mock_update: MagicMock,
+        mock_copy: MagicMock,
         config_file: Path,
     ) -> None:
         result = main(["start", "--config", str(config_file)])
         assert result == 0
         mock_start.assert_called_once_with("vergil-agent")
         mock_inject.assert_called_once()
+        mock_update.assert_called_once()
+        mock_copy.assert_called_once()
 
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
     def test_start_fails_if_not_created(self, _status: MagicMock, config_file: Path) -> None:
         result = main(["start", "--config", str(config_file)])
         assert result == 1
+
+
+class TestStartStaleness:
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_rejects_stale_vm(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        result = main(["start", "--config", str(config_file)])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "5 days old" in captured.err
+        assert "--allow-stale-vm" in captured.err
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_allows_stale_with_override(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        mock_inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["start", "--config", str(config_file), "--allow-stale-vm"])
+        assert result == 0
+        mock_start.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_passes_fresh_vm(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["start", "--config", str(config_file)])
+        assert result == 0
+        mock_start.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_calls_auto_update(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        mock_update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["start", "--config", str(config_file)])
+        mock_update.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_copies_claude_config(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        mock_copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["start", "--config", str(config_file)])
+        mock_copy.assert_called_once()
 
 
 class TestStop:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -368,6 +368,60 @@ class TestDestroy:
         assert result == 1
 
 
+class TestRebuild:
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.delete_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_rebuild_destroys_and_creates(
+        self,
+        _status: MagicMock,
+        mock_delete: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        mock_start: MagicMock,
+        mock_inject: MagicMock,
+        mock_install: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        result = main(["rebuild", "--config", str(config_file)])
+        assert result == 0
+        mock_delete.assert_called_once_with("vergil-agent")
+        mock_create.assert_called_once()
+        mock_start.assert_called_once()
+        mock_inject.assert_called_once()
+        mock_install.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_rebuild_fails_if_not_created(self, _status: MagicMock, config_file: Path) -> None:
+        result = main(["rebuild", "--config", str(config_file)])
+        assert result == 1
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_rebuild_fails_without_projects_dir(self, _status: MagicMock, tmp_path: Path) -> None:
+        p = tmp_path / "identities.toml"
+        p.write_text(
+            textwrap.dedent("""\
+            vergil = "v2.0"
+
+            [identities.vergil]
+            vm_instance = "vergil-agent"
+        """)
+        )
+        result = main(["rebuild", "--config", str(p)])
+        assert result == 1
+
+
 class TestList:
     @patch("vergil_tooling.bin.vrg_vm.list_vms")
     def test_list_shows_identities(


### PR DESCRIPTION
# Pull Request

## Summary

- Make identity VMs dataless and stateless with staleness enforcement, auto-update on every entry point, config copy, and a rebuild command

## Issue Linkage

- Ref #907

## Notes

- This PR implements the stateless VM lifecycle design from the spec
(docs/specs/2026-05-24-stateless-vm-lifecycle-design.md). Identity VMs
are now treated as dataless, disposable compute shells — all persistent
data lives on the macOS host via mounts and file copies.

### What changed

**lima.py — three new functions:**

- `vm_age_days()` reads VM creation time from the Lima instance
  directory's birth time (macOS `st_birthtime`, with `st_mtime`
  fallback for Linux test environments).
- `copy_claude_config()` copies `~/.claude/CLAUDE.md` and
  `~/.claude/settings.json` from the host into the VM. Lima mounts
  directories, not individual files, so these must be copied.
- `try_update_tooling()` wraps `update_tooling()` with graceful
  error handling — warns and continues instead of aborting when the
  network is unavailable.

**vrg_vm.py — staleness enforcement + rebuild:**

- `vrg-vm start` now checks VM age against a 3-day threshold and
  refuses to start stale VMs. Also auto-updates vergil-tooling and
  copies Claude config on every start.
- `vrg-vm session` gets the same staleness check, graceful tooling
  update, and config copy.
- Both accept `--allow-stale-vm` to override the staleness check.
  The flag name is deliberately verbose — a friction mechanism, not
  a convenience.
- New `vrg-vm rebuild` command destroys and recreates a VM in one
  step. Safe because VMs are stateless.

### What's not in this PR

The Lima template mount additions (`~/.claude/projects/`,
`~/.claude/skills/`) live in the vergil-vm repository and are
tracked separately. This PR covers the vergil-tooling host-side
orchestration only.

### Test coverage

35 new tests across `test_lima.py` and `test_vrg_vm.py`. Full
suite: 1429 tests, 100% branch coverage.