### PR TITLE
feat(vrg-vm): add --timeout to start/rebuild and fix mkdir for tooling-tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,13 +13,13 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
     with:
       language: python
       container-tag: "3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
@@ -28,7 +28,7 @@ jobs:
       container-suffix: python
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
@@ -36,7 +36,7 @@ jobs:
       container-suffix: python
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     permissions:
       contents: read
       security-events: write
@@ -48,7 +48,7 @@ jobs:
       container-suffix: python
 
   test:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
@@ -56,7 +56,7 @@ jobs:
       container-suffix: python
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: python
       run-release: ${{ inputs.run-release != 'false' }}

--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   github-config:
-    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@develop
+    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.0
     permissions:
       contents: read
       issues: write

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -125,7 +125,7 @@ def _cmd_start(args: argparse.Namespace) -> int:
             return 1
 
     print(f"Starting VM '{identity.vm_instance}' (identity: {name})...")
-    start_vm(identity.vm_instance)
+    start_vm(identity.vm_instance, timeout=args.timeout)
 
     print("Injecting credentials...")
     inject_credentials(identity.vm_instance, identity)
@@ -257,7 +257,7 @@ def _cmd_rebuild(args: argparse.Namespace) -> int:
         )
 
         print("  Starting VM...")
-        start_vm(identity.vm_instance)
+        start_vm(identity.vm_instance, timeout=args.timeout)
 
         print("  Injecting credentials...")
         inject_credentials(identity.vm_instance, identity)
@@ -370,6 +370,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Start even if the VM exceeds the staleness threshold",
     )
+    p_start.add_argument(
+        "--timeout",
+        default="30m",
+        help="How long to wait for VM to reach running status (default: 30m)",
+    )
 
     p_stop = sub.add_parser("stop", help="Stop VM")
     _add_identity_args(p_stop)
@@ -390,6 +395,11 @@ def main(argv: list[str] | None = None) -> int:
     _add_identity_args(p_rebuild)
     p_rebuild.add_argument(
         "--tag", default="", help="VM template version tag (default: vergil version from config)"
+    )
+    p_rebuild.add_argument(
+        "--timeout",
+        default="30m",
+        help="How long to wait for VM to reach running status (default: 30m)",
     )
 
     p_list = sub.add_parser("list", help="List all identity VMs and their status")

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -189,11 +189,11 @@ def create_vm(
     _limactl(*args)
 
 
-def start_vm(instance: str) -> None:
+def start_vm(instance: str, *, timeout: str = "30m") -> None:
     status = vm_status(instance)
     if status == "Running":
         return
-    _limactl("start", instance)
+    _limactl("start", f"--timeout={timeout}", instance)
 
 
 def stop_vm(instance: str) -> None:
@@ -344,6 +344,7 @@ def install_tooling(instance: str, tag: str) -> None:
         "-c",
         f'export PATH="$HOME/.local/bin:$PATH" && uv tool install "{install_spec}"',
     )
+    shell_run(instance, "bash", "-c", f"mkdir -p $(dirname {_TOOLING_TAG_FILE})")
     shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
 
@@ -373,6 +374,7 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
         f'export PATH="$HOME/.local/bin:$PATH" && uv tool install --reinstall "{install_spec}"',
     )
     if not explicit:
+        shell_run(instance, "bash", "-c", f"mkdir -p $(dirname {_TOOLING_TAG_FILE})")
         shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
 

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -379,9 +379,17 @@ class TestCreateVm:
 class TestStartStopVm:
     @patch("vergil_tooling.lib.lima._limactl")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Stopped")
-    def test_start_calls_limactl(self, _status: MagicMock, mock: MagicMock) -> None:
+    def test_start_calls_limactl_with_default_timeout(
+        self, _status: MagicMock, mock: MagicMock
+    ) -> None:
         start_vm("vergil-agent")
-        mock.assert_called_once_with("start", "vergil-agent")
+        mock.assert_called_once_with("start", "--timeout=30m", "vergil-agent")
+
+    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima.vm_status", return_value="Stopped")
+    def test_start_passes_custom_timeout(self, _status: MagicMock, mock: MagicMock) -> None:
+        start_vm("vergil-agent", timeout="1h")
+        mock.assert_called_once_with("start", "--timeout=1h", "vergil-agent")
 
     @patch("vergil_tooling.lib.lima._limactl")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Running")
@@ -626,11 +634,20 @@ class TestInstallTooling:
     @patch("vergil_tooling.lib.lima.shell_run")
     def test_installs_with_tag(self, mock_run: MagicMock, mock_pipe: MagicMock) -> None:
         install_tooling("vergil-agent", "v2.0")
