### PR TITLE
feat(vm): forward terminal env vars in vrg-vm session

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -40,6 +40,8 @@ _default_config_path = default_config_path
 
 _DEFAULT_STALENESS_DAYS = 3
 
+_TERMINAL_ENV_VARS = "COLORTERM,TERM_PROGRAM,TERM_PROGRAM_VERSION"
+
 
 def _resolve(args: argparse.Namespace) -> tuple[str, Identity, IdentityConfig]:
     config_path = args.config if args.config else _default_config_path()
@@ -319,7 +321,17 @@ def _cmd_session(args: argparse.Namespace) -> int:
         workspace = resolve_workspace(args.workspace, identity.projects_dir)
 
     workdir = workspace if workspace else identity.projects_dir
-    cmd = ["limactl", "shell", "--start", f"--workdir={workdir}", identity.vm_instance]
+
+    os.environ["LIMA_SHELLENV_ALLOW"] = _TERMINAL_ENV_VARS
+
+    cmd = [
+        "limactl",
+        "shell",
+        "--start",
+        "--preserve-env",
+        f"--workdir={workdir}",
+        identity.vm_instance,
+    ]
 
     if workspace:
         source = ". ~/.config/vergil/claude.env 2>/dev/null;"

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import textwrap
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -687,7 +688,25 @@ class TestSession:
         assert args[0] == "limactl"
         assert "vergil-agent" in args[1]
         assert "--start" in args[1]
+        assert "--preserve-env" in args[1]
         assert "--workdir=/home/user/projects" in args[1]
+
+    @patch("vergil_tooling.bin.vrg_vm.os.execvp")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    def test_session_sets_terminal_env_forwarding(
+        self,
+        _age: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        _exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(["session", "--config", str(config_file)])
+        allow = os.environ.get("LIMA_SHELLENV_ALLOW", "")
+        for var in ("COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION"):
+            assert var in allow
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")


### PR DESCRIPTION
# Pull Request

## Summary

- Forward COLORTERM, TERM_PROGRAM, and TERM_PROGRAM_VERSION into Lima VMs so Claude Code can detect kitty keyboard protocol support

## Issue Linkage

- Ref #1239

## Notes

- Sets LIMA_SHELLENV_ALLOW and adds --preserve-env to the limactl shell invocation in _cmd_session(). Server-side AcceptEnv landed in vergil-vm PR #46; this is the client-side counterpart.