### PR TITLE
fix(config): include config path in vergil.toml warnings and errors

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -58,7 +58,7 @@ def _load_local_config(path: str) -> VergilConfig:
     """Load and parse vergil.toml from a local file path."""
     with Path(path).open("rb") as f:
         raw = tomllib.load(f)
-    return _parse_raw_config(raw)
+    return _parse_raw_config(raw, source=path)
 
 
 def _fetch_remote_config(repo: str) -> VergilConfig:
@@ -76,7 +76,7 @@ def _fetch_remote_config(repo: str) -> VergilConfig:
         raise RuntimeError(msg)
     raw_bytes = base64.b64decode(content)
     raw = tomllib.loads(raw_bytes.decode())
-    return _parse_raw_config(raw)
+    return _parse_raw_config(raw, source=f"{repo}:vergil.toml")
 
 
 def _audit_repo(repo: str, config: VergilConfig) -> ConfigDiff:

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -122,10 +122,10 @@ _VM_KEYS = frozenset(
 )
 
 
-def _parse_role_overlay(name: str, raw: dict[str, Any]) -> RoleOverlay:
+def _parse_role_overlay(name: str, raw: dict[str, Any], source: str = CONFIG_FILE) -> RoleOverlay:
     for key in raw:
         if key not in _VM_KEYS:
-            print(f"{CONFIG_FILE}: unrecognized key '{key}' in [vm.{name}]", file=sys.stderr)
+            print(f"{source}: unrecognized key '{key}' in [vm.{name}]", file=sys.stderr)
     return RoleOverlay(
         packages=list(raw.get("packages", [])),
         cpus=raw.get("cpus"),
@@ -137,7 +137,7 @@ def _parse_role_overlay(name: str, raw: dict[str, Any]) -> RoleOverlay:
     )
 
 
-def parse_vm_stanza(raw: dict[str, Any]) -> VmStanza | None:
+def parse_vm_stanza(raw: dict[str, Any], source: str = CONFIG_FILE) -> VmStanza | None:
     """Parse the repo ``[vm]`` cascade. Returns None when no ``[vm]`` section exists."""
     vm_raw = raw.get("vm")
     if vm_raw is None:
@@ -146,11 +146,11 @@ def parse_vm_stanza(raw: dict[str, Any]) -> VmStanza | None:
     fields: dict[str, Any] = {}
     for key, value in vm_raw.items():
         if isinstance(value, dict):
-            roles[key] = _parse_role_overlay(key, value)
+            roles[key] = _parse_role_overlay(key, value, source)
         elif key in _VM_KEYS:
             fields[key] = value
         else:
-            print(f"{CONFIG_FILE}: unrecognized key '{key}' in [vm]", file=sys.stderr)
+            print(f"{source}: unrecognized key '{key}' in [vm]", file=sys.stderr)
     return VmStanza(
         packages=list(fields.get("packages", [])),
         cpus=fields.get("cpus"),
@@ -163,10 +163,10 @@ def parse_vm_stanza(raw: dict[str, Any]) -> VmStanza | None:
     )
 
 
-def _warn_unrecognized_keys(raw: dict[str, Any]) -> None:
+def _warn_unrecognized_keys(raw: dict[str, Any], source: str = CONFIG_FILE) -> None:
     for section in raw:
         if section not in _KNOWN_SECTIONS:
-            print(f"vergil.toml: unrecognized section [{section}]", file=sys.stderr)
+            print(f"{source}: unrecognized section [{section}]", file=sys.stderr)
             continue
         if not isinstance(raw[section], dict):
             continue
@@ -176,33 +176,37 @@ def _warn_unrecognized_keys(raw: dict[str, Any]) -> None:
         for key in raw[section]:
             if key not in known:
                 print(
-                    f"vergil.toml: unrecognized key '{key}' in [{section}]",
+                    f"{source}: unrecognized key '{key}' in [{section}]",
                     file=sys.stderr,
                 )
 
 
