### PR TITLE
feat(release): replace --skip-cd with --skip-cd-docs

### DIFF
--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -38,10 +38,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Skip rolling-tag promotion after release.",
     )
     parser.add_argument(
-        "--skip-cd",
+        "--skip-cd-docs",
         action="store_true",
         default=False,
-        help="Skip CD workflow verification (confirm-main and confirm-develop phases).",
+        help="Skip docs job verification in CD workflows (release job still verified).",
     )
     return parser.parse_args(argv)
 
@@ -59,7 +59,7 @@ def main(argv: list[str] | None = None) -> int:
             verbose=args.verbose,
         )
         ctx.promote = not args.no_promote
-        ctx.skip_cd = args.skip_cd
+        ctx.skip_cd_docs = args.skip_cd_docs
         elapsed = time.monotonic() - start
         print(f"=== preflight: done ({_format_elapsed(elapsed)}) ===")
         run_release(ctx)

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -21,8 +21,13 @@ _CD_POLL_ATTEMPTS = 30
 
 def confirm_main(ctx: ReleaseContext) -> None:
     """Watch CD on main and verify publish artifacts."""
-    run_id, run_url = _watch_cd(ctx, branch="main")
-    _verify_jobs(ctx, run_id, _MAIN_EXPECTED_JOBS, phase="confirm-main")
+    skip_docs = ctx.skip_cd_docs
+    run_id, run_url = _watch_cd(ctx, branch="main", check_status=not skip_docs)
+    expected: tuple[str, ...] = _MAIN_EXPECTED_JOBS
+    if skip_docs:
+        expected = tuple(j for j in expected if j != "docs")
+        print("  Skipping docs job verification (--skip-cd-docs).")
+    _verify_jobs(ctx, run_id, expected, phase="confirm-main")
 
     ctx.cd_run_id = run_id
     ctx.cd_run_url = run_url
@@ -33,22 +38,33 @@ def confirm_main(ctx: ReleaseContext) -> None:
 
 def confirm_develop(ctx: ReleaseContext) -> None:
     """Watch CD on develop after back-merge."""
-    run_id, run_url = _watch_cd(ctx, branch="develop")
-    _verify_jobs(ctx, run_id, _DEVELOP_EXPECTED_JOBS, phase="confirm-develop")
+    skip_docs = ctx.skip_cd_docs
+    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=not skip_docs)
+    expected: tuple[str, ...] = _DEVELOP_EXPECTED_JOBS
+    if skip_docs:
+        expected = tuple(j for j in expected if j != "docs")
+        print("  Skipping docs job verification (--skip-cd-docs).")
+    if expected:
+        _verify_jobs(ctx, run_id, expected, phase="confirm-develop")
 
     ctx.develop_cd_run_id = run_id
     ctx.develop_cd_run_url = run_url
     print("Develop CD verified.")
 
 
-def _watch_cd(ctx: ReleaseContext, *, branch: str) -> tuple[str, str]:
+def _watch_cd(
+    ctx: ReleaseContext,
+    *,
+    branch: str,
+    check_status: bool = True,
+) -> tuple[str, str]:
     print(f"Waiting for {_CD_WORKFLOW} on {branch}...")
     git.run("fetch", "origin", branch)
     head_sha = git.read_output("rev-parse", f"origin/{branch}")
 
     run_id = _poll_for_run(ctx.repo, branch, head_sha)
 
-    watch_workflow(ctx.repo, run_id, verbose=ctx.verbose)
+    watch_workflow(ctx.repo, run_id, verbose=ctx.verbose, check_status=check_status)
 
     run_url = github.read_output(
         "run",
@@ -62,7 +78,10 @@ def _watch_cd(ctx: ReleaseContext, *, branch: str) -> tuple[str, str]:
         ".url",
     )
 
-    print(f"  CD workflow succeeded: {run_url}")
+    if check_status:
+        print(f"  CD workflow succeeded: {run_url}")
+    else:
+        print(f"  CD workflow completed: {run_url}")
     return run_id, run_url
 
 

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -39,7 +39,7 @@ class ReleaseContext:
     develop_cd_run_url: str | None = None
 
     promote: bool = True
