### PR TITLE
fix(release): accept base as a valid language in validate-inputs

### DIFF
--- a/src/vergil_tooling/bin/vrg_release_validate_inputs.py
+++ b/src/vergil_tooling/bin/vrg_release_validate_inputs.py
@@ -13,6 +13,7 @@ from vergil_tooling.lib.languages import ecosystem_metadata, supported_languages
 from vergil_tooling.lib.output import emit_error
 
 _CONTAINER_LANGUAGES = frozenset({"python", "java", "ruby", "rust", "go"})
+_NON_LANGUAGE_TYPES = frozenset({"base"})
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -36,7 +37,12 @@ def main(argv: list[str] | None = None) -> int:
     errors: list[str] = []
     langs = supported_languages()
 
-    if args.language not in langs:
+    if args.language in _NON_LANGUAGE_TYPES:
+        if args.registry_publish:
+            errors.append(f"--registry-publish is not supported for {args.language}")
+        if args.container_tag:
+            errors.append(f"--container-tag is not supported for {args.language}")
+    elif args.language not in langs:
         errors.append(
             f"unsupported language: {args.language} (supported: {', '.join(sorted(langs))})"
         )

--- a/tests/vergil_tooling/test_vrg_release_validate_inputs.py
+++ b/tests/vergil_tooling/test_vrg_release_validate_inputs.py
@@ -61,6 +61,24 @@ def test_container_tag_unsupported_language_fails(capsys: pytest.CaptureFixture[
     assert rc == 1
 
 
+def test_base_language_accepted(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("vergil_tooling.lib.output.is_ci", return_value=False):
+        rc = main(["base"])
+    assert rc == 0
+
+
+def test_base_rejects_registry_publish(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("vergil_tooling.lib.output.is_ci", return_value=False):
+        rc = main(["base", "--registry-publish"])
+    assert rc == 1
+
+
+def test_base_rejects_container_tag(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("vergil_tooling.lib.output.is_ci", return_value=False):
+        rc = main(["base", "--container-tag", "v1.0.0"])
+    assert rc == 1
+
+
 def test_no_args_fails() -> None:
     import pytest
 


### PR DESCRIPTION
# Pull Request

## Summary

- Accept base as a valid non-language project type in vrg-release-validate-inputs, unblocking CD releases for repos like vergil-claude-plugin that do not override the language input. Skips ecosystem-specific validation for non-language types while rejecting incompatible flags (--registry-publish, --container-tag). Adds three tests covering acceptance and both rejection cases.

## Issue Linkage

- Ref #1266

## Notes

- -