-def _parse_raw_config(raw: dict[str, Any]) -> VergilConfig:
-    """Parse and validate a raw TOML dict into VergilConfig."""
-    _warn_unrecognized_keys(raw)
+def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilConfig:
+    """Parse and validate a raw TOML dict into VergilConfig.
+
+    ``source`` labels warnings and errors with the config's origin
+    (e.g. a resolved file path) so multi-repo scans stay diagnosable.
+    """
+    _warn_unrecognized_keys(raw, source)
     project_raw = raw.get("project", {})
 
     for field in _REQUIRED_PROJECT_FIELDS:
         if field not in project_raw or not project_raw[field]:
-            msg = f"{CONFIG_FILE}: missing or empty required field '{field}'"
+            msg = f"{source}: missing or empty required field '{field}'"
             raise ConfigError(msg)
 
     for field in _REQUIRED_PROJECT_FIELDS:
         value = project_raw[field]
         if value not in _ENUMS[field]:
             allowed = ", ".join(sorted(_ENUMS[field]))
-            msg = f"{CONFIG_FILE}: invalid {field} '{value}' (allowed: {allowed})"
+            msg = f"{source}: invalid {field} '{value}' (allowed: {allowed})"
             raise ConfigError(msg)
 
     raw_lang = project_raw.get("primary-language", "")
     if raw_lang and raw_lang not in _ENUMS["primary-language"]:
         allowed = ", ".join(sorted(_ENUMS["primary-language"]))
         print(
-            f"warning: {CONFIG_FILE}: unrecognized primary-language '{raw_lang}'"
+            f"warning: {source}: unrecognized primary-language '{raw_lang}'"
             f" (known: {allowed}); treating as unset",
             file=sys.stderr,
         )
@@ -210,29 +214,29 @@ def _parse_raw_config(raw: dict[str, Any]) -> VergilConfig:
 
     deps = raw.get("dependencies", {})
     if "vergil" not in deps:
-        msg = f"{CONFIG_FILE}: [dependencies] must contain 'vergil'"
+        msg = f"{source}: [dependencies] must contain 'vergil'"
         raise ConfigError(msg)
 
     ml_raw = raw.get("markdownlint", {})
     ml_ignore = ml_raw.get("ignore", [])
     if not isinstance(ml_ignore, list) or not all(isinstance(p, str) for p in ml_ignore):
-        msg = f"{CONFIG_FILE}: [markdownlint].ignore must be a list of strings"
+        msg = f"{source}: [markdownlint].ignore must be a list of strings"
         raise ConfigError(msg)
     markdownlint = MarkdownlintConfig(ignore=ml_ignore)
 
     ci_raw = raw.get("ci")
     if ci_raw is None:
-        msg = f"{CONFIG_FILE}: missing required section [ci]"
+        msg = f"{source}: missing required section [ci]"
         raise ConfigError(msg)
     versions = ci_raw.get("versions")
     if versions is None:
-        msg = f"{CONFIG_FILE}: [ci] missing required field 'versions'"
+        msg = f"{source}: [ci] missing required field 'versions'"
         raise ConfigError(msg)
     if not isinstance(versions, list) or not versions:
-        msg = f"{CONFIG_FILE}: [ci].versions must be a list with at least one entry"
+        msg = f"{source}: [ci].versions must be a list with at least one entry"
         raise ConfigError(msg)
     if not all(isinstance(v, str) for v in versions):