-    skip_cd: bool = False
+    skip_cd_docs: bool = False
 
 
 class ReleaseError(Exception):

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING
 
-from vergil_tooling.lib import git
 from vergil_tooling.lib.promote import promote
 from vergil_tooling.lib.release.bump import back_merge_and_bump
 from vergil_tooling.lib.release.confirm import confirm_develop, confirm_main
@@ -54,11 +53,6 @@ def _promote_phase(ctx: ReleaseContext) -> None:
     if not ctx.promote:
         print("Skipping promote (--no-promote).")
         return
-    if ctx.skip_cd:
-        tag = f"v{ctx.version}"
-        if not git.ref_exists(tag):
-            print(f"Skipping promote — tag {tag} not found (CD may not have completed).")
-            return
     promote(ctx.version)
 
 
@@ -76,18 +70,12 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
         if ctx.release_pr_url:
             lines.append(f"Merged: {ctx.release_pr_url}")
     elif phase == "confirm-main":
-        if ctx.skip_cd:
-            if ctx.tag:
-                lines.append(f"CD skipped. Tag `{ctx.tag}` found.")
-            else:
-                lines.append(f"CD skipped. Tag v{ctx.version} not yet available.")
-        else:
-            if ctx.tag:
-                lines.append(f"Tag: `{ctx.tag}`")
-            if ctx.release_url:
-                lines.append(f"Release: {ctx.release_url}")
-            if ctx.cd_run_url:
-                lines.append(f"CD workflow: {ctx.cd_run_url}")
+        if ctx.tag:
+            lines.append(f"Tag: `{ctx.tag}`")
+        if ctx.release_url:
+            lines.append(f"Release: {ctx.release_url}")
+        if ctx.cd_run_url:
+            lines.append(f"CD workflow: {ctx.cd_run_url}")
     elif phase == "back-merge-bump":
         if ctx.bump_pr_url:
             lines.append(f"Back-merge PR: {ctx.bump_pr_url}")
@@ -109,35 +97,14 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
     return "\n".join(lines)
 
 
-def _confirm_main_phase(ctx: ReleaseContext) -> None:
-    if ctx.skip_cd:
-        print("Skipping CD verification (--skip-cd).")
-        git.run("fetch", "--tags", "--force", "origin")
-        tag = f"v{ctx.version}"
-        if git.ref_exists(tag):
-            ctx.tag = tag
-            print(f"  Tag {tag} found.")
-        else:
-            print(f"  Tag {tag} not yet available.")
-        return
-    confirm_main(ctx)
-
-
-def _confirm_develop_phase(ctx: ReleaseContext) -> None:
-    if ctx.skip_cd:
-        print("Skipping develop CD verification (--skip-cd).")
-        return
-    confirm_develop(ctx)
-
-
 def run_release(ctx: ReleaseContext) -> None:
     """Execute the release workflow phase by phase."""
     phases: list[tuple[str, Callable[[ReleaseContext], None]]] = [
         ("prepare", prepare),
         ("merge-release", merge_release),
-        ("confirm-main", _confirm_main_phase),
+        ("confirm-main", confirm_main),
         ("back-merge-bump", back_merge_and_bump),
-        ("confirm-develop", _confirm_develop_phase),
+        ("confirm-develop", confirm_develop),
         ("promote", _promote_phase),
         ("close-finalize", close_and_finalize),
         ("consumer-refresh", consumer_refresh),

--- a/src/vergil_tooling/lib/release/subprocess.py
+++ b/src/vergil_tooling/lib/release/subprocess.py
@@ -63,9 +63,16 @@ def wait_for_checks(pr: str, *, verbose: bool) -> None:
     )
 
 
-def watch_workflow(repo: str, run_id: str, *, verbose: bool) -> None:
+def watch_workflow(
+    repo: str,
+    run_id: str,
+    *,
+    verbose: bool,
+    check_status: bool = True,
+) -> None:
     """Block until a workflow run completes. Verbose controls output."""
