### PR TITLE
feat(identity): add per-identity VM resource overrides (cpus, memory, disk)

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -74,7 +74,14 @@ def _cmd_create(args: argparse.Namespace) -> int:
 
     try:
         print(f"  Creating VM with projects mount: {identity.projects_dir}")
-        create_vm(identity.vm_instance, template, identity.projects_dir)
+        create_vm(
+            identity.vm_instance,
+            template,
+            identity.projects_dir,
+            cpus=identity.cpus,
+            memory=identity.memory,
+            disk=identity.disk,
+        )
 
         print("  Starting VM...")
         start_vm(identity.vm_instance)
@@ -226,7 +233,14 @@ def _cmd_rebuild(args: argparse.Namespace) -> int:
 
     try:
         print(f"  Creating VM with projects mount: {identity.projects_dir}")
-        create_vm(identity.vm_instance, template, identity.projects_dir)
+        create_vm(
+            identity.vm_instance,
+            template,
+            identity.projects_dir,
+            cpus=identity.cpus,
+            memory=identity.memory,
+            disk=identity.disk,
+        )
 
         print("  Starting VM...")
         start_vm(identity.vm_instance)

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import re
 import sys
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+
+_SIZE_PATTERN = re.compile(r"^\d+GiB$")
 
 
 @dataclass
@@ -29,6 +32,26 @@ class IdentityConfig:
     default_identity: str | None = None
     vergil: str = ""
     vergil_vm: str = ""