-        msg = f"{CONFIG_FILE}: [ci].versions entries must be strings"
+        msg = f"{source}: [ci].versions entries must be strings"
         raise ConfigError(msg)
     ci = CiConfig(
         versions=versions,
@@ -250,10 +254,10 @@ def _parse_raw_config(raw: dict[str, Any]) -> VergilConfig:
     if container_raw is not None:
         env_prefixes = container_raw.get("env-prefixes")
         if env_prefixes is None:
-            msg = f"{CONFIG_FILE}: [container] missing required field 'env-prefixes'"
+            msg = f"{source}: [container] missing required field 'env-prefixes'"
             raise ConfigError(msg)
         if not isinstance(env_prefixes, list) or not all(isinstance(p, str) for p in env_prefixes):
-            msg = f"{CONFIG_FILE}: [container].env-prefixes must be a list of strings"
+            msg = f"{source}: [container].env-prefixes must be a list of strings"
             raise ConfigError(msg)
         container = ContainerConfig(env_prefixes=env_prefixes)
     else:
@@ -273,7 +277,7 @@ def _parse_raw_config(raw: dict[str, Any]) -> VergilConfig:
         ci=ci,
         publish=publish,
         container=container,
-        vm=parse_vm_stanza(raw),
+        vm=parse_vm_stanza(raw, source),
     )
 
 
@@ -288,10 +292,10 @@ def read_config(repo_root: Path) -> VergilConfig:
         with config_path.open("rb") as f:
             raw = tomllib.load(f)
     except tomllib.TOMLDecodeError as exc:
-        msg = f"{CONFIG_FILE} is not valid TOML: {exc}"
+        msg = f"{config_path} is not valid TOML: {exc}"
         raise ConfigError(msg) from exc
 
-    return _parse_raw_config(raw)
+    return _parse_raw_config(raw, source=str(config_path))
 
 
 def vrg_install_tag(repo_root: Path) -> str:

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -441,6 +441,72 @@ def test_no_warnings_for_valid_config(tmp_path: Path, capsys: pytest.CaptureFixt
     assert err == ""
 
 
+# -- messages include the config path (issue #1411) ---------------------------
+
+
+def test_primary_language_warning_includes_config_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "none"')
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    err = capsys.readouterr().err
+    assert f"warning: {tmp_path / 'vergil.toml'}: unrecognized primary-language 'none'" in err
+    assert cfg.project.primary_language is None
+
+
+def test_unrecognized_key_warning_includes_config_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "vergil.toml").write_text(_EXTRA_PROJECT_KEY_TOML)
+    read_config(tmp_path)
+    err = capsys.readouterr().err
+    assert f"{tmp_path / 'vergil.toml'}: unrecognized key 'version-file' in [project]" in err
+
+
+def test_unrecognized_section_warning_includes_config_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    toml = _VALID_TOML + '\n[custom]\nfoo = "bar"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    read_config(tmp_path)
+    err = capsys.readouterr().err
+    assert f"{tmp_path / 'vergil.toml'}: unrecognized section [custom]" in err
+
+
+def test_config_error_includes_config_path(tmp_path: Path) -> None:
+    toml = _VALID_TOML.replace('release-model = "tagged-release"\n', "")
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError) as excinfo:
+        read_config(tmp_path)
+    assert str(tmp_path / "vergil.toml") in str(excinfo.value)
+
+
+def test_invalid_toml_error_includes_config_path(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text("[invalid\n")
+    with pytest.raises(ConfigError) as excinfo:
+        read_config(tmp_path)
+    assert str(tmp_path / "vergil.toml") in str(excinfo.value)
+
+
+def test_vm_key_warning_includes_config_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML + "\n[vm]\nbogus = 1\n")
+    read_config(tmp_path)
+    err = capsys.readouterr().err
+    assert f"{tmp_path / 'vergil.toml'}: unrecognized key 'bogus' in [vm]" in err
+
+
+def test_vm_role_warning_includes_config_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML + "\n[vm.vergil-user]\nbogus = 1\n")
+    read_config(tmp_path)
+    err = capsys.readouterr().err
+    assert f"{tmp_path / 'vergil.toml'}: unrecognized key 'bogus' in [vm.vergil-user]" in err
+
+
 # -- [container] section ------------------------------------------------------
 
 _CONTAINER_TOML = (


### PR DESCRIPTION
# Pull Request

## Summary

- Thread the resolved config path through config.py parsers so warnings and ConfigError messages name the file that triggered them.

## Issue Linkage

- Ref #1411

## Notes

- >-