### PR TITLE
fix(identity): provision and detect identity mode so agent VMs never resolve to human

### DIFF
--- a/docs/site/docs/guides/account-setup.md
+++ b/docs/site/docs/guides/account-setup.md
@@ -263,10 +263,14 @@ Notes:
   agent identities lets the agent VMs run new tooling while the human
   host stays on a stable `v2.0` (the top-level default). Only set the
   `v2.1` pin once 2.1 has been released.
-- **`VRG_IDENTITY_MODE`** (`user` / `audit`) is set by VM
-  provisioning in the vergil-vm repo, not here. It selects the
-  identity-aware allowlists at runtime; it is a soft-gate ergonomic,
-  not the security boundary (the App credential is).
+- **`VRG_IDENTITY_MODE`** (`user` / `audit`) is derived from the
+  identity's stanza name at provisioning time — a name containing
+  `user` provisions as user mode, `audit` as audit mode; a name
+  containing neither (or both) fails provisioning. The mode is
+  written to `~/.config/vergil/identity-mode` in the VM and exported
+  from the shell profile. It selects the identity-aware allowlists
+  at runtime; it is a soft-gate ergonomic, not the security boundary
+  (the App credential is).
 
 ## Verification checklist
 

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -19,6 +19,7 @@ _DEFAULT_SESSION_ARCHIVE_DAYS = 14
 class Identity:
     vm_instance: str
     auth_type: str = "app"
+    mode: str = ""  # "user" / "audit", derived from the stanza name at load time
     app_id: str = ""
     private_key_path: str = ""
     claude_token_path: str = ""
@@ -79,6 +80,22 @@ def _validate_identity_resources(name: str, identity: Identity) -> None:
             raise SystemExit(1)
 
 
+def derive_identity_mode(name: str) -> str:
+    """Derive the identity mode (``"user"`` or ``"audit"``) from an identity name.
+
+    The dual-identity convention names stanzas ``vergil-user`` and
+    ``vergil-audit``; the role token in the name is the mode. Returns
+    ``""`` when the name contains neither token or both — callers that
+    require a mode (VM provisioning) must fail loudly on ``""`` rather
+    than guess.
+    """
+    has_user = "user" in name
+    has_audit = "audit" in name
+    if has_user == has_audit:
+        return ""
+    return "user" if has_user else "audit"
+
+
 def load_config(path: Path) -> IdentityConfig:
     if not path.exists():
         print(f"ERROR: identity config not found: {path}", file=sys.stderr)
