### PR TITLE
feat(audit): show status check delta instead of full lists

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -17,10 +17,12 @@ from vergil_tooling.lib import github
 from vergil_tooling.lib.config import VergilConfig, _parse_raw_config
 from vergil_tooling.lib.github_config import (
     ConfigDiff,
+    DiffItem,
     apply_desired_state,
     compute_desired_state,
     compute_diff,
     fetch_actual_state,
+    format_rules_delta,
 )
 from vergil_tooling.lib.repo_config import audit_local_config
 
@@ -85,6 +87,15 @@ def _audit_repo(repo: str, config: VergilConfig) -> ConfigDiff:
     return compute_diff(desired=desired, actual=result.state)
 
 
+def _format_item(item: DiffItem) -> str:
+    if item.field.startswith("rulesets.") and item.field.endswith(".rules"):
+        delta = format_rules_delta(item.expected, item.actual)
+        if delta is not None:
+            indented = "\n".join(f"      {line}" for line in delta.splitlines())
+            return f"    {item.field}:\n{indented}"
+    return f"    {item.field}: expected={item.expected!r}, actual={item.actual!r}"
+
+
 def _print_local_diff(diff: ConfigDiff) -> None:
     """Print local config audit results."""
     if diff.is_compliant():
@@ -92,7 +103,7 @@ def _print_local_diff(diff: ConfigDiff) -> None:
         return
     print(f"  local: NON-COMPLIANT ({len(diff.items)} issues)")
     for item in diff.items:
-        print(f"    {item.field}: expected={item.expected!r}, actual={item.actual!r}")
+        print(_format_item(item))
 
 
 def _print_diff(repo: str, diff: ConfigDiff) -> None:
@@ -102,7 +113,7 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
     else:
         print(f"  {repo}: NON-COMPLIANT ({len(diff.items)} issues)")
         for item in diff.items:
-            print(f"    {item.field}: expected={item.expected!r}, actual={item.actual!r}")
+            print(_format_item(item))
     for field_name in diff.skipped:
         if field_name.startswith("security."):
             print(

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -530,6 +530,77 @@ def fetch_actual_state(repo: str) -> FetchResult:
 
 
 # ---------------------------------------------------------------------------
+# Diff formatting
+# ---------------------------------------------------------------------------
+
+
+def _extract_status_checks(
+    rules: Sequence[object],
+) -> list[dict[str, object]] | None:
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rd = cast("dict[str, object]", rule)
+        if rd.get("type") != "required_status_checks":
+            continue
+        params = rd.get("parameters")
+        if not isinstance(params, dict):
+            continue
+        pd = cast("dict[str, object]", params)
+        checks = pd.get("required_status_checks")
+        if isinstance(checks, list):
+            return cast("list[dict[str, object]]", checks)
+    return None
+
+
+def _format_check(check: dict[str, object]) -> str:
+    ctx = check.get("context", "?")
+    iid = check.get("integration_id", "?")
+    return f"{ctx} (integration_id: {iid})"
+
+
+def format_rules_delta(expected: object, actual: object) -> str | None:
+    if not isinstance(expected, list) or not isinstance(actual, list):
+        return None
+    expected_checks = _extract_status_checks(cast("Sequence[object]", expected))
+    actual_checks = _extract_status_checks(cast("Sequence[object]", actual))
+    if expected_checks is None and actual_checks is None:
+        return None
+
+    expected_set = {(c.get("context"), c.get("integration_id")) for c in (expected_checks or [])}
+    actual_set = {(c.get("context"), c.get("integration_id")) for c in (actual_checks or [])}
+
+    extra_keys = actual_set - expected_set
+    missing_keys = expected_set - actual_set
+
+    extra_labels = sorted(
+        _format_check(c)
+        for c in (actual_checks or [])
+        if (c.get("context"), c.get("integration_id")) in extra_keys
+    )
+    missing_labels = sorted(
+        _format_check(c)
+        for c in (expected_checks or [])
+        if (c.get("context"), c.get("integration_id")) in missing_keys
+    )
+
+    lines = [f"extra ({len(extra_labels)}):"]
+    if extra_labels:
+        for label in extra_labels:
+            lines.append(f"  - {label}")
+    else:
+        lines.append("  none")
+    lines.append(f"missing ({len(missing_labels)}):")
+    if missing_labels:
+        for label in missing_labels:
+            lines.append(f"  - {label}")
+    else:
+        lines.append("  none")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Diff computation
 # ---------------------------------------------------------------------------
 

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -36,6 +36,7 @@ from vergil_tooling.lib.github_config import (
     desired_security_settings,
     desired_tag_protection_ruleset,
     fetch_actual_state,
+    format_rules_delta,
 )
 
 
@@ -1452,3 +1453,133 @@ def test_fetch_actual_state_defaults_owner_type_to_user() -> None:
         result = fetch_actual_state("o/r")
 
     assert result.owner_type == "User"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1210: format_rules_delta — human-readable status check diffs
+# ---------------------------------------------------------------------------
+
+
+def _make_rules(checks: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Build a minimal rules list containing required_status_checks."""
+    return [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": checks,
+            },
+        },
+    ]
+
+
+def test_format_rules_delta_shows_extra_checks() -> None:
+    expected = _make_rules(
+        [
+            {"context": "quality / common", "integration_id": 15368},
+        ]
+    )
+    actual = _make_rules(
+        [
+            {"context": "quality / common", "integration_id": 15368},
+            {"context": "CodeQL", "integration_id": 57789},
+        ]
+    )
+    result = format_rules_delta(expected, actual)
+    assert result is not None
+    assert "extra (1)" in result
+    assert "CodeQL (integration_id: 57789)" in result
+    assert "missing (0)" in result
+
+
+def test_format_rules_delta_shows_missing_checks() -> None:
+    expected = _make_rules(
+        [
+            {"context": "quality / common", "integration_id": 15368},
+            {"context": "security / trivy", "integration_id": 15368},
+        ]
+    )
+    actual = _make_rules(
+        [
+            {"context": "quality / common", "integration_id": 15368},
+        ]
+    )
+    result = format_rules_delta(expected, actual)
+    assert result is not None
+    assert "missing (1)" in result
+    assert "security / trivy (integration_id: 15368)" in result
+    assert "extra (0)" in result
+
+
+def test_format_rules_delta_shows_both_extra_and_missing() -> None:
+    expected = _make_rules(
+        [
+            {"context": "quality / common", "integration_id": 15368},
+            {"context": "security / trivy", "integration_id": 15368},
+        ]
+    )
+    actual = _make_rules(
+        [
+            {"context": "quality / common", "integration_id": 15368},
+            {"context": "CodeQL", "integration_id": 57789},
+        ]
+    )
+    result = format_rules_delta(expected, actual)
+    assert result is not None
+    assert "extra (1)" in result
+    assert "CodeQL (integration_id: 57789)" in result
+    assert "missing (1)" in result
+    assert "security / trivy (integration_id: 15368)" in result
+
+
+def test_format_rules_delta_returns_none_for_non_list() -> None:
+    assert format_rules_delta("foo", "bar") is None
+
+
+def test_format_rules_delta_returns_none_without_status_checks() -> None:
+    expected = [{"type": "deletion"}]
+    actual = [{"type": "deletion"}, {"type": "non_fast_forward"}]
+    assert format_rules_delta(expected, actual) is None
+
+
+def test_format_rules_delta_skips_non_dict_rules() -> None:
+    expected: list[object] = ["not-a-dict", *_make_rules([{"context": "a", "integration_id": 1}])]
+    actual = _make_rules([{"context": "a", "integration_id": 1}])
+    result = format_rules_delta(expected, actual)
+    assert result is not None
+    assert "extra (0)" in result
+    assert "missing (0)" in result
+
+
+def test_format_rules_delta_skips_non_list_checks() -> None:
+    expected: list[dict[str, object]] = [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": "not-a-list",
+            },
+        },
+    ]
+    actual = _make_rules([{"context": "a", "integration_id": 1}])
+    result = format_rules_delta(expected, actual)
+    assert result is not None
+    assert "missing (0)" in result
+
+
+def test_format_rules_delta_skips_non_dict_params() -> None:
+    expected: list[dict[str, object]] = [
+        {"type": "required_status_checks", "parameters": "not-a-dict"},
+    ]
+    actual = _make_rules([{"context": "a", "integration_id": 1}])
+    result = format_rules_delta(expected, actual)
+    assert result is not None
+    assert "missing (0)" in result
+
+
+def test_format_rules_delta_identical_checks() -> None:
+    checks: list[dict[str, object]] = [{"context": "quality / common", "integration_id": 15368}]
+    result = format_rules_delta(_make_rules(checks), _make_rules(checks))
+    assert result is not None
+    assert "extra (0)" in result
+    assert "missing (0)" in result

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -490,6 +490,153 @@ def test_audit_runs_local_when_repo_matches_cwd() -> None:
     assert result == 0
 
 
+# -- Issue #1210: delta output for status check mismatches -------------------
+
+
+def test_print_diff_shows_delta_for_rules_mismatch(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    expected_rules: list[dict[str, object]] = [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": [
+                    {"context": "quality / common", "integration_id": 15368},
+                ],
+            },
+        },
+    ]
+    actual_rules: list[dict[str, object]] = [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": [
+                    {"context": "quality / common", "integration_id": 15368},
+                    {"context": "CodeQL", "integration_id": 57789},
+                ],
+            },
+        },
+    ]
+    diff = ConfigDiff(
+        items=[
+            DiffItem(
+                field="rulesets.CI gates.rules",
+                expected=expected_rules,
+                actual=actual_rules,
+            )
+        ]
+    )
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
+        patch(f"{_MODULE}._audit_repo", return_value=diff),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(f"{_MODULE}._fetch_remote_config"),
+    ):
+        main(["audit", "--repo", "o/r"])
+    output = capsys.readouterr().out
+    assert "extra (1)" in output
+    assert "CodeQL (integration_id: 57789)" in output
+    assert "missing (0)" in output
+
+
+def test_print_local_diff_shows_delta_for_rules_mismatch(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from vergil_tooling.bin.vrg_github_repo_config import _print_local_diff
+
+    expected_rules: list[dict[str, object]] = [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": [
+                    {"context": "quality / common", "integration_id": 15368},
+                    {"context": "security / trivy", "integration_id": 15368},
+                ],
+            },
+        },
+    ]
+    actual_rules: list[dict[str, object]] = [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": [
+                    {"context": "quality / common", "integration_id": 15368},
+                ],
+            },
+        },
+    ]
+    diff = ConfigDiff(
+        items=[
+            DiffItem(
+                field="rulesets.CI gates.rules",
+                expected=expected_rules,
+                actual=actual_rules,
+            )
+        ]
+    )
+    _print_local_diff(diff)
+    output = capsys.readouterr().out
+    assert "missing (1)" in output
+    assert "security / trivy (integration_id: 15368)" in output
+    assert "extra (0)" in output
+
+
+def test_print_diff_falls_back_for_rules_without_status_checks(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    expected_rules: list[dict[str, object]] = [{"type": "deletion"}]
+    actual_rules: list[dict[str, object]] = [
+        {"type": "deletion"},
+        {"type": "non_fast_forward"},
+    ]
+    diff = ConfigDiff(
+        items=[
+            DiffItem(
+                field="rulesets.Branch protection.rules",
+                expected=expected_rules,
+                actual=actual_rules,
+            )
+        ]
+    )
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
+        patch(f"{_MODULE}._audit_repo", return_value=diff),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(f"{_MODULE}._fetch_remote_config"),
+    ):
+        main(["audit", "--repo", "o/r"])
+    output = capsys.readouterr().out
+    assert "expected=" in output
+    assert "actual=" in output
+
+
+def test_print_diff_falls_back_for_non_rules_field(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    diff = ConfigDiff(
+        items=[DiffItem(field="repo_settings.allow_auto_merge", expected=False, actual=True)]
+    )
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
+        patch(f"{_MODULE}._audit_repo", return_value=diff),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(f"{_MODULE}._fetch_remote_config"),
+    ):
+        main(["audit", "--repo", "o/r"])
+    output = capsys.readouterr().out
+    assert "expected=False, actual=True" in output
+
+
+# -- Local check skip on --repo mismatch --------------------------------------
+
+
 def test_audit_skips_local_when_cwd_origin_unavailable() -> None:
     import subprocess
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace full-list dumps with extra/missing delta when reporting required_status_checks mismatches in vrg-github-repo-config audit

## Issue Linkage

- Ref #1210

## Notes

- Adds format_rules_delta() to github_config.py which extracts and compares the required_status_checks lists, reporting only the delta. The _print_diff and _print_local_diff functions now use this for any rulesets.*.rules mismatch.