### PR TITLE
fix(git): inject credentials for remote operations in git.py library

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -5,13 +5,12 @@ Enforces a subcommand allowlist and flag deny lists.
 
 from __future__ import annotations
 
-import base64
-import os
 import subprocess
 import sys
 from pathlib import Path
 
 from vergil_tooling.lib import github
+from vergil_tooling.lib.git import _git_auth_env
 
 _ALLOWED_SIMPLE: set[str] = {
     "status",
@@ -195,17 +194,6 @@ def _check_worktree_convention(subcmd: str, args: list[str]) -> str | None:
         "Branch switches in the main worktree are blocked. "
         "Use a worktree under .worktrees/ instead."
     )
-
-
-def _git_auth_env(token: str) -> dict[str, str]:
-    """Return env dict that authenticates HTTPS git to GitHub."""
-    credentials = base64.b64encode(f"x-access-token:{token}".encode()).decode()
-    return {
-        **os.environ,
-        "GIT_CONFIG_COUNT": "1",
-        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraHeader",
-        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {credentials}",
-    }
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -2,19 +2,47 @@
 
 from __future__ import annotations
 
+import base64
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+from vergil_tooling.lib import github
+
+_REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote"}
+
+
+def _git_auth_env(token: str) -> dict[str, str]:
+    """Return env dict that authenticates HTTPS git to GitHub."""
+    credentials = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return {
+        **os.environ,
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraHeader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {credentials}",
+    }
+
+
+def _remote_env(args: tuple[str, ...]) -> dict[str, str] | None:
+    """Return auth env if *args* begins with a remote-capable subcommand."""
+    if args and args[0] in _REMOTE_SUBCOMMANDS:
+        token = github.get_installation_token()
+        if token is not None:
+            return _git_auth_env(token)
+    return None
+
 
 def run(*args: str) -> None:
     """Run a git command and raise on failure."""
+    env = _remote_env(args)
     try:
         result = subprocess.run(  # noqa: S603
             ("git", *args),  # noqa: S607
             check=True,
             capture_output=True,
             text=True,
+            env=env,
         )
     except subprocess.CalledProcessError as exc:
         if exc.stdout:
@@ -30,12 +58,14 @@ def run(*args: str) -> None:
 
 def read_output(*args: str) -> str:
     """Run a git command and return stripped stdout."""
+    env = _remote_env(args)
     try:
         result = subprocess.run(  # noqa: S603
             ("git", *args),  # noqa: S607
             check=True,
             text=True,
             capture_output=True,
+            env=env,
         )
     except subprocess.CalledProcessError as exc:
         if exc.stderr:

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -19,7 +19,9 @@ def test_run_delegates_to_subprocess() -> None:
     with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed()
         git.run("status")
-    mock_run.assert_called_once_with(("git", "status"), check=True, capture_output=True, text=True)
+    mock_run.assert_called_once_with(
+        ("git", "status"), check=True, capture_output=True, text=True, env=None
+    )
 
 
 def test_run_commit_no_env_var_gate() -> None:
@@ -110,7 +112,9 @@ def test_read_output_returns_stripped_stdout() -> None:
     with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed(stdout="  hello world  \n")
         assert git.read_output("log") == "hello world"
-    mock_run.assert_called_once_with(("git", "log"), check=True, text=True, capture_output=True)
+    mock_run.assert_called_once_with(
+        ("git", "log"), check=True, text=True, capture_output=True, env=None
+    )
 
 
 def test_repo_root_returns_path() -> None:
@@ -203,3 +207,106 @@ def test_working_tree_status_returns_porcelain_output() -> None:
 def test_working_tree_status_returns_empty_when_clean() -> None:
     with patch("vergil_tooling.lib.git.read_output", return_value=""):
         assert git.working_tree_status() == ""
+
+
+# -- remote credential injection -----------------------------------------------
+
+
+class TestRunRemoteCredentialInjection:
+    """git.run() injects credentials for remote-capable subcommands."""
+
+    @pytest.mark.parametrize("subcmd", ["push", "pull", "fetch", "ls-remote"])
+    def test_injects_token_for_remote_commands(self, subcmd: str) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.git.github.get_installation_token",
+                return_value="ghs_test_token",
+            ),
+            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            git.run(subcmd, "origin", "main")
+        _, kwargs = mock_run.call_args
+        env = kwargs.get("env")
+        assert env is not None
+        assert env["GIT_CONFIG_COUNT"] == "1"
+        assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
+        assert "Authorization: Basic" in env["GIT_CONFIG_VALUE_0"]
+
+    @pytest.mark.parametrize("subcmd", ["status", "log", "diff", "add", "branch", "commit"])
+    def test_no_injection_for_local_commands(self, subcmd: str) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.git.github.get_installation_token",
+                return_value="ghs_test_token",
+            ),
+            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            git.run(subcmd)
+        _, kwargs = mock_run.call_args
+        assert "env" not in kwargs or kwargs.get("env") is None
+
+    def test_no_injection_when_no_token(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.git.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            git.run("push", "origin", "main")
+        _, kwargs = mock_run.call_args
+        assert "env" not in kwargs or kwargs.get("env") is None
+
+    def test_token_encodes_as_basic_auth(self) -> None:
+        import base64
+
+        with (
+            patch(
+                "vergil_tooling.lib.git.github.get_installation_token",
+                return_value="ghs_test_token",
+            ),
+            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            git.run("push", "origin", "main")
+        _, kwargs = mock_run.call_args
+        header_value = kwargs["env"]["GIT_CONFIG_VALUE_0"]
+        expected = base64.b64encode(b"x-access-token:ghs_test_token").decode()
+        assert expected in header_value
+
+
+class TestReadOutputRemoteCredentialInjection:
+    """git.read_output() injects credentials for remote-capable subcommands."""
+
+    @pytest.mark.parametrize("subcmd", ["ls-remote", "fetch"])
+    def test_injects_token_for_remote_commands(self, subcmd: str) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.git.github.get_installation_token",
+                return_value="ghs_test_token",
+            ),
+            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed(stdout="output\n")
+            git.read_output(subcmd, "origin")
+        _, kwargs = mock_run.call_args
+        env = kwargs.get("env")
+        assert env is not None
+        assert "Authorization: Basic" in env["GIT_CONFIG_VALUE_0"]
+
+    @pytest.mark.parametrize("subcmd", ["log", "rev-parse", "status"])
+    def test_no_injection_for_local_commands(self, subcmd: str) -> None:
+        with (
+            patch(
+                "vergil_tooling.lib.git.github.get_installation_token",
+                return_value="ghs_test_token",
+            ),
+            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed(stdout="output\n")
+            git.read_output(subcmd)
+        _, kwargs = mock_run.call_args
+        assert "env" not in kwargs or kwargs.get("env") is None


### PR DESCRIPTION
# Pull Request

## Summary

- Move credential injection into git.py so run()/read_output() authenticate remote-capable subcommands, fixing push failures from vrg-submit-pr and other internal callers

## Issue Linkage

- Ref #1203

## Notes

- vrg_git.py now imports the shared _git_auth_env from git.py instead of duplicating it. 17 new tests added covering injection for remote commands, no-injection for local commands, and token encoding.