### PR TITLE
fix(vrg-git): add rm to subcommand allowlist; fix hook guard false positives

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -23,6 +23,7 @@ _ALLOWED_SIMPLE: set[str] = {
     "rev-parse",
     "add",
     "mv",
+    "rm",
     "push",
     "fetch",
     "pull",

--- a/src/vergil_tooling/bin/vrg_hook_guard.py
+++ b/src/vergil_tooling/bin/vrg_hook_guard.py
@@ -28,6 +28,10 @@ _RAW_GH_RE = re.compile(
     r"(?:\s|$)",
 )
 
+_QUOTED_STR_RE = re.compile(r""""[^"]*"|'[^']*'""")
+
+_SH_EXEC_RE = re.compile(r"(?:^|\s)(?:bash|sh)\s+-c\s")
+
 
 def _find_vergil_toml(start: Path) -> Path | None:
     current = start.resolve()
@@ -69,7 +73,9 @@ def main() -> int:
     if not command:
         return 0
 
-    if _RAW_GIT_RE.search(command):
+    stripped = _QUOTED_STR_RE.sub('""', command)
+
+    if _RAW_GIT_RE.search(stripped):
         _deny(
             "Raw git is blocked in Vergil-managed repos. "
             "Use vrg-git instead. All git operations must go "
@@ -77,12 +83,29 @@ def main() -> int:
         )
         return 0
 
-    if _RAW_GH_RE.search(command):
+    if _RAW_GH_RE.search(stripped):
         _deny(
             "Raw gh is blocked in Vergil-managed repos. "
             "Use vrg-gh instead. All GitHub CLI operations must "
             "go through the vrg-gh wrapper."
         )
         return 0
+
+    if _SH_EXEC_RE.search(stripped):
+        if _RAW_GIT_RE.search(command):
+            _deny(
+                "Raw git is blocked in Vergil-managed repos. "
+                "Use vrg-git instead. All git operations must go "
+                "through the vrg-git wrapper."
+            )
+            return 0
+
+        if _RAW_GH_RE.search(command):
+            _deny(
+                "Raw gh is blocked in Vergil-managed repos. "
+                "Use vrg-gh instead. All GitHub CLI operations must "
+                "go through the vrg-gh wrapper."
+            )
+            return 0
 
     return 0

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -43,6 +43,7 @@ _ALLOWED_SIMPLE = [
     "rev-parse",
     "add",
     "mv",
+    "rm",
     "push",
     "fetch",
     "pull",

--- a/tests/vergil_tooling/test_vrg_hook_guard.py
+++ b/tests/vergil_tooling/test_vrg_hook_guard.py
@@ -202,6 +202,51 @@ class TestWrapperExclusion:
         assert out == ""
 
 
+# -- quoted argument text must not trigger false positives --------------------
+
+
+class TestQuotedArgumentExclusion:
+    def test_vrg_submit_pr_with_git_in_summary(self) -> None:
+        rc, out = _run('vrg-submit-pr --summary "Add git rm to allowlist"')
+        assert rc == 0
+        assert out == ""
+
+    def test_vrg_submit_pr_with_gh_in_notes(self) -> None:
+        rc, out = _run('vrg-submit-pr --notes "Use gh api for checks"')
+        assert rc == 0
+        assert out == ""
+
+    def test_vrg_commit_with_git_in_message(self) -> None:
+        rc, out = _run('vrg-commit --message "fix git hook detection"')
+        assert rc == 0
+        assert out == ""
+
+    def test_echo_with_git_in_quotes(self) -> None:
+        rc, out = _run('echo "git push origin main"')
+        assert rc == 0
+        assert out == ""
+
+    def test_single_quoted_git_arg(self) -> None:
+        rc, out = _run("vrg-submit-pr --title 'fix git allowlist'")
+        assert rc == 0
+        assert out == ""
+
+    def test_bash_c_git_still_blocked(self) -> None:
+        rc, out = _run('bash -c "git push origin main"')
+        result = json.loads(out)
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_sh_c_gh_still_blocked(self) -> None:
+        rc, out = _run("sh -c 'gh pr create --title test'")
+        result = json.loads(out)
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_bash_c_vrg_git_allowed(self) -> None:
+        rc, out = _run('bash -c "vrg-git push origin main"')
+        assert rc == 0
+        assert out == ""
+
+
 # -- non-git/gh commands must be allowed --------------------------------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add rm to vrg-git allowlist and fix hook guard matching quoted argument text

## Issue Linkage

- Ref #1164

## Notes

- Two fixes: (1) add rm to vrg-git subcommand allowlist, (2) fix hook guard false positives when vrg-* commands have blocked command names in quoted arguments (e.g. --summary or --body text).