-        mock_run.assert_called_once()
-        args = mock_run.call_args[0]
-        cmd_str = " ".join(str(a) for a in args)
+        assert mock_run.call_count == 2
+        install_args = mock_run.call_args_list[0][0]
+        cmd_str = " ".join(str(a) for a in install_args)
         assert "uv tool install" in cmd_str
         assert "v2.0" in cmd_str
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_creates_tag_dir_before_write(self, mock_run: MagicMock, mock_pipe: MagicMock) -> None:
+        install_tooling("vergil-agent", "v2.0")
+        assert mock_run.call_count == 2
+        mkdir_args = mock_run.call_args_list[1][0]
+        cmd_str = " ".join(str(a) for a in mkdir_args)
+        assert "mkdir -p" in cmd_str
 
     @patch("vergil_tooling.lib.lima.shell_pipe")
     @patch("vergil_tooling.lib.lima.shell_run")
@@ -657,9 +674,10 @@ class TestUpdateTooling:
         mock_run.side_effect = [
             subprocess.CompletedProcess([], 0, stdout="v2.0\n", stderr=""),
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
         ]
         update_tooling("vergil-agent")
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         cmd_str = " ".join(str(a) for a in mock_run.call_args_list[1][0])
         assert "uv tool install --reinstall" in cmd_str
         assert "v2.0" in cmd_str
@@ -678,6 +696,7 @@ class TestUpdateTooling:
         mock_run.side_effect = [
             subprocess.CompletedProcess([], 0, stdout="v2.1\n", stderr=""),
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
         ]
         update_tooling("vergil-agent")
         mock_pipe.assert_called_once()
@@ -688,6 +707,7 @@ class TestUpdateTooling:
     @patch("vergil_tooling.lib.lima.shell_run")
     def test_fallback_tag_persists_marker(self, mock_run: MagicMock, mock_pipe: MagicMock) -> None:
         mock_run.side_effect = [
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
         ]
@@ -702,12 +722,26 @@ class TestUpdateTooling:
         mock_run.side_effect = [
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
         ]
         update_tooling("vergil-agent", fallback_tag="v2.0")
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         cmd_str = " ".join(str(a) for a in mock_run.call_args_list[1][0])
         assert "uv tool install --reinstall" in cmd_str
         assert "v2.0" in cmd_str
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_creates_tag_dir_before_write(self, mock_run: MagicMock, mock_pipe: MagicMock) -> None:
+        mock_run.side_effect = [
+            subprocess.CompletedProcess([], 0, stdout="v2.0\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        update_tooling("vergil-agent")
+        mkdir_args = mock_run.call_args_list[2][0]
+        cmd_str = " ".join(str(a) for a in mkdir_args)
+        assert "mkdir -p" in cmd_str
 
     @patch("vergil_tooling.lib.lima.shell_run")
     def test_exits_if_no_tag_and_no_fallback(self, mock_run: MagicMock) -> None:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -259,10 +259,30 @@ class TestStart:
     ) -> None:
         result = main(["start", "--config", str(config_file)])
         assert result == 0
-        mock_start.assert_called_once_with("vergil-agent")
+        mock_start.assert_called_once_with("vergil-agent", timeout="30m")
         mock_inject.assert_called_once()
         mock_update.assert_called_once()
         mock_copy.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_custom_timeout(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["start", "--config", str(config_file), "--timeout", "1h"])
+        assert result == 0
+        mock_start.assert_called_once_with("vergil-agent", timeout="1h")
 
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
     def test_start_fails_if_not_created(self, _status: MagicMock, config_file: Path) -> None:
@@ -443,9 +463,38 @@ class TestRebuild:
         assert result == 0
         mock_delete.assert_called_once_with("vergil-agent")
         mock_create.assert_called_once()
-        mock_start.assert_called_once()
+        mock_start.assert_called_once_with("vergil-agent", timeout="30m")
         mock_inject.assert_called_once()
         mock_install.assert_called_once()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.delete_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_rebuild_custom_timeout(
+        self,
+        _status: MagicMock,
+        _delete: MagicMock,
+        mock_fetch: MagicMock,
+        _create: MagicMock,
+        mock_start: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
+        result = main(["rebuild", "--config", str(config_file), "--timeout", "45m"])
+        assert result == 0
+        mock_start.assert_called_once_with("vergil-agent", timeout="45m")
 
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
     def test_rebuild_fails_if_not_created(self, _status: MagicMock, config_file: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add --timeout CLI argument to vrg-vm start and rebuild (default 30m) and ensure ~/.config/vergil/ exists before writing tooling-tag marker file

## Issue Linkage

- Ref #1251

## Notes

- Two changes from issue 1251: (1) limactl start default timeout is too short for fresh VM provisioning — add --timeout flag that passes through to limactl start --timeout, defaulting to 30m; (2) install_tooling() and update_tooling() now run mkdir -p before writing the tooling-tag marker file, fixing the failure when vrg-vm session calls try_update_tooling() without prior inject_credentials().