+
+
+def _validate_identity_resources(name: str, identity: Identity) -> None:
+    if identity.cpus is not None:
+        if not isinstance(identity.cpus, int) or identity.cpus < 1:
+            print(
+                f"ERROR: identity '{name}': cpus must be a positive integer,"
+                f" got {identity.cpus!r}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+    for field in ("memory", "disk"):
+        value = getattr(identity, field)
+        if value is not None and not _SIZE_PATTERN.fullmatch(value):
+            print(
+                f"ERROR: identity '{name}': {field} must be '<number>GiB'"
+                f' (e.g., "32GiB"), got {value!r}',
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
 
 
 def load_config(path: Path) -> IdentityConfig:
@@ -58,6 +81,7 @@ def load_config(path: Path) -> IdentityConfig:
             memory=data.get("memory"),
             disk=data.get("disk"),
         )
+        _validate_identity_resources(name, identities[name])
     return IdentityConfig(
         identities=identities,
         default_identity=default_identity,

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -18,6 +18,9 @@ class Identity:
     projects_dir: str = ""
     vergil: str = ""
     vergil_vm: str = ""
+    cpus: int | None = None
+    memory: str | None = None
+    disk: str | None = None
 
 
 @dataclass
@@ -51,6 +54,9 @@ def load_config(path: Path) -> IdentityConfig:
             projects_dir=data.get("projects_dir", ""),
             vergil=data.get("vergil", ""),
             vergil_vm=data.get("vergil-vm", ""),
+            cpus=data.get("cpus"),
+            memory=data.get("memory"),
+            disk=data.get("disk"),
         )
     return IdentityConfig(
         identities=identities,

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -35,8 +35,7 @@ class IdentityConfig:
 
 
 def _validate_identity_resources(name: str, identity: Identity) -> None:
-    if identity.cpus is not None:
-        if not isinstance(identity.cpus, int) or identity.cpus < 1:
+    if identity.cpus is not None and (not isinstance(identity.cpus, int) or identity.cpus < 1):
             print(
                 f"ERROR: identity '{name}': cpus must be a positive integer,"
                 f" got {identity.cpus!r}",

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -36,12 +36,11 @@ class IdentityConfig:
 
 def _validate_identity_resources(name: str, identity: Identity) -> None:
     if identity.cpus is not None and (not isinstance(identity.cpus, int) or identity.cpus < 1):
-            print(
-                f"ERROR: identity '{name}': cpus must be a positive integer,"
-                f" got {identity.cpus!r}",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
+        print(
+            f"ERROR: identity '{name}': cpus must be a positive integer, got {identity.cpus!r}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
     for field in ("memory", "disk"):
         value = getattr(identity, field)
         if value is not None and not _SIZE_PATTERN.fullmatch(value):

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -144,14 +144,29 @@ def fetch_template(tag: str) -> Path:
     return Path(tmp.name)
 
 
-def create_vm(instance: str, template: Path, projects_dir: str) -> None:
-    _limactl(
+def create_vm(
+    instance: str,
+    template: Path,
+    projects_dir: str,
+    *,
+    cpus: int | None = None,
+    memory: str | None = None,
+    disk: str | None = None,
+) -> None:
+    args = [
         "create",
         f"--name={instance}",
         "--tty=false",
         f'--set=.mounts[0].location = "{projects_dir}"',
-        str(template),
-    )
+    ]
+    if cpus is not None:
+        args.append(f"--set=.cpus = {cpus}")
+    if memory is not None:
+        args.append(f'--set=.memory = "{memory}"')
+    if disk is not None:
+        args.append(f'--set=.disk = "{disk}"')
+    args.append(str(template))
+    _limactl(*args)
 
 
 def start_vm(instance: str) -> None:

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -375,3 +375,29 @@ def test_claude_token_path_parsed(tmp_path: Path) -> None:
 def test_claude_token_path_defaults_empty(config_file: Path) -> None:
     cfg = load_config(config_file)
     assert cfg.identities["vergil"].claude_token_path == ""
+
+
+def test_resource_fields_parsed(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        cpus = 12
+        memory = "32GiB"
+        disk = "100GiB"
+    """)
+    )
+    cfg = load_config(p)
+    ident = cfg.identities["vergil"]
+    assert ident.cpus == 12
+    assert ident.memory == "32GiB"
+    assert ident.disk == "100GiB"
+
+
+def test_resource_fields_default_none(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    ident = cfg.identities["vergil"]
+    assert ident.cpus is None
+    assert ident.memory is None
+    assert ident.disk is None

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -401,3 +401,102 @@ def test_resource_fields_default_none(config_file: Path) -> None:
     assert ident.cpus is None
     assert ident.memory is None
     assert ident.disk is None
+
+
+def test_resource_validation_rejects_negative_cpus(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        cpus = -1
+    """)
+    )
+    with pytest.raises(SystemExit):
+        load_config(p)
+
+
+def test_resource_validation_rejects_zero_cpus(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        cpus = 0
+    """)
+    )
+    with pytest.raises(SystemExit):
+        load_config(p)
+
+
+def test_resource_validation_rejects_string_cpus(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        cpus = "four"
+    """)
+    )
+    with pytest.raises(SystemExit):
+        load_config(p)
+
+
+def test_resource_validation_rejects_bad_memory(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        memory = "32GB"
+    """)
+    )
+    with pytest.raises(SystemExit):
+        load_config(p)
+
+
+def test_resource_validation_rejects_bad_disk(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        disk = "lots"
+    """)
+    )
+    with pytest.raises(SystemExit):
+        load_config(p)
+
+
+def test_resource_validation_accepts_valid_values(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        cpus = 12
+        memory = "32GiB"
+        disk = "100GiB"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.identities["vergil"].cpus == 12
+
+
+def test_resource_validation_error_message(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        memory = "32GB"
+    """)
+    )
+    with pytest.raises(SystemExit):
+        load_config(p)
+    captured = capsys.readouterr()
+    assert "vergil" in captured.err
+    assert "memory" in captured.err
+    assert "<number>GiB" in captured.err

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -298,8 +298,12 @@ class TestCreateVm:
     def test_passes_all_overrides(self, mock: MagicMock) -> None:
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm(
-            "vergil-agent", tpl, "/home/user/projects",
-            cpus=8, memory="24GiB", disk="100GiB",
+            "vergil-agent",
+            tpl,
+            "/home/user/projects",
+            cpus=8,
+            memory="24GiB",
+            disk="100GiB",
         )
         args = mock.call_args[0]
         assert "--set=.cpus = 8" in args

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -258,6 +258,55 @@ class TestCreateVm:
         assert len(mount_arg) == 1
         assert "/home/user/projects" in mount_arg[0]
 
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_passes_cpu_override(self, mock: MagicMock) -> None:
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects", cpus=12)
+        args = mock.call_args[0]
+        cpu_args = [a for a in args if "cpus" in a]
+        assert len(cpu_args) == 1
+        assert "--set=.cpus = 12" == cpu_args[0]
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_passes_memory_override(self, mock: MagicMock) -> None:
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects", memory="32GiB")
+        args = mock.call_args[0]
+        mem_args = [a for a in args if "memory" in a]
+        assert len(mem_args) == 1
+        assert '--set=.memory = "32GiB"' == mem_args[0]
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_passes_disk_override(self, mock: MagicMock) -> None:
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects", disk="100GiB")
+        args = mock.call_args[0]
+        disk_args = [a for a in args if "disk" in a]
+        assert len(disk_args) == 1
+        assert '--set=.disk = "100GiB"' == disk_args[0]
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_omits_none_overrides(self, mock: MagicMock) -> None:
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects")
+        args = mock.call_args[0]
+        assert not any("cpus" in a for a in args)
+        assert not any("memory" in a for a in args)
+        assert not any("disk" in a for a in args)
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_passes_all_overrides(self, mock: MagicMock) -> None:
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm(
+            "vergil-agent", tpl, "/home/user/projects",
+            cpus=8, memory="24GiB", disk="100GiB",
+        )
+        args = mock.call_args[0]
+        assert "--set=.cpus = 8" in args
+        assert '--set=.memory = "24GiB"' in args
+        assert '--set=.disk = "100GiB"' in args
+        assert str(tpl) == args[-1]
+
 
 class TestStartStopVm:
     @patch("vergil_tooling.lib.lima._limactl")

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -265,7 +265,7 @@ class TestCreateVm:
         args = mock.call_args[0]
         cpu_args = [a for a in args if "cpus" in a]
         assert len(cpu_args) == 1
-        assert "--set=.cpus = 12" == cpu_args[0]
+        assert cpu_args[0] == "--set=.cpus = 12"
 
     @patch("vergil_tooling.lib.lima._limactl")
     def test_passes_memory_override(self, mock: MagicMock) -> None:
@@ -274,7 +274,7 @@ class TestCreateVm:
         args = mock.call_args[0]
         mem_args = [a for a in args if "memory" in a]
         assert len(mem_args) == 1
-        assert '--set=.memory = "32GiB"' == mem_args[0]
+        assert mem_args[0] == '--set=.memory = "32GiB"'
 
     @patch("vergil_tooling.lib.lima._limactl")
     def test_passes_disk_override(self, mock: MagicMock) -> None:
@@ -283,7 +283,7 @@ class TestCreateVm:
         args = mock.call_args[0]
         disk_args = [a for a in args if "disk" in a]
         assert len(disk_args) == 1
-        assert '--set=.disk = "100GiB"' == disk_args[0]
+        assert disk_args[0] == '--set=.disk = "100GiB"'
 
     @patch("vergil_tooling.lib.lima._limactl")
     def test_omits_none_overrides(self, mock: MagicMock) -> None:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -194,6 +194,50 @@ class TestCreate:
         mock_fetch.assert_called_once_with("v2.1")
         mock_install.assert_called_once_with("vergil-agent", "v2.0")
 
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_create_passes_resource_overrides(
+        self,
+        _status: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        p = tmp_path / "identities.toml"
+        p.write_text(
+            textwrap.dedent("""\
+            vergil = "v2.0"
+
+            [identities.vergil]
+            vm_instance = "vergil-agent"
+            projects_dir = "/home/user/projects"
+            cpus = 12
+            memory = "32GiB"
+            disk = "100GiB"
+        """)
+        )
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        result = main(["create", "--config", str(p)])
+        assert result == 0
+        mock_create.assert_called_once_with(
+            "vergil-agent",
+            template,
+            "/home/user/projects",
+            cpus=12,
+            memory="32GiB",
+            disk="100GiB",
+        )
+
 
 class TestStart:
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
@@ -420,6 +464,53 @@ class TestRebuild:
         )
         result = main(["rebuild", "--config", str(p)])
         assert result == 1
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.delete_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_rebuild_passes_resource_overrides(
+        self,
+        _status: MagicMock,
+        _delete: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        _copy: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        p = tmp_path / "identities.toml"
+        p.write_text(
+            textwrap.dedent("""\
+            vergil = "v2.0"
+
+            [identities.vergil]
+            vm_instance = "vergil-agent"
+            projects_dir = "/home/user/projects"
+            cpus = 8
+            memory = "24GiB"
+        """)
+        )
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        result = main(["rebuild", "--config", str(p)])
+        assert result == 0
+        mock_create.assert_called_once_with(
+            "vergil-agent",
+            template,
+            "/home/user/projects",
+            cpus=8,
+            memory="24GiB",
+            disk=None,
+        )
 
 
 class TestList:


### PR DESCRIPTION
# Pull Request

## Summary

- Add optional cpus, memory, and disk fields to Identity for per-identity VM resource sizing

## Issue Linkage

- Ref vergil-project/vergil-vm#34

## Notes

- Adds three optional fields (cpus, memory, disk) to the Identity dataclass, with input validation at config load time and --set overrides passed through create_vm to limactl. This is the vergil-tooling half of vergil-vm#34; the template default updates are in the companion vergil-vm PR.