### PR TITLE
fix(release): raise fatal error when no CI checks register after poll timeout

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -230,7 +230,7 @@ class GitHubAPIError(subprocess.CalledProcessError):
 
 _NO_CHECKS_PHRASE = "no checks reported"
 _POLL_INTERVAL_SECS = 5
-_POLL_TIMEOUT_SECS = 60
+_POLL_TIMEOUT_SECS = 180
 
 
 def _run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -346,6 +346,15 @@ def wait_for_checks(
         if time.monotonic() >= deadline:
             break
         time.sleep(poll_interval)
+
+    if not _checks_registered(pr):
+        cmd = ("gh", "pr", "checks", pr, "--watch", "--fail-fast")
+        raise GitHubAPIError(
+            1,
+            cmd,
+            stderr=f"no checks reported after {poll_timeout}s — GitHub may be experiencing delays",
+        )
+
     run("pr", "checks", pr, "--watch", "--fail-fast")
 
 

--- a/src/vergil_tooling/lib/release/subprocess.py
+++ b/src/vergil_tooling/lib/release/subprocess.py
@@ -6,10 +6,10 @@ import subprocess as _subprocess
 import sys
 import time
 
-from vergil_tooling.lib.github import _checks_registered, _run_with_retry
+from vergil_tooling.lib.github import GitHubAPIError, _checks_registered, _run_with_retry
 
 _POLL_INTERVAL_SECS = 5
-_POLL_TIMEOUT_SECS = 60
+_POLL_TIMEOUT_SECS = 180
 
 
 def _run_verbose(cmd: tuple[str, ...], *, verbose: bool) -> None:
@@ -37,6 +37,14 @@ def wait_for_checks(pr: str, *, verbose: bool) -> None:
         if time.monotonic() >= deadline:
             break
         time.sleep(_POLL_INTERVAL_SECS)
+
+    if not _checks_registered(pr):
+        raise GitHubAPIError(
+            1,
+            ("gh", "pr", "checks", pr, "--watch", "--fail-fast"),
+            stderr=f"no checks reported after {_POLL_TIMEOUT_SECS}s"
+            " — GitHub may be experiencing delays",
+        )
 
     _run_verbose(
         ("gh", "pr", "checks", pr, "--watch", "--fail-fast"),  # noqa: S607

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -78,7 +78,7 @@ def test_wait_for_checks_polls_until_registered() -> None:
     with (
         patch(
             "vergil_tooling.lib.github._checks_registered",
-            side_effect=[False, False, True],
+            side_effect=[False, False, True, True],
         ),
         patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
         patch("vergil_tooling.lib.github.run") as mock_run,
@@ -92,8 +92,7 @@ def test_wait_for_checks_polls_until_registered() -> None:
     )
 
 
-def test_wait_for_checks_proceeds_after_timeout() -> None:
-    # monotonic: [initial (deadline), loop iter1 check, loop iter2 check (expired)]
+def test_wait_for_checks_raises_after_timeout() -> None:
     with (
         patch("vergil_tooling.lib.github._checks_registered", return_value=False),
         patch(
@@ -102,19 +101,18 @@ def test_wait_for_checks_proceeds_after_timeout() -> None:
         ),
         patch("vergil_tooling.lib.github.time.sleep"),
         patch("vergil_tooling.lib.github.run") as mock_run,
+        pytest.raises(github.GitHubAPIError, match="no checks reported"),
     ):
         github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
 
-    mock_run.assert_called_once_with(
-        "pr", "checks", "https://github.com/pr/1", "--watch", "--fail-fast"
-    )
+    mock_run.assert_not_called()
 
 
 def test_wait_for_checks_uses_poll_interval_for_sleep() -> None:
     with (
         patch(
             "vergil_tooling.lib.github._checks_registered",
-            side_effect=[False, True],
+            side_effect=[False, True, True],
         ),
         patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
         patch("vergil_tooling.lib.github.run"),

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -99,7 +99,7 @@ class TestWaitForChecks:
         assert "error" in captured.err
 
     def test_polls_until_checks_registered(self) -> None:
-        registered_calls = iter([False, False, True])
+        registered_calls = iter([False, False, True, True])
         with (
             patch(_MOD + "._checks_registered", side_effect=registered_calls),
             patch(_MOD + "._run_with_retry", return_value=_completed()),
@@ -108,14 +108,16 @@ class TestWaitForChecks:
         ):
             wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
 
-    def test_polls_timeout_falls_through(self) -> None:
+    def test_polls_timeout_raises(self) -> None:
         with (
             patch(_MOD + "._checks_registered", return_value=False),
-            patch(_MOD + "._run_with_retry", return_value=_completed()),
+            patch(_MOD + "._run_with_retry") as mock_run,
             patch(_MOD + ".time.sleep"),
-            patch(_MOD + ".time.monotonic", side_effect=[0, 100]),
+            patch(_MOD + ".time.monotonic", side_effect=[0, 200]),
+            pytest.raises(subprocess.CalledProcessError, match="no checks reported"),
         ):
             wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
+        mock_run.assert_not_called()
 
 
 class TestWatchWorkflow:


### PR DESCRIPTION
# Pull Request

## Summary

- Increase poll timeout from 60s to 180s and raise a clear GitHubAPIError when no checks register, instead of falling through to a confusing check-watch failure.

## Issue Linkage

- Ref #1148

## Notes

- Both wait_for_checks implementations (github.py and release/subprocess.py) had a bug where they unconditionally called the check-watch command after the poll timeout, even when no checks existed. Now they raise a GitHubAPIError with a clear message indicating GitHub may be experiencing delays. The poll timeout is increased from 60s to 180s to accommodate GitHub performance degradation.