### PR TITLE
fix(release): guard promote when --skip-cd skips tag creation

### DIFF
--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING
 
+from vergil_tooling.lib import git
 from vergil_tooling.lib.promote import promote
 from vergil_tooling.lib.release.bump import back_merge_and_bump
 from vergil_tooling.lib.release.confirm import confirm_develop, confirm_main
@@ -53,6 +54,11 @@ def _promote_phase(ctx: ReleaseContext) -> None:
     if not ctx.promote:
         print("Skipping promote (--no-promote).")
         return
+    if ctx.skip_cd:
+        tag = f"v{ctx.version}"
+        if not git.ref_exists(tag):
+            print(f"Skipping promote — tag {tag} not found (CD may not have completed).")
+            return
     promote(ctx.version)
 
 
@@ -70,12 +76,18 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
         if ctx.release_pr_url:
             lines.append(f"Merged: {ctx.release_pr_url}")
     elif phase == "confirm-main":
-        if ctx.tag:
-            lines.append(f"Tag: `{ctx.tag}`")
-        if ctx.release_url:
-            lines.append(f"Release: {ctx.release_url}")
-        if ctx.cd_run_url:
-            lines.append(f"CD workflow: {ctx.cd_run_url}")
+        if ctx.skip_cd:
+            if ctx.tag:
+                lines.append(f"CD skipped. Tag `{ctx.tag}` found.")
+            else:
+                lines.append(f"CD skipped. Tag v{ctx.version} not yet available.")
+        else:
+            if ctx.tag:
+                lines.append(f"Tag: `{ctx.tag}`")
+            if ctx.release_url:
+                lines.append(f"Release: {ctx.release_url}")
+            if ctx.cd_run_url:
+                lines.append(f"CD workflow: {ctx.cd_run_url}")
     elif phase == "back-merge-bump":
         if ctx.bump_pr_url:
             lines.append(f"Back-merge PR: {ctx.bump_pr_url}")
@@ -100,6 +112,13 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
 def _confirm_main_phase(ctx: ReleaseContext) -> None:
     if ctx.skip_cd:
         print("Skipping CD verification (--skip-cd).")
+        git.run("fetch", "--tags", "--force", "origin")
+        tag = f"v{ctx.version}"
+        if git.ref_exists(tag):
+            ctx.tag = tag
+            print(f"  Tag {tag} found.")
+        else:
+            print(f"  Tag {tag} not yet available.")
         return
     confirm_main(ctx)
 

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -54,10 +54,12 @@ def test_skip_cd_skips_confirm_phases() -> None:
     with (
         patch(_MOD + ".prepare") as m_prepare,
         patch(_MOD + ".merge_release"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.ref_exists", return_value=False),
         patch(_MOD + ".confirm_main") as m_confirm_main,
         patch(_MOD + ".back_merge_and_bump"),
         patch(_MOD + ".confirm_develop") as m_confirm_develop,
-        patch(_MOD + "._promote_phase"),
+        patch(_MOD + ".promote"),
         patch(_MOD + ".close_and_finalize"),
         patch(_MOD + ".consumer_refresh"),
         patch(_MOD + ".comment_phase_complete"),
@@ -66,6 +68,59 @@ def test_skip_cd_skips_confirm_phases() -> None:
     m_prepare.assert_called_once()
     m_confirm_main.assert_not_called()
     m_confirm_develop.assert_not_called()
+
+
+def test_skip_cd_confirm_main_fetches_tags() -> None:
+    from vergil_tooling.lib.release.orchestrator import _confirm_main_phase
+
+    ctx = _ctx()
+    ctx.skip_cd = True
+    with (
+        patch(_MOD + ".git.run") as m_run,
+        patch(_MOD + ".git.ref_exists", return_value=True),
+    ):
+        _confirm_main_phase(ctx)
+    m_run.assert_called_once_with("fetch", "--tags", "--force", "origin")
+    assert ctx.tag == "v2.1.0"
+
+
+def test_skip_cd_confirm_main_no_tag() -> None:
+    from vergil_tooling.lib.release.orchestrator import _confirm_main_phase
+
+    ctx = _ctx()
+    ctx.skip_cd = True
+    with (
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.ref_exists", return_value=False),
+    ):
+        _confirm_main_phase(ctx)
+    assert ctx.tag is None
+
+
+def test_promote_skips_when_skip_cd_and_no_tag() -> None:
+    from vergil_tooling.lib.release.orchestrator import _promote_phase
+
+    ctx = _ctx(promote=True)
+    ctx.skip_cd = True
+    with (
+        patch(_MOD + ".git.ref_exists", return_value=False),
+        patch(_MOD + ".promote") as mock_promote,
+    ):
+        _promote_phase(ctx)
+    mock_promote.assert_not_called()
+
+
+def test_promote_runs_when_skip_cd_and_tag_exists() -> None:
+    from vergil_tooling.lib.release.orchestrator import _promote_phase
+
+    ctx = _ctx(promote=True)
+    ctx.skip_cd = True
+    with (
+        patch(_MOD + ".git.ref_exists", return_value=True),
+        patch(_MOD + ".promote") as mock_promote,
+    ):
+        _promote_phase(ctx)
+    mock_promote.assert_called_once_with(ctx.version)
 
 
 def test_promote_phase_calls_promote_when_enabled() -> None:
@@ -125,6 +180,27 @@ def test_phase_details_confirm_main() -> None:
     details = _phase_details(ctx, "confirm-main")
     assert "v2.1.0" in details
     assert "runs/123" in details
+
+
+def test_phase_details_confirm_main_skip_cd_tag_found() -> None:
+    from vergil_tooling.lib.release.orchestrator import _phase_details
+
+    ctx = _ctx()
+    ctx.skip_cd = True
+    ctx.tag = "v2.1.0"
+    details = _phase_details(ctx, "confirm-main")
+    assert "skipped" in details.lower()
+    assert "v2.1.0" in details
+
+
+def test_phase_details_confirm_main_skip_cd_no_tag() -> None:
+    from vergil_tooling.lib.release.orchestrator import _phase_details
+
+    ctx = _ctx()
+    ctx.skip_cd = True
+    details = _phase_details(ctx, "confirm-main")
+    assert "skipped" in details.lower()
+    assert "not yet" in details.lower()
 
 
 def test_phase_details_back_merge_bump() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Fix --skip-cd causing promote to fail on missing release tag

## Issue Linkage

- Ref #1258

## Notes

- When --skip-cd is used, confirm-main is skipped entirely, which means the release tag is never fetched locally. The promote phase then fails trying to resolve the tag. Fix: confirm-main now fetches tags best-effort when --skip-cd is active, and promote checks for tag existence before attempting to update the rolling tag.