### PR TITLE
feat(vrg-vm): list enumerates dedicated VMs from instances only

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -18,7 +18,7 @@ from vergil_tooling.bin.vrg_vm_resolve import (
     name_by_session,
     projects_glob,
 )
-from vergil_tooling.lib.config import ConfigError, read_config
+from vergil_tooling.lib.config import ConfigError, VmStanza, read_config
 from vergil_tooling.lib.identity import (
     Identity,
     IdentityConfig,
@@ -455,34 +455,57 @@ def _cmd_rebuild(args: argparse.Namespace) -> int:
 
 @dataclass
 class DedicatedRow:
-    org: str | None
-    repo: str | None
+    org: str
+    repo: str
     instance: str
-    state: str  # "present" | "orphaned" | "not-created"
+    state: str  # "present" | "orphaned"
+    stanza: VmStanza | None = None
 
 
-def _repo_has_vm_spec(projects_dir: str, org: str, repo: str) -> bool:
+def _classify_instance(
+    projects_dir: str, org: str, repo: str, instance: str
+) -> tuple[str, VmStanza | None]:
+    """Classify one existing instance against its repo's [vm] stanza.
+
+    Returns ``(state, stanza)``: ``("present", stanza)`` when the repo declares
+    a spec, ``("orphaned", None)`` when it provably lacks one. A repo whose
+    ``vergil.toml`` fails to parse is classified ``present`` conservatively —
+    flagging it orphaned would invite destroying a VM whose spec may still be
+    declared — and the failure is warned loudly with the config path.
+    """
     repo_dir = Path(projects_dir) / org / repo
-    if not (repo_dir / "vergil.toml").exists():
-        return False
+    config_path = repo_dir / "vergil.toml"
+    if not config_path.exists():
+        return "orphaned", None
     try:
-        return read_config(repo_dir).vm is not None
-    except ConfigError:
-        return False
+        stanza = read_config(repo_dir).vm
+    except ConfigError as exc:
+        print(
+            f"WARNING: cannot parse {config_path}: {exc} — "
+            f"listing '{instance}' as present (unverified)",
+            file=sys.stderr,
+        )
+        return "present", None
+    if stanza is None:
+        return "orphaned", None
+    return "present", stanza
 
 
 def discover_dedicated(
     identity_name: str, instances: list[str], projects_dir: str
 ) -> list[DedicatedRow]:
-    """Reconcile existing <identity>.* instances with spec-bearing local repos.
+    """Classify existing <identity>.<org>.<repo> instances against local repos.
 
-    - instance + spec   -> present
+    Enumeration is from instances only — O(instances), one targeted
+    ``read_config()`` each:
+
+    - instance + spec   -> present (carrying the parsed stanza)
     - instance, no spec -> orphaned
-    - spec, no instance -> not-created
+
+    A spec-bearing repo with no instance is not listed here; the session/start
+    preflight gate surfaces it loudly when the repo is actually used.
     """
     rows: list[DedicatedRow] = []
-    seen: set[tuple[str, str]] = set()
-
     for name in instances:
         try:
             ident, org, repo = parse_instance_name(name)
@@ -490,24 +513,8 @@ def discover_dedicated(
             continue
         if ident != identity_name or org is None or repo is None:
             continue
-        seen.add((org, repo))
-        state = "present" if _repo_has_vm_spec(projects_dir, org, repo) else "orphaned"
-        rows.append(DedicatedRow(org, repo, name, state))
-
-    # Spec-bearing repos with no instance yet -> not-created.
-    root = Path(projects_dir)
-    if root.is_dir():
-        for org_dir in sorted(p for p in root.iterdir() if p.is_dir()):
-            for repo_dir in sorted(p for p in org_dir.iterdir() if p.is_dir()):
-                org, repo = org_dir.name, repo_dir.name
-                if (org, repo) in seen:
-                    continue
-                if _repo_has_vm_spec(projects_dir, org, repo):
-                    rows.append(
-                        DedicatedRow(
-                            org, repo, instance_name(identity_name, org, repo), "not-created"
-                        )
-                    )
+        state, stanza = _classify_instance(projects_dir, org, repo, name)
+        rows.append(DedicatedRow(org, repo, name, state, stanza))
     return rows
 
 
@@ -555,20 +562,6 @@ def _list_rows(
 
     for d in dedicated:
         scope = f"{d.org}/{d.repo}"
-        if d.state == "not-created":
-            rows.append(
-                {
-                    "scope": scope,
-                    "status": "Not Created",
-                    "cpus": "—",
-                    "memory": "—",
-                    "disk": "—",
-                    "agents": "—",
-                    "humans": "—",
-                    "spec": "not-created",
-                }
-            )
-            continue
         agents, humans = _occupancy(d.instance, status)
         st = status.get(d.instance, "Not Created")
         if d.state == "orphaned":
@@ -585,13 +578,10 @@ def _list_rows(
                 }
             )
             continue
-        repo_dir = Path(resolve_workspace(scope, identity.projects_dir))
-        try:
-            stanza = read_config(repo_dir).vm
-        except (FileNotFoundError, ConfigError):
-            stanza = None
-        override = identity.overrides.get(cast("tuple[str, str]", (d.org, d.repo)))
-        spec = compose_vm_spec(identity=identity_name, base=base, stanza=stanza, override=override)
+        override = identity.overrides.get((d.org, d.repo))
+        spec = compose_vm_spec(
+            identity=identity_name, base=base, stanza=d.stanza, override=override
+        )
         rows.append(
             {
                 "scope": scope,
@@ -901,12 +891,14 @@ def main(argv: list[str] | None = None) -> int:
         help="List all identity VMs and their status",
         description=(
             "List each identity's base and dedicated VMs with configured footprint "
-            "(CPUS/MEM/DISK), live occupancy, and SPEC health. AGENTS counts harness "
-            "instances (Claude Code sessions); HUMANS counts open human-held interactive "
-            "shells (a tally of shells, not distinct people). SPEC is one of: ok, "
-            "NEEDS-REBUILD (drift — rebuild it), not-created (a spec'd repo with no VM "
-            "yet), orphaned (a VM whose repo dropped its [vm]), or an 'under' flag when a "
-            "host override sized the box below the repo's declared footprint."
+            "(CPUS/MEM/DISK), live occupancy, and SPEC health. Dedicated rows enumerate "
+            "existing VM instances only; a spec'd repo whose VM was never built is "
+            "surfaced by the session/start preflight gate, not here. AGENTS counts "
+            "harness instances (Claude Code sessions); HUMANS counts open human-held "
+            "interactive shells (a tally of shells, not distinct people). SPEC is one "
+            "of: ok, NEEDS-REBUILD (drift — rebuild it), orphaned (a VM whose repo "
+            "dropped its [vm]), or an 'under' flag when a host override sized the box "
+            "below the repo's declared footprint."
         ),
     )
     p_list.add_argument("--config", type=Path, help="Path to identities.toml")

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1504,20 +1504,16 @@ class TestLifecyclePositional:
 
 
 class TestDiscoverDedicated:
-    def test_present_orphan_and_not_created(self, tmp_path: Path) -> None:
+    def test_classifies_instances_via_targeted_reads(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         projects = tmp_path / "projects"
         _make_repo(projects, "org", "present", '\n[vm]\npackages = ["x"]\n')
-        _make_repo(projects, "org", "todo", '\n[vm]\npackages = ["x"]\n')
         _make_repo(projects, "org", "nospec", "")  # valid vergil.toml, no [vm]
-        _make_repo(projects, "org", "plain", "")  # no [vm], no instance -> not listed
-        broken = projects / "org" / "broken"
-        broken.mkdir(parents=True)
-        (broken / "vergil.toml").write_text("[invalid toml")  # ConfigError on read
         instances = [
             "vergil-user.org.present",  # instance + spec -> present
             "vergil-user.org.gone",  # instance, no repo -> orphaned
             "vergil-user.org.nospec",  # repo without [vm] -> orphaned
-            "vergil-user.org.broken",  # repo with broken toml -> orphaned
             "vergil-user",  # base instance -> ignored (org is None)
             "weird.name",  # unparseable (2 tiers) -> ignored
             "vergil-audit.org.present",  # other identity -> ignored
@@ -1528,14 +1524,41 @@ class TestDiscoverDedicated:
             "present": "present",
             "gone": "orphaned",
             "nospec": "orphaned",
-            "broken": "orphaned",
-            "todo": "not-created",
         }
         assert all(isinstance(r, DedicatedRow) for r in rows)
+        assert capsys.readouterr().err == ""  # clean configs -> no warnings
+
+    def test_present_row_carries_parsed_stanza(self, tmp_path: Path) -> None:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "org", "present", '\n[vm]\npackages = ["x"]\n')
+        rows = discover_dedicated("vergil-user", ["vergil-user.org.present"], str(projects))
+        assert rows[0].stanza is not None
+        assert rows[0].stanza.packages == ["x"]
+
+    def test_broken_config_is_loud_and_conservative(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        projects = tmp_path / "projects"
+        broken = projects / "org" / "broken"
+        broken.mkdir(parents=True)
+        (broken / "vergil.toml").write_text("[invalid toml")  # ConfigError on read
+        rows = discover_dedicated("vergil-user", ["vergil-user.org.broken"], str(projects))
+        assert [(r.repo, r.state, r.stanza) for r in rows] == [("broken", "present", None)]
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert str(broken / "vergil.toml") in err
+        assert "vergil-user.org.broken" in err
+
+    def test_no_instances_means_no_tree_scan(self, tmp_path: Path) -> None:
+        projects = tmp_path / "projects"
+        # Spec-bearing repos with no instance are NOT enumerated (no tree walk);
+        # the session/start preflight gate owns that signal.
+        _make_repo(projects, "org", "todo", '\n[vm]\npackages = ["x"]\n')
+        assert discover_dedicated("vergil-user", [], str(projects)) == []
 
     def test_nonexistent_projects_dir(self, tmp_path: Path) -> None:
-        rows = discover_dedicated("vergil-user", [], str(tmp_path / "nope"))
-        assert rows == []
+        rows = discover_dedicated("vergil-user", ["vergil-user.org.gone"], str(tmp_path / "nope"))
+        assert [(r.repo, r.state) for r in rows] == [("gone", "orphaned")]
 
 
 class TestListRows:
@@ -1553,15 +1576,19 @@ class TestListRows:
     def _row(self, rows: list[dict[str, object]], scope: str) -> dict[str, object]:
         return next(r for r in rows if r["scope"] == scope)
 
+    def _present(self, projects: Path) -> list[DedicatedRow]:
+        """One present lmf/mq row with its stanza threaded through discovery."""
+        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
+        return discover_dedicated("vergil-user", ["vergil-user.lmf.mq"], str(projects))
+
     @patch("vergil_tooling.bin.vrg_vm.vm_occupancy", return_value=(2, 1))
     @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="ok")
     def test_base_and_present_running_ok(
         self, _spec: MagicMock, _occ: MagicMock, tmp_path: Path
     ) -> None:
         projects = tmp_path / "projects"
-        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
         ident = self._identity(projects)
-        dedic = [DedicatedRow("lmf", "mq", "vergil-user.lmf.mq", "present")]
+        dedic = self._present(projects)
         status = {"vergil-user": "Running", "vergil-user.lmf.mq": "Running"}
         rows = _list_rows("vergil-user", ident, dedic, status)
         base = self._row(rows, "base")
@@ -1578,9 +1605,8 @@ class TestListRows:
         self, _spec: MagicMock, _occ: MagicMock, tmp_path: Path
     ) -> None:
         projects = tmp_path / "projects"
-        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
         ident = self._identity(projects)
-        dedic = [DedicatedRow("lmf", "mq", "vergil-user.lmf.mq", "present")]
+        dedic = self._present(projects)
         rows = _list_rows("vergil-user", ident, dedic, {"vergil-user.lmf.mq": "Running"})
         assert self._row(rows, "lmf/mq")["spec"] == "NEEDS-REBUILD"
 
@@ -1588,39 +1614,33 @@ class TestListRows:
     @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="ok")
     def test_present_running_under(self, _spec: MagicMock, _occ: MagicMock, tmp_path: Path) -> None:
         projects = tmp_path / "projects"
-        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
         ident = self._identity(projects, overrides={("lmf", "mq"): {"memory": "32GiB"}})
-        dedic = [DedicatedRow("lmf", "mq", "vergil-user.lmf.mq", "present")]
+        dedic = self._present(projects)
         rows = _list_rows("vergil-user", ident, dedic, {"vergil-user.lmf.mq": "Running"})
         assert "under (mem)" in str(self._row(rows, "lmf/mq")["spec"])
 
     def test_present_not_running_is_ok(self, tmp_path: Path) -> None:
         projects = tmp_path / "projects"
-        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
         ident = self._identity(projects)
-        dedic = [DedicatedRow("lmf", "mq", "vergil-user.lmf.mq", "present")]
+        dedic = self._present(projects)
         rows = _list_rows("vergil-user", ident, dedic, {})  # nothing running
         ded = self._row(rows, "lmf/mq")
         assert ded["spec"] == "ok"
         assert ded["agents"] == "—"
 
-    def test_present_repo_without_vergil_toml_uses_base(self, tmp_path: Path) -> None:
-        projects = tmp_path / "projects"
-        ident = self._identity(projects)  # projects/lmf/mq does not exist
-        dedic = [DedicatedRow("lmf", "mq", "vergil-user.lmf.mq", "present")]
+    def test_present_without_stanza_uses_base(self, tmp_path: Path) -> None:
+        # An unverified present row (broken config -> stanza None) falls back
+        # to the base footprint.
+        ident = self._identity(tmp_path / "projects")
+        dedic = [DedicatedRow("lmf", "mq", "vergil-user.lmf.mq", "present", None)]
         rows = _list_rows("vergil-user", ident, dedic, {})
         assert self._row(rows, "lmf/mq")["cpus"] == 4  # stanza None -> base footprint
 
-    def test_orphaned_and_not_created(self, tmp_path: Path) -> None:
+    def test_orphaned(self, tmp_path: Path) -> None:
         ident = self._identity(tmp_path / "projects")
-        dedic = [
-            DedicatedRow("o", "gone", "vergil-user.o.gone", "orphaned"),
-            DedicatedRow("o", "todo", "vergil-user.o.todo", "not-created"),
-        ]
+        dedic = [DedicatedRow("o", "gone", "vergil-user.o.gone", "orphaned")]
         rows = _list_rows("vergil-user", ident, dedic, {})
-        by_scope = {r["scope"]: r["spec"] for r in rows}
-        assert by_scope["o/gone"] == "orphaned"
-        assert by_scope["o/todo"] == "not-created"
+        assert self._row(rows, "o/gone")["spec"] == "orphaned"
 
     @patch("vergil_tooling.bin.vrg_vm.vm_occupancy", return_value=(1, 0))
     def test_orphaned_running_shows_occupancy(self, _occ: MagicMock, tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- discover_dedicated drops the projects-tree scan and the not-created state; targeted per-instance reads classify present/orphaned, thread the parsed stanza to _list_rows, and make ConfigError loud.

## Issue Linkage

- Ref #1412

## Notes

- Implements the spec amendment tracked in vergil-vm#111 (still open — issue #1412 allows landing alongside). Release notes in releases/v2.1.2.md mention not-created but are historical records and were left untouched.