### PR TITLE
fix(vrg-vm): scope session resolve to the current cwd's project slug

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -41,6 +41,17 @@ def _claude_dir() -> Path:
     return Path.home() / ".claude"
 
 
+def _project_slug(cwd: str) -> str:
+    """Encode a cwd into Claude's project-slug form.
+
+    Claude stores each session's transcript under
+    ``~/.claude/projects/<slug>/`` where ``<slug>`` is the cwd with every
+    non-alphanumeric character (slashes, dots, etc.) replaced by ``-`` — the
+    same directory ``claude --resume`` searches.
+    """
+    return "".join(c if c.isalnum() else "-" for c in cwd)
+
+
 def _last_agent_name(transcript: Path) -> str | None:
     """Return the last ``agent-name`` value in a transcript, or ``None``."""
     last: str | None = None
@@ -63,12 +74,17 @@ def _last_agent_name(transcript: Path) -> str | None:
     return last
 
 
-def name_by_session(projects_dir: Path) -> dict[str, str]:
-    """Map session id (transcript stem) to its current name."""
+def name_by_session(projects_dir: Path, slug: str | None = None) -> dict[str, str]:
+    """Map session id (transcript stem) to its current name.
+
+    With ``slug`` set, only that one project slug's transcripts are read — the
+    scoping ``claude --resume`` itself uses. Without it, every slug is scanned.
+    """
     result: dict[str, str] = {}
     if not projects_dir.is_dir():
         return result
-    for transcript in sorted(projects_dir.glob("*/*.jsonl")):
+    pattern = f"{slug}/*.jsonl" if slug is not None else "*/*.jsonl"
+    for transcript in sorted(projects_dir.glob(pattern)):
         name = _last_agent_name(transcript)
         if name is not None:
             result[transcript.stem] = name
@@ -201,10 +217,12 @@ def _roster_updated_at(roster: list[dict[str, object]]) -> dict[str, float]:
     return out
 
 
-def _read_state() -> tuple[dict[str, str], set[str], dict[str, float]]:
+def _read_state(
+    slug: str | None = None,
+) -> tuple[dict[str, str], set[str], dict[str, float]]:
     cdir = _claude_dir()
     projects = cdir / "projects"
-    names = name_by_session(projects)
+    names = name_by_session(projects, slug)
     roster = read_roster(cdir / "sessions")
     active = active_session_ids(roster)
     last_active = _roster_updated_at(roster)
@@ -314,7 +332,7 @@ def resolve(
     archive_days: int,
 ) -> int:
     """Plan, auto-archive stale cold slots, then exec Claude for one identity + path."""
-    names, active, last_active = _read_state()
+    names, active, last_active = _read_state(_project_slug(str(Path.cwd())))
     slots = build_slots(identity, path, names, active, last_active)
     plan = plan_session(
         identity, path, slots, _now(), stale_days, archive_days, requested_slot, fork, fresh

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -270,7 +270,7 @@ def test_resolve_create(
     capture_exec: list[list[str]],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda: ({}, set(), {}))
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
     assert _resolve("id", "p", extra=["--model", "opus"]) == 0
     assert capture_exec == [["claude", "-n", "id:01:p", "--model", "opus"]]
     assert "Creating session id:01:p" in capsys.readouterr().err
@@ -281,7 +281,7 @@ def test_resolve_resume(
     capture_exec: list[list[str]],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda: ({"s1": "id:01:p"}, set(), {}))
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, set(), {}))
     assert _resolve("id", "p") == 0
     assert capture_exec == [["claude", "--resume", "s1"]]
     assert "Resuming session id:01:p" in capsys.readouterr().err
@@ -292,7 +292,7 @@ def test_resolve_fork(
     capture_exec: list[list[str]],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda: ({"s1": "id:01:p"}, {"s1"}, {}))
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, {"s1"}, {}))
     assert _resolve("id", "p", requested_slot=1, fork=True) == 0
     assert capture_exec == [["claude", "--resume", "s1", "--fork-session", "-n", "id:02:p"]]
     assert "Forking session id:01:p -> id:02:p" in capsys.readouterr().err
