### PR TITLE
Fix guard.sh fallback regex false positives on filenames

### DIFF
--- a/.claude/hooks/guard.sh
+++ b/.claude/hooks/guard.sh
@@ -10,28 +10,21 @@ if command -v vrg-hook-guard &>/dev/null; then
 fi
 
 input=$(cat)
-command=$(echo "$input" | jq -r '.tool_input.command // empty')
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+bin=$(printf '%s' "$command" | awk '{print $1}')
+base=$(basename "$bin" 2>/dev/null || printf '%s' "$bin")
 
-if echo "$command" | grep -qE '(^|[^-])\bgit\b'; then
-  jq -n '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
-    }
-  }'
-  exit 0
-fi
-
-if echo "$command" | grep -qE '(^|[^-])\bgh\b'; then
-  jq -n '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
-    }
-  }'
-  exit 0
-fi
+case "$base" in
+  git|gh)
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
+      }
+    }'
+    exit 0
+    ;;
+esac
 
 exit 0

--- a/src/vergil_tooling/data/hook_guard_shim.sh
+++ b/src/vergil_tooling/data/hook_guard_shim.sh
@@ -10,28 +10,21 @@ if command -v vrg-hook-guard &>/dev/null; then
 fi
 
 input=$(cat)
-command=$(echo "$input" | jq -r '.tool_input.command // empty')
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+bin=$(printf '%s' "$command" | awk '{print $1}')
+base=$(basename "$bin" 2>/dev/null || printf '%s' "$bin")
 
-if echo "$command" | grep -qE '(^|[^-])\bgit\b'; then
-  jq -n '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
-    }
-  }'
-  exit 0
-fi
-
-if echo "$command" | grep -qE '(^|[^-])\bgh\b'; then
-  jq -n '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
-    }
-  }'
-  exit 0
-fi
+case "$base" in
+  git|gh)
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
+      }
+    }'
+    exit 0
+    ;;
+esac
 
 exit 0


### PR DESCRIPTION
# Pull Request

## Summary

- Replace grep regex with case statement on first token to avoid matching command names in filenames

## Issue Linkage

- Ref #1144

## Notes

- ## Summary

- Replace grep-based regex matching in `guard.sh` jq fallback with a case statement that checks only the first token (command binary name)
- Fixes false positives when filenames contain blocked command names (e.g., `docs/git-hooks-and-validation.md`)
- Applied to both `.claude/hooks/guard.sh` and `src/vergil_tooling/data/hook_guard_shim.sh` (the template for new repos)

Ref #1144

## Test plan

- [x] All 1474 tests pass with 100% coverage
- [x] `vrg-validate` passes all checks including shellcheck on the modified scripts
- [x] Verified the bug: old regex matched `\bgit\b` anywhere in the command string, including in filenames