### PR TITLE
feat(commit): add --allow-empty flag to vrg-commit

### DIFF
--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -73,6 +73,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--scope", required=True, help="Conventional commit scope")
     parser.add_argument("--message", required=True, help="Commit description")
     parser.add_argument("--body", default="", help="Detailed commit body")
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        default=False,
+        help="Allow a commit with no staged changes (e.g. to re-trigger CI)",
+    )
     return parser.parse_args(argv)
 
 
@@ -186,7 +192,7 @@ def main(argv: list[str] | None = None) -> int:
 
     co_author = os.environ.get("VRG_CO_AUTHOR")
 
-    if not git.has_staged_changes():
+    if not args.allow_empty and not git.has_staged_changes():
         print(
             "ERROR: no staged changes. Stage files with 'git add' before committing.",
             file=sys.stderr,
@@ -204,7 +210,10 @@ def main(argv: list[str] | None = None) -> int:
         tmp_path = f.name
 
     try:
-        git.run("commit", "--file", tmp_path)
+        commit_args = ["commit", "--file", tmp_path]
+        if args.allow_empty:
+            commit_args.append("--allow-empty")
+        git.run(*commit_args)
     finally:
         Path(tmp_path).unlink(missing_ok=True)
 

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -75,6 +75,14 @@ def test_parse_args_required() -> None:
     assert args.scope == "core"
     assert args.message == "add thing"
     assert args.body == ""
+    assert args.allow_empty is False
+
+
+def test_parse_args_allow_empty() -> None:
+    args = parse_args(
+        ["--type", "chore", "--scope", "ci", "--message", "trigger rebuild", "--allow-empty"]
+    )
+    assert args.allow_empty is True
 
 
 def test_parse_args_with_scope_and_body() -> None:
@@ -109,6 +117,24 @@ def test_main_no_staged_changes(tmp_path: Path) -> None:
     with _commit_environment(tmp_path, has_staged=False):
         result = main(["--type", "feat", "--scope", "core", "--message", "test"])
     assert result == 1
+
+
+def test_main_allow_empty_skips_staged_check(tmp_path: Path) -> None:
+    git_args: list[tuple[str, ...]] = []
+
+    def capture_run(*args: str) -> None:
+        git_args.append(args)
+
+    with (
+        _commit_environment(tmp_path, has_staged=False),
+        patch("vergil_tooling.bin.vrg_commit.git.run", side_effect=capture_run),
+    ):
+        result = main(
+            ["--type", "chore", "--scope", "ci", "--message", "trigger rebuild", "--allow-empty"]
+        )
+    assert result == 0
+    commit_call = git_args[0]
+    assert "--allow-empty" in commit_call
 
 
 def test_main_with_staged_changes(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add --allow-empty flag support to vrg-commit for CI re-trigger scenarios where no file changes exist

## Issue Linkage

- Ref #1278

## Notes

- When the only fix is a PR metadata change (e.g. fixing issue linkage in the PR body), a new commit is needed to trigger a fresh CI run but there are no file changes to commit. This adds --allow-empty flag support that skips the staged-changes check and passes --allow-empty through to git commit.