### PR TITLE
fix(trivy): call trivy directly instead of wrapping in docker run

### DIFF
--- a/src/vergil_tooling/bin/vrg_trivy_scan.py
+++ b/src/vergil_tooling/bin/vrg_trivy_scan.py
@@ -53,7 +53,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    scan_result = run_scan(args.scan_type, args.target, args.output_dir)
+    scan_result = run_scan(
+        args.scan_type,
+        args.target,
+        args.output_dir,
+        severity=args.severity,
+        trivyignore=str(args.trivyignore) if args.trivyignore else None,
+    )
 
     if scan_result.returncode > 1:
         emit_error(f"trivy scan failed with exit code {scan_result.returncode}")

--- a/src/vergil_tooling/lib/trivy.py
+++ b/src/vergil_tooling/lib/trivy.py
@@ -1,4 +1,4 @@
-"""Trivy scan orchestration: Docker argument construction and scan execution."""
+"""Trivy scan orchestration: direct subprocess invocation."""
 
 from __future__ import annotations
 
@@ -17,44 +17,6 @@ class ScanResult:
     table_path: str
 
 
-def build_docker_args(
-    scan_type: str,
-    target: str,
-    output_dir: str,
-    *,
-    trivyignore: str | None = None,
-    severity: str = "MEDIUM,HIGH,CRITICAL",
-) -> list[str]:
-    """Construct the docker run argument list for a Trivy scan."""
-    args = [
-        "docker",
-        "run",
-        "--rm",
-        "-v",
-        f"{output_dir}:/output",
-    ]
-
-    if scan_type == "filesystem":
-        args.extend(["-v", f"{target}:/scan:ro"])
-
-    if scan_type == "image":
-        args.extend(["-v", "/var/run/docker.sock:/var/run/docker.sock"])
-
-    if trivyignore:
-        args.extend(["-v", f"{trivyignore}:/trivyignore:ro"])
-        args.extend(["-e", "TRIVY_IGNOREFILE=/trivyignore"])
-
-    args.extend(
-        [
-            "aquasec/trivy:latest",
-            "--severity",
-            severity,
-        ]
-    )
-
-    return args
-
-
 def _run_trivy_command(args: list[str]) -> subprocess.CompletedProcess[bytes]:
     return subprocess.run(args, capture_output=True)  # noqa: S603
 