@@ -301,7 +301,7 @@ def test_resolve_fork(
 def test_resolve_refuse(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda: ({}, set(), {}))
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
     assert _resolve("id", "p", fork=True) == 1  # fork without slot
     assert "ERROR" in capsys.readouterr().err
 
@@ -313,7 +313,7 @@ def test_resolve_sweeps_stale_and_creates(
 ) -> None:
     now = 100 * DAY
     monkeypatch.setattr(
-        r, "_read_state", lambda: ({"old": "vergil:01:p"}, set(), {"old": now - 20 * DAY})
+        r, "_read_state", lambda *_a: ({"old": "vergil:01:p"}, set(), {"old": now - 20 * DAY})
     )
     monkeypatch.setattr(r, "_now", lambda: now)
     monkeypatch.setattr(r, "_now_iso", lambda: "2026-05-30T00:00:00Z")
@@ -334,7 +334,7 @@ def test_resolve_warn_prompt_resume(
 ) -> None:
     now = 100 * DAY
     monkeypatch.setattr(
-        r, "_read_state", lambda: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
+        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
     )
     monkeypatch.setattr(r, "_now", lambda: now)
     monkeypatch.setattr(r, "_prompt_stale", lambda *_a: "r")
@@ -350,7 +350,7 @@ def test_resolve_warn_prompt_fresh(
 ) -> None:
     now = 100 * DAY
     monkeypatch.setattr(
-        r, "_read_state", lambda: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
+        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
     )
     monkeypatch.setattr(r, "_now", lambda: now)
     monkeypatch.setattr(r, "_now_iso", lambda: "2026-05-30T00:00:00Z")
@@ -370,7 +370,7 @@ def test_resolve_warn_prompt_cancel(
 ) -> None:
     now = 100 * DAY
     monkeypatch.setattr(
-        r, "_read_state", lambda: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
+        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
     )
     monkeypatch.setattr(r, "_now", lambda: now)
     monkeypatch.setattr(r, "_prompt_stale", lambda *_a: "c")
@@ -423,7 +423,7 @@ def test_list_json_includes_age_and_state(
 def test_list_json_idle_state(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda: ({"s1": "vergil:01:p"}, set(), {}))
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {}))
     assert r.list_json() == 0
     rows = json.loads(capsys.readouterr().out)
     assert rows[0]["state"] == "idle"
@@ -434,7 +434,7 @@ def test_archived_rows_skips_unparseable_original(
 ) -> None:
     # archived label whose embedded "original" is not a valid slot name
     monkeypatch.setattr(
-        r, "_read_state", lambda: ({"a1": "archived@2026-05-01T00:00:00Z@garbage"}, set(), {})
+        r, "_read_state", lambda *_a: ({"a1": "archived@2026-05-01T00:00:00Z@garbage"}, set(), {})
     )
     assert r.list_json() == 0
     assert json.loads(capsys.readouterr().out) == []
