### PR TITLE
feat(vm): host-path-preserving workspace mount and Claude sub-mounts

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -304,9 +304,9 @@ def _cmd_session(args: argparse.Namespace) -> int:
 
     workspace: str | None = None
     if args.workspace:
-        workspace = resolve_workspace(args.workspace)
+        workspace = resolve_workspace(args.workspace, identity.projects_dir)
 
-    workdir = workspace if workspace else "/projects"
+    workdir = workspace if workspace else identity.projects_dir
     cmd = ["limactl", "shell", "--start", f"--workdir={workdir}", identity.vm_instance]
 
     if workspace:
@@ -379,7 +379,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Connect even if the VM exceeds the staleness threshold",
     )
     p_session.add_argument(
-        "workspace", nargs="?", help="Workspace path (relative to /projects or absolute)"
+        "workspace", nargs="?", help="Workspace path (relative to projects_dir or absolute)"
     )
     p_session.add_argument("cmd", nargs=argparse.REMAINDER, help="Command to run inside the VM")
 

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -166,10 +166,7 @@ def resolve_vm_tag(config: IdentityConfig, identity: Identity) -> str:
     return resolve_vergil_version(config, identity)
 
 
-_PROJECTS_PREFIX = "/projects"
-
-
-def resolve_workspace(path: str) -> str:
+def resolve_workspace(path: str, projects_dir: str) -> str:
     if path.startswith("/"):
         return path
-    return f"{_PROJECTS_PREFIX}/{path}"
+    return f"{projects_dir}/{path}"

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -153,11 +153,25 @@ def create_vm(
     memory: str | None = None,
     disk: str | None = None,
 ) -> None:
+    claude_projects_path = Path.home() / ".claude" / "projects"
+    claude_skills_path = Path.home() / ".claude" / "skills"
+    claude_projects_path.mkdir(parents=True, exist_ok=True)
+    claude_skills_path.mkdir(parents=True, exist_ok=True)
+    claude_projects = str(claude_projects_path)
+    claude_skills = str(claude_skills_path)
+
     args = [
         "create",
         f"--name={instance}",
         "--tty=false",
         f'--set=.mounts[0].location = "{projects_dir}"',
+        f'--set=.mounts[0].mountPoint = "{projects_dir}"',
+        f'--set=.mounts[1].location = "{claude_projects}"',
+        f'--set=.mounts[1].mountPoint = "{claude_projects}"',
+        "--set=.mounts[1].writable = true",
+        f'--set=.mounts[2].location = "{claude_skills}"',
+        f'--set=.mounts[2].mountPoint = "{claude_skills}"',
+        "--set=.mounts[2].writable = false",
     ]
     if cpus is not None:
         args.append(f"--set=.cpus = {cpus}")

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -97,13 +97,13 @@ def test_resolve_identity_ambiguous(tmp_path: Path) -> None:
 
 
 def test_resolve_workspace_relative() -> None:
