### PR TITLE
feat(vrg-vm): show version delta on update

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -24,6 +24,7 @@ from vergil_tooling.lib.lima import (
     create_vm,
     delete_vm,
     fetch_template,
+    get_tooling_version,
     inject_credentials,
     install_tooling,
     list_vms,
@@ -178,7 +179,18 @@ def _cmd_update(args: argparse.Namespace) -> int:
     tag = args.tag if args.tag else None
     fallback = resolve_vergil_version(config, identity)
     print(f"Updating vergil-tooling in VM '{identity.vm_instance}' (identity: {name})...")
+
+    before = get_tooling_version(identity.vm_instance)
     update_tooling(identity.vm_instance, tag, fallback_tag=fallback)
+    after = get_tooling_version(identity.vm_instance)
+
+    if before and after:
+        if before == after:
+            print(f"  vergil-tooling: {after} (already up to date)")
+        else:
+            print(f"  vergil-tooling: {before} → {after}")
+    elif after:
+        print(f"  vergil-tooling: {after}")
 
     print("Update complete.")
     return 0

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -311,6 +311,23 @@ def _inject_claude_token(instance: str, token_path: str) -> None:
 _TOOLING_TAG_FILE = "~/.config/vergil/tooling-tag"
 
 
+def get_tooling_version(instance: str) -> str | None:
+    """Return the installed vergil-tooling version string, or None."""
+    try:
+        result = shell_run(
+            instance,
+            "bash",
+            "-c",
+            'export PATH="$HOME/.local/bin:$PATH" && uv tool list 2>/dev/null',
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("vergil-tooling "):
+                return line.split()[1]
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+
 def install_tooling(instance: str, tag: str) -> None:
     """Install vergil-tooling inside the VM and record the tag."""
     install_spec = _TOOLING_INSTALL.format(tag=tag)

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib.lima import (
     create_vm,
     delete_vm,
     fetch_template,
+    get_tooling_version,
     inject_credentials,
     install_tooling,
     list_vms,
@@ -684,6 +685,31 @@ class TestUpdateTooling:
         mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with pytest.raises(SystemExit):
             update_tooling("vergil-agent")
+
+
+class TestGetToolingVersion:
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_parses_version_from_uv_tool_list(self, mock_run: MagicMock) -> None:
+        uv_output = "vergil-tooling v2.0.63\n    - vrg-commit\n"
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout=uv_output, stderr="")
+        assert get_tooling_version("vergil-agent") == "v2.0.63"
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_returns_none_when_not_installed(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 0, stdout="some-other-tool v1.0\n", stderr=""
+        )
+        assert get_tooling_version("vergil-agent") is None
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_returns_none_on_empty_output(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        assert get_tooling_version("vergil-agent") is None
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_returns_none_on_command_failure(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "limactl")
+        assert get_tooling_version("vergil-agent") is None
 
 
 class TestVmAgeDays:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -540,19 +540,21 @@ class TestList:
 
 
 class TestUpdate:
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
     def test_update_default_tag(
-        self, _status: MagicMock, mock_update: MagicMock, config_file: Path
+        self, _status: MagicMock, mock_update: MagicMock, _ver: MagicMock, config_file: Path
     ) -> None:
         result = main(["update", "--config", str(config_file)])
         assert result == 0
         mock_update.assert_called_once_with("vergil-agent", None, fallback_tag="v2.0")
 
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
     def test_update_explicit_tag(
-        self, _status: MagicMock, mock_update: MagicMock, config_file: Path
+        self, _status: MagicMock, mock_update: MagicMock, _ver: MagicMock, config_file: Path
     ) -> None:
         result = main(["update", "--config", str(config_file), "--tag", "v2.1"])
         assert result == 0
@@ -567,6 +569,52 @@ class TestUpdate:
     def test_update_fails_if_not_created(self, _status: MagicMock, config_file: Path) -> None:
         result = main(["update", "--config", str(config_file)])
         assert result == 1
+
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", side_effect=["v2.0.60", "v2.0.63"])
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_shows_version_change(
+        self,
+        _status: MagicMock,
+        _update: MagicMock,
+        _ver: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        main(["update", "--config", str(config_file)])
+        out = capsys.readouterr().out
+        assert "v2.0.60 → v2.0.63" in out
+
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", side_effect=["v2.0.63", "v2.0.63"])
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_shows_already_up_to_date(
+        self,
+        _status: MagicMock,
+        _update: MagicMock,
+        _ver: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        main(["update", "--config", str(config_file)])
+        out = capsys.readouterr().out
+        assert "v2.0.63 (already up to date)" in out
+
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", side_effect=[None, "v2.0.63"])
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_shows_version_when_before_unknown(
+        self,
+        _status: MagicMock,
+        _update: MagicMock,
+        _ver: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        main(["update", "--config", str(config_file)])
+        out = capsys.readouterr().out
+        assert "vergil-tooling: v2.0.63" in out
+        assert "→" not in out
 
 
 class TestSessionStaleness:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm update now shows the previous and new vergil-tooling version after each update, with distinct output for version changes vs no-ops

## Issue Linkage

- Ref #1212

## Notes

- Adds get_tooling_version() to lima.py that queries uv tool list inside the VM. _cmd_update() captures the version before and after the reinstall and prints a version-change line (v2.0.60 → v2.0.63) or an already-up-to-date line (v2.0.63 (already up to date)). Gracefully degrades when version detection fails (e.g., pre-existing VMs without uv). Seven new tests with 100% coverage.