### PR TITLE
feat(vrg-gh): add issue reopen to allowed subcommands

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -13,7 +13,7 @@ import sys
 from vergil_tooling.lib import github, retry
 
 _ALLOWED: dict[str, set[str]] = {
-    "issue": {"view", "create", "close", "edit", "list", "comment"},
+    "issue": {"view", "create", "close", "reopen", "edit", "list", "comment"},
     "pr": {"view", "checks", "list", "diff", "comment", "edit", "review", "merge"},
     "run": {"list", "view", "watch"},
     "repo": {"view", "list"},

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -40,6 +40,7 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
     ("issue", "view"),
     ("issue", "create"),
     ("issue", "close"),
+    ("issue", "reopen"),
     ("issue", "edit"),
     ("issue", "list"),
     ("issue", "comment"),


### PR DESCRIPTION
# Pull Request

## Summary

- Add issue reopen to the vrg-gh allowlist alongside issue close

## Issue Linkage

- Ref #1200

## Notes

- Allows agents to reopen issues via vrg-gh. Needed for multi-PR umbrella issues where partial delivery triggers premature closure — previously required dropping out of the wrapper to run raw gh issue reopen.