### PR TITLE
fix(ecosystem-resolve): output shell strings instead of JSON arrays

### DIFF
--- a/src/vergil_tooling/bin/vrg_ecosystem_resolve.py
+++ b/src/vergil_tooling/bin/vrg_ecosystem_resolve.py
@@ -33,16 +33,16 @@ def main(argv: list[str] | None = None) -> int:
 
     build_str = shlex.join(info.build_cmd) if info.build_cmd else ""
     publish_str = shlex.join(info.publish_cmd) if info.publish_cmd else ""
-    credential_secret = info.publish_env_var or ""
+    env_name = info.publish_env_var or ""
 
     if is_ci():
         write_output("build", build_str)
         write_output("publish", publish_str)
-        write_output("credential-secret", credential_secret)
+        write_output("credential-secret", env_name)
     else:
         print(f"build: {build_str}")
         print(f"publish: {publish_str}")
-        print(f"credential-secret: {credential_secret}")
+        print(f"credential-secret: {env_name}")
 
     return 0
 

--- a/src/vergil_tooling/bin/vrg_ecosystem_resolve.py
+++ b/src/vergil_tooling/bin/vrg_ecosystem_resolve.py
@@ -1,13 +1,13 @@
 """Resolve ecosystem metadata for a language.
 
-Resolves build command, publish command, and publish environment
-variable for the given language identifier.
+Resolves build command, publish command, and credential secret
+name for the given language identifier.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
+import shlex
 import sys
 
 from vergil_tooling.lib.languages import ecosystem_metadata, supported_languages
@@ -31,19 +31,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    build_str = json.dumps(info.build_cmd) if info.build_cmd else ""
-    publish_str = json.dumps(info.publish_cmd) if info.publish_cmd else ""
-    env_var = info.publish_env_var or ""
+    build_str = shlex.join(info.build_cmd) if info.build_cmd else ""
+    publish_str = shlex.join(info.publish_cmd) if info.publish_cmd else ""
+    credential_secret = info.publish_env_var or ""
 
     if is_ci():
-        write_output("build_cmd", build_str)
-        write_output("publish_cmd", publish_str)
-        write_output("publish_env_var", env_var)
+        write_output("build", build_str)
+        write_output("publish", publish_str)
+        write_output("credential-secret", credential_secret)
     else:
-        print(f"build_cmd: {build_str}")
-        print(f"publish_cmd: {publish_str}")
-        print(f"publish_env_var: {env_var}")
-        print(f"publish_requires_auth: {bool(env_var)}")
+        print(f"build: {build_str}")
+        print(f"publish: {publish_str}")
+        print(f"credential-secret: {credential_secret}")
 
     return 0
 

--- a/tests/vergil_tooling/test_vrg_ecosystem_resolve.py
+++ b/tests/vergil_tooling/test_vrg_ecosystem_resolve.py
@@ -19,10 +19,9 @@ def test_python_ecosystem_interactive(capsys: pytest.CaptureFixture[str]) -> Non
         rc = main(["python"])
     captured = capsys.readouterr()
     assert rc == 0
-    assert "build_cmd:" in captured.out
-    assert "publish_cmd:" in captured.out
-    assert "publish_env_var:" in captured.out
-    assert "publish_requires_auth: True" in captured.out
+    assert "build: uv build\n" in captured.out
+    assert "publish: uv publish\n" in captured.out
+    assert "credential-secret: PYPI_TOKEN\n" in captured.out
 
 
 def test_python_ecosystem_ci_mode(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
@@ -35,9 +34,24 @@ def test_python_ecosystem_ci_mode(capsys: pytest.CaptureFixture[str], tmp_path: 
         rc = main(["python"])
     assert rc == 0
     content = output_file.read_text()
-    assert "build_cmd=" in content
-    assert "publish_cmd=" in content
-    assert "publish_env_var=" in content
+    assert "build=uv build\n" in content
+    assert "publish=uv publish\n" in content
+    assert "credential-secret=PYPI_TOKEN\n" in content
+
+
+def test_go_ecosystem_ci_mode(tmp_path: Path) -> None:
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+    with (
+        patch("vergil_tooling.bin.vrg_ecosystem_resolve.is_ci", return_value=True),
+        patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}),
+    ):
+        rc = main(["go"])
+    assert rc == 0
+    content = output_file.read_text()
+    assert "build=go build ./...\n" in content
+    assert "publish=\n" in content
+    assert "credential-secret=\n" in content
 
 
 def test_go_ecosystem_no_credential(capsys: pytest.CaptureFixture[str]) -> None:
@@ -45,8 +59,23 @@ def test_go_ecosystem_no_credential(capsys: pytest.CaptureFixture[str]) -> None:
         rc = main(["go"])
     captured = capsys.readouterr()
     assert rc == 0
-    assert "publish_cmd:" in captured.out
-    assert "publish_requires_auth: False" in captured.out
+    assert "build: go build ./...\n" in captured.out
+    assert "credential-secret: \n" in captured.out
+
+
+def test_rust_ecosystem_ci_mode(tmp_path: Path) -> None:
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+    with (
+        patch("vergil_tooling.bin.vrg_ecosystem_resolve.is_ci", return_value=True),
+        patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}),
+    ):
+        rc = main(["rust"])
+    assert rc == 0
+    content = output_file.read_text()
+    assert "build=cargo build --release\n" in content
+    assert "publish=cargo publish\n" in content
+    assert "credential-secret=CRATES_IO_TOKEN\n" in content
 
 
 def test_unknown_language_fails() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Change vrg-ecosystem-resolve to output shell-compatible command strings instead of JSON arrays, and rename output keys to match composite action expectations.

## Issue Linkage

- Ref #1224

## Notes

- Replaces json.dumps() with shlex.join() for proper shell quoting. Renames CI output keys: build_cmd to build, publish_cmd to publish, publish_env_var to credential-secret. Interactive output updated to match. Added CI-mode tests for Go and Rust ecosystems.