### PR TITLE
fix(config): warn instead of reject unrecognized primary-language values

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -126,8 +126,12 @@ def _parse_raw_config(raw: dict[str, Any]) -> VergilConfig:
     raw_lang = project_raw.get("primary-language", "")
     if raw_lang and raw_lang not in _ENUMS["primary-language"]:
         allowed = ", ".join(sorted(_ENUMS["primary-language"]))
-        msg = f"{CONFIG_FILE}: invalid primary-language '{raw_lang}' (allowed: {allowed})"
-        raise ConfigError(msg)
+        print(
+            f"warning: {CONFIG_FILE}: unrecognized primary-language '{raw_lang}'"
+            f" (known: {allowed}); treating as unset",
+            file=sys.stderr,
+        )
+        raw_lang = ""
 
     deps = raw.get("dependencies", {})
     if "vergil" not in deps:

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -154,25 +154,30 @@ def test_config_without_primary_language(tmp_path: Path) -> None:
     assert cfg.project.primary_language is None
 
 
-def test_config_rejects_shell_language(tmp_path: Path) -> None:
+def test_config_warns_on_shell_language(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "shell"')
     (tmp_path / "vergil.toml").write_text(toml)
-    with pytest.raises(ConfigError, match="primary-language"):
-        read_config(tmp_path)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language is None
+    assert "unrecognized primary-language 'shell'" in capsys.readouterr().err
 
 
-def test_config_rejects_none_language(tmp_path: Path) -> None:
+def test_config_warns_on_none_language(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "none"')
     (tmp_path / "vergil.toml").write_text(toml)
-    with pytest.raises(ConfigError, match="primary-language"):
-        read_config(tmp_path)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language is None
+    assert "unrecognized primary-language 'none'" in capsys.readouterr().err
 
 
-def test_config_rejects_claude_plugin_language(tmp_path: Path) -> None:
+def test_config_warns_on_claude_plugin_language(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "claude-plugin"')
     (tmp_path / "vergil.toml").write_text(toml)
-    with pytest.raises(ConfigError, match="primary-language"):
-        read_config(tmp_path)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language is None
+    assert "unrecognized primary-language 'claude-plugin'" in capsys.readouterr().err
 
 
 # -- [markdownlint] section ---------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Unknown primary-language values now emit a stderr warning and are treated as unset (None) instead of raising ConfigError

## Issue Linkage

- Ref #1213

## Notes

- Repos with primary-language = shell, none, or claude-plugin were broken after v2.0.61 tightened the enum. This makes the config parser lenient — unknown values degrade to None with a warning, so existing repos keep working.