@@ -486,7 +486,7 @@ def test_read_state_returns_last_active(monkeypatch: pytest.MonkeyPatch, tmp_pat
 def test_main_list_json(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda: ({}, set(), {}))
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
     assert r.main(["--list-json"]) == 0
     assert json.loads(capsys.readouterr().out) == []
 
@@ -536,3 +536,66 @@ def test_main_strips_leading_double_dash(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     r.main(["--identity", "id", "--path", "p", "--", "claude", "--model", "opus"])
     assert captured["extra"] == ["claude", "--model", "opus"]
+
+
+# --- cwd-scoped resolution (issue #1339) ---
+
+
+def test_project_slug_encodes_path() -> None:
+    # Claude encodes a cwd into a project slug by replacing every
+    # non-alphanumeric character (including the leading slash and dots) with "-".
+    assert r._project_slug("/work/tool") == "-work-tool"
+    assert r._project_slug("/a.b/c") == "-a-b-c"
+
+
+def test_name_by_session_scoped_to_one_slug(tmp_path: Path) -> None:
+    (tmp_path / "-a").mkdir()
+    (tmp_path / "-b").mkdir()
+    (tmp_path / "-a" / "s1.jsonl").write_text(
+        '{"type":"agent-name","agentName":"id:01:a","sessionId":"s1"}\n'
+    )
+    (tmp_path / "-b" / "s2.jsonl").write_text(
+        '{"type":"agent-name","agentName":"id:01:b","sessionId":"s2"}\n'
+    )
+    # Scoped to "-a": only that slug's transcript is read.
+    assert r.name_by_session(tmp_path, "-a") == {"s1": "id:01:a"}
+    # No slug: full scan across every slug (unchanged behavior).
+    assert r.name_by_session(tmp_path) == {"s1": "id:01:a", "s2": "id:01:b"}
+
+
+def test_resolve_ignores_session_under_other_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
+) -> None:
+    # A session whose NAME claims path "tool" but whose transcript physically
+    # lives under a different workspace's slug must be ignored: claude --resume
+    # is scoped to the current cwd's slug, so resuming it would hard-fail.
+    claude = tmp_path / ".claude"
+    projects = claude / "projects"
+    (projects / "-work-tool").mkdir(parents=True)
+    (projects / "-work-vm").mkdir(parents=True)
+    (projects / "-work-vm" / "mis.jsonl").write_text(
+        '{"type":"agent-name","agentName":"id:01:tool","sessionId":"mis"}\n'
+    )
+    (claude / "sessions").mkdir()
+    monkeypatch.setattr(r, "_claude_dir", lambda: claude)
+    monkeypatch.setattr(os, "getcwd", lambda: "/work/tool")
+    assert _resolve("id", "tool") == 0
+    assert capture_exec == [["claude", "-n", "id:01:tool"]]
+
+
+def test_resolve_resumes_session_under_current_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
+) -> None:
+    # Regression guard: a session whose transcript lives under the current cwd's
+    # slug is still resumable after scoping.
+    claude = tmp_path / ".claude"
+    projects = claude / "projects"
+    (projects / "-work-tool").mkdir(parents=True)
+    (projects / "-work-tool" / "good.jsonl").write_text(
+        '{"type":"agent-name","agentName":"id:01:tool","sessionId":"good"}\n'
+    )
+    (claude / "sessions").mkdir()
+    monkeypatch.setattr(r, "_claude_dir", lambda: claude)
+    monkeypatch.setattr(os, "getcwd", lambda: "/work/tool")
+    assert _resolve("id", "tool") == 0
+    assert capture_exec == [["claude", "--resume", "good"]]


### PR DESCRIPTION
# Pull Request

## Summary

- Scope the in-VM session resolver to the current cwd's project slug so a session whose name-path differs from its transcript's slug no longer hard-fails 'No conversation found'; it falls back to a fresh session instead.

## Issue Linkage

- Ref #1339

## Notes

- **Root cause:** the in-VM resolver (`vrg_vm_resolve.py`) discovered sessions by globbing **every** project slug (`~/.claude/projects/*/*.jsonl`) and matched them to a workspace purely by the path embedded in each session's `agent-name`. It never verified the chosen transcript physically lives under the project slug for the current cwd — the slug `claude --resume` actually searches. When a session's name-path pointed at workspace X while its transcript lived under another slug, the resolver execed `claude --resume <id>` from X's cwd, where Claude can't find the transcript → hard failure with no fallback.

**Fix:** scope discovery in the **resolve path** to the current cwd's project slug. `list --sessions` keeps its full-scan view. This converts the hard failure into the correct behavior — create a fresh session when none is resumable for the workspace.

### Changes

- `_project_slug(cwd)` — encodes a cwd into Claude's project-slug form (every non-alphanumeric char → `-`).
- `name_by_session(projects_dir, slug=None)` — optional `slug` scopes the glob to a single slug; omitting it preserves the full scan.
- `_read_state(slug=None)` — threads the slug through to `name_by_session`.
- `resolve(...)` now reads state scoped to `_project_slug(str(Path.cwd()))`; `list_json()` is unchanged (full scan).

### Test plan

- New tests (TDD, written failing first):
  - `test_project_slug_encodes_path`
  - `test_name_by_session_scoped_to_one_slug`
  - `test_resolve_ignores_session_under_other_slug` (the key regression: a session whose name claims the cwd's path but whose transcript lives under another slug is now ignored → fresh session)
  - `test_resolve_resumes_session_under_current_slug` (guard: legitimate same-slug session still resumes)
- `vrg-container-run -- uv run vrg-validate` passes (lint, format, mypy, ty, pytest @ 100% branch coverage, audit, licenses).