@@ -63,11 +25,14 @@ def run_scan(
     scan_type: str,
     target: str,
     output_dir: Path,
+    *,
+    severity: str = "MEDIUM,HIGH,CRITICAL",
+    trivyignore: str | None = None,
 ) -> ScanResult:
     """Execute the scan-once-convert-twice workflow.
 
     1. Trivy scan to JSON
-    2. Convert to table (stdout)
+    2. Convert to table (file)
     3. Convert to SARIF (file)
     """
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -75,19 +40,20 @@ def run_scan(
     table_path = str(output_dir / "trivy-results.table")
     sarif_path = str(output_dir / "trivy-results.sarif")
 
-    base_args = build_docker_args(scan_type, target, str(output_dir))
-
-    scan_target = "/scan" if scan_type == "filesystem" else target
-    json_output = "/output/trivy-results.json"
     scan_cmd = [
-        *base_args,
+        "trivy",
         scan_type,
+        "--severity",
+        severity,
         "--format",
         "json",
         "--output",
-        json_output,
-        scan_target,
+        json_path,
     ]
+    if trivyignore:
+        scan_cmd.extend(["--ignorefile", trivyignore])
+    scan_cmd.append(target)
+
     scan_result = _run_trivy_command(scan_cmd)
 
     if scan_result.returncode > 1:
@@ -98,23 +64,23 @@ def run_scan(
         )
 
     table_cmd = [
-        *base_args,
+        "trivy",
         "convert",
         "--format",
         "table",
         "--output",
-        "/output/trivy-results.table",
+        table_path,
         json_path,
     ]
     _run_trivy_command(table_cmd)
 
     sarif_cmd = [
-        *base_args,
+        "trivy",
         "convert",
         "--format",
         "sarif",
         "--output",
-        "/output/trivy-results.sarif",
+        sarif_path,
         json_path,
     ]
     _run_trivy_command(sarif_cmd)
@@ -126,28 +92,17 @@ def run_scan(
     )
 
 
-def build_sbom_args(target: str, output_path: str) -> list[str]:
-    """Construct docker run arguments for CycloneDX SBOM generation."""
-    return [
-        "docker",
-        "run",
-        "--rm",
-        "-v",
-        f"{target}:/scan:ro",
-        "aquasec/trivy:latest",
+def generate_sbom(target: str, output_path: Path) -> int:
+    """Generate a CycloneDX SBOM."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    args = [
+        "trivy",
         "filesystem",
         "--format",
         "cyclonedx",
         "--output",
-        f"/output/{output_path}",
-        "/scan",
+        str(output_path),
+        target,
     ]
-
-
-def generate_sbom(target: str, output_path: Path) -> int:
-    """Generate a CycloneDX SBOM via Docker."""
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    args = build_sbom_args(target, output_path.name)
-    args[5] = f"{output_path.parent}:/output"
     result = _run_trivy_command(args)
     return result.returncode

--- a/tests/vergil_tooling/test_trivy.py
+++ b/tests/vergil_tooling/test_trivy.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 
 from vergil_tooling.lib.trivy import (
     _run_trivy_command,
-    build_docker_args,
-    build_sbom_args,
     generate_sbom,
     run_scan,
 )
@@ -17,56 +15,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _MOD = "vergil_tooling.lib.trivy"
-
-
-class TestBuildDockerArgs:
-    def test_filesystem_scan(self) -> None:
-        args = build_docker_args("filesystem", "/project", "/out")
-        assert "-v" in args
-        assert "/project:/scan:ro" in args
-        assert "aquasec/trivy:latest" in args
-
-    def test_image_scan(self) -> None:
-        args = build_docker_args("image", "myimage:latest", "/out")
-        assert "/var/run/docker.sock:/var/run/docker.sock" in args
-        assert "/project:/scan:ro" not in list(args)
-
-    def test_trivyignore(self) -> None:
-        args = build_docker_args(
-            "filesystem",
-            "/project",
-            "/out",
-            trivyignore="/path/.trivyignore",
-        )
-        assert "/path/.trivyignore:/trivyignore:ro" in args
-        assert "TRIVY_IGNOREFILE=/trivyignore" in args
-
-    def test_custom_severity(self) -> None:
-        args = build_docker_args(
-            "filesystem",
-            "/project",
-            "/out",
-            severity="HIGH,CRITICAL",
-        )
-        idx = args.index("--severity")
-        assert args[idx + 1] == "HIGH,CRITICAL"
-
-    def test_default_severity(self) -> None:
-        args = build_docker_args("filesystem", "/project", "/out")
-        idx = args.index("--severity")
-        assert args[idx + 1] == "MEDIUM,HIGH,CRITICAL"
-
-    def test_output_volume(self) -> None:
-        args = build_docker_args("filesystem", "/project", "/out")
-        assert "/out:/output" in args
-
-
-class TestBuildSbomArgs:
-    def test_structure(self) -> None:
-        args = build_sbom_args("/project", "sbom.json")
-        assert "aquasec/trivy:latest" in args
-        assert "cyclonedx" in args
-        assert "/project:/scan:ro" in args
 
 
 class TestRunScan:
@@ -94,13 +42,15 @@ class TestRunScan:
 
         assert out.is_dir()
 
-    def test_filesystem_uses_scan_target(self, tmp_path: Path) -> None:
+    def test_filesystem_uses_target_directly(self, tmp_path: Path) -> None:
         with patch(f"{_MOD}._run_trivy_command") as mock_run:
             mock_run.return_value.returncode = 0
             run_scan("filesystem", "/project", tmp_path)
 
         scan_cmd = mock_run.call_args_list[0][0][0]
-        assert scan_cmd[-1] == "/scan"
+        assert scan_cmd[-1] == "/project"
+        assert scan_cmd[0] == "trivy"
+        assert scan_cmd[1] == "filesystem"
 
     def test_image_uses_target_name(self, tmp_path: Path) -> None:
         with patch(f"{_MOD}._run_trivy_command") as mock_run:
@@ -109,6 +59,7 @@ class TestRunScan:
 
         scan_cmd = mock_run.call_args_list[0][0][0]
         assert scan_cmd[-1] == "myimage:latest"
+        assert scan_cmd[1] == "image"
 
     def test_result_paths(self, tmp_path: Path) -> None:
         with patch(f"{_MOD}._run_trivy_command") as mock_run:
@@ -117,6 +68,80 @@ class TestRunScan:
 
         assert result.sarif_path == str(tmp_path / "trivy-results.sarif")
         assert result.table_path == str(tmp_path / "trivy-results.table")
+
+    def test_default_severity(self, tmp_path: Path) -> None:
+        with patch(f"{_MOD}._run_trivy_command") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan("filesystem", "/project", tmp_path)
+
+        scan_cmd = mock_run.call_args_list[0][0][0]
+        idx = scan_cmd.index("--severity")
+        assert scan_cmd[idx + 1] == "MEDIUM,HIGH,CRITICAL"
+
+    def test_custom_severity(self, tmp_path: Path) -> None:
+        with patch(f"{_MOD}._run_trivy_command") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan(
+                "filesystem",
+                "/project",
+                tmp_path,
+                severity="HIGH,CRITICAL",
+            )
+
+        scan_cmd = mock_run.call_args_list[0][0][0]
+        idx = scan_cmd.index("--severity")
+        assert scan_cmd[idx + 1] == "HIGH,CRITICAL"
+
+    def test_trivyignore(self, tmp_path: Path) -> None:
+        with patch(f"{_MOD}._run_trivy_command") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan(
+                "filesystem",
+                "/project",
+                tmp_path,
+                trivyignore="/path/.trivyignore",
+            )
+
+        scan_cmd = mock_run.call_args_list[0][0][0]
+        idx = scan_cmd.index("--ignorefile")
+        assert scan_cmd[idx + 1] == "/path/.trivyignore"
+
+    def test_no_docker_in_commands(self, tmp_path: Path) -> None:
+        with patch(f"{_MOD}._run_trivy_command") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan("filesystem", "/project", tmp_path)
+
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            assert cmd[0] == "trivy"
+            assert "docker" not in cmd
+
+    def test_convert_commands_use_host_paths(self, tmp_path: Path) -> None:
+        with patch(f"{_MOD}._run_trivy_command") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan("filesystem", "/project", tmp_path)
+
+        table_cmd = mock_run.call_args_list[1][0][0]
+        assert table_cmd == [
+            "trivy",
+            "convert",
+            "--format",
+            "table",
+            "--output",
+            str(tmp_path / "trivy-results.table"),
+            str(tmp_path / "trivy-results.json"),
+        ]
+
+        sarif_cmd = mock_run.call_args_list[2][0][0]
+        assert sarif_cmd == [
+            "trivy",
+            "convert",
+            "--format",
+            "sarif",
+            "--output",
+            str(tmp_path / "trivy-results.sarif"),
+            str(tmp_path / "trivy-results.json"),
+        ]
 
 
 class TestRunTrivyCommand:
@@ -130,14 +155,24 @@ class TestRunTrivyCommand:
 
 
 class TestGenerateSbom:
-    def test_calls_docker(self, tmp_path: Path) -> None:
+    def test_calls_trivy_directly(self, tmp_path: Path) -> None:
         output = tmp_path / "sbom.json"
         with patch(f"{_MOD}._run_trivy_command") as mock_run:
             mock_run.return_value.returncode = 0
             rc = generate_sbom("/project", output)
 
         assert rc == 0
-        mock_run.assert_called_once()
+        mock_run.assert_called_once_with(
+            [
+                "trivy",
+                "filesystem",
+                "--format",
+                "cyclonedx",
+                "--output",
+                str(output),
+                "/project",
+            ]
+        )
 
     def test_creates_parent_dir(self, tmp_path: Path) -> None:
         output = tmp_path / "sub" / "sbom.json"

--- a/tests/vergil_tooling/test_vrg_trivy_scan.py
+++ b/tests/vergil_tooling/test_vrg_trivy_scan.py
@@ -203,3 +203,68 @@ def test_outputs_finding_count(tmp_path: Path) -> None:
         )
     calls = {c[0][0]: c[0][1] for c in mock_out.call_args_list}
     assert calls["finding_count"] == "1"
+
+
+def test_forwards_severity(tmp_path: Path) -> None:
+    result = _make_scan_result(tmp_path, _CLEAN_SARIF)
+    with (
+        patch(f"{_MOD}.run_scan", return_value=result) as mock_scan,
+        patch(f"{_MOD}.write_output"),
+    ):
+        main(
+            [
+                "--type",
+                "filesystem",
+                "--target",
+                "/project",
+                "--output-dir",
+                str(tmp_path),
+                "--severity",
+                "HIGH,CRITICAL",
+            ]
+        )
+    _, kwargs = mock_scan.call_args
+    assert kwargs["severity"] == "HIGH,CRITICAL"
+
+
+def test_forwards_trivyignore(tmp_path: Path) -> None:
+    result = _make_scan_result(tmp_path, _CLEAN_SARIF)
+    with (
+        patch(f"{_MOD}.run_scan", return_value=result) as mock_scan,
+        patch(f"{_MOD}.write_output"),
+    ):
+        main(
+            [
+                "--type",
+                "filesystem",
+                "--target",
+                "/project",
+                "--output-dir",
+                str(tmp_path),
+                "--trivyignore",
+                "/path/.trivyignore",
+            ]
+        )
+    _, kwargs = mock_scan.call_args
+    assert kwargs["trivyignore"] == "/path/.trivyignore"
+
+
+def test_default_severity_forwarded(tmp_path: Path) -> None:
+    result = _make_scan_result(tmp_path, _CLEAN_SARIF)
+    with (
+        patch(f"{_MOD}.run_scan", return_value=result) as mock_scan,
+        patch(f"{_MOD}.write_output"),
+    ):
+        main(
+            [
+                "--type",
+                "filesystem",
+                "--target",
+                "/project",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+    _, kwargs = mock_scan.call_args
+    assert kwargs["severity"] == "MEDIUM,HIGH,CRITICAL"
+    assert kwargs["trivyignore"] is None


### PR DESCRIPTION
# Pull Request

## Summary

- Replace Docker-wrapped trivy invocations with direct subprocess calls, removing build_docker_args/build_sbom_args and wiring --severity/--trivyignore CLI flags through to run_scan.

## Issue Linkage

- Ref #1246

## Notes

- Removes all Docker orchestration from trivy.py (volume mounts, container-path remapping, docker run construction). The tool now calls trivy directly via subprocess, matching how other tools like vrg-semgrep-scan assume the binary is available in the environment. Also fixes a latent bug where --severity and --trivyignore CLI args were parsed but never forwarded to run_scan.