### PR TITLE
fix(container-cache): rename _ST_GIT_URL to _VRG_GIT_URL

### DIFF
--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 _SELF_PROJECT_NAME = "vergil-tooling"
 
-_ST_GIT_URL = "https://github.com/vergil-project/vergil-tooling"
+_VRG_GIT_URL = "https://github.com/vergil-project/vergil-tooling"
 
 _CACHE_FILES: dict[str, list[str]] = {
     "python": ["uv.lock", "vergil.toml"],
@@ -120,7 +120,7 @@ def _build_cached_image(
         setup = warmup or "true"
     else:
         tag = vrg_install_tag(repo_root)
-        uv_install = f"uv tool install --quiet 'vergil-tooling @ git+{_ST_GIT_URL}@{tag}'"
+        uv_install = f"uv tool install --quiet 'vergil-tooling @ git+{_VRG_GIT_URL}@{tag}'"
         setup = f"{uv_install} && {warmup}" if warmup else uv_install
 
     print(f"Building cached image: {target_tag}")


### PR DESCRIPTION
# Pull Request

## Summary

- Rename the last ST_-prefixed identifier in production code to VRG_ for consistency with the completed standard-tooling to vergil-tooling rename

## Issue Linkage

- Ref #1169

## Notes

- All ST_ environment variables were already migrated. This catches the private constant in container_cache.py that was missed. Historical docs referencing ST_ are left as-is since they document the migration itself.