-    assert resolve_workspace("vergil-project/vergil-tooling") == (
-        "/projects/vergil-project/vergil-tooling"
+    assert resolve_workspace("vergil-project/vergil-tooling", "/home/user/dev") == (
+        "/home/user/dev/vergil-project/vergil-tooling"
     )
 
 
 def test_resolve_workspace_absolute() -> None:
-    assert resolve_workspace("/custom/path") == "/custom/path"
+    assert resolve_workspace("/custom/path", "/home/user/dev") == "/custom/path"
 
 
 def test_projects_dir_field(tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -246,8 +246,12 @@ class TestFetchTemplate:
 
 
 class TestCreateVm:
+    @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
-    def test_constructs_create_command(self, mock: MagicMock) -> None:
+    def test_constructs_create_command(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm("vergil-agent", tpl, "/home/user/projects")
         mock.assert_called_once()
@@ -256,12 +260,48 @@ class TestCreateVm:
         assert "--name=vergil-agent" in args
         assert "--tty=false" in args
         assert str(tpl) in args
-        mount_arg = [a for a in args if ".mounts[0].location" in a]
-        assert len(mount_arg) == 1
-        assert "/home/user/projects" in mount_arg[0]
+        location_arg = [a for a in args if ".mounts[0].location" in a]
+        assert len(location_arg) == 1
+        assert "/home/user/projects" in location_arg[0]
+        mount_point_arg = [a for a in args if ".mounts[0].mountPoint" in a]
+        assert len(mount_point_arg) == 1
+        assert "/home/user/projects" in mount_point_arg[0]
 
+    @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
-    def test_passes_cpu_override(self, mock: MagicMock) -> None:
+    def test_adds_claude_submounts(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects")
+        args = mock.call_args[0]
+        claude_projects = str(tmp_path / ".claude" / "projects")
+        claude_skills = str(tmp_path / ".claude" / "skills")
+        assert f'--set=.mounts[1].location = "{claude_projects}"' in args
+        assert f'--set=.mounts[1].mountPoint = "{claude_projects}"' in args
+        assert "--set=.mounts[1].writable = true" in args
+        assert f'--set=.mounts[2].location = "{claude_skills}"' in args
+        assert f'--set=.mounts[2].mountPoint = "{claude_skills}"' in args
+        assert "--set=.mounts[2].writable = false" in args
+
+    @patch("vergil_tooling.lib.lima.Path.home")
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_creates_host_claude_dirs(
+        self, _mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects")
+        assert (tmp_path / ".claude" / "projects").is_dir()
+        assert (tmp_path / ".claude" / "skills").is_dir()
+
+    @patch("vergil_tooling.lib.lima.Path.home")
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_passes_cpu_override(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm("vergil-agent", tpl, "/home/user/projects", cpus=12)
         args = mock.call_args[0]
@@ -269,35 +309,51 @@ class TestCreateVm:
         assert len(cpu_args) == 1
         assert cpu_args[0] == "--set=.cpus = 12"
 
+    @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
-    def test_passes_memory_override(self, mock: MagicMock) -> None:
+    def test_passes_memory_override(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm("vergil-agent", tpl, "/home/user/projects", memory="32GiB")
         args = mock.call_args[0]
-        mem_args = [a for a in args if "memory" in a]
+        mem_args = [a for a in args if ".memory" in a]
         assert len(mem_args) == 1
         assert mem_args[0] == '--set=.memory = "32GiB"'
 
+    @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
-    def test_passes_disk_override(self, mock: MagicMock) -> None:
+    def test_passes_disk_override(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm("vergil-agent", tpl, "/home/user/projects", disk="100GiB")
         args = mock.call_args[0]
-        disk_args = [a for a in args if "disk" in a]
+        disk_args = [a for a in args if ".disk" in a]
         assert len(disk_args) == 1
         assert disk_args[0] == '--set=.disk = "100GiB"'
 
+    @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
-    def test_omits_none_overrides(self, mock: MagicMock) -> None:
+    def test_omits_none_overrides(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm("vergil-agent", tpl, "/home/user/projects")
         args = mock.call_args[0]
-        assert not any("cpus" in a for a in args)
-        assert not any("memory" in a for a in args)
-        assert not any("disk" in a for a in args)
+        assert not any(".cpus" in a for a in args)
+        assert not any(".memory" in a for a in args)
+        assert not any(".disk" in a for a in args)
 
+    @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
-    def test_passes_all_overrides(self, mock: MagicMock) -> None:
+    def test_passes_all_overrides(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
         tpl = Path("/tmp/template.yaml")  # noqa: S108
         create_vm(
             "vergil-agent",

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -639,7 +639,7 @@ class TestSession:
         assert args[0] == "limactl"
         assert "vergil-agent" in args[1]
         assert "--start" in args[1]
-        assert "--workdir=/projects" in args[1]
+        assert "--workdir=/home/user/projects" in args[1]
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
@@ -655,12 +655,12 @@ class TestSession:
     ) -> None:
         main(["session", "--config", str(config_file), "vergil-tooling"])
         cmd = mock_exec.call_args[0][1]
-        assert "--workdir=/projects/vergil-tooling" in cmd
+        assert "--workdir=/home/user/projects/vergil-tooling" in cmd
         assert "bash" in cmd
         assert "-c" in cmd
         inner = cmd[cmd.index("-c") + 1]
         assert "claude.env" in inner
-        assert "cd /projects/vergil-tooling" in inner
+        assert "cd /home/user/projects/vergil-tooling" in inner
         assert "exec bash --login" in inner
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
@@ -681,7 +681,7 @@ class TestSession:
         assert "-c" in cmd
         inner = cmd[cmd.index("-c") + 1]
         assert "claude.env" in inner
-        assert "cd /projects/vergil-tooling" in inner
+        assert "cd /home/user/projects/vergil-tooling" in inner
         assert "exec claude" in inner
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")


### PR DESCRIPTION
# Pull Request

## Summary

- Implement host-path-preserving workspace mount and ~/.claude sub-mounts for session portability and state persistence across VM rebuilds

## Issue Linkage

- Ref #1205

## Notes

- Changes: (1) create_vm now sets mountPoint = host path for workspace mount, making VM and host derive identical Claude Code project memory keys. (2) Adds ~/.claude/projects (read-write) and ~/.claude/skills (read-only) mounts so session transcripts, memory files, and user skills persist across VM rebuilds. (3) Ensures host-side ~/.claude/projects and ~/.claude/skills directories exist before VM creation. (4) Updates session workdir from hardcoded /projects to identity.projects_dir, and resolve_workspace accepts projects_dir parameter. Note: the vergil-vm template changes (agent.yaml) are tracked separately in the vergil-vm repo.