### PR TITLE
feat(vm): mount ~/.claude/sessions for persistence across rebuilds

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -155,10 +155,13 @@ def create_vm(
 ) -> None:
     claude_projects_path = Path.home() / ".claude" / "projects"
     claude_skills_path = Path.home() / ".claude" / "skills"
+    claude_sessions_path = Path.home() / ".claude" / "sessions"
     claude_projects_path.mkdir(parents=True, exist_ok=True)
     claude_skills_path.mkdir(parents=True, exist_ok=True)
+    claude_sessions_path.mkdir(parents=True, exist_ok=True)
     claude_projects = str(claude_projects_path)
     claude_skills = str(claude_skills_path)
+    claude_sessions = str(claude_sessions_path)
 
     args = [
         "create",
@@ -172,6 +175,9 @@ def create_vm(
         f'--set=.mounts[2].location = "{claude_skills}"',
         f'--set=.mounts[2].mountPoint = "{claude_skills}"',
         "--set=.mounts[2].writable = false",
+        f'--set=.mounts[3].location = "{claude_sessions}"',
+        f'--set=.mounts[3].mountPoint = "{claude_sessions}"',
+        "--set=.mounts[3].writable = true",
     ]
     if cpus is not None:
         args.append(f"--set=.cpus = {cpus}")

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -279,12 +279,16 @@ class TestCreateVm:
         args = mock.call_args[0]
         claude_projects = str(tmp_path / ".claude" / "projects")
         claude_skills = str(tmp_path / ".claude" / "skills")
+        claude_sessions = str(tmp_path / ".claude" / "sessions")
         assert f'--set=.mounts[1].location = "{claude_projects}"' in args
         assert f'--set=.mounts[1].mountPoint = "{claude_projects}"' in args
         assert "--set=.mounts[1].writable = true" in args
         assert f'--set=.mounts[2].location = "{claude_skills}"' in args
         assert f'--set=.mounts[2].mountPoint = "{claude_skills}"' in args
         assert "--set=.mounts[2].writable = false" in args
+        assert f'--set=.mounts[3].location = "{claude_sessions}"' in args
+        assert f'--set=.mounts[3].mountPoint = "{claude_sessions}"' in args
+        assert "--set=.mounts[3].writable = true" in args
 
     @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
@@ -296,6 +300,7 @@ class TestCreateVm:
         create_vm("vergil-agent", tpl, "/home/user/projects")
         assert (tmp_path / ".claude" / "projects").is_dir()
         assert (tmp_path / ".claude" / "skills").is_dir()
+        assert (tmp_path / ".claude" / "sessions").is_dir()
 
     @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")


### PR DESCRIPTION
# Pull Request

## Summary

- Add a writable Lima mount for ~/.claude/sessions so Claude Code sessions survive VM rebuilds

## Issue Linkage

- Ref #1244

## Notes

- Adds a fourth mount (index 3) in create_vm() for ~/.claude/sessions, writable, at the same host path. This mirrors the existing pattern for projects (mount 1) and skills (mount 2). Existing VMs need a rebuild to pick up the new mount.