@@ -109,6 +126,7 @@ def load_config(path: Path) -> IdentityConfig:
         identities[name] = Identity(
             vm_instance=data["vm_instance"],
             auth_type=data.get("auth_type", "app"),
+            mode=derive_identity_mode(name),
             app_id=str(data.get("app_id", "")),
             private_key_path=data.get("private_key_path", ""),
             claude_token_path=data.get("claude_token_path", ""),

--- a/src/vergil_tooling/lib/identity_mode.py
+++ b/src/vergil_tooling/lib/identity_mode.py
@@ -1,8 +1,17 @@
 """Agent identity-mode detection from VM environment.
 
-The VM provisioning sets ``VRG_IDENTITY_MODE`` alongside the GitHub App
-credentials. The mode determines which allowlists and behaviors apply
-in identity-aware tools (``vrg-gh``, ``vrg-submit-pr``, ``vrg-git``).
+VM provisioning (``lima.inject_credentials``) derives the mode from the
+identity's name in ``identities.toml``, writes it to
+``~/.config/vergil/identity-mode``, and adds a ``~/.bashrc`` line that
+exports it as ``VRG_IDENTITY_MODE``. The mode determines which
+allowlists and behaviors apply in identity-aware tools (``vrg-gh``,
+``vrg-submit-pr``, ``vrg-git``).
+
+Detection falls back from the environment variable to the mode file to
+the presence of provisioned App credentials, so an agent VM resolves to
+an agent mode even when the shell never sourced the export — bare
+credentials with no recorded mode resolve to USER (the most-gated
+mode), never HUMAN.
 
 ``VRG_IDENTITY_MODE`` is a Layer 1 ergonomic, not a security control.
 An adversarial agent that becomes root inside the VM can set or unset
@@ -20,6 +29,7 @@ from __future__ import annotations
 
 import enum
 import os
+from pathlib import Path
 
 
 class IdentityMode(enum.Enum):
@@ -32,15 +42,42 @@ _AGENT_MODES = frozenset({IdentityMode.USER, IdentityMode.AUDIT})
 
 _ENV_VAR = "VRG_IDENTITY_MODE"
 
+_MODE_FILE = "~/.config/vergil/identity-mode"
+_APP_KEY_FILE = "~/.config/vergil/app.pem"
+
+
+def _parse_mode(raw: str) -> IdentityMode | None:
+    raw = raw.strip().lower()
+    if not raw:
+        return None
+    try:
+        return IdentityMode(raw)
+    except ValueError:
+        return None
+
 
 def current_mode() -> IdentityMode:
-    """Detect the current identity mode from the environment."""
-    raw = os.environ.get(_ENV_VAR, "").strip().lower()
-    if raw:
-        try:
-            return IdentityMode(raw)
-        except ValueError:
-            pass
+    """Detect the current identity mode from the environment.
+
+    Resolution order:
+
+    1. ``VRG_IDENTITY_MODE`` environment variable (valid value)
+    2. ``~/.config/vergil/identity-mode`` written by VM provisioning
+    3. presence of ``~/.config/vergil/app.pem`` (provisioned App
+       credential) implies an agent VM and resolves to USER
+    4. ``VRG_APP_ID`` environment variable resolves to USER
+    5. HUMAN
+    """
+    mode = _parse_mode(os.environ.get(_ENV_VAR, ""))
+    if mode is not None:
+        return mode
+    mode_file = Path(_MODE_FILE).expanduser()
+    if mode_file.exists():
+        mode = _parse_mode(mode_file.read_text())
+        if mode is not None:
+            return mode
+    if Path(_APP_KEY_FILE).expanduser().exists():
+        return IdentityMode.USER
     if os.environ.get("VRG_APP_ID"):
         return IdentityMode.USER
     return IdentityMode.HUMAN

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -259,6 +259,14 @@ def inject_credentials(instance: str, identity: Identity) -> None:
         print(f"ERROR: private key not found: {key_path}", file=sys.stderr)
         raise SystemExit(1)
 
+    if not identity.mode:
+        print(
+            f"ERROR: cannot derive identity mode for VM '{instance}' — rename the"
+            " identity in identities.toml so the name contains 'user' or 'audit'",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     key_content = key_path.read_text()
 
     print("  Injecting App private key...")
@@ -276,6 +284,8 @@ def inject_credentials(instance: str, identity: Identity) -> None:
         f"APP_ID={identity.app_id}\n",
     )
 
+    _inject_identity_mode(instance, identity.mode)
+
     _inject_host_git_identity(instance)
 
     print("  Configuring git for HTTPS GitHub access...")
@@ -290,6 +300,33 @@ def inject_credentials(instance: str, identity: Identity) -> None:
 
     if identity.claude_token_path:
         _inject_claude_token(instance, identity.claude_token_path)
+
+
+_BASHRC_MODE_LINE = (
+    "[ -f ~/.config/vergil/identity-mode ]"
+    ' && export VRG_IDENTITY_MODE="$(cat ~/.config/vergil/identity-mode)"'
+)
+
+
+def _inject_identity_mode(instance: str, mode: str) -> None:
+    """Write the identity-mode file and export it from the shell profile.
+
+    The plain-text mode file is the single source of truth: the bashrc
+    line exports it as ``VRG_IDENTITY_MODE`` for interactive shells (and
+    skill preflights), and ``identity_mode.current_mode()`` reads the
+    file directly as a fallback for processes that never sourced bashrc.
+    """
+    print(f"  Injecting identity mode ({mode})...")
+    shell_pipe(
+        instance,
+        "cat > ~/.config/vergil/identity-mode && chmod 600 ~/.config/vergil/identity-mode",
+        f"{mode}\n",
+    )
+    export_cmd = (
+        f'grep -qF "identity-mode" ~/.bashrc 2>/dev/null'
+        f" || echo '{_BASHRC_MODE_LINE}' >> ~/.bashrc"
+    )
+    shell_run(instance, "bash", "-c", export_cmd)
 
 
 _BASHRC_SOURCE_LINE = "[ -f ~/.config/vergil/claude.env ] && . ~/.config/vergil/claude.env"

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -12,6 +12,7 @@ from vergil_tooling.lib.identity import (
     Identity,
     IdentityConfig,
     default_config_path,
+    derive_identity_mode,
     load_config,
     resolve_identity,
     resolve_identity_by_name,
@@ -66,6 +67,43 @@ def test_identity_model_parsed(tmp_path: Path) -> None:
     )
     ident = load_config(p).identities["vergil"]
     assert ident.model == "opus"
+
+
+def test_derive_mode_user() -> None:
+    assert derive_identity_mode("vergil-user") == "user"
+
+
+def test_derive_mode_audit() -> None:
+    assert derive_identity_mode("vergil-audit") == "audit"
+
+
+def test_derive_mode_underivable() -> None:
+    assert derive_identity_mode("mimir") == ""
+
+
+def test_derive_mode_ambiguous() -> None:
+    assert derive_identity_mode("user-audit") == ""
+
+
+def test_load_config_derives_mode_from_name(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil-user]
+        vm_instance = "vergil-user"
+
+        [identities.vergil-audit]
+        vm_instance = "vergil-audit"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.identities["vergil-user"].mode == "user"
+    assert cfg.identities["vergil-audit"].mode == "audit"
+
+
+def test_load_config_mode_empty_when_underivable(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    assert cfg.identities["vergil"].mode == ""
 
 
 def test_missing_config_file(tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_identity_mode.py
+++ b/tests/vergil_tooling/test_identity_mode.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
 from vergil_tooling.lib.identity_mode import (
     IdentityMode,
     current_mode,
@@ -11,8 +16,27 @@ from vergil_tooling.lib.identity_mode import (
     is_human,
 )
 
-if TYPE_CHECKING:
-    import pytest
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate HOME so real ~/.config/vergil files can't leak into tests."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
+    monkeypatch.delenv("VRG_APP_ID", raising=False)
+
+
+def _vergil_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".config" / "vergil"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_mode_file(tmp_path: Path, value: str) -> None:
+    (_vergil_dir(tmp_path) / "identity-mode").write_text(value)
+
+
+def _write_app_key(tmp_path: Path) -> None:
+    (_vergil_dir(tmp_path) / "app.pem").write_text("fake-key\n")
 
 
 class TestCurrentMode:
@@ -24,13 +48,10 @@ class TestCurrentMode:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "audit")
         assert current_mode() == IdentityMode.AUDIT
 
-    def test_human_when_no_env_and_no_app(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
-        monkeypatch.delenv("VRG_APP_ID", raising=False)
+    def test_human_when_no_env_and_no_app(self) -> None:
         assert current_mode() == IdentityMode.HUMAN
 
     def test_fallback_to_user_with_app_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
         monkeypatch.setenv("VRG_APP_ID", "12345")
         assert current_mode() == IdentityMode.USER
 
@@ -53,8 +74,40 @@ class TestCurrentMode:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "invalid")
-        monkeypatch.delenv("VRG_APP_ID", raising=False)
         assert current_mode() == IdentityMode.HUMAN
+
+
+class TestCurrentModeFileFallback:
+    def test_user_from_mode_file(self, tmp_path: Path) -> None:
+        _write_mode_file(tmp_path, "user\n")
+        assert current_mode() == IdentityMode.USER
+
+    def test_audit_from_mode_file(self, tmp_path: Path) -> None:
+        _write_mode_file(tmp_path, "audit\n")
+        assert current_mode() == IdentityMode.AUDIT
+
+    def test_env_wins_over_mode_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_mode_file(tmp_path, "user\n")
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "audit")
+        assert current_mode() == IdentityMode.AUDIT
+
+    def test_invalid_mode_file_without_app_key_is_human(self, tmp_path: Path) -> None:
+        _write_mode_file(tmp_path, "garbage\n")
+        assert current_mode() == IdentityMode.HUMAN
+
+    def test_invalid_mode_file_with_app_key_is_user(self, tmp_path: Path) -> None:
+        _write_mode_file(tmp_path, "garbage\n")
+        _write_app_key(tmp_path)
+        assert current_mode() == IdentityMode.USER
+
+    def test_app_key_presence_means_user(self, tmp_path: Path) -> None:
+        _write_app_key(tmp_path)
+        assert current_mode() == IdentityMode.USER
+
+    def test_mode_file_wins_over_app_key(self, tmp_path: Path) -> None:
+        _write_mode_file(tmp_path, "audit\n")
+        _write_app_key(tmp_path)
+        assert current_mode() == IdentityMode.AUDIT
 
 
 class TestIsAgent:
@@ -66,16 +119,16 @@ class TestIsAgent:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "audit")
         assert is_agent() is True
 
-    def test_human_is_not_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
-        monkeypatch.delenv("VRG_APP_ID", raising=False)
+    def test_human_is_not_agent(self) -> None:
         assert is_agent() is False
+
+    def test_provisioned_vm_is_agent(self, tmp_path: Path) -> None:
+        _write_app_key(tmp_path)
+        assert is_agent() is True
 
 
 class TestIsHuman:
-    def test_human_when_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
-        monkeypatch.delenv("VRG_APP_ID", raising=False)
+    def test_human_when_no_env(self) -> None:
         assert is_human() is True
 
     def test_agent_is_not_human(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -433,21 +433,25 @@ class TestInjectCredentials:
 
         identity = Identity(
             vm_instance="vergil-agent",
+            mode="user",
             app_id="12345",
             private_key_path=str(key_file),
         )
 
         inject_credentials("vergil-agent", identity)
 
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         mkdir_call = mock_run.call_args_list[0]
         assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
 
-        git_call = mock_run.call_args_list[1]
+        mode_bashrc_call = mock_run.call_args_list[1]
+        assert "identity-mode" in " ".join(str(a) for a in mode_bashrc_call[0])
+
+        git_call = mock_run.call_args_list[2]
         assert "git" in git_call[0]
         assert "insteadOf" in " ".join(str(a) for a in git_call[0])
 
-        assert mock_pipe.call_count == 2
+        assert mock_pipe.call_count == 3
         pem_call = mock_pipe.call_args_list[0]
         assert "app.pem" in pem_call[0][1]
         assert "fakekey" in pem_call[0][2]
@@ -455,6 +459,10 @@ class TestInjectCredentials:
         env_call = mock_pipe.call_args_list[1]
         assert "app.env" in env_call[0][1]
         assert "APP_ID=12345" in env_call[0][2]
+
+        mode_call = mock_pipe.call_args_list[2]
+        assert "identity-mode" in mode_call[0][1]
+        assert mode_call[0][2] == "user\n"
 
     @patch("vergil_tooling.lib.lima._inject_host_git_identity")
     @patch("vergil_tooling.lib.lima.shell_run")
@@ -469,6 +477,7 @@ class TestInjectCredentials:
 
         identity = Identity(
             vm_instance="vergil-agent",
+            mode="user",
             app_id="12345",
             private_key_path=str(key_file),
             claude_token_path=str(token_file),
@@ -476,22 +485,22 @@ class TestInjectCredentials:
 
         inject_credentials("vergil-agent", identity)
 
-        assert mock_run.call_count == 4
-        bashrc_call = mock_run.call_args_list[2]
+        assert mock_run.call_count == 5
+        bashrc_call = mock_run.call_args_list[3]
         assert "claude.env" in " ".join(str(a) for a in bashrc_call[0])
-        mkdir_call = mock_run.call_args_list[3]
+        mkdir_call = mock_run.call_args_list[4]
         assert "mkdir" in " ".join(str(a) for a in mkdir_call[0])
         assert ".claude" in " ".join(str(a) for a in mkdir_call[0])
 
-        assert mock_pipe.call_count == 5
-        claude_call = mock_pipe.call_args_list[2]
+        assert mock_pipe.call_count == 6
+        claude_call = mock_pipe.call_args_list[3]
         assert "claude.env" in claude_call[0][1]
         assert "CLAUDE_CODE_OAUTH_TOKEN=test-oauth-token-abc123" in claude_call[0][2]
-        creds_call = mock_pipe.call_args_list[3]
+        creds_call = mock_pipe.call_args_list[4]
         assert ".credentials.json" in creds_call[0][1]
         assert "claudeAiOauth" in creds_call[0][2]
         assert "test-oauth-token-abc123" in creds_call[0][2]
-        onboarding_call = mock_pipe.call_args_list[4]
+        onboarding_call = mock_pipe.call_args_list[5]
         assert ".claude.json" in onboarding_call[0][1]
         assert "hasCompletedOnboarding" in onboarding_call[0][2]
 
@@ -506,14 +515,15 @@ class TestInjectCredentials:
 
         identity = Identity(
             vm_instance="vergil-agent",
+            mode="user",
             app_id="12345",
             private_key_path=str(key_file),
         )
 
         inject_credentials("vergil-agent", identity)
 
-        assert mock_run.call_count == 2
-        assert mock_pipe.call_count == 2
+        assert mock_run.call_count == 3
+        assert mock_pipe.call_count == 3
 
     @patch("vergil_tooling.lib.lima._inject_host_git_identity")
     @patch("vergil_tooling.lib.lima.shell_run")
@@ -527,6 +537,7 @@ class TestInjectCredentials:
 
         identity = Identity(
             vm_instance="vergil-agent",
+            mode="user",
             app_id="12345",
             private_key_path=str(key_file),
             claude_token_path=bad_path,
@@ -537,11 +548,49 @@ class TestInjectCredentials:
     def test_exits_if_key_missing(self) -> None:
         identity = Identity(
             vm_instance="vergil-agent",
+            mode="user",
             app_id="12345",
             private_key_path="/nonexistent/key.pem",
         )
         with pytest.raises(SystemExit):
             inject_credentials("vergil-agent", identity)
+
+    def test_exits_if_mode_missing(self, tmp_path: Path) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        identity = Identity(
+            vm_instance="vergil-agent",
+            app_id="12345",
+            private_key_path=str(key_file),
+        )
+        with pytest.raises(SystemExit):
+            inject_credentials("vergil-agent", identity)
+
+    @patch("vergil_tooling.lib.lima._inject_host_git_identity")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    def test_injects_audit_mode(
+        self, mock_pipe: MagicMock, mock_run: MagicMock, _mock_id: MagicMock, tmp_path: Path
+    ) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        identity = Identity(
+            vm_instance="vergil-audit",
+            mode="audit",
+            app_id="12345",
+            private_key_path=str(key_file),
+        )
+
+        inject_credentials("vergil-audit", identity)
+
+        mode_call = mock_pipe.call_args_list[2]
+        assert "identity-mode" in mode_call[0][1]
+        assert mode_call[0][2] == "audit\n"
+
+        mode_bashrc_call = mock_run.call_args_list[1]
+        bashrc_cmd = " ".join(str(a) for a in mode_bashrc_call[0])
+        assert "VRG_IDENTITY_MODE" in bashrc_cmd
+        assert ".bashrc" in bashrc_cmd
 
     @patch("vergil_tooling.lib.lima._inject_host_git_identity")
     @patch("vergil_tooling.lib.lima.shell_run")
@@ -553,6 +602,7 @@ class TestInjectCredentials:
         key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
         identity = Identity(
             vm_instance="vergil-agent",
+            mode="user",
             app_id="12345",
             private_key_path=str(key_file),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -519,11 +519,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Summary

- Derive VRG_IDENTITY_MODE from the identities.toml stanza name at provisioning, persist it to ~/.config/vergil/identity-mode with a bashrc export, and harden current_mode() to fall back file -> App-credential presence -> USER so unset never fails open to HUMAN.

## Issue Linkage

- Ref #1415

## Notes

- Also bumps pip 26.1.1 -> 26.1.2 in uv.lock for PYSEC-2026-196 (separate chore commit) to keep the audit gate green.