### PR TITLE
fix(hook-guard): correct deny reason in guard.sh fallback

### DIFF
--- a/src/vergil_tooling/data/hook_guard_shim.sh
+++ b/src/vergil_tooling/data/hook_guard_shim.sh
@@ -20,7 +20,7 @@ case "$base" in
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
-        permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
+        permissionDecisionReason: "Raw git/gh is blocked in Vergil-managed repos. Install vergil-tooling to enable the vrg-git/vrg-gh wrappers."
       }
     }'
     exit 0


### PR DESCRIPTION
# Pull Request

## Summary

- Fix misleading deny message in guard.sh fallback path

## Issue Linkage

- Ref #1196

## Notes

- The fallback path (when vrg-hook-guard is not installed) previously stated 'vergil-tooling is not available', conflating the reason for denial (wrapper policy) with why the fallback was active (missing tooling). The message now leads with the policy — 'Raw git/gh is blocked in Vergil-managed repos' — and notes installation of vergil-tooling as the actionable fix.