### PR TITLE
chore(repo): ignore .superpowers/ and refresh stale agent-facing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ build/
 .ruff_cache/
 .worktrees/
 .vergil/
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,22 @@ Raw `git` and `gh` are denied by the permission model. If a command
 is not available through the wrappers, explain the situation to the
 human who can run it directly via `! <command>` in the prompt.
 
+### Identity modes and PR submission
+
+Identity-aware tools (`vrg-git`, `vrg-gh`, `vrg-submit-pr`) read
+`VRG_IDENTITY_MODE` (`human`, `user`, or `audit`; see
+`src/vergil_tooling/lib/identity_mode.py`). Agent sessions run as
+`user` or `audit`.
+
+**Agents must not run `vrg-submit-pr`.** PR submission, merge, and
+finalization are human actions. The PR handoff is:
+
+1. The agent writes `.vergil/pr-template.yml` with `issue`, `title`,
+   and `summary` fields (optional: `linkage`, `notes`).
+2. The human runs `vrg-submit-pr` with no arguments, which reads the
+   template, previews the PR, and submits after confirmation.
+3. The human merges and runs post-merge cleanup (`vrg-finalize-pr`).
+
 ## Validation
 
 ```bash
@@ -118,7 +134,7 @@ CI checkout (GitHub Actions).
 
 **Project name**: vergil-tooling
 
-**Status**: Stable (v1.x)
+**Status**: Stable (v2.x)
 
 **Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
 — historical reference; active standards documentation lives in this
@@ -199,7 +215,8 @@ CLI tools installed as `vrg-*` console scripts:
 
 - **`vrg-commit`** — Construct standards-compliant conventional
   commits with co-author resolution
-- **`vrg-submit-pr`** — Create standards-compliant PRs (manual merge)
+- **`vrg-submit-pr`** — Create standards-compliant PRs (manual merge;
+  human-run — agents hand off via `.vergil/pr-template.yml`)
 - **`vrg-release`** — Mechanized end-to-end release workflow (develop to main)
 - **`vrg-resolve-tracking-issue`** — Extract tracking issue number from a merge commit's PR linkage
 - **`vrg-finalize-pr`** — Merge a PR and run post-merge cleanup (branch/worktree deletion, remote pruning)
@@ -253,11 +270,12 @@ wrappers through. Only active in repos with a `vergil.toml`.
 ### Consumption Model
 
 `vergil-tooling` has two coordinated deployment targets (see
-`docs/specs/host-level-tool.md` for the full spec):
+`docs/specs/host-level-tool.md` — historical spec, written under the
+old `standard-tooling`/`st-*` naming):
 
 | Target | Install mechanism | Who uses it |
 |---|---|---|
-| **Developer host** | `uv tool install` from git URL | Host-side commands: `vrg-container-run`, `vrg-commit`, `vrg-submit-pr`, `vrg-prepare-release`, `vrg-finalize-pr` |
+| **Developer host** | `uv tool install` from git URL | Host-side commands: `vrg-container-run`, `vrg-commit`, `vrg-submit-pr`, `vrg-release`, `vrg-finalize-pr` |
 | **Container runtime** (all languages) | `vrg-container-run` cache-first install per `vergil.toml` | `vrg-*` inside the container for all consumers |
 
 **Host install** (canonical):

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ export PATH="$(pwd)/.venv/bin:$PATH"
 ## CLI tools
 
 - `vrg-commit` — Standards-compliant conventional commits
-- `vrg-submit-pr` — Standards-compliant PR creation with auto-merge
-- `vrg-prepare-release` — Automated release preparation
+- `vrg-submit-pr` — Standards-compliant PR creation (manual merge)
+- `vrg-release` — Mechanized end-to-end release workflow
 - `vrg-finalize-pr` — Merge a PR and run post-merge cleanup
 - `vrg-validate` — Unified validation driver (via vrg-container-run)
 - `vrg-ensure-label` — Idempotent GitHub label creation

--- a/docs/specs/worktree-convention.md
+++ b/docs/specs/worktree-convention.md
@@ -129,7 +129,7 @@ Your branch is:   feature/<N>-<slug>
 
 Rules for this session:
 - Do all git operations from inside your worktree:
-    cd <absolute-worktree-path> && git <command>
+    cd <absolute-worktree-path> && vrg-git <command>
 - For Read / Edit / Write tools, use the absolute worktree path.
 - For Bash commands that touch files, cd into the worktree first
   or use absolute paths.


### PR DESCRIPTION
# Pull Request

## Summary

- Add .superpowers/ to .gitignore so Superpowers plugin state stops
interfering with repo tooling, and sweep CLAUDE.md, README.md, and
docs/specs/worktree-convention.md for stale references left behind
by the vergil 2.1 migration: replace the nonexistent
vrg-prepare-release with vrg-release, correct vrg-submit-pr's
auto-merge description, update the v1.x status line, use vrg-git in
the canonical agent prompt template, mark host-level-tool.md as a
historical standard-tooling spec, and document the identity-mode
PR handoff (agents write .vergil/pr-template.yml; the human runs
vrg-submit-pr).

## Issue Linkage

- Ref #1417

## Notes

- The doc sweep was folded into the .gitignore PR to move quickly.
Out of scope, found during the sweep: the vergil-claude-plugin
PostToolUse hook (hooks/scripts/remind-finalize.sh) still tells
agents to run the removed vrg-finalize-repo — needs a plugin issue.