### PR TITLE
feat(git): add mv to vrg-git subcommand allowlist

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -21,6 +21,7 @@ _ALLOWED_SIMPLE: set[str] = {
     "ls-remote",
     "rev-parse",
     "add",
+    "mv",
     "push",
     "fetch",
     "pull",

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -34,6 +34,7 @@ _ALLOWED_SIMPLE = [
     "ls-remote",
     "rev-parse",
     "add",
+    "mv",
     "push",
     "fetch",
     "pull",


### PR DESCRIPTION
# Pull Request

## Summary

- Add git mv to the vrg-git allowed subcommands

## Issue Linkage

- Ref #1134

## Notes

- Adds mv to _ALLOWED_SIMPLE in vrg_git.py. git mv is a safe local staging operation (equivalent to mv + git add) with no remote side effects.