### PR TITLE
refactor(config): rename StConfig to VergilConfig

### DIFF
--- a/docs/plans/proposed/2026-05-25-configurable-container-env-passthrough.md
+++ b/docs/plans/proposed/2026-05-25-configurable-container-env-passthrough.md
@@ -162,11 +162,11 @@ class ContainerConfig:
     env_prefixes: list[str]
 ```
 
-Add `container: ContainerConfig` to `StConfig`:
+Add `container: ContainerConfig` to `VergilConfig`:
 
 ```python
 @dataclass
-class StConfig:
+class VergilConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
@@ -213,10 +213,10 @@ Add `[container]` parsing in `_parse_raw_config`, after the `publish` block and 
         container = ContainerConfig(env_prefixes=[])
 ```
 
-Add `container=container` to the `StConfig(...)` return:
+Add `container=container` to the `VergilConfig(...)` return:
 
 ```python
-    return StConfig(
+    return VergilConfig(
         project=project,
         dependencies=dict(deps),
         markdownlint=markdownlint,

--- a/docs/specs/2026-05-25-configurable-container-env-passthrough-design.md
+++ b/docs/specs/2026-05-25-configurable-container-env-passthrough-design.md
@@ -88,7 +88,7 @@ vergil-tooling changes.
   class ContainerConfig:
       env_prefixes: list[str]
   ```
-- Add `container: ContainerConfig` to `StConfig`, defaulting to
+- Add `container: ContainerConfig` to `VergilConfig`, defaulting to
   `ContainerConfig(env_prefixes=[])` when the section is absent.
 - Validation: if `[container]` is present, `env-prefixes` must be a
   list of strings. Same validation pattern as `[markdownlint].ignore`.

--- a/docs/specs/standard-tooling-toml.md
+++ b/docs/specs/standard-tooling-toml.md
@@ -138,7 +138,7 @@ class ProjectConfig:
     co_authors: dict[str, str]  # agent name -> full trailer string
 
 @dataclass
-class StConfig:
+class VergilConfig:
     project: ProjectConfig
     dependencies: dict[str, str]  # component name -> version tag
 ```
@@ -153,7 +153,7 @@ class StConfig:
 5. Validate co-author trailer format when `[project.co-authors]`
    is present.
 6. Validate `[dependencies]` contains `standard-tooling`.
-7. Return typed `StConfig`. No raw dicts leak to callers.
+7. Return typed `VergilConfig`. No raw dicts leak to callers.
 
 ### Backward compatibility
 
@@ -226,7 +226,7 @@ switch.
 
 ### Unit tests for `config.py`
 
-- Valid config parses into typed `StConfig` dataclass.
+- Valid config parses into typed `VergilConfig` dataclass.
 - Missing required `[project]` field produces an error.
 - Invalid enum value produces an error with diagnostic.
 - Malformed co-author trailer format produces an error.

--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -167,10 +167,10 @@ def main(argv: list[str] | None = None) -> int:
     root = git.repo_root()
 
     try:
-        st_config = config.read_config(root)
-        branching_model = st_config.project.branching_model
+        vergil_config = config.read_config(root)
+        branching_model = vergil_config.project.branching_model
     except FileNotFoundError:
-        st_config = None
+        vergil_config = None
         branching_model = ""
     except config.ConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/src/vergil_tooling/bin/vrg_finalize_repo.py
+++ b/src/vergil_tooling/bin/vrg_finalize_repo.py
@@ -158,8 +158,8 @@ def main(argv: list[str] | None = None) -> int:
     root = git.repo_root()
 
     try:
-        st_config = config.read_config(root)
-        model = st_config.project.branching_model
+        vergil_config = config.read_config(root)
+        model = vergil_config.project.branching_model
     except FileNotFoundError:
         model = ""
     except config.ConfigError as exc:

--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -14,7 +14,7 @@ import tomllib
 from pathlib import Path
 
 from vergil_tooling.lib import github
-from vergil_tooling.lib.config import StConfig, _parse_raw_config
+from vergil_tooling.lib.config import VergilConfig, _parse_raw_config
 from vergil_tooling.lib.github_config import (
     ConfigDiff,
     apply_desired_state,
@@ -52,14 +52,14 @@ def _resolve_repo(args: argparse.Namespace) -> str:
     return github.current_repo()
 
 
-def _load_local_config(path: str) -> StConfig:
+def _load_local_config(path: str) -> VergilConfig:
     """Load and parse vergil.toml from a local file path."""
     with Path(path).open("rb") as f:
         raw = tomllib.load(f)
     return _parse_raw_config(raw)
 
 
-def _fetch_remote_config(repo: str) -> StConfig:
+def _fetch_remote_config(repo: str) -> VergilConfig:
     """Fetch and parse vergil.toml from a remote repo."""
     content_data = github.read_json(
         "api",
@@ -77,7 +77,7 @@ def _fetch_remote_config(repo: str) -> StConfig:
     return _parse_raw_config(raw)
 
 
-def _audit_repo(repo: str, config: StConfig) -> ConfigDiff:
+def _audit_repo(repo: str, config: VergilConfig) -> ConfigDiff:
     """Compute diff between desired and actual GitHub state for a repo."""
     result = fetch_actual_state(repo)
     is_org = result.owner_type == "Organization"
@@ -110,7 +110,7 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
             )
 
 
-def _apply_repo(repo: str, config: StConfig) -> list[str]:
+def _apply_repo(repo: str, config: VergilConfig) -> list[str]:
     """Apply desired state to a repo. Returns branches with legacy protection removed."""
     result = fetch_actual_state(repo)
     is_org = result.owner_type == "Organization"

--- a/src/vergil_tooling/bin/vrg_validate.py
+++ b/src/vergil_tooling/bin/vrg_validate.py
@@ -100,8 +100,8 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = git.repo_root()
 
     try:
-        st_config = config.read_config(repo_root)
-        language = st_config.project.primary_language
+        vergil_config = config.read_config(repo_root)
+        language = vergil_config.project.primary_language
     except FileNotFoundError:
         language = ""
     except config.ConfigError as exc:

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -80,7 +80,7 @@ class ContainerConfig:
 
 
 @dataclass
-class StConfig:
+class VergilConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
     markdownlint: MarkdownlintConfig
@@ -105,8 +105,8 @@ def _warn_unrecognized_keys(raw: dict[str, Any]) -> None:
                 )
 
 
-def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
-    """Parse and validate a raw TOML dict into StConfig."""
+def _parse_raw_config(raw: dict[str, Any]) -> VergilConfig:
+    """Parse and validate a raw TOML dict into VergilConfig."""
     _warn_unrecognized_keys(raw)
     project_raw = raw.get("project", {})
 
@@ -180,7 +180,7 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
         release_model=project_raw["release-model"],
         primary_language=project_raw["primary-language"],
     )
-    return StConfig(
+    return VergilConfig(
         project=project,
         dependencies=dict(deps),
         markdownlint=markdownlint,
@@ -190,7 +190,7 @@ def _parse_raw_config(raw: dict[str, Any]) -> StConfig:
     )
 
 
-def read_config(repo_root: Path) -> StConfig:
+def read_config(repo_root: Path) -> VergilConfig:
     """Parse, validate, and return ``vergil.toml``."""
     config_path = repo_root / CONFIG_FILE
     if not config_path.is_file():

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from vergil_tooling.lib.config import CiConfig, ProjectConfig, StConfig
+    from vergil_tooling.lib.config import CiConfig, ProjectConfig, VergilConfig
 
 from vergil_tooling.lib import github
 
@@ -304,8 +304,8 @@ def desired_ci_gates_ruleset(
     )
 
 
-def compute_desired_state(config: StConfig, *, visibility: str, is_org: bool) -> DesiredState:
-    """Compute the full desired GitHub configuration from a repo's StConfig."""
+def compute_desired_state(config: VergilConfig, *, visibility: str, is_org: bool) -> DesiredState:
+    """Compute the full desired GitHub configuration from a repo's VergilConfig."""
     rulesets: list[DesiredRuleset] = []
 
     rulesets.append(desired_branch_protection_ruleset())

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -12,7 +12,7 @@ from vergil_tooling.lib.config import (
     MarkdownlintConfig,
     ProjectConfig,
     PublishConfig,
-    StConfig,
+    VergilConfig,
 )
 from vergil_tooling.lib.github_config import (
     DesiredRuleset,
@@ -303,14 +303,14 @@ def test_lang_has_check_returns_false_for_unknown_check() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _st_config(
+def _vergil_config(
     *,
     language: str = "python",
     release_model: str = "tagged-release",
     versions: list[str] | None = None,
     integration_tests: bool = False,
-) -> StConfig:
-    return StConfig(
+) -> VergilConfig:
+    return VergilConfig(
         project=_project(language=language, release_model=release_model),
         dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
@@ -321,7 +321,7 @@ def _st_config(
 
 
 def test_compute_desired_state_has_three_rulesets() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     assert len(state.rulesets) == 3
     names = [r.name for r in state.rulesets]
     assert "Branch protection" in names
@@ -330,17 +330,17 @@ def test_compute_desired_state_has_three_rulesets() -> None:
 
 
 def test_compute_desired_state_includes_repo_settings() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     assert state.repo_settings.default_branch == "develop"
 
 
 def test_compute_desired_state_includes_security() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     assert state.security.secret_scanning == "enabled"  # noqa: S105
 
 
 def test_compute_desired_state_includes_actions() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     assert state.actions_permissions.allowed_actions == "selected"
     assert "pypa/*" in state.actions_permissions.patterns_allowed
 
@@ -865,15 +865,15 @@ def test_fetch_vulnerability_alerts_disabled() -> None:
 
 
 def test_diff_identical_states_is_empty() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     diff = compute_diff(desired=state, actual=state)
     assert diff.is_compliant()
     assert diff.items == []
 
 
 def test_diff_detects_repo_setting_mismatch() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.repo_settings.allow_auto_merge = True
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -881,8 +881,8 @@ def test_diff_detects_repo_setting_mismatch() -> None:
 
 
 def test_diff_detects_missing_ruleset() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.rulesets = []
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -890,8 +890,8 @@ def test_diff_detects_missing_ruleset() -> None:
 
 
 def test_diff_detects_extra_ruleset() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.rulesets.append(
         DesiredRuleset(
             name="Extra",
@@ -908,8 +908,8 @@ def test_diff_detects_extra_ruleset() -> None:
 
 
 def test_diff_detects_actions_permission_mismatch() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.actions_permissions.default_workflow_permissions = "write"
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -917,8 +917,8 @@ def test_diff_detects_actions_permission_mismatch() -> None:
 
 
 def test_diff_detects_security_mismatch() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.security.vulnerability_alerts = True
     diff = compute_diff(desired=desired, actual=actual)
     assert not diff.is_compliant()
@@ -926,8 +926,8 @@ def test_diff_detects_security_mismatch() -> None:
 
 
 def test_diff_detects_new_repo_setting_drift() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.repo_settings.merge_commit_title = "PR_TITLE"
     actual.repo_settings.web_commit_signoff_required = False
     diff = compute_diff(desired=desired, actual=actual)
@@ -937,8 +937,8 @@ def test_diff_detects_new_repo_setting_drift() -> None:
 
 
 def test_diff_records_skipped_security_fields_for_private_repo() -> None:
-    desired = compute_desired_state(_st_config(), visibility="private", is_org=True)
-    actual = compute_desired_state(_st_config(), visibility="private", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="private", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="private", is_org=True)
     actual.security.secret_scanning = "enabled"  # noqa: S105
     actual.security.secret_scanning_push_protection = "enabled"  # noqa: S105
     diff = compute_diff(desired=desired, actual=actual)
@@ -948,7 +948,7 @@ def test_diff_records_skipped_security_fields_for_private_repo() -> None:
 
 
 def test_diff_public_repo_has_no_security_skipped() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     diff = compute_diff(desired=state, actual=state)
     assert diff.is_compliant()
     assert not any(s.startswith("security.") for s in diff.skipped)
@@ -1178,7 +1178,7 @@ def test_ruleset_body_structure() -> None:
 
 
 def test_apply_desired_state_orchestrates_all() -> None:
-    state = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     with (
         patch("vergil_tooling.lib.github_config._apply_repo_settings") as mock_repo,
         patch("vergil_tooling.lib.github_config._apply_security_settings") as mock_sec,
@@ -1315,7 +1315,7 @@ def test_normalize_rules_skips_non_dict_entries() -> None:
 
 
 def test_compute_desired_state_includes_publish() -> None:
-    config = _st_config()
+    config = _vergil_config()
     state = compute_desired_state(config, visibility="public", is_org=True)
     assert state.publish is not None
     assert state.publish.release is False
@@ -1323,7 +1323,7 @@ def test_compute_desired_state_includes_publish() -> None:
 
 
 def test_compute_desired_state_publish_release_true() -> None:
-    config = StConfig(
+    config = VergilConfig(
         project=_project(),
         dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
@@ -1370,8 +1370,8 @@ def test_apply_repo_settings_includes_allow_forking_for_private_org() -> None:
 
 
 def test_diff_skips_allow_forking_when_desired_is_none() -> None:
-    desired = compute_desired_state(_st_config(), visibility="public", is_org=False)
-    actual = compute_desired_state(_st_config(), visibility="public", is_org=True)
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=False)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
     actual.repo_settings.allow_forking = False
     diff = compute_diff(desired=desired, actual=actual)
     assert not any(d.field == "repo_settings.allow_forking" for d in diff.items)

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -26,7 +26,7 @@ from vergil_tooling.lib.config import (
     MarkdownlintConfig,
     ProjectConfig,
     PublishConfig,
-    StConfig,
+    VergilConfig,
 )
 from vergil_tooling.lib.github_config import ConfigDiff, DiffItem
 
@@ -372,8 +372,8 @@ def test_load_local_config_success(tmp_path: Path) -> None:
 # -- _audit_repo --------------------------------------------------------------
 
 
-def _make_config() -> StConfig:
-    return StConfig(
+def _make_config() -> VergilConfig:
+    return VergilConfig(
         project=ProjectConfig(
             repository_type="library",
             versioning_scheme="semver",


### PR DESCRIPTION
# Pull Request

## Summary

- Rename stale St* prefixes from the standard-tooling era to Vergil*

## Issue Linkage

- Ref #1136

## Notes

- Pure rename with no behavioral changes. StConfig → VergilConfig (class, imports, type annotations, docstrings), st_config → vergil_config (local variables). Historical plan documents left untouched for provenance.