### PR TITLE
feat(release): add --skip-cd flag to bypass CD verification

### DIFF
--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -37,6 +37,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         help="Skip rolling-tag promotion after release.",
     )
+    parser.add_argument(
+        "--skip-cd",
+        action="store_true",
+        default=False,
+        help="Skip CD workflow verification (confirm-main and confirm-develop phases).",
+    )
     return parser.parse_args(argv)
 
 
@@ -53,6 +59,7 @@ def main(argv: list[str] | None = None) -> int:
             verbose=args.verbose,
         )
         ctx.promote = not args.no_promote
+        ctx.skip_cd = args.skip_cd
         elapsed = time.monotonic() - start
         print(f"=== preflight: done ({_format_elapsed(elapsed)}) ===")
         run_release(ctx)

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -39,6 +39,7 @@ class ReleaseContext:
     develop_cd_run_url: str | None = None
 
     promote: bool = True
+    skip_cd: bool = False
 
 
 class ReleaseError(Exception):

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -97,14 +97,28 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
     return "\n".join(lines)
 
 
+def _confirm_main_phase(ctx: ReleaseContext) -> None:
+    if ctx.skip_cd:
+        print("Skipping CD verification (--skip-cd).")
+        return
+    confirm_main(ctx)
+
+
+def _confirm_develop_phase(ctx: ReleaseContext) -> None:
+    if ctx.skip_cd:
+        print("Skipping develop CD verification (--skip-cd).")
+        return
+    confirm_develop(ctx)
+
+
 def run_release(ctx: ReleaseContext) -> None:
     """Execute the release workflow phase by phase."""
     phases: list[tuple[str, Callable[[ReleaseContext], None]]] = [
         ("prepare", prepare),
         ("merge-release", merge_release),
-        ("confirm-main", confirm_main),
+        ("confirm-main", _confirm_main_phase),
         ("back-merge-bump", back_merge_and_bump),
-        ("confirm-develop", confirm_develop),
+        ("confirm-develop", _confirm_develop_phase),
         ("promote", _promote_phase),
         ("close-finalize", close_and_finalize),
         ("consumer-refresh", consumer_refresh),

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -48,6 +48,26 @@ def test_orchestrator_runs_all_phases() -> None:
     m_handoff.assert_called_once_with(ctx)
 
 
+def test_skip_cd_skips_confirm_phases() -> None:
+    ctx = _ctx()
+    ctx.skip_cd = True
+    with (
+        patch(_MOD + ".prepare") as m_prepare,
+        patch(_MOD + ".merge_release"),
+        patch(_MOD + ".confirm_main") as m_confirm_main,
+        patch(_MOD + ".back_merge_and_bump"),
+        patch(_MOD + ".confirm_develop") as m_confirm_develop,
+        patch(_MOD + "._promote_phase"),
+        patch(_MOD + ".close_and_finalize"),
+        patch(_MOD + ".consumer_refresh"),
+        patch(_MOD + ".comment_phase_complete"),
+    ):
+        run_release(ctx)
+    m_prepare.assert_called_once()
+    m_confirm_main.assert_not_called()
+    m_confirm_develop.assert_not_called()
+
+
 def test_promote_phase_calls_promote_when_enabled() -> None:
     from vergil_tooling.lib.release.orchestrator import _promote_phase
 

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -35,6 +35,17 @@ def test_parse_args_default_promote() -> None:
     assert args.no_promote is False
 
 
+def test_parse_args_skip_cd() -> None:
+    args = parse_args(["--skip-cd"])
+    assert args.skip_cd is True
+    assert args.version_override is None
+
+
+def test_parse_args_default_skip_cd() -> None:
+    args = parse_args([])
+    assert args.skip_cd is False
+
+
 def test_parse_args_no_promote_with_minor() -> None:
     args = parse_args(["--no-promote", "minor"])
     assert args.no_promote is True


### PR DESCRIPTION
# Pull Request

## Summary

- Add --skip-cd flag to vrg-release to bypass CD verification phases

## Issue Linkage

- Ref #1253

## Notes

- Adds a --skip-cd CLI flag to vrg-release that bypasses the confirm-main and confirm-develop CD verification phases. This provides an escape hatch when CD workflows are broken due to circular dependencies (e.g., docs deployment failing until a new vergil-actions version is released, but the release itself blocked by CD verification).

Changes:
- Added skip_cd field to ReleaseContext dataclass
- Added --skip-cd argument to vrg-release CLI parser
- Wrapped confirm_main and confirm_develop in orchestrator with skip_cd guards
- Tests for argument parsing and phase-skipping behavior