-    _run_verbose(
-        ("gh", "run", "watch", "--repo", repo, "--exit-status", run_id),  # noqa: S607
-        verbose=verbose,
-    )
+    cmd: tuple[str, ...] = ("gh", "run", "watch", "--repo", repo)
+    if check_status:
+        cmd = (*cmd, "--exit-status")
+    cmd = (*cmd, run_id)
+    _run_verbose(cmd, verbose=verbose)  # noqa: S607

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -236,5 +236,60 @@ def test_confirm_develop_fails_job_not_success() -> None:
         confirm_develop(ctx)
 
 
+def test_confirm_main_skip_cd_docs_skips_docs_job() -> None:
+    ctx = _ctx()
+    ctx.skip_cd_docs = True
+    with (
+        patch(
+            _MOD + ".github.read_output",
+            side_effect=[
+                "12345",
+                "https://github.com/o/r/actions/runs/12345",
+                "success",
+                "https://github.com/o/r/releases/tag/v2.1.0",
+            ],
+        ),
+        patch(_MOD + ".watch_workflow") as m_watch,
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.read_output", return_value=_SHA),
+        patch(_MOD + ".git.ref_exists", return_value=True),
+    ):
+        confirm_main(ctx)
+
+    m_watch.assert_called_once_with(
+        "owner/repo",
+        "12345",
+        verbose=False,
+        check_status=False,
+    )
+    assert ctx.tag == "v2.1.0"
+
+
+def test_confirm_develop_skip_cd_docs_skips_verify() -> None:
+    ctx = _ctx()
+    ctx.skip_cd_docs = True
+    with (
+        patch(
+            _MOD + ".github.read_output",
+            side_effect=[
+                "67890",
+                "https://github.com/o/r/actions/runs/67890",
+            ],
+        ),
+        patch(_MOD + ".watch_workflow") as m_watch,
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.read_output", return_value=_SHA),
+    ):
+        confirm_develop(ctx)
+
+    m_watch.assert_called_once_with(
+        "owner/repo",
+        "67890",
+        verbose=False,
+        check_status=False,
+    )
+    assert ctx.develop_cd_run_id == "67890"
+
+
 def test_poll_attempts_constant() -> None:
     assert _CD_POLL_ATTEMPTS == 30

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -48,81 +48,6 @@ def test_orchestrator_runs_all_phases() -> None:
     m_handoff.assert_called_once_with(ctx)
 
 
-def test_skip_cd_skips_confirm_phases() -> None:
-    ctx = _ctx()
-    ctx.skip_cd = True
-    with (
-        patch(_MOD + ".prepare") as m_prepare,
-        patch(_MOD + ".merge_release"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.ref_exists", return_value=False),
-        patch(_MOD + ".confirm_main") as m_confirm_main,
-        patch(_MOD + ".back_merge_and_bump"),
-        patch(_MOD + ".confirm_develop") as m_confirm_develop,
-        patch(_MOD + ".promote"),
-        patch(_MOD + ".close_and_finalize"),
-        patch(_MOD + ".consumer_refresh"),
-        patch(_MOD + ".comment_phase_complete"),
-    ):
-        run_release(ctx)
-    m_prepare.assert_called_once()
-    m_confirm_main.assert_not_called()
-    m_confirm_develop.assert_not_called()
-
-
-def test_skip_cd_confirm_main_fetches_tags() -> None:
-    from vergil_tooling.lib.release.orchestrator import _confirm_main_phase
-
-    ctx = _ctx()
-    ctx.skip_cd = True
-    with (
-        patch(_MOD + ".git.run") as m_run,
-        patch(_MOD + ".git.ref_exists", return_value=True),
-    ):
-        _confirm_main_phase(ctx)
-    m_run.assert_called_once_with("fetch", "--tags", "--force", "origin")
-    assert ctx.tag == "v2.1.0"
-
-
-def test_skip_cd_confirm_main_no_tag() -> None:
-    from vergil_tooling.lib.release.orchestrator import _confirm_main_phase
-
-    ctx = _ctx()
-    ctx.skip_cd = True
-    with (
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.ref_exists", return_value=False),
-    ):
-        _confirm_main_phase(ctx)
-    assert ctx.tag is None
-
-
-def test_promote_skips_when_skip_cd_and_no_tag() -> None:
-    from vergil_tooling.lib.release.orchestrator import _promote_phase
-
-    ctx = _ctx(promote=True)
-    ctx.skip_cd = True
-    with (
-        patch(_MOD + ".git.ref_exists", return_value=False),
-        patch(_MOD + ".promote") as mock_promote,
-    ):
-        _promote_phase(ctx)
-    mock_promote.assert_not_called()
-
-
-def test_promote_runs_when_skip_cd_and_tag_exists() -> None:
-    from vergil_tooling.lib.release.orchestrator import _promote_phase
-
-    ctx = _ctx(promote=True)
-    ctx.skip_cd = True
-    with (
-        patch(_MOD + ".git.ref_exists", return_value=True),
-        patch(_MOD + ".promote") as mock_promote,
-    ):
-        _promote_phase(ctx)
-    mock_promote.assert_called_once_with(ctx.version)
-
-
 def test_promote_phase_calls_promote_when_enabled() -> None:
     from vergil_tooling.lib.release.orchestrator import _promote_phase
 
@@ -180,27 +105,6 @@ def test_phase_details_confirm_main() -> None:
     details = _phase_details(ctx, "confirm-main")
     assert "v2.1.0" in details
     assert "runs/123" in details
-
-
-def test_phase_details_confirm_main_skip_cd_tag_found() -> None:
-    from vergil_tooling.lib.release.orchestrator import _phase_details
-
-    ctx = _ctx()
-    ctx.skip_cd = True
-    ctx.tag = "v2.1.0"
-    details = _phase_details(ctx, "confirm-main")
-    assert "skipped" in details.lower()
-    assert "v2.1.0" in details
-
-
-def test_phase_details_confirm_main_skip_cd_no_tag() -> None:
-    from vergil_tooling.lib.release.orchestrator import _phase_details
-
-    ctx = _ctx()
-    ctx.skip_cd = True
-    details = _phase_details(ctx, "confirm-main")
-    assert "skipped" in details.lower()
-    assert "not yet" in details.lower()
 
 
 def test_phase_details_back_merge_bump() -> None:

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -189,3 +189,15 @@ class TestWatchWorkflow:
         captured = capsys.readouterr()
         assert captured.out == ""
         assert "error" in captured.err
+
+    def test_check_status_false_omits_exit_status(self) -> None:
+        with patch(_MOD + "._run_with_retry", return_value=_completed()) as m:
+            watch_workflow("owner/repo", "12345", verbose=False, check_status=False)
+        cmd = m.call_args[0][0]
+        assert "--exit-status" not in cmd
+
+    def test_check_status_true_includes_exit_status(self) -> None:
+        with patch(_MOD + "._run_with_retry", return_value=_completed()) as m:
+            watch_workflow("owner/repo", "12345", verbose=False, check_status=True)
+        cmd = m.call_args[0][0]
+        assert "--exit-status" in cmd

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -35,15 +35,15 @@ def test_parse_args_default_promote() -> None:
     assert args.no_promote is False
 
 
-def test_parse_args_skip_cd() -> None:
-    args = parse_args(["--skip-cd"])
-    assert args.skip_cd is True
+def test_parse_args_skip_cd_docs() -> None:
+    args = parse_args(["--skip-cd-docs"])
+    assert args.skip_cd_docs is True
     assert args.version_override is None
 
 
-def test_parse_args_default_skip_cd() -> None:
+def test_parse_args_default_skip_cd_docs() -> None:
     args = parse_args([])
-    assert args.skip_cd is False
+    assert args.skip_cd_docs is False
 
 
 def test_parse_args_no_promote_with_minor() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Replace --skip-cd with --skip-cd-docs to skip only docs job verification

## Issue Linkage

- Ref #1260

## Notes

- The --skip-cd flag (PRs #1254, #1259) was the wrong approach: skipping all CD verification also skipped the release job that creates tags and GitHub releases, causing promote to fail. This PR replaces it with --skip-cd-docs, which skips only docs job verification while still waiting for CD workflows to complete and verifying the release job. Changes: context.py (skip_cd -> skip_cd_docs), vrg_release.py (--skip-cd -> --skip-cd-docs), orchestrator.py (reverted to clean state, no skip wrappers), confirm.py (filter docs from expected jobs when flag set), subprocess.py (check_status param on watch_workflow).