### PR TITLE
fix(vrg-gh): add 'repo list' to subcommand allowlist

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -16,7 +16,7 @@ _ALLOWED: dict[str, set[str]] = {
     "issue": {"view", "create", "close", "edit", "list", "comment"},
     "pr": {"view", "checks", "list", "diff", "comment", "edit", "review", "merge"},
     "run": {"list", "view", "watch"},
-    "repo": {"view"},
+    "repo": {"view", "list"},
     "label": {"list", "create"},
 }
 

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -53,6 +53,7 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
     ("run", "view"),
     ("run", "watch"),
     ("repo", "view"),
+    ("repo", "list"),
     ("label", "list"),
     ("label", "create"),
 ]


### PR DESCRIPTION
# Pull Request

## Summary

- Allow repo list through vrg-gh as a read-only operation

## Issue Linkage

- Ref #1159

## Notes

- Read-only operation needed for auditing repos across an org (e.g., enumerating repos to check container-suffix defaults). Added to the allowlist alongside the existing repo view permission.