### PR TITLE
docs(permissions): agent permission model design + implementation plan

### DIFF
--- a/docs/specs/2026-05-29-agent-permission-model-design.md
+++ b/docs/specs/2026-05-29-agent-permission-model-design.md
@@ -38,6 +38,21 @@ Three problems converge:
    consistency, coding standards compliance) requires LLM-based
    review.
 
+### Resolution adopted
+
+This spec does **not** create an elevated identity that carries
+`workflows: write`. Instead, no agent identity holds `workflows` at
+all. The rare push that touches `.github/workflows/` is carried by
+the human, whose rights are the superset of every agent's — folded
+into the human-triggered `vrg-submit-pr` (see Ensure-pushed below).
+The most common workflow-touching change — bumping pinned action
+versions — is absorbed by the mechanized, human-run
+`vrg-dependency-update` (#918). An elevated "admin" identity remains
+**defined as a reserved architectural slot**, filled only when a
+concrete use case requires it. This is the YAGNI-disciplined
+outcome: we keep the slot and its governing invariant, not a
+speculative implementation.
+
 ### Compliance alignment
 
 The AI contribution compliance review
@@ -69,6 +84,17 @@ tooling should enforce — not merely encourage — that accountability.
 
 ## Design Principles
 
+**Agent rights are a subset of the human's.** The human operates the
+infrastructure with the full set of administrative rights — that is
+simply what it means to be the developer working on their own host.
+Sandboxing exists to contain that full access into a deliberately
+minimal subset for each agent identity, as basic risk management.
+The agent is never granted a right the human lacks, and — the
+operative corollary — **if the human cannot perform an action,
+neither can the agent.** This is why a human-triggered tool can
+always carry an operation the agent could not: the human is the
+superset.
+
 **Minimize agent write permissions.** Every write permission granted
 to the agent must have a documented, real-world justification. Read
 access is generally acceptable; write access is the attack surface.
@@ -83,9 +109,10 @@ trigger operational tools. Every step that "really matters and causes
 damage" is encapsulated in a `vrg-*` CLI utility that the human
 invokes. `vrg-release` is the model.
 
-**The human switches, the agent doesn't.** Agents never decide to
-escalate their own privileges. The human makes a conscious decision
-to use elevated-access tooling, which concentrates attention on the
+**The human triggers; the agent doesn't.** Agents never escalate
+their own privileges or perform the operations that really matter and
+cause damage. Those are encapsulated in `vrg-*` tools the human
+invokes deliberately, which concentrates human attention on the
 higher-risk work.
 
 **Correctness over cost.** Token cost is a real constraint. Granting
@@ -132,17 +159,24 @@ Where a soft gate exists without a corresponding hard gate, this
 spec documents it explicitly. Known gaps:
 
 - **Audit App `pull_requests: write` grants more than review.**
-  GitHub does not offer a "review-only" PR permission. The soft gate
-  (vrg-gh audit allowlist) restricts to view/comment/review, but the
-  server-side permits PR creation, editing, and closing. Mitigation:
-  the audit identity is a Read-level collaborator and cannot merge
-  anything it creates. This is a Mimir validation target.
+  GitHub offers no "review-only" PR permission and — more
+  fundamentally — does not separate *merging* a PR (an administrative
+  act) from *writing or updating* one. The soft gate (vrg-gh audit
+  allowlist) restricts the audit identity to view/comment/review, but
+  server-side the permission also permits PR creation, editing, and
+  closing. Mitigation: the audit identity is a Read-level
+  collaborator and cannot merge anything it creates. This is the
+  sharpest known hard-gate gap — and because audit is the identity we
+  most want to run with minimal human attention, it warrants the most
+  Mimir scrutiny. It is also a candidate for upstream infrastructure
+  advocacy: the correct fix is for GitHub to expose finer-grained PR
+  permissions. Documenting it precisely builds the data to make that
+  case.
 
 - **Agent can attempt `vrg-submit-pr`.** The soft gate is
   identity-aware tool rejection. The hard gate is `pull_requests:
-  read` on the street-mode App, which causes the underlying
-  `gh pr create` to fail server-side. This gap is fully covered
-  by a hard gate.
+  read` on the user App, which causes the underlying `gh pr create`
+  to fail server-side. This gap is fully covered by a hard gate.
 
 Additional gaps will be documented as they are discovered. Mimir
 testing is specifically designed to find and exploit undocumented
@@ -153,38 +187,44 @@ gaps.
 The identity architecture uses a motorsport analogy as its conceptual
 framework. This is not decoration — the analogy maps cleanly to the
 trust relationships and decision authority in the system, and the
-documentation uses these terms as the primary vocabulary.
+documentation uses these terms as the primary vocabulary. The model
+is still evolving; the terms below describe the current roles, not a
+fixed law derived from first principles.
 
 | Racing role | Description | Vergil identity |
 |---|---|---|
-| **Driver** | On track, makes tactical decisions, follows the rules | `<user>-vergil-user` — daily development agent |
-| **Track mode** | Driver with safety systems off, Race Director on radio | `<user>-vergil-admin` — elevated rights, human supervising |
+| **Driver** | Competes on track, makes tactical decisions, works within the rules | `<user>-vergil-user` — daily development agent |
 | **Officials** | Walk pit lane, observe, report infractions — cannot penalize | `<user>-vergil-audit` — reviews PRs, comments on violations |
 | **Race Director** | Full authority over the event, makes the calls | `<user>` — human, ultimate authority |
+| **Admin** (reserved) | A competitor granted escorted access to a normally off-limits area | reserved slot — not provisioned |
 
-**Driver (street mode):** The agent in its normal operating mode.
-Restricted write permissions, safe for autonomous and unattended
-work. The safety nannies are on. This is the 24/7 mode.
+**Driver (the user identity):** The everyday agent — the workhorse,
+used all the time. Restricted write permissions, safe for autonomous
+and unattended work within those limits. This is the 24/7 identity.
 
-**Track mode:** The same driver in a more powerful car. The human
-(Race Director) made the conscious decision to use the elevated-access
-VM. Attention is concentrated. You don't use this for routine work —
-you use it for specific tasks that require elevated rights, then shut
-it down. Like turning off traction control at the racetrack: you
-accept more risk, so your behavior adjusts accordingly.
+**Officials (the audit identity):** An independent observer that can
+only watch and report. Officials walk pit lane looking for
+violations. They can flag "you dropped a lug nut" but cannot issue
+penalties themselves — they report to Race Control (the human). The
+audit identity reads code, reviews PRs against standards, and
+comments. It cannot modify code, create PRs, or close issues.
+Deliberately scoped for the smallest blast radius, because it is the
+identity we most want to run close to unattended.
 
-**Officials (audit mode):** An independent observer that can only
-watch and report. Officials walk pit lane looking for violations.
-They can flag "you dropped a lug nut" but cannot issue penalties
-themselves — they report to Race Control (the human). The audit
-identity reads code, reviews PRs against standards, and comments.
-It cannot modify code, create PRs, or close issues.
+**Race Director (the human):** The ultimate authority. Reviews
+reports from Officials, makes merge/release/strategy decisions,
+triggers operational tools. No one overrules the Race Director. The
+Driver and Officials never interact directly — everything goes
+through Race Control.
 
-**Race Director (human):** The ultimate authority. Reviews reports
-from Officials, makes merge/release/strategy decisions, triggers
-operational tools. No one overrules the Race Director. The Driver
-and Officials never interact directly — everything goes through
-Race Control.
+**Admin (a reserved slot, not a built identity):** This is *not* a
+faster car. It is the same development role granted escorted access
+to a normally off-limits area — the regulated CI/CD infrastructure a
+competitor never touches unsupervised. The slot is defined but
+unoccupied. It is instantiated only when a concrete use case requires
+elevated access, and its governing constraint is fixed in advance:
+**elevated access is paired with an elevated level of human control
+and interaction.** Access and supervision are the same dial.
 
 ## Identity Architecture
 
@@ -192,40 +232,36 @@ Race Control.
 
 | Identity | Account pattern | Collaborator access | Purpose |
 |---|---|---|---|
-| Driver | `<user>-vergil-user` | Outside collaborator, Write | Daily development |
-| Admin | `<user>-vergil-admin` | Outside collaborator, Write | Elevated operations |
-| Audit | `<user>-vergil-audit` | Outside collaborator, Read | PR review |
-| Human | `<user>` | Owner/Admin | Ultimate authority |
+| User (Driver) | `<user>-vergil-user` | Outside collaborator, Write | Daily development |
+| Audit (Officials) | `<user>-vergil-audit` | Outside collaborator, Read | PR review |
+| Human (Race Director) | `<user>` | Owner/Admin | Ultimate authority |
+| Admin (reserved) | `<user>-vergil-admin` | — | Reserved — not provisioned until a use case requires it |
 | Release bot | `vergil-release[bot]` | GitHub App | Release automation |
 
 ### GitHub App Configuration
 
-Three separate GitHub Apps, each with distinct permission sets.
-Each VM gets exactly one App's credentials. The credential
-environment determines the operating mode — no config flag, no
-mode switch command.
+Two GitHub Apps are provisioned today (user, audit); a third (admin)
+is a reserved slot. Each VM gets exactly one App's credentials. The
+credential environment determines the operating mode — no config
+flag, no mode switch command.
 
-**Street-mode App (`vergil-app`):**
+**User App (`vergil-app`):**
 
 | Permission | Level | Rationale |
 |---|---|---|
-| `contents` | write | Push feature branches |
+| `contents` | write | Push feature branches; push code fixes to iterate on CI |
 | `issues` | write | Create and comment on issues |
 | `pull_requests` | read | View PRs, check status |
 | `metadata` | read | Required baseline |
 | `workflows` | none | Server-side hard gate blocks workflow file pushes |
 
-**Track-mode App (`vergil-admin-app`):**
+Note that `contents: write` — not `workflows: write` — is what lets
+the agent handle a failing CI gate: it pushes *code fixes* to
+re-trigger CI. Editing the workflow files themselves is never part of
+fixing a gate; that would be changing the rules to pass, the exact
+escape hatch we are closing.
 
-| Permission | Level | Rationale |
-|---|---|---|
-| `contents` | write | Push feature branches |
-| `issues` | write | Create and comment on issues |
-| `pull_requests` | read | View PRs, check status |
-| `metadata` | read | Required baseline |
-| `workflows` | write | Push workflow file changes under human supervision |
-
-**Audit-mode App (`vergil-audit-app`):**
+**Audit App (`vergil-audit-app`):**
 
 | Permission | Level | Rationale |
 |---|---|---|
@@ -235,13 +271,25 @@ mode switch command.
 | `metadata` | read | Required baseline |
 | `workflows` | none | No need |
 
-The audit App has an inverted permission shape compared to street
-mode: more PR permission (write vs. read) but less code permission
+The audit App has an inverted permission shape compared to the user
+App: more PR permission (write vs. read) but less code permission
 (read vs. write). The permissions are shaped exactly for the role.
 
-**Provisional status.** The audit identity's architectural position
-(third identity, inverted permission shape, Officials role) is
-load-bearing for the overall design and is defined here. The
+**Admin App (`vergil-admin-app`) — reserved, not provisioned.**
+
+This is a defined architectural slot, not a built identity. Its
+permissions are intentionally left undefined: there is no concrete
+use case yet that requires elevated agent access, and guessing the
+permission set would bake in speculation we cannot justify. The one
+property fixed now is its governing invariant — elevated access is
+paired with an elevated level of human control and interaction. When
+a real use case appears, the App is created with the minimal
+permissions that case requires, and its delta is recorded in the
+Permission Delta Registry.
+
+**Provisional status (audit).** The audit identity's architectural
+position (second agent identity, inverted permission shape, Officials
+role) is load-bearing for the overall design and is defined here. The
 specific permissions and vrg-gh allowlist are provisional — they
 are based on the one confirmed use case (PR standards review) and
 are subject to revision as additional use cases emerge and the
@@ -251,28 +299,26 @@ triggering mechanism is designed.
 
 ```text
 Human host
-├── Street-mode VM  (daily use, always available)
+├── User VM  (daily use, always available)
 │   ├── VRG_APP_ID → vergil-app
 │   ├── VRG_PRIVATE_KEY_PATH → vergil-app key
 │   └── Agent operates as <user>-vergil-user
 │
-├── Track-mode VM  (on-demand, human supervising)
-│   ├── VRG_APP_ID → vergil-admin-app
-│   ├── VRG_PRIVATE_KEY_PATH → vergil-admin-app key
-│   └── Agent operates as <user>-vergil-admin
+├── Audit VM  (persistent or on-demand)
+│   ├── VRG_APP_ID → vergil-audit-app
+│   ├── VRG_PRIVATE_KEY_PATH → vergil-audit-app key
+│   └── Agent operates as <user>-vergil-audit
 │
-└── Audit VM  (persistent or on-demand)
-    ├── VRG_APP_ID → vergil-audit-app
-    ├── VRG_PRIVATE_KEY_PATH → vergil-audit-app key
-    └── Agent operates as <user>-vergil-audit
+└── Admin VM  (reserved — not provisioned)
+    └── Created only when the admin slot is filled
 ```
 
 The human launches each VM deliberately. There is no mode-switching
 within a running session. The visual presentation of each VM must be
-distinct — the human must never be uncertain about which mode they
-are in. Specific visual treatment (color scheme, prompt indicator,
-login banner) is an implementation detail, but the requirement is
-ambient, persistent differentiation.
+distinct — the human must never be uncertain about which identity
+they are in. Specific visual treatment (color scheme, prompt
+indicator, login banner) is an implementation detail, but the
+requirement is ambient, persistent differentiation.
 
 **Shared filesystem.** All VMs mount the host's project directory
 tree at the same path. The agent writes to the same filesystem the
@@ -282,8 +328,8 @@ immediately on their host terminal. The VM is a credential sandbox
 with a shared filesystem, not an isolated environment.
 
 **Mode detection.** Each VM is provisioned with a
-`VRG_IDENTITY_MODE` environment variable (values: `street`,
-`track`, `audit`) set by the VM build configuration in the
+`VRG_IDENTITY_MODE` environment variable (values: `user`, `audit`;
+`admin` reserved) set by the VM build configuration in the
 vergil-vm repo. The variable is written into the user's shell
 profile during provisioning, making it ambient and persistent.
 The tooling (`vrg-git`, `vrg-gh`, `vrg-submit-pr`) reads
@@ -314,11 +360,11 @@ created on demand by whichever tool writes to it first.
 # .vergil/pr-template.yml
 # Generated by agent — review and edit before running vrg-submit-pr
 issue: 1289
-title: "feat(permissions): remove workflow permission from street-mode App"
+title: "feat(permissions): remove workflow permission from user App"
 summary: |
-  Removes the workflows permission from the street-mode GitHub App
-  and adds vrg-gh restrictions to block issue close/reopen/edit
-  in street mode.
+  Removes the workflows permission from the user GitHub App and adds
+  vrg-gh restrictions to block issue close/reopen/edit for the user
+  identity.
 linkage: Ref
 notes: |
   This PR does not include workflow file changes.
@@ -340,7 +386,7 @@ The template file is ephemeral:
 
 ## Revised Agent Workflow
 
-### Street Mode (Daily Development)
+### User Identity (Daily Development)
 
 ```text
 Agent                              Human (Race Director)
@@ -354,7 +400,7 @@ Agent                              Human (Race Director)
 4. Write .vergil/pr-template.yml
 5. Signal: "ready for PR"
                                    6. Review template, edit if needed
-                                   7. Run vrg-submit-pr (creates PR)
+                                   7. Run vrg-submit-pr (push + PR)
                                    8. Review PR + CI results
                                    9. Merge (vrg-finalize-pr)
 ```
@@ -366,20 +412,37 @@ operation triggered by `vrg-*` CLI tools.
 App token lacks `workflows` permission, the wrapper detects the
 specific GitHub error and provides identity-aware feedback: the
 agent is told its identity is not permitted to push workflow file
-changes, and it must stop and escalate to the Race Director. The
-agent must not attempt to work around the failure (e.g., by
-removing workflow files from the commit and re-pushing). The human
-decides whether to use the track-mode VM or remove the workflow
-changes from scope.
+changes, and it must stop and escalate to the human. The agent must
+not attempt to work around the failure (e.g., by removing workflow
+files from the commit and re-pushing). The human carries the
+workflow-touching push themselves — in practice via `vrg-submit-pr`,
+which pushes the branch with the human's credentials before opening
+the PR (see Ensure-pushed below). For the common case of action-pin
+bumps, the human runs `vrg-dependency-update` (#918), which
+mechanizes the whole update. The escalation must not silently drop
+the workflow change: the agent reports clearly what is blocked and
+why.
 
-### Track Mode (Elevated Operations)
+### Workflow File Changes
 
-Same workflow, except step 3 succeeds for workflow file changes
-because the admin App has `workflows:write`. The human is actively
-supervising because they made the conscious decision to use the
-track-mode VM.
+No agent identity can push changes under `.github/workflows/` — the
+server rejects the entire push (not just the offending file) when the
+App token lacks `workflows`. This is deliberate: workflow files
+define CI/CD containment, so altering them is reserved to the human.
+The human carries such pushes via `vrg-submit-pr`'s ensure-pushed
+behavior, and the routine action-pin case is mechanized in
+`vrg-dependency-update` (#918).
 
-### Audit Mode (PR Review)
+One honest cost: a branch that mixes workflow changes with code
+cannot be pushed — and therefore cannot be CI-iterated — by the agent
+at all until the human pushes it. In practice workflow changes are
+usually isolated, so this rarely bites; when it does, it is the kind
+of change that warrants human attention anyway. The anticipated first
+trigger for filling the reserved admin slot is this friction becoming
+common enough to justify a supervised elevated identity — but the
+mechanized dependency update is expected to absorb most of it.
+
+### Audit Identity (PR Review)
 
 The triggering mechanism is a separate design problem (see Open
 Questions). For v1, the human directs the audit agent to review
@@ -394,7 +457,7 @@ agent can fix them before submission.
 ## `vrg-submit-pr` Changes
 
 The tool gains a new operating mode driven by the `.vergil/`
-template.
+template, and an ensure-pushed step.
 
 **Template mode (no CLI args):**
 
@@ -402,9 +465,10 @@ template.
 2. Show the human a summary: title, body preview, issue linkage,
    target branch.
 3. Prompt for confirmation.
-4. Create the PR via `gh pr create`.
-5. Delete the template file.
-6. Print the PR URL.
+4. Ensure-pushed (see below).
+5. Create the PR via `gh pr create`.
+6. Delete the template file.
+7. Print the PR URL.
 
 **CLI argument mode (args provided):**
 
@@ -415,13 +479,28 @@ changes without an agent.
 
 **Neither template nor args:** Fatal error. The tool does not guess.
 
+**Ensure-pushed.** Before creating the PR, `vrg-submit-pr` verifies
+the branch is fully pushed to the remote. If the branch has commits
+not yet on the remote, it performs the push using the human's host
+credentials, then creates the PR. Because the human's credentials are
+the superset of any agent's, this push succeeds even when the branch
+touches `.github/workflows/` — which the agent's own push would have
+been rejected for. This is precisely how workflow-touching changes
+reach the remote without any agent holding `workflows: write`.
+
+This depends on a credential assumption made explicit by the
+subset-of-human-rights principle: `vrg-submit-pr` runs in the human's
+host context with the human's full GitHub credentials. The whole
+model relies on the agent's rights being a subset of these — if the
+human cannot push a change, neither tool nor agent can.
+
 **Identity-aware enforcement.** `vrg-submit-pr` checks the
 credential environment on startup. If it detects any agent identity
-(driver, admin, or audit), it aborts immediately with a clear
-message: PR submission is a Race Director operation. This is a
-Layer 1 soft gate. The Layer 2 hard gate is `pull_requests: read`
-on the street-mode App, which causes the underlying `gh pr create`
-to fail server-side even if the soft gate is bypassed.
+(user or audit), it aborts immediately with a clear message: PR
+submission is a Race Director operation. This is a Layer 1 soft gate.
+The Layer 2 hard gate is `pull_requests: read` on the user App, which
+causes the underlying `gh pr create` to fail server-side even if the
+soft gate is bypassed.
 
 **Wrapper denial messages.** When `vrg-gh` blocks a subcommand, the
 denial message is identity-aware. For human identities, `pr create`
@@ -446,7 +525,7 @@ This is a human (Race Director) operation. No agent invokes it.
 
 ## `vrg-gh` Restriction Changes
 
-### Street Mode Subcommand Allowlist
+### User Identity Subcommand Allowlist
 
 | Command | Status | Rationale |
 |---|---|---|
@@ -474,15 +553,7 @@ This is a human (Race Director) operation. No agent invokes it.
 | `repo view` | allowed | Read operation |
 | `repo list` | allowed | Read operation |
 
-### Track Mode Subcommand Allowlist
-
-Identical to street mode. Track mode does not relax the `vrg-gh`
-allowlist. The only difference is server-side: workflow file pushes
-succeed via `vrg-git push` because the admin App has
-`workflows:write`. This keeps the design simple and avoids
-permission creep ("I'm in admin mode so I might as well...").
-
-### Audit Mode Subcommand Allowlist
+### Audit Identity Subcommand Allowlist
 
 | Command | Status | Rationale |
 |---|---|---|
@@ -494,29 +565,35 @@ permission creep ("I'm in admin mode so I might as well...").
 | `pr review` | allowed | Submit formal review (including approval) |
 | Everything else | **blocked** | Audit is read-and-comment only |
 
+### Admin Identity Subcommand Allowlist
+
+Reserved. Defined when the admin slot is filled, scoped to the
+minimal set its use case requires.
+
 ### Mode Detection
 
 The `vrg-gh` wrapper reads `VRG_IDENTITY_MODE` from the environment.
-If the value is `audit`, the audit allowlist applies. If `street` or
-`track`, the agent-restricted allowlist applies. Absence of the
-variable implies human identity, which retains the full allowlist.
-The environment variable is set by VM provisioning — the agent does
-not choose its own mode.
+If the value is `audit`, the audit allowlist applies. If `user`, the
+user allowlist applies. Absence of the variable implies human
+identity, which retains the full allowlist. The environment variable
+is set by VM provisioning — the agent does not choose its own mode.
 
 ## Permission Delta Registry
 
 Every difference between identities is explicitly documented with
 a justification.
 
-### Street → Admin Delta
+### Reserved: User → Admin Delta
 
-| Permission | Street | Admin | Justification | Added |
-|---|---|---|---|---|
-| `workflows` | none | write | Workflow files define CI/CD containment. Changes require elevated access under direct human supervision in the track-mode VM. | 2026-05-29 |
+The admin identity is a reserved slot with no permissions granted
+today, so there is no delta to record yet. When the slot is filled,
+its delta is added here with a documented use case, per the rules
+below. The governing constraint is fixed in advance: any admin delta
+must pair elevated access with elevated human involvement.
 
-### Street → Audit Delta
+### User → Audit Delta
 
-| Permission | Street | Audit | Justification | Added |
+| Permission | User | Audit | Justification | Added |
 |---|---|---|---|---|
 | `contents` | write | read | Audit reads code but must not modify it. | 2026-05-29 |
 | `pull_requests` | read | write | Audit must comment on and submit reviews. | 2026-05-29 |
@@ -534,14 +611,15 @@ a justification.
 
 ### Identity transition
 
-The new identities (`<user>-vergil-user`, `<user>-vergil-admin`,
-`<user>-vergil-audit`) are created from scratch alongside the
-existing `<user>-vergil` identity. Both sets operate in parallel
-during the transition:
+The new identities (`<user>-vergil-user`, `<user>-vergil-audit`) are
+created from scratch alongside the existing `<user>-vergil` identity.
+(The admin identity is a reserved slot — not created until a use case
+requires it.) Both sets operate in parallel during the transition:
 
-- **Phase 1:** Create the three new GitHub accounts and GitHub
-  Apps. Provision new VMs with the new credentials. The existing
-  `<user>-vergil` identity and tooling on 2.0.x continue unchanged.
+- **Phase 1:** Create the two new GitHub accounts and GitHub Apps
+  (user, audit). Provision new VMs with the new credentials. The
+  existing `<user>-vergil` identity and tooling on 2.0.x continue
+  unchanged.
 
 - **Phase 2:** Build the tooling changes (Track A below) as a 2.1
   release using the 2.0 tooling. The new 2.1 tooling is used in the
@@ -587,20 +665,20 @@ Parallel tracks with safe sequencing:
 
 **Track A — Tooling changes:**
 
-- Build revised `vrg-submit-pr` (template mode, human-triggered).
+- Build revised `vrg-submit-pr` (template mode + ensure-pushed,
+  human-triggered).
 - Implement `.vergil/` scratch convention.
 - Update `vrg-gh` subcommand allowlists (block issue close/reopen/edit,
   block PR merge unconditionally, block PR create/edit/close).
 - Rename `vrg-finalize-repo` to `vrg-finalize-pr`.
-- Define the audit mode `vrg-gh` allowlist.
+- Define the audit identity `vrg-gh` allowlist.
 
 **Track B — Identity and permissions:**
 
-- Create `vergil-admin-app` GitHub App with the documented permissions.
 - Create `vergil-audit-app` GitHub App with the documented permissions.
-- Set up `<user>-vergil-admin` and `<user>-vergil-audit` GitHub accounts.
-- Configure track-mode and audit-mode VMs with respective credentials.
-- Remove `workflows` permission from the street-mode App.
+- Set up `<user>-vergil-user` and `<user>-vergil-audit` GitHub accounts.
+- Configure user and audit VMs with respective credentials.
+- Confirm the user App holds no `workflows` permission.
 - Implement visual differentiation for each VM.
 
 **Track C — Audit integration (deferred details):**
@@ -614,8 +692,8 @@ Tracks A and B proceed in parallel. Track C is architecturally
 defined in this spec (identity, permissions, vrg-gh allowlist) but
 the triggering and integration details are a follow-up design.
 
-**Immediate safe restriction:** Remove `workflows` permission from
-the street-mode App now. No workflow changes are queued, so this
+**Immediate safe restriction:** Ensure the user App holds no
+`workflows` permission now. No workflow changes are queued, so this
 costs nothing and activates the server-side hard gate immediately.
 
 ## Open Questions
@@ -640,6 +718,15 @@ branch protection could require audit approval before merge. This
 adds a quality gate but also adds a dependency — if the audit agent
 is down or slow, merges are blocked.
 
+**When does the admin slot get filled?** The reserved admin identity
+has no permissions today. The anticipated first trigger is workflow
+iteration becoming too tedious to route through the human on every CI
+turn — but the common case (action-pin bumps) is already handled by
+`vrg-dependency-update` (#918), so the trigger may not arrive soon.
+The slot is instantiated only when a concrete elevated-access use
+case appears, and its design must pair the elevated rights with
+heightened human involvement.
+
 **Visual differentiation specifics.** The requirement is that each
 VM is visually distinct. The specific treatment (color scheme, prompt
 indicators, login banners) needs design and user testing.
@@ -657,17 +744,39 @@ output. As local LLM infrastructure matures (Ollama on developer
 hardware), the audit identity becomes cost-neutral. The architecture
 should not assume cloud API access.
 
+**Cooperative vs. adversarial agents.** The model assumes a
+cooperative agent (Vergil) for routine operation, but does not *rely*
+on cooperation for containment. A prompt injection can transiently
+turn a cooperative agent into an adversarial one (Mimir) for the
+duration of the compromise. Soft gates correct a cooperative agent;
+the server-side hard gates must contain a momentarily-hostile one.
+Where a hard gate is missing (the documented gaps), that is a known,
+accepted, and tracked exposure — not an oversight. The dependence on
+agent good behavior inside the VM is a strategic risk we name
+explicitly rather than pretend away.
+
 **Mimir validation.** The Mimir identity (adversarial testing agent)
 will be used to validate this permission model. Mimir should
 demonstrate that:
 
-- In street mode, workflow file pushes are rejected (server-side).
-- In track mode, an adversarial agent can exploit elevated rights —
-  confirming why track mode requires active human supervision.
+- In the user identity, workflow file pushes are rejected
+  (server-side).
 - The audit identity cannot modify code or escalate privileges.
 
 Documenting known attack surfaces for Mimir rather than waiting for
-discovery is part of the validation strategy.
+discovery is part of the validation strategy. (Mimir's own
+implementation is out of scope here and will be designed separately.)
+
+**Infrastructure advocacy.** Some gaps cannot be closed from inside
+this architecture because the underlying platform lacks the needed
+control — the GitHub PR-permission granularity gap is the clearest
+example. Documenting these precisely serves a second purpose beyond
+our own validation: it builds the evidence to advocate for the
+platform improvements (e.g., separating PR merge from PR write) that
+would let any AI-assisted workflow contain agents more tightly. The
+architecture is, in part, an opportunity to make the current limits
+of AI-safety tooling visible and argue — with data — for taking them
+seriously.
 
 **Human accountability.** Every contribution standard reviewed
 (including CPython's) requires human accountability. This

--- a/docs/specs/2026-05-29-agent-permission-model-design.md
+++ b/docs/specs/2026-05-29-agent-permission-model-design.md
@@ -579,10 +579,26 @@ cannot use. (The hook guard itself is a dumb gate — it only
 redirects raw `git`/`gh` to the wrapper scripts and knows nothing
 about subcommands or identity.)
 
-## `vrg-finalize-pr` (Renamed from `vrg-finalize-repo`)
+## `vrg-finalize-pr` (Consolidates merge + cleanup, formerly `vrg-finalize-repo`)
 
-The rename signals the scope change. This tool finalizes a specific
-PR:
+This is not a rename — it is a consolidation. Previously two separate
+human actions finished a PR: the human merged it by hand (on the web),
+then ran `vrg-finalize-repo` to clean up the branch and prune refs.
+Both collapse into one human tool. Moving the merge off the web and
+into a `vrg-*` tool is the same move applied everywhere in this design:
+take a mechanized operation that really matters and put it behind a
+human-triggered command. It also creates the exact insertion point the
+provenance check needs — a single place, under human control, that
+performs the merge and can gate it.
+
+Until now the implicit merge rule was "if the CI gates are green, merge
+it" — sound only because every sanity check was assumed to live in the
+GitHub CI gates, which today is true. The provenance check is the first
+sanity check that *cannot* live in a CI gate (GitHub attributes
+identity actions outside the PR's own checks), so it runs in the tool
+that performs the merge, immediately before the merge.
+
+This tool finalizes a specific PR:
 
 1. **Pre-merge provenance check.** Fetch the PR's action history —
    reviews and timeline events, each attributed by GitHub to the
@@ -598,6 +614,13 @@ PR:
 3. Delete the feature branch (local and remote).
 4. Prune remote references.
 5. Post-merge housekeeping.
+
+The action history is fetched with read-only `gh api` GET calls to
+the PR reviews and issue timeline endpoints. This is available because
+the tool runs in the human context, and the same calls are reachable
+from the audit context under the identity-aware API allowance (see
+"Identity-aware API access") — without ever granting the user agent a
+raw-API escape hatch.
 
 This is a human (Race Director) operation. No agent invokes it. The
 pre-merge provenance check is the worked example of the "human
@@ -636,6 +659,7 @@ action its role forbids on the PR being merged.
 | `run watch` | allowed | Read operation |
 | `repo view` | allowed | Read operation |
 | `repo list` | allowed | Read operation |
+| `api` | **blocked** | Raw API is a broad escape hatch — abusable by a compromised user agent to reach endpoints the subcommand allowlist would otherwise gate |
 
 ### Audit Identity Subcommand Allowlist
 
@@ -647,6 +671,7 @@ action its role forbids on the PR being merged.
 | `pr checks` | allowed | Check CI status |
 | `pr comment` | allowed | Post review findings |
 | `pr review` | allowed | Submit formal review (including approval) |
+| `api` (GET only) | allowed | Read-only API access for review tooling (e.g., PR reviews and timeline endpoints). The audit App's narrow permissions (`contents: read`, `pull_requests: write`, `issues: read`) bound what any API call can reach, so the raw API is low-risk for this identity |
 | Everything else | **blocked** | Audit is read-and-comment only |
 
 ### Admin Identity Subcommand Allowlist
@@ -661,6 +686,32 @@ If the value is `audit`, the audit allowlist applies. If `user`, the
 user allowlist applies. Absence of the variable implies human
 identity, which retains the full allowlist. The environment variable
 is set by VM provisioning — the agent does not choose its own mode.
+
+### Identity-aware API access
+
+The raw `gh api` escape hatch is gated per identity rather than
+denied wholesale. This is the general principle that the `vrg-gh`
+allow/disallow decision is a function of identity, not a single
+fixed list:
+
+- **User** — blocked. The user App holds `contents: write`, so a
+  compromised user agent with raw API access could reach write
+  endpoints that the curated subcommand allowlist deliberately
+  withholds. The broad surface is not worth the ergonomic gain.
+- **Audit** — allowed for read (GET) calls. The audit App's
+  permissions are narrow and mostly read-only (`contents: read`,
+  `issues: read`, with `pull_requests: write` the only write
+  scope), so even the raw API cannot reach anything the identity
+  is not already trusted with. This is what makes read-only API
+  access safe to grant here but not to the user.
+- **Human** — full, as with every other subcommand.
+
+This identity-aware allowance is what lets the pre-merge provenance
+check in `vrg-finalize-pr` query GitHub's review and timeline
+endpoints (see that section). The check runs in the human context,
+where the API is available; the same endpoints are reachable from
+the audit context for review tooling without granting the user
+agent a write-capable escape hatch.
 
 ## Permission Delta Registry
 
@@ -754,7 +805,12 @@ Parallel tracks with safe sequencing:
 - Implement `.vergil/` scratch convention.
 - Update `vrg-gh` subcommand allowlists (block issue close/reopen/edit,
   block PR merge unconditionally, block PR create/edit/close).
-- Rename `vrg-finalize-repo` to `vrg-finalize-pr`.
+- Make `vrg-gh`'s `gh api` allowance identity-aware: full for human,
+  read-only GET for audit, denied for user.
+- Consolidate the merge and post-merge cleanup into `vrg-finalize-pr`
+  (formerly `vrg-finalize-repo`): the tool now performs the merge and
+  runs the pre-merge provenance check immediately before it, fetching
+  the PR's action history via read-only `gh api` calls.
 - Define the audit identity `vrg-gh` allowlist.
 
 **Track B — Identity and permissions:**

--- a/docs/specs/2026-05-29-agent-permission-model-design.md
+++ b/docs/specs/2026-05-29-agent-permission-model-design.md
@@ -47,7 +47,11 @@ the human, whose rights are the superset of every agent's — folded
 into the human-triggered `vrg-submit-pr` (see Ensure-pushed below).
 The most common workflow-touching change — bumping pinned action
 versions — is absorbed by the mechanized, human-run
-`vrg-dependency-update` (#918). An elevated "admin" identity remains
+`vrg-dependency-update` (#918). That tool is an ergonomic
+optimization, not a prerequisite: until it exists, action-pin bumps
+flow through the same ensure-pushed path as any other
+workflow-touching change, so this permission model does not block on
+#918. An elevated "admin" identity remains
 **defined as a reserved architectural slot**, filled only when a
 concrete use case requires it. This is the YAGNI-disciplined
 outcome: we keep the slot and its governing invariant, not a
@@ -82,18 +86,51 @@ emerging industry consensus on AI-assisted engineering: the human
 contributor bears full responsibility for all submissions, and the
 tooling should enforce — not merely encourage — that accountability.
 
+## Foundational Assumption
+
+The entire architecture rests on one assumption, stated here so that
+nothing downstream has to restate it: **the human who operates the
+host is the owner, and holds the maximum set of developer and
+administrative rights over every resource in play** — the
+repositories, the GitHub organization, the Apps, the VMs, the host
+itself. The human is the all-powerful party. Everything else is
+defined relative to that.
+
+From this, three things follow and are true everywhere in this spec:
+
+1. **Agents are sandboxed minions holding a strict subset.** An agent
+   is never the owner. Each agent identity is granted a deliberately
+   minimal subset of the human's rights, scoped to its role. It can
+   never be granted a right the human does not have.
+
+2. **Delegation to the host is the mechanism, not a workaround.** The
+   host is precisely where commands run under *human* control rather
+   than *agent* control. When an operation is too dangerous to hand an
+   agent, it is delegated to a human-triggered tool on the host — and
+   that tool can always carry it, because the host runs with the
+   owner's full rights. `vrg-submit-pr`'s ensure-pushed is the worked
+   example: it pushes with the human's superset credentials a change
+   the agent's subset would have been rejected for.
+
+3. **If the human lacks a required right, the architecture does not
+   function — by design.** This is not a gap to be patched with a
+   fallback or a runtime probe. If the operator is not the owner with
+   the umbrella rights this model assumes, the model is the wrong
+   model for that situation, and that is the correct, intended
+   outcome. We do not build degraded modes for a non-owner operator;
+   we assume the owner.
+
+The corollary used throughout: **if the human cannot perform an
+action, neither can the agent.**
+
 ## Design Principles
 
-**Agent rights are a subset of the human's.** The human operates the
-infrastructure with the full set of administrative rights — that is
-simply what it means to be the developer working on their own host.
-Sandboxing exists to contain that full access into a deliberately
-minimal subset for each agent identity, as basic risk management.
-The agent is never granted a right the human lacks, and — the
-operative corollary — **if the human cannot perform an action,
-neither can the agent.** This is why a human-triggered tool can
-always carry an operation the agent could not: the human is the
-superset.
+**Agent rights are a subset of the human's.** Per the Foundational
+Assumption above, the human operates the host with the full set of
+ownership rights, and sandboxing exists to contain that full access
+into a minimal per-identity subset. The agent is never granted a
+right the human lacks. This is why a human-triggered tool can always
+carry an operation the agent could not: the human is the superset.
 
 **Minimize agent write permissions.** Every write permission granted
 to the agent must have a documented, real-world justification. Read
@@ -114,6 +151,21 @@ their own privileges or perform the operations that really matter and
 cause damage. Those are encapsulated in `vrg-*` tools the human
 invokes deliberately, which concentrates human attention on the
 higher-risk work.
+
+**Human chokepoints are verification points.** Every high-risk,
+irreversible operation is denied to agents and reserved to a
+human-triggered `vrg-*` tool on the host. Because that tool runs in
+the owner's trusted context — outside any agent's reach — it is also
+the place to impose programmatic verification the hard gates cannot.
+Where GitHub's permission model is too coarse to *prevent* an unwanted
+agent action (the documented gaps), the human-run tool at the
+chokepoint can *detect* it before the irreversible step and refuse to
+proceed. Each destructive operation thus becomes a sanity-check
+opportunity: the merge gate verifies a PR's provenance, a release gate
+could verify a release's, and so on. This is the architectural answer
+to gaps that cannot be closed server-side — and it complements CI
+gates, which check the *content* of a change, by adding host-side
+checks on the *conduct* of the identities that produced it.
 
 **Correctness over cost.** Token cost is a real constraint. Granting
 agents the ability to perform trivial operations (closing issues,
@@ -151,7 +203,12 @@ Validates that controls are working. Detects moments when soft gates
 were bypassed, whether hard gates caught the attempt, and whether
 any gaps were exploited. This is the ultimate safety net. Even when
 all hard gates are working, auditing confirms they are working and
-surfaces patterns that indicate drift or attack.
+surfaces patterns that indicate drift or attack. Detection need not
+be purely retrospective: at a human-run chokepoint (such as merge), a
+detection check can be promoted into a *synchronous gate* that runs
+before the irreversible operation and refuses to proceed — see
+`vrg-finalize-pr`'s pre-merge provenance check. This is how Layer 3
+closes specific gaps that Layer 2 cannot.
 
 ### Documented gaps
 
@@ -165,8 +222,10 @@ spec documents it explicitly. Known gaps:
   allowlist) restricts the audit identity to view/comment/review, but
   server-side the permission also permits PR creation, editing, and
   closing. Mitigation: the audit identity is a Read-level
-  collaborator and cannot merge anything it creates. This is the
-  sharpest known hard-gate gap — and because audit is the identity we
+  collaborator and cannot merge anything it creates, and
+  `vrg-finalize-pr`'s pre-merge provenance check detects and blocks
+  any out-of-role audit action on a PR before the human merges it (see
+  that section). This is the sharpest known hard-gate gap — and because audit is the identity we
   most want to run with minimal human attention, it warrants the most
   Mimir scrutiny. It is also a candidate for upstream infrastructure
   advocacy: the correct fix is for GitHub to expose finer-grained PR
@@ -335,8 +394,16 @@ profile during provisioning, making it ambient and persistent.
 The tooling (`vrg-git`, `vrg-gh`, `vrg-submit-pr`) reads
 `VRG_IDENTITY_MODE` to select allowlists and behaviors. Absence
 of the variable (or an unrecognized value) implies human identity.
-This is a derived value from VM configuration, not a user-controlled
-flag — the agent does not choose its own mode.
+
+`VRG_IDENTITY_MODE` is set by VM provisioning rather than chosen by
+the agent, but it is a **Layer 1 ergonomic, not a security control**.
+An adversarial agent that becomes root inside the VM can set or unset
+it and thereby relax the soft-gate allowlists. This changes nothing
+that matters: the identity boundary is the App credential provisioned
+to the VM, not the variable. No value of `VRG_IDENTITY_MODE` alters
+which private key is present, so none of it alters what GitHub will
+actually permit. Spoofing the mode loosens soft gates the spec
+already treats as bypassable; the hard gate is untouched.
 
 ## The `.vergil/` Scratch Convention
 
@@ -488,11 +555,12 @@ touches `.github/workflows/` — which the agent's own push would have
 been rejected for. This is precisely how workflow-touching changes
 reach the remote without any agent holding `workflows: write`.
 
-This depends on a credential assumption made explicit by the
-subset-of-human-rights principle: `vrg-submit-pr` runs in the human's
-host context with the human's full GitHub credentials. The whole
-model relies on the agent's rights being a subset of these — if the
-human cannot push a change, neither tool nor agent can.
+This is the Foundational Assumption in action, not a separate
+credential requirement: `vrg-submit-pr` runs on the host, in the
+owner's context, with the human's full GitHub credentials. The push
+succeeds because the human holds the superset. If the human cannot
+push the change, neither tool nor agent can — and that is the correct
+behavior, not a failure to handle.
 
 **Identity-aware enforcement.** `vrg-submit-pr` checks the
 credential environment on startup. If it detects any agent identity
@@ -516,12 +584,28 @@ about subcommands or identity.)
 The rename signals the scope change. This tool finalizes a specific
 PR:
 
-1. Merge the PR (or confirm already merged).
-2. Delete the feature branch (local and remote).
-3. Prune remote references.
-4. Post-merge housekeeping.
+1. **Pre-merge provenance check.** Fetch the PR's action history —
+   reviews and timeline events, each attributed by GitHub to the
+   identity that performed it — and cross-check every agent action
+   against what that identity's role permits. The audit identity must
+   never have created, edited, closed, or reopened the PR; if it did,
+   the tool aborts with the offending action named. An audit *approval*
+   is permitted but surfaced explicitly, so the human knows a green
+   review came from an advisory identity, not an authoritative one. The
+   human can override — they hold every right — but only consciously,
+   with the violation in front of them.
+2. Merge the PR (or confirm already merged).
+3. Delete the feature branch (local and remote).
+4. Prune remote references.
+5. Post-merge housekeeping.
 
-This is a human (Race Director) operation. No agent invokes it.
+This is a human (Race Director) operation. No agent invokes it. The
+pre-merge provenance check is the worked example of the "human
+chokepoints are verification points" principle: at the irreversible
+step it closes the audit identity's `pull_requests: write` hard-gate
+gap that GitHub's permission model cannot. It generalizes beyond
+audit — the check verifies that *no* agent identity performed an
+action its role forbids on the PR being merged.
 
 ## `vrg-gh` Restriction Changes
 
@@ -727,6 +811,15 @@ The slot is instantiated only when a concrete elevated-access use
 case appears, and its design must pair the elevated rights with
 heightened human involvement.
 
+**Programmatic PR review at the merge gate.** The pre-merge
+provenance check in `vrg-finalize-pr` establishes a host-side
+insertion point that runs before merge. Today the PR-quality strategy
+relies almost entirely on CI gates; the PR *review* process is not yet
+leveraged for substantive review of AI-authored changes. The same
+chokepoint is the natural home for future programmatic or agentic
+review of the PR's *content*, not just its provenance. Scope and
+mechanism are a follow-up design.
+
 **Visual differentiation specifics.** The requirement is that each
 VM is visually distinct. The specific treatment (color scheme, prompt
 indicators, login banners) needs design and user testing.
@@ -763,6 +856,13 @@ demonstrate that:
   (server-side).
 - The audit identity cannot modify code or escalate privileges.
 
+Mimir is expected to defeat every Layer 1 soft gate trivially —
+becoming root, finding the raw binaries, spoofing `VRG_IDENTITY_MODE`,
+reverse-engineering the wrappers — and that is the point: the soft
+gates are not where containment lives. Mimir's real work is sustained
+pressure on the Layer 2 hard gates and the documented gaps, which is
+where the architecture either holds or fails.
+
 Documenting known attack surfaces for Mimir rather than waiting for
 discovery is part of the validation strategy. (Mimir's own
 implementation is out of scope here and will be designed separately.)
@@ -777,6 +877,19 @@ would let any AI-assisted workflow contain agents more tightly. The
 architecture is, in part, an opportunity to make the current limits
 of AI-safety tooling visible and argue — with data — for taking them
 seriously.
+
+**Radical transparency about weak controls.** This spec deliberately
+documents its own soft spots loudly rather than burying them — a
+strategic choice, not an admission of sloppiness. The current state of
+AI-agent security tooling is alarmingly immature; much of what ships
+as a "control" is trivially bypassable, and in important respects the
+field has regressed against security ground that was settled decades
+ago. Naming our gaps precisely is how we prioritize closing them and
+how we build the evidence to argue the field must do better. The
+documented gaps are a work list, not a disclaimer. Where
+vendor-provided agent controls are weak, we say so plainly and route
+real containment to the hard gates we control rather than pretending
+the soft ones suffice.
 
 **Human accountability.** Every contribution standard reviewed
 (including CPython's) requires human accountability. This

--- a/docs/specs/2026-05-29-agent-permission-model-plan.md
+++ b/docs/specs/2026-05-29-agent-permission-model-plan.md
@@ -20,22 +20,24 @@
 |---|---|
 | `src/vergil_tooling/lib/identity.py` | Identity mode detection from environment — `current_mode()`, `is_agent()`, `is_human()` |
 | `src/vergil_tooling/lib/pr_template.py` | Read, write, delete `.vergil/pr-template.yml` — simple YAML-subset parser |
-| `src/vergil_tooling/bin/vrg_finalize_pr.py` | Renamed from `vrg_finalize_repo.py` — all logic moves here |
+| `src/vergil_tooling/lib/pr_provenance.py` | Pre-merge PR provenance check — classify identities, evaluate forbidden/advisory actions |
+| `src/vergil_tooling/bin/vrg_finalize_pr.py` | Consolidation of `vrg_finalize_repo.py` cleanup + merge + provenance check |
 | `tests/vergil_tooling/test_identity.py` | Tests for identity module |
 | `tests/vergil_tooling/test_pr_template.py` | Tests for PR template module |
-| `tests/vergil_tooling/test_vrg_finalize_pr.py` | Tests for renamed tool (moved from `test_vrg_finalize_repo.py`) |
+| `tests/vergil_tooling/test_pr_provenance.py` | Tests for PR provenance module |
+| `tests/vergil_tooling/test_vrg_finalize_pr.py` | Tests for consolidated tool (cleanup + merge + provenance) |
 
 **Modified files:**
 
 | File | Change |
 |---|---|
 | `.gitignore` | Add `.vergil/` entry |
-| `src/vergil_tooling/bin/vrg_gh.py` | Identity-aware allowlists and denial messages |
+| `src/vergil_tooling/bin/vrg_gh.py` | Identity-aware allowlists, denial messages, and `gh api` access (human full / audit GET / user denied) |
 | `src/vergil_tooling/bin/vrg_submit_pr.py` | Template mode, identity gate, refactored into CLI/template paths |
 | `src/vergil_tooling/bin/vrg_git.py` | Push workflow-error detection with identity-aware feedback |
 | `src/vergil_tooling/bin/vrg_finalize_repo.py` | Reduced to deprecated alias that imports `vrg_finalize_pr` |
 | `src/vergil_tooling/lib/release/finalize.py` | Update subprocess call from `vrg-finalize-repo` to `vrg-finalize-pr` |
-| `src/vergil_tooling/lib/github.py` | Update docstring reference to `vrg-finalize-pr` |
+| `src/vergil_tooling/lib/github.py` | Add `pr_state` helper; update merge docstring reference to `vrg-finalize-pr` |
 | `pyproject.toml` | Add `vrg-finalize-pr` console script entry |
 | `tests/vergil_tooling/test_vrg_gh.py` | Update allowed/denied pairs, add identity-aware tests |
 | `tests/vergil_tooling/test_vrg_submit_pr.py` | Add template mode, identity gate, and confirmation tests |
@@ -89,13 +91,9 @@ from vergil_tooling.lib.identity import IdentityMode, current_mode, is_agent, is
 
 
 class TestCurrentMode:
-    def test_street_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "street")
-        assert current_mode() == IdentityMode.STREET
-
-    def test_track_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "track")
-        assert current_mode() == IdentityMode.TRACK
+    def test_user_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
+        assert current_mode() == IdentityMode.USER
 
     def test_audit_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "audit")
@@ -106,27 +104,27 @@ class TestCurrentMode:
         monkeypatch.delenv("VRG_APP_ID", raising=False)
         assert current_mode() == IdentityMode.HUMAN
 
-    def test_fallback_to_street_with_app_credentials(
+    def test_fallback_to_user_with_app_credentials(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
         monkeypatch.setenv("VRG_APP_ID", "12345")
-        assert current_mode() == IdentityMode.STREET
+        assert current_mode() == IdentityMode.USER
 
     def test_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "TRACK")
-        assert current_mode() == IdentityMode.TRACK
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "USER")
+        assert current_mode() == IdentityMode.USER
 
     def test_whitespace_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "  audit  ")
         assert current_mode() == IdentityMode.AUDIT
 
-    def test_invalid_mode_with_app_creds_falls_back_to_street(
+    def test_invalid_mode_with_app_creds_falls_back_to_user(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "invalid")
         monkeypatch.setenv("VRG_APP_ID", "12345")
-        assert current_mode() == IdentityMode.STREET
+        assert current_mode() == IdentityMode.USER
 
     def test_invalid_mode_without_app_creds_falls_back_to_human(
         self, monkeypatch: pytest.MonkeyPatch
@@ -137,12 +135,8 @@ class TestCurrentMode:
 
 
 class TestIsAgent:
-    def test_street_is_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "street")
-        assert is_agent() is True
-
-    def test_track_is_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "track")
+    def test_user_is_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
         assert is_agent() is True
 
     def test_audit_is_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -162,7 +156,7 @@ class TestIsHuman:
         assert is_human() is True
 
     def test_agent_is_not_human(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "street")
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
         assert is_human() is False
 ```
 
@@ -181,6 +175,13 @@ Create `src/vergil_tooling/lib/identity.py`:
 The VM provisioning sets ``VRG_IDENTITY_MODE`` alongside the GitHub App
 credentials. The mode determines which allowlists and behaviors apply
 in identity-aware tools (``vrg-gh``, ``vrg-submit-pr``, ``vrg-git``).
+
+``VRG_IDENTITY_MODE`` is a Layer 1 ergonomic, not a security control.
+An adversarial agent that becomes root inside the VM can set or unset
+it; doing so only relaxes soft-gate allowlists. The real identity
+boundary is the GitHub App credential provisioned to the VM, which no
+value of this variable can change. See the design spec's Three-Layer
+Security Model.
 """
 
 from __future__ import annotations
@@ -191,12 +192,11 @@ import os
 
 class IdentityMode(enum.Enum):
     HUMAN = "human"
-    STREET = "street"
-    TRACK = "track"
+    USER = "user"
     AUDIT = "audit"
 
 
-_AGENT_MODES = frozenset({IdentityMode.STREET, IdentityMode.TRACK, IdentityMode.AUDIT})
+_AGENT_MODES = frozenset({IdentityMode.USER, IdentityMode.AUDIT})
 
 _ENV_VAR = "VRG_IDENTITY_MODE"
 
@@ -210,7 +210,7 @@ def current_mode() -> IdentityMode:
         except ValueError:
             pass
     if os.environ.get("VRG_APP_ID"):
-        return IdentityMode.STREET
+        return IdentityMode.USER
     return IdentityMode.HUMAN
 
 
@@ -247,10 +247,10 @@ vrg-commit --type feat --scope identity --message "add identity detection module
 **Architecture note:** This task modifies `vrg-gh`, the *wrapper script* layer — not the hook guard. The two layers have distinct responsibilities: (1) the hook guard (`vrg-hook-guard`) is a dumb gate that blocks raw `git`/`gh` and redirects to `vrg-git`/`vrg-gh` — it knows nothing about subcommands or identity; (2) the wrapper scripts (`vrg-gh`, `vrg-git`) parse subcommands, apply identity-aware allowlists, and redirect to custom tools like `vrg-submit-pr`. No changes to the hook guard are needed for this task.
 
 This task converts `vrg-gh` from a static allowlist to an identity-aware system:
-- Street/track agents lose: `issue close`, `issue reopen`, `issue edit`, `pr edit`, `pr merge`
+- User agents lose: `issue close`, `issue reopen`, `issue edit`, `pr edit`, `pr merge`
 - Audit agents can only use: `pr view`, `pr diff`, `pr list`, `pr checks`, `pr comment`, `pr review`
 - `pr create` denied message stops mentioning `vrg-submit-pr` for agent identities
-- `pr review --approve` is allowed for audit and human identities, denied for street/track
+- `pr review --approve` is allowed for audit and human identities, denied for the user identity
 - Human identity retains the full current allowlist
 
 The approach: keep `_ALLOWED` as the human-level allowlist (maximum permissions). Add a `_denied_pairs()` function that returns identity-specific denied pairs. For audit mode, use a separate restricted allowlist. The denied-pairs check runs before the allowlist check, so agent-specific denials take precedence.
@@ -274,16 +274,11 @@ Add a new test class after the existing tests:
 
 
 class TestAgentDenials:
-    """Commands blocked for street/track agent identities.
+    """Commands blocked for the user agent identity."""
 
-    Both street and track modes share the same restricted allowlist.
-    The fixture parametrizes over both to ensure neither can bypass
-    agent-specific denials.
-    """
-
-    @pytest.fixture(autouse=True, params=["street", "track"])
-    def _agent_mode(self, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", request.param)
+    @pytest.fixture(autouse=True)
+    def _agent_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
 
     @pytest.mark.parametrize(
         ("top", "sub"),
@@ -441,12 +436,70 @@ class TestAuditAllowlist:
         self, top: str, sub: str, capsys: pytest.CaptureFixture[str]
     ) -> None:
         assert main([top, sub]) != 0
+
+
+class TestApiAccess:
+    """`gh api` is identity-aware: human full, audit GET-only, user denied."""
+
+    def test_user_api_denied(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
+        rc = main(["api", "repos/o/r/pulls/1/reviews"])
+        assert rc == 1
+        assert "denied for the user identity" in capsys.readouterr().err
+
+    def test_audit_api_get_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "audit")
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["api", "repos/o/r/pulls/1/reviews"])
+        assert rc == 0
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            ["-X", "POST"],
+            ["--method", "DELETE"],
+            ["-f", "title=x"],
+            ["--field", "body=y"],
+        ],
+    )
+    def test_audit_api_write_denied(
+        self, extra: list[str], monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "audit")
+        rc = main(["api", "repos/o/r/issues/1/comments", *extra])
+        assert rc == 1
+        assert "read-only GET" in capsys.readouterr().err
+
+    def test_human_api_allowed(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["api", "repos/o/r/pulls/1/merge", "-X", "PUT"])
+        assert rc == 0
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_gh.py::TestAgentDenials -v`
 Expected: FAIL — `vrg_gh` does not read identity mode yet.
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_gh.py::TestApiAccess -v`
+Expected: FAIL — `gh api` is not yet identity-aware.
 
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_gh.py::TestAuditAllowlist -v`
 Expected: FAIL — no audit allowlist.
@@ -513,9 +566,13 @@ _DENIED_HUMAN: dict[str, dict[str, str]] = {
 }
 
 _DENIED_TOP: dict[str, str] = {
-    "api": "gh api is denied by vrg-gh.",
     "auth": "gh auth is denied by vrg-gh.",
 }
+
+# `gh api` is identity-aware (handled in main, not in _DENIED_TOP):
+#   human -> full; audit -> read-only GET; user/other agent -> denied.
+# These flags flip gh's default verb from GET to POST.
+_API_WRITE_FLAGS: set[str] = {"-f", "-F", "--field", "--raw-field", "--input"}
 
 
 def _get_allowed() -> dict[str, set[str]]:
@@ -538,6 +595,59 @@ def _get_denied_pairs() -> dict[str, dict[str, str]]:
     return merged
 
 
+def _api_is_get(argv: list[str]) -> bool:
+    """Return True if a ``gh api`` invocation is a read-only GET.
+
+    gh defaults to GET, flips to POST when fields are present, and
+    honors an explicit ``-X``/``--method``.
+    """
+    method: str | None = None
+    has_fields = False
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("-X", "--method"):
+            if i + 1 < len(argv):
+                method = argv[i + 1].upper()
+            i += 2
+            continue
+        if arg.startswith("--method="):
+            method = arg.split("=", 1)[1].upper()
+        elif arg in _API_WRITE_FLAGS or arg.startswith(("--field=", "--raw-field=")):
+            has_fields = True
+        i += 1
+    if method is not None:
+        return method == "GET"
+    return not has_fields
+
+
+def _exec_gh(argv: list[str]) -> int:
+    """Inject the installation token and execute ``gh`` with retry."""
+    token = github.get_installation_token()
+    env: dict[str, str] | None = None
+    if token is not None:
+        env = {**os.environ, "GH_TOKEN": token}
+    try:
+        result = retry.run_with_retry(
+            ["gh", *argv],  # noqa: S607
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.stdout:
+            sys.stdout.write(exc.stdout)
+        if exc.stderr:
+            sys.stderr.write(exc.stderr)
+        return exc.returncode
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -552,6 +662,27 @@ def main(argv: list[str] | None = None) -> int:
         msg = _DENIED_TOP[top]
         print(f"vrg-gh: {top} is denied. {msg}", file=sys.stderr)
         return 1
+
+    # Identity-aware `gh api`: the broad escape hatch is gated per identity.
+    if top == "api":
+        mode = identity.current_mode()
+        if mode == identity.IdentityMode.USER:
+            print(
+                "vrg-gh: gh api is denied for the user identity "
+                "(broad write-capable escape hatch).",
+                file=sys.stderr,
+            )
+            return 1
+        if mode == identity.IdentityMode.AUDIT and not _api_is_get(argv):
+            print(
+                "vrg-gh: gh api is restricted to read-only GET calls "
+                "for the audit identity.",
+                file=sys.stderr,
+            )
+            return 1
+        # human (full) or audit GET: execute directly, bypassing the
+        # subcommand-pair allowlist (api has no fixed sub-actions).
+        return _exec_gh(argv)
 
     allowed = _get_allowed()
 
@@ -603,34 +734,12 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
-    token = github.get_installation_token()
-    env: dict[str, str] | None = None
-    if token is not None:
-        env = {**os.environ, "GH_TOKEN": token}
-    try:
-        result = retry.run_with_retry(
-            ["gh", *argv],  # noqa: S607
-            env=env,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        if exc.stdout:
-            sys.stdout.write(exc.stdout)
-        if exc.stderr:
-            sys.stderr.write(exc.stderr)
-        return exc.returncode
-    if result.stdout:
-        sys.stdout.write(result.stdout)
-    if result.stderr:
-        sys.stderr.write(result.stderr)
-    return 0
+    return _exec_gh(argv)
 ```
 
 - [ ] **Step 4: Update existing tests for compatibility**
 
-The existing `_ALLOWED_PAIRS` and `_DENIED_PAIRS` parametrized tests run without an identity mode set, so they default to human mode. Six existing tests need updates:
+The existing `_ALLOWED_PAIRS` and `_DENIED_PAIRS` parametrized tests run without an identity mode set, so they default to human mode. Seven existing tests need updates:
 
 **4a.** Remove `("pr", "merge")` from `_ALLOWED_PAIRS` — it's tested separately in `TestHumanAllowlist`:
 
@@ -692,7 +801,7 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
 
 **4d.** Remove `test_pr_create_denied_suggests_vrg_submit_pr` — replaced by `TestHumanAllowlist.test_pr_create_mentions_vrg_submit_pr`.
 
-**4e.** Update `test_pr_review_approve_denied` to set street identity (without it, human mode allows approve):
+**4e.** Update `test_pr_review_approve_denied` to set the user identity (without it, human mode allows approve):
 
 Replace:
 ```python
@@ -704,16 +813,18 @@ def test_pr_review_approve_denied(capsys: pytest.CaptureFixture[str]) -> None:
 
 With:
 ```python
-def test_pr_review_approve_denied_for_street(
+def test_pr_review_approve_denied_for_user(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setenv("VRG_IDENTITY_MODE", "street")
+    monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
     assert main(["pr", "review", "--approve"]) != 0
     err = capsys.readouterr().err
     assert "approve" in err.lower()
 ```
 
 **4f.** `test_pr_review_no_flags_allowed` and `test_pr_review_comment_allowed` — no changes needed (human mode, no --approve).
+
+**4g.** Remove `test_api_denied` — `gh api` is no longer denied unconditionally. With no identity mode set the test defaulted to human, where `api` is now allowed. The identity-aware behavior is covered by `TestApiAccess` (user denied, audit GET-only, human full).
 
 - [ ] **Step 5: Run all vrg-gh tests**
 
@@ -1038,11 +1149,12 @@ vrg-commit --type feat --scope pr-template --message "add PR template library fo
 - Modify: `src/vergil_tooling/bin/vrg_submit_pr.py`
 - Modify: `tests/vergil_tooling/test_vrg_submit_pr.py`
 
-The tool gains two major changes:
+The tool gains three major changes:
 1. **Identity gate:** Aborts immediately for any agent identity.
-2. **Template mode:** When no `--issue`/`--summary`/`--title` CLI args are provided, reads `.vergil/pr-template.yml` instead. Template mode does NOT push (agent already pushed). Template mode prompts for confirmation before creating the PR.
+2. **Template mode:** When no `--issue`/`--summary`/`--title` CLI args are provided, reads `.vergil/pr-template.yml` instead. Template mode prompts for confirmation before creating the PR.
+3. **Ensure-pushed:** Before creating the PR, the tool pushes the branch to the remote using the human's host credentials. Because `vrg-submit-pr` runs in the human's context (the superset of any agent's rights, per the spec's Foundational Assumption), this push succeeds even when the branch touches `.github/workflows/` — which the agent's own push would have been rejected for. This is how workflow-touching changes reach the remote without any agent holding `workflows: write`. The agent never pushed (its push of a workflow-touching branch would fail), so template mode must push, not assume the branch is already on the remote.
 
-CLI argument mode (existing behavior) is preserved for direct human use and does push.
+CLI argument mode (existing behavior) is preserved for direct human use and also pushes.
 
 - [ ] **Step 1: Write failing tests for identity gate**
 
@@ -1052,20 +1164,13 @@ Add to `tests/vergil_tooling/test_vrg_submit_pr.py`:
 class TestIdentityGate:
     """Agent identities are blocked from PR submission."""
 
-    def test_street_mode_blocked(
+    def test_user_mode_blocked(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "street")
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
         result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug"])
         assert result != 0
         assert "race director" in capsys.readouterr().err.lower()
-
-    def test_track_mode_blocked(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        monkeypatch.setenv("VRG_IDENTITY_MODE", "track")
-        result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug"])
-        assert result != 0
 
     def test_audit_mode_blocked(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -1168,7 +1273,7 @@ class TestTemplateMode:
         assert result == 1
         assert (vergil / "pr-template.yml").exists()
 
-    def test_template_does_not_push(self, tmp_path: Path) -> None:
+    def test_template_ensures_pushed(self, tmp_path: Path) -> None:
         vergil = tmp_path / ".vergil"
         vergil.mkdir()
         (vergil / "pr-template.yml").write_text(
@@ -1184,11 +1289,17 @@ class TestTemplateMode:
             patch(
                 "vergil_tooling.bin.vrg_submit_pr.github.create_pr",
                 return_value="https://github.com/pr/1",
-            ),
+            ) as mock_pr,
             patch("builtins.input", return_value="y"),
         ):
             main([])
-        mock_git_run.assert_not_called()
+        # Ensure-pushed: the branch is pushed with the human's credentials
+        # before the PR is created.
+        push_calls = [
+            c for c in mock_git_run.call_args_list if c.args and c.args[0] == "push"
+        ]
+        assert push_calls, "expected vrg-submit-pr to push the branch"
+        mock_pr.assert_called_once()
 
     def test_no_template_and_no_args_errors(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1243,9 +1354,15 @@ Replace `src/vergil_tooling/bin/vrg_submit_pr.py`:
 
 Supports two modes:
 - **Template mode** (no CLI args): reads ``.vergil/pr-template.yml``,
-  shows a summary, prompts for confirmation, creates the PR.
+  shows a summary, prompts for confirmation, pushes the branch, and
+  creates the PR.
 - **CLI argument mode** (args provided): existing direct invocation
   for human emergency use.
+
+Both modes ensure the branch is pushed using the human's host
+credentials before creating the PR. Because the human is the superset
+of any agent's rights, this carries workflow-touching pushes that the
+agent's own credentials would be rejected for.
 
 Agent identities are blocked — PR submission is a Race Director
 (human) operation.
@@ -1400,6 +1517,13 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     if answer != "y":
         print("Aborted.")
         return 1
+
+    # Ensure-pushed: push with the human's host credentials before creating
+    # the PR. The human is the superset of any agent's rights, so this push
+    # succeeds even for branches that touch .github/workflows/ — which the
+    # agent's own push would have been rejected for.
+    print(f"Ensuring branch '{branch}' is pushed to origin...")
+    git.run("push", "-u", "origin", branch)
 
     print("Creating PR...")
     pr_url = _create_pr(target_branch=target, title=title, pr_body=pr_body)
@@ -1682,24 +1806,304 @@ vrg-commit --type feat --scope vrg-git --message "detect workflow permission err
 
 ---
 
-### Task 7: `vrg-finalize-pr` Rename
+### Task 7: `vrg-finalize-pr` (merge consolidation + pre-merge provenance check)
+
+This is not a rename — it is a consolidation. `vrg-finalize-repo` was
+post-merge cleanup only (branch deletion, prune, validation, CD
+check); the human merged the PR by hand on the web first. We collapse
+both into one human tool, `vrg-finalize-pr`, and add a pre-merge
+provenance check — the host-side "human chokepoint" verification from
+the design spec that closes gaps GitHub's coarse permission model
+cannot enforce server-side.
+
+The tool has two modes, keyed on whether a PR argument is given:
+
+- **`vrg-finalize-pr <PR>`** (human feature-PR path): run the pre-merge
+  provenance check, then merge the PR (or confirm it is already
+  merged), then run the existing cleanup. This replaces the manual web
+  merge + `vrg-finalize-repo`.
+- **`vrg-finalize-pr`** (no PR — release path, backward compatible):
+  cleanup only, exactly as `vrg-finalize-repo` did today. The release
+  workflow already merges programmatically, so it must not merge again;
+  it calls this no-argument form for cleanup.
+
+**Provenance check.** Fetch the PR's action history with read-only
+`gh api` GET calls (running in the human context, where the API is
+available) and verify no agent identity performed an action its role
+forbids. Identities are recognized by account naming convention
+(`*-vergil-user`, `*-vergil-audit`); everything else is human and
+never forbidden. The audit identity must never have created, edited,
+closed, reopened, or merged the PR; an audit *approval* is permitted
+but surfaced as advisory. A fetch failure must abort the merge — never
+silently pass (no silent failures).
 
 **Files:**
+- Create: `src/vergil_tooling/lib/pr_provenance.py`
+- Create: `tests/vergil_tooling/test_pr_provenance.py`
 - Create: `src/vergil_tooling/bin/vrg_finalize_pr.py`
 - Modify: `src/vergil_tooling/bin/vrg_finalize_repo.py` (becomes deprecated alias)
 - Create: `tests/vergil_tooling/test_vrg_finalize_pr.py`
 - Modify: `tests/vergil_tooling/test_vrg_finalize_repo.py` (reduce to alias test)
+- Modify: `src/vergil_tooling/lib/github.py` (add `pr_state` helper; update merge docstring)
 - Modify: `src/vergil_tooling/lib/release/finalize.py` (update subprocess call)
-- Modify: `src/vergil_tooling/lib/github.py:448` (update docstring)
 - Modify: `tests/vergil_tooling/test_release_finalize.py:94` (update match string)
 - Modify: `pyproject.toml:25` (add entry point)
 
-- [ ] **Step 1: Copy the implementation file**
+- [ ] **Step 1: Write failing tests for `pr_provenance`**
 
-Copy `src/vergil_tooling/bin/vrg_finalize_repo.py` to `src/vergil_tooling/bin/vrg_finalize_pr.py`. In the new file, update:
+Create `tests/vergil_tooling/test_pr_provenance.py`. These tests cover
+the pure classification logic (`classify_login`, `evaluate`) and the
+API-collection path (`check_pr`, with `github` mocked).
 
-1. The module docstring (first line): `"""Finalize a pull request after merge."""`
-2. The error message at line 151: change `vrg-finalize-repo` to `vrg-finalize-pr`
+```python
+"""Tests for vergil_tooling.lib.pr_provenance."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from vergil_tooling.lib import pr_provenance
+from vergil_tooling.lib.pr_provenance import Action, Role
+
+
+def test_classify_login_user() -> None:
+    assert pr_provenance.classify_login("alice-vergil-user") is Role.USER
+
+
+def test_classify_login_audit() -> None:
+    assert pr_provenance.classify_login("alice-vergil-audit") is Role.AUDIT
+
+
+def test_classify_login_human() -> None:
+    assert pr_provenance.classify_login("alice") is Role.HUMAN
+
+
+def test_evaluate_human_actions_ignored() -> None:
+    actions = [Action("alice", Role.HUMAN, "created"), Action("alice", Role.HUMAN, "merged")]
+    result = pr_provenance.evaluate(actions)
+    assert result.ok
+    assert not result.violations
+    assert not result.advisories
+
+
+def test_evaluate_audit_approval_is_advisory() -> None:
+    actions = [Action("a-vergil-audit", Role.AUDIT, "approved")]
+    result = pr_provenance.evaluate(actions)
+    assert result.ok
+    assert len(result.advisories) == 1
+    assert not result.violations
+
+
+def test_evaluate_audit_close_is_violation() -> None:
+    actions = [Action("a-vergil-audit", Role.AUDIT, "closed")]
+    result = pr_provenance.evaluate(actions)
+    assert not result.ok
+    assert len(result.violations) == 1
+
+
+def test_evaluate_user_approval_is_violation() -> None:
+    actions = [Action("a-vergil-user", Role.USER, "approved")]
+    result = pr_provenance.evaluate(actions)
+    assert not result.ok
+    assert len(result.violations) == 1
+
+
+def test_check_pr_flags_audit_close() -> None:
+    reviews = json.dumps([])
+    timeline = json.dumps([{"event": "closed", "actor": {"login": "a-vergil-audit"}}])
+
+    def fake_read_output(*args: str, **_: object) -> str:
+        if args[0] == "api" and args[1].endswith("/reviews"):
+            return reviews
+        if args[0] == "api" and args[1].endswith("/timeline"):
+            return timeline
+        if args[:2] == ("pr", "view") and "number" in args:
+            return "42"
+        if args[:2] == ("pr", "view") and "author" in args:
+            return "alice"  # human author
+        raise AssertionError(f"unexpected call: {args}")
+
+    with (
+        patch("vergil_tooling.lib.pr_provenance.github.current_repo", return_value="o/r"),
+        patch("vergil_tooling.lib.pr_provenance.github.read_output", side_effect=fake_read_output),
+    ):
+        result = pr_provenance.check_pr("42")
+    assert not result.ok
+    assert result.violations[0].action == "closed"
+```
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_pr_provenance.py -v`
+Expected: FAIL (module does not exist yet).
+
+- [ ] **Step 2: Implement `pr_provenance`**
+
+Create `src/vergil_tooling/lib/pr_provenance.py`:
+
+```python
+"""Pre-merge provenance verification for vrg-finalize-pr.
+
+Fetches a PR's action history (reviews and timeline events) from
+GitHub and verifies that no agent identity performed an action its
+role forbids on the PR being merged. Agent identities are recognized
+by the account naming convention (``*-vergil-user`` and
+``*-vergil-audit``); everything else is treated as human and is never
+forbidden — the human holds every right.
+
+This is the host-side "human chokepoint" verification described in
+docs/specs/2026-05-29-agent-permission-model-design.md: it closes the
+gap the coarse GitHub permission model cannot enforce server-side
+(notably the audit identity's ``pull_requests: write`` scope, which
+GitHub cannot narrow to "review but never author/close/merge").
+
+Read-only ``gh api`` GET calls back this check. They run in the human
+context where the API is available; the same endpoints are reachable
+from the audit context under the identity-aware API allowance. A fetch
+failure propagates (``github.read_output`` raises on nonzero exit) so a
+broken check aborts the merge rather than silently passing.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import dataclass, field
+
+from vergil_tooling.lib import github
+
+
+class Role(enum.Enum):
+    HUMAN = "human"
+    USER = "user"
+    AUDIT = "audit"
+
+
+def classify_login(login: str) -> Role:
+    """Map a GitHub login to an identity role by naming convention."""
+    if login.endswith("-vergil-audit"):
+        return Role.AUDIT
+    if login.endswith("-vergil-user"):
+        return Role.USER
+    return Role.HUMAN
+
+
+# Actions an agent role must never perform on a PR it is merging.
+_FORBIDDEN: dict[Role, frozenset[str]] = {
+    Role.USER: frozenset({"created", "edited", "closed", "reopened", "merged", "approved"}),
+    Role.AUDIT: frozenset({"created", "edited", "closed", "reopened", "merged"}),
+}
+
+# Actions permitted but advisory — surfaced to the human, not blocked.
+_ADVISORY: dict[Role, frozenset[str]] = {
+    Role.AUDIT: frozenset({"approved"}),
+}
+
+
+@dataclass(frozen=True)
+class Action:
+    """A single agent-attributed action on the PR."""
+
+    login: str
+    role: Role
+    action: str
+
+
+@dataclass
+class ProvenanceResult:
+    violations: list[Action] = field(default_factory=list)
+    advisories: list[Action] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+
+_EVENT_MAP = {
+    "closed": "closed",
+    "reopened": "reopened",
+    "merged": "merged",
+    "renamed": "edited",
+}
+
+
+def _collect_actions(pr: str) -> list[Action]:
+    """Collect agent-attributed actions on *pr* from GitHub."""
+    repo = github.current_repo()
+    number = github.read_output("pr", "view", pr, "--json", "number", "--jq", ".number").strip()
+    actions: list[Action] = []
+
+    author = github.read_output(
+        "pr", "view", pr, "--json", "author", "--jq", ".author.login"
+    ).strip()
+    if author:
+        actions.append(Action(author, classify_login(author), "created"))
+
+    reviews_raw = github.read_output("api", f"repos/{repo}/pulls/{number}/reviews")
+    for review in json.loads(reviews_raw or "[]"):
+        if review.get("state") == "APPROVED":
+            login = (review.get("user") or {}).get("login", "")
+            if login:
+                actions.append(Action(login, classify_login(login), "approved"))
+
+    timeline_raw = github.read_output("api", f"repos/{repo}/issues/{number}/timeline")
+    for event in json.loads(timeline_raw or "[]"):
+        mapped = _EVENT_MAP.get(event.get("event", ""))
+        if mapped is None:
+            continue
+        login = (event.get("actor") or {}).get("login", "")
+        if login:
+            actions.append(Action(login, classify_login(login), mapped))
+
+    return actions
+
+
+def evaluate(actions: list[Action]) -> ProvenanceResult:
+    """Partition *actions* into violations and advisories. Pure."""
+    result = ProvenanceResult()
+    for act in actions:
+        if act.role is Role.HUMAN:
+            continue
+        if act.action in _ADVISORY.get(act.role, frozenset()):
+            result.advisories.append(act)
+        elif act.action in _FORBIDDEN.get(act.role, frozenset()):
+            result.violations.append(act)
+    return result
+
+
+def check_pr(pr: str) -> ProvenanceResult:
+    """Verify PR provenance by fetching and evaluating its action history."""
+    return evaluate(_collect_actions(pr))
+```
+
+- [ ] **Step 3: Run `pr_provenance` tests**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_pr_provenance.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Add `pr_state` helper and update merge docstring in `github.py`**
+
+In `src/vergil_tooling/lib/github.py`, add a small helper near `merge`:
+
+```python
+def pr_state(pr: str) -> str:
+    """Return the PR state: ``OPEN``, ``CLOSED``, or ``MERGED``."""
+    return read_output("pr", "view", pr, "--json", "state", "--jq", ".state")
+```
+
+And update the `merge` docstring (was `vrg-finalize-repo`):
+
+```python
+    Does not pass ``--delete-branch`` — branch cleanup is handled by
+    ``vrg-finalize-pr`` after the merge completes.
+```
+
+- [ ] **Step 5: Create `vrg_finalize_pr.py` from `vrg_finalize_repo.py`**
+
+Copy `src/vergil_tooling/bin/vrg_finalize_repo.py` to `src/vergil_tooling/bin/vrg_finalize_pr.py`. Then apply the changes below.
+
+Update the module docstring (first line): `"""Finalize a pull request: provenance check, merge, and cleanup."""`
+
+Update the error message at line 151: change `vrg-finalize-repo` to `vrg-finalize-pr`:
 
 ```python
         print(
@@ -1710,7 +2114,254 @@ Copy `src/vergil_tooling/bin/vrg_finalize_repo.py` to `src/vergil_tooling/bin/vr
         )
 ```
 
-- [ ] **Step 2: Replace `vrg_finalize_repo.py` with deprecated alias**
+Add the new imports at the top alongside the existing ones:
+
+```python
+from vergil_tooling.lib import config, git, github, pr_provenance
+```
+
+Extend `parse_args` with the PR argument and merge controls:
+
+```python
+    parser.add_argument(
+        "pr",
+        nargs="?",
+        default=None,
+        help="PR number or URL to merge and finalize. Omit for cleanup-only (release path).",
+    )
+    parser.add_argument(
+        "--strategy",
+        default="squash",
+        choices=["merge", "squash", "rebase"],
+        help="Merge strategy for the PR (feature PRs default to squash)",
+    )
+    parser.add_argument(
+        "--allow-provenance-violation",
+        action="store_true",
+        help="Proceed despite provenance violations (conscious human override)",
+    )
+```
+
+Add the provenance-check-and-merge helper:
+
+```python
+def _finalize_specific_pr(args: argparse.Namespace) -> int:
+    """Run the pre-merge provenance check, then merge (or confirm merged).
+
+    Returns 0 to continue to cleanup, nonzero to abort.
+    """
+    print(f"Checking provenance for PR {args.pr}...")
+    result = pr_provenance.check_pr(args.pr)
+
+    for adv in result.advisories:
+        print(
+            f"  ADVISORY: {adv.login} ({adv.role.value}) performed '{adv.action}' "
+            "— permitted but advisory.",
+            file=sys.stderr,
+        )
+
+    if result.violations:
+        print(f"ERROR: PR {args.pr} has provenance violations:", file=sys.stderr)
+        for v in result.violations:
+            print(
+                f"  {v.login} ({v.role.value}) performed forbidden action '{v.action}'.",
+                file=sys.stderr,
+            )
+        if not args.allow_provenance_violation:
+            print(
+                "\n  Aborting merge. Re-run with --allow-provenance-violation to\n"
+                "  override consciously — you hold every right, but the violation\n"
+                "  is in front of you.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "  Overriding provenance violations per --allow-provenance-violation.",
+            file=sys.stderr,
+        )
+
+    if github.pr_state(args.pr) == "MERGED":
+        print(f"PR {args.pr} already merged.")
+    elif args.dry_run:
+        print(f"  [dry-run] merge PR {args.pr} (--{args.strategy})")
+    else:
+        print(f"Merging PR {args.pr} (--{args.strategy})...")
+        github.merge(args.pr, strategy=args.strategy)
+
+    return 0
+```
+
+Wire it into `main`, immediately after the main-worktree guard and before the cleanup flow (i.e., right after `root = git.repo_root()`):
+
+```python
+    if args.pr is not None:
+        rc = _finalize_specific_pr(args)
+        if rc != 0:
+            return rc
+```
+
+The existing cleanup flow (switch branch, pull, delete merged branches, prune, validation, CD check) runs unchanged afterward in both modes.
+
+- [ ] **Step 6: Write failing tests for `vrg_finalize_pr` merge + provenance integration**
+
+Create `tests/vergil_tooling/test_vrg_finalize_pr.py` by copying
+`tests/vergil_tooling/test_vrg_finalize_repo.py` and applying these
+replacements throughout:
+
+| Old | New |
+|---|---|
+| `vergil_tooling.bin.vrg_finalize_repo` | `vergil_tooling.bin.vrg_finalize_pr` |
+| `_MOD = "vergil_tooling.bin.vrg_finalize_repo"` | `_MOD = "vergil_tooling.bin.vrg_finalize_pr"` |
+| `from vergil_tooling.bin.vrg_finalize_repo import` | `from vergil_tooling.bin.vrg_finalize_pr import` |
+| `"""Tests for vergil_tooling.bin.vrg_finalize_repo."""` | `"""Tests for vergil_tooling.bin.vrg_finalize_pr."""` |
+
+The copied tests exercise the no-PR cleanup-only path (backward
+compatibility — they pass no positional argument, so `args.pr` is
+`None` and the merge path is skipped). Then add the merge + provenance
+tests below.
+
+```python
+from vergil_tooling.lib.pr_provenance import Action, ProvenanceResult, Role
+
+
+def _clean() -> ProvenanceResult:
+    return ProvenanceResult()
+
+
+def _with_violation() -> ProvenanceResult:
+    return ProvenanceResult(violations=[Action("a-vergil-audit", Role.AUDIT, "closed")])
+
+
+def _with_advisory() -> ProvenanceResult:
+    return ProvenanceResult(advisories=[Action("a-vergil-audit", Role.AUDIT, "approved")])
+
+
+def test_pr_arg_runs_provenance_then_merges() -> None:
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr", return_value=_clean()) as mock_check,
+        patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+        patch(f"{_MOD}.git.current_branch", return_value="develop"),
+        patch(f"{_MOD}.git.merged_branches", return_value=[]),
+        patch(f"{_MOD}.git.run"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+        patch(f"{_MOD}.git.repo_root", return_value="/tmp/repo"),
+        patch(f"{_MOD}.config.read_config", side_effect=FileNotFoundError),
+        patch(f"{_MOD}.subprocess.run") as mock_sub,
+    ):
+        mock_sub.return_value.returncode = 0
+        result = main(["42"])
+    assert result == 0
+    mock_check.assert_called_once_with("42")
+    mock_merge.assert_called_once()
+
+
+def test_provenance_violation_aborts_without_merge(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr", return_value=_with_violation()),
+        patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+    ):
+        result = main(["42"])
+    assert result == 1
+    mock_merge.assert_not_called()
+    err = capsys.readouterr().err
+    assert "provenance violation" in err.lower()
+    assert "closed" in err
+
+
+def test_provenance_violation_override_merges() -> None:
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr", return_value=_with_violation()),
+        patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+        patch(f"{_MOD}.git.current_branch", return_value="develop"),
+        patch(f"{_MOD}.git.merged_branches", return_value=[]),
+        patch(f"{_MOD}.git.run"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+        patch(f"{_MOD}.git.repo_root", return_value="/tmp/repo"),
+        patch(f"{_MOD}.config.read_config", side_effect=FileNotFoundError),
+        patch(f"{_MOD}.subprocess.run") as mock_sub,
+    ):
+        mock_sub.return_value.returncode = 0
+        result = main(["42", "--allow-provenance-violation"])
+    assert result == 0
+    mock_merge.assert_called_once()
+
+
+def test_advisory_surfaced_and_merge_proceeds(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr", return_value=_with_advisory()),
+        patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+        patch(f"{_MOD}.git.current_branch", return_value="develop"),
+        patch(f"{_MOD}.git.merged_branches", return_value=[]),
+        patch(f"{_MOD}.git.run"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+        patch(f"{_MOD}.git.repo_root", return_value="/tmp/repo"),
+        patch(f"{_MOD}.config.read_config", side_effect=FileNotFoundError),
+        patch(f"{_MOD}.subprocess.run") as mock_sub,
+    ):
+        mock_sub.return_value.returncode = 0
+        result = main(["42"])
+    assert result == 0
+    mock_merge.assert_called_once()
+    assert "advisory" in capsys.readouterr().err.lower()
+
+
+def test_already_merged_skips_merge() -> None:
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr", return_value=_clean()),
+        patch(f"{_MOD}.github.pr_state", return_value="MERGED"),
+        patch(f"{_MOD}.github.merge") as mock_merge,
+        patch(f"{_MOD}.git.current_branch", return_value="develop"),
+        patch(f"{_MOD}.git.merged_branches", return_value=[]),
+        patch(f"{_MOD}.git.run"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+        patch(f"{_MOD}.git.repo_root", return_value="/tmp/repo"),
+        patch(f"{_MOD}.config.read_config", side_effect=FileNotFoundError),
+        patch(f"{_MOD}.subprocess.run") as mock_sub,
+    ):
+        mock_sub.return_value.returncode = 0
+        result = main(["42"])
+    assert result == 0
+    mock_merge.assert_not_called()
+
+
+def test_no_pr_arg_is_cleanup_only() -> None:
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr") as mock_check,
+        patch(f"{_MOD}.github.merge") as mock_merge,
+        patch(f"{_MOD}.git.current_branch", return_value="develop"),
+        patch(f"{_MOD}.git.merged_branches", return_value=[]),
+        patch(f"{_MOD}.git.run"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+        patch(f"{_MOD}.git.repo_root", return_value="/tmp/repo"),
+        patch(f"{_MOD}.config.read_config", side_effect=FileNotFoundError),
+        patch(f"{_MOD}.subprocess.run") as mock_sub,
+    ):
+        mock_sub.return_value.returncode = 0
+        result = main([])
+    assert result == 0
+    mock_check.assert_not_called()
+    mock_merge.assert_not_called()
+```
+
+Note: the copied tests assume the autouse `is_main_worktree` fixture
+from the original file is preserved. If the original file lacks one,
+add `patch(f"{_MOD}.git.is_main_worktree", return_value=True)` to each
+new test (or as an autouse fixture).
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py -v`
+Expected: FAIL (merge/provenance wiring not yet present, or module missing).
+
+- [ ] **Step 7: Run `vrg_finalize_pr` tests**
+
+After Step 5's implementation is in place, run:
+`vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 8: Replace `vrg_finalize_repo.py` with deprecated alias**
 
 Replace the contents of `src/vergil_tooling/bin/vrg_finalize_repo.py` with:
 
@@ -1740,20 +2391,7 @@ if __name__ == "__main__":
     sys.exit(main())
 ```
 
-- [ ] **Step 3: Copy and update the test file**
-
-Copy `tests/vergil_tooling/test_vrg_finalize_repo.py` to `tests/vergil_tooling/test_vrg_finalize_pr.py`.
-
-In the new test file, make these replacements throughout:
-
-| Old | New |
-|---|---|
-| `vergil_tooling.bin.vrg_finalize_repo` | `vergil_tooling.bin.vrg_finalize_pr` |
-| `_MOD = "vergil_tooling.bin.vrg_finalize_repo"` | `_MOD = "vergil_tooling.bin.vrg_finalize_pr"` |
-| `from vergil_tooling.bin.vrg_finalize_repo import` | `from vergil_tooling.bin.vrg_finalize_pr import` |
-| `"""Tests for vergil_tooling.bin.vrg_finalize_repo."""` | `"""Tests for vergil_tooling.bin.vrg_finalize_pr."""` |
-
-- [ ] **Step 4: Reduce `test_vrg_finalize_repo.py` to a deprecated-alias test**
+- [ ] **Step 9: Reduce `test_vrg_finalize_repo.py` to a deprecated-alias test**
 
 Replace `tests/vergil_tooling/test_vrg_finalize_repo.py` with:
 
@@ -1803,9 +2441,10 @@ def test_deprecated_alias_prints_warning(capsys: pytest.CaptureFixture[str]) -> 
     assert "vrg-finalize-pr" in err
 ```
 
-- [ ] **Step 5: Update `release/finalize.py`**
+- [ ] **Step 10: Update `release/finalize.py`**
 
-In `src/vergil_tooling/lib/release/finalize.py`, update all references:
+In `src/vergil_tooling/lib/release/finalize.py`, update all references
+(the release path still calls the no-argument cleanup-only form):
 
 Line 1: `"""Phase 5: Close tracking issue and run vrg-finalize-pr."""`
 
@@ -1817,21 +2456,7 @@ Line 33: `command="vrg-finalize-pr",`
 
 Line 34: `message="vrg-finalize-pr failed.",`
 
-- [ ] **Step 6: Update `lib/github.py` docstring**
-
-In `src/vergil_tooling/lib/github.py` at line 448, change:
-
-```python
-    """Merge a PR synchronously (without ``--auto``).
-
-    ...
-
-    Does not pass ``--delete-branch`` — branch cleanup is handled by
-    ``vrg-finalize-pr`` after the merge completes.
-    """
-```
-
-- [ ] **Step 7: Update `test_release_finalize.py`**
+- [ ] **Step 11: Update `test_release_finalize.py`**
 
 In `tests/vergil_tooling/test_release_finalize.py` at line 94, change the match string:
 
@@ -1839,7 +2464,7 @@ In `tests/vergil_tooling/test_release_finalize.py` at line 94, change the match 
         pytest.raises(ReleaseError, match="vrg-finalize-pr"),
 ```
 
-- [ ] **Step 8: Add `vrg-finalize-pr` entry point to `pyproject.toml`**
+- [ ] **Step 12: Add `vrg-finalize-pr` entry point to `pyproject.toml`**
 
 In `pyproject.toml`, add the new entry point after the existing `vrg-finalize-repo` line:
 
@@ -1848,24 +2473,26 @@ vrg-finalize-pr = "vergil_tooling.bin.vrg_finalize_pr:main"
 vrg-finalize-repo = "vergil_tooling.bin.vrg_finalize_repo:main"
 ```
 
-- [ ] **Step 9: Run all affected tests**
+- [ ] **Step 13: Run all affected tests**
 
-Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py tests/vergil_tooling/test_vrg_finalize_repo.py tests/vergil_tooling/test_release_finalize.py -v`
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_pr_provenance.py tests/vergil_tooling/test_vrg_finalize_pr.py tests/vergil_tooling/test_vrg_finalize_repo.py tests/vergil_tooling/test_release_finalize.py -v`
 Expected: All tests PASS.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 14: Commit**
 
 ```bash
 vrg-git add \
+  src/vergil_tooling/lib/pr_provenance.py \
   src/vergil_tooling/bin/vrg_finalize_pr.py \
   src/vergil_tooling/bin/vrg_finalize_repo.py \
   src/vergil_tooling/lib/release/finalize.py \
   src/vergil_tooling/lib/github.py \
+  tests/vergil_tooling/test_pr_provenance.py \
   tests/vergil_tooling/test_vrg_finalize_pr.py \
   tests/vergil_tooling/test_vrg_finalize_repo.py \
   tests/vergil_tooling/test_release_finalize.py \
   pyproject.toml
-vrg-commit --type refactor --scope finalize --message "rename vrg-finalize-repo to vrg-finalize-pr with deprecated alias"
+vrg-commit --type feat --scope finalize --message "consolidate merge + cleanup into vrg-finalize-pr with pre-merge provenance check"
 ```
 
 ---


### PR DESCRIPTION
# Pull Request

## Summary

- Rework the agent permission model around subset-of-human-rights and add the implementation plan

## Issue Linkage

- Ref #1289

## Notes

- Design spec and TDD implementation plan for the agent permission model and identity architecture (issue #1289). Documentation only — no code changes.

## Design (`2026-05-29-agent-permission-model-design.md`)
- **Foundational assumption:** the host operator is the all-powerful owner; agents are sandboxed minions holding a strict subset of the human's rights. Delegation to the host is the mechanism, not a workaround. If the human lacks a required right, the architecture does not function — by design.
- **Three-layer model:** soft gates (wrappers, hook guards, allowlists), hard gates (GitHub App permissions, branch protection), and operational auditing — with auditing promotable to a synchronous gate at human-run chokepoints.
- **Human chokepoints are verification points:** human-run destructive operations are where programmatic checks the hard gates cannot express get imposed. CI gates check content; chokepoints check conduct/provenance.
- **Identities:** user (`*-vergil-user`) and audit (`*-vergil-audit`, inverted shape); admin is a reserved slot. Track mode removed.
- **Identity-aware `gh api`:** full for human, read-only GET for audit, denied for user.

## Implementation plan (`2026-05-29-agent-permission-model-plan.md`)
- Realigned to the revised design (track mode removed; street→user).
- `vrg-gh` gains identity-aware allowlists and identity-aware `gh api` access.
- `vrg-submit-pr` gains template mode + ensure-pushed.
- **`vrg-finalize-pr` consolidation:** collapses the manual web merge and `vrg-finalize-repo` cleanup into one human tool, and adds a pre-merge provenance check (new `pr_provenance` lib) that aborts on out-of-role agent actions, with a conscious `--allow-provenance-violation` override.

This PR establishes the design and plan; the tooling changes land in subsequent PRs.