### PR TITLE
fix(vrg-vm): treat --tag as temporary override, not persistent

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -347,7 +347,11 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
     Uses *tag* if given, otherwise reads the tag from the marker file
     written by ``install_tooling``.  Falls back to *fallback_tag* when
     no marker exists (pre-existing VMs created before marker support).
+
+    An explicit *tag* is treated as a temporary override and is not
+    persisted to the marker file.
     """
+    explicit = tag is not None
     if tag is None:
         result = shell_run(instance, "bash", "-c", f"cat {_TOOLING_TAG_FILE} 2>/dev/null || true")
         tag = result.stdout.strip() or fallback_tag
@@ -362,7 +366,8 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
         "-c",
         f'export PATH="$HOME/.local/bin:$PATH" && uv tool install --reinstall "{install_spec}"',
     )
-    shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
+    if not explicit:
+        shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
 
 def vm_age_days(instance: str) -> float | None:

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -661,8 +661,32 @@ class TestUpdateTooling:
 
     @patch("vergil_tooling.lib.lima.shell_pipe")
     @patch("vergil_tooling.lib.lima.shell_run")
-    def test_writes_tag_marker(self, _mock_run: MagicMock, mock_pipe: MagicMock) -> None:
+    def test_explicit_tag_does_not_persist_marker(
+        self, _mock_run: MagicMock, mock_pipe: MagicMock
+    ) -> None:
         update_tooling("vergil-agent", "v2.1")
+        mock_pipe.assert_not_called()
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_resolved_tag_persists_marker(self, mock_run: MagicMock, mock_pipe: MagicMock) -> None:
+        mock_run.side_effect = [
+            subprocess.CompletedProcess([], 0, stdout="v2.1\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        update_tooling("vergil-agent")
+        mock_pipe.assert_called_once()
+        assert "tooling-tag" in mock_pipe.call_args[0][1]
+        assert "v2.1" in mock_pipe.call_args[0][2]
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_fallback_tag_persists_marker(self, mock_run: MagicMock, mock_pipe: MagicMock) -> None:
+        mock_run.side_effect = [
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        update_tooling("vergil-agent", fallback_tag="v2.1")
         mock_pipe.assert_called_once()
         assert "tooling-tag" in mock_pipe.call_args[0][1]
         assert "v2.1" in mock_pipe.call_args[0][2]


### PR DESCRIPTION
# Pull Request

## Summary

- Make vrg-vm update --tag a one-time override that does not persist to the marker file

## Issue Linkage

- Ref #1221

## Notes

- An explicit --tag argument to vrg-vm update now installs the specified version without writing it to the marker file. The next bare vrg-vm update returns to the configured version from create time instead of silently sticking to the override.