### PR TITLE
fix(vrg-gh): select App installation from -R/--repo owner

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -108,9 +108,69 @@ def _api_is_get(argv: list[str]) -> bool:
     return not has_fields
 
 
+def _parse_repo_owner(value: str) -> str | None:
+    """Extract the owner from a ``-R``/``--repo`` value.
+
+    gh accepts ``OWNER/REPO``, ``HOST/OWNER/REPO``, and full URL forms.
+    """
+    for prefix in ("https://", "http://"):
+        if value.startswith(prefix):
+            value = value[len(prefix) :]
+            break
+    parts = [part for part in value.split("/") if part]
+    if len(parts) >= 3:  # noqa: PLR2004 -- HOST/OWNER/REPO
+        return parts[1]
+    if len(parts) == 2:  # noqa: PLR2004 -- OWNER/REPO
+        return parts[0]
+    return None
+
+
+def _extract_repo_owner(argv: list[str]) -> str | None:
+    """Return the owner named by ``-R``/``--repo`` in the wrapped argv.
+
+    Handles separate-value (``-R x``, ``--repo x``), equals
+    (``--repo=x``, ``-R=x``), and glued-shorthand (``-Rx``) forms;
+    the last occurrence wins, matching gh's flag parsing.
+    """
+    value: str | None = None
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("-R", "--repo"):
+            if i + 1 < len(argv):
+                value = argv[i + 1]
+            i += 2
+            continue
+        if arg.startswith("--repo="):
+            value = arg.split("=", 1)[1]
+        elif arg.startswith("-R") and arg != "-R":
+            value = arg[2:].removeprefix("=")
+        i += 1
+    if value is None:
+        return None
+    return _parse_repo_owner(value)
+
+
 def _exec_gh(argv: list[str]) -> int:
-    """Inject the installation token and execute ``gh`` with retry."""
-    token = github.get_installation_token()
+    """Inject the installation token and execute ``gh`` with retry.
+
+    The App installation is selected by the ``-R``/``--repo`` owner
+    when present, falling back to cwd remote detection otherwise.
+    A targeted owner with no installation fails loudly: a token
+    minted for a different installation cannot reach that owner's
+    private repos (#1413).
+    """
+    owner = _extract_repo_owner(argv)
+    try:
+        token = github.get_installation_token(org=owner, require_installation=owner is not None)
+    except github.NoInstallationError as exc:
+        known = ", ".join(exc.known) if exc.known else "none"
+        print(
+            f"vrg-gh: the GitHub App has no installation for owner "
+            f"'{exc.org}' (from -R/--repo). Known installations: {known}.",
+            file=sys.stderr,
+        )
+        return 1
     env: dict[str, str] | None = None
     if token is not None:
         env = {**os.environ, "GH_TOKEN": token}

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -26,6 +26,15 @@ _token_cache: dict[str, tuple[str, float]] = {}
 _installation_cache: dict[str, str] | None = None
 
 
+class NoInstallationError(Exception):
+    """The GitHub App has no installation for the requested owner."""
+
+    def __init__(self, org: str, known: list[str]) -> None:
+        super().__init__(f"no App installation for owner {org!r}")
+        self.org = org
+        self.known = known
+
+
 def _load_app_config() -> tuple[str, Path] | None:
     """Read GitHub App credentials from env vars or ~/.config/vergil/.
 
@@ -150,13 +159,23 @@ def _generate_jwt(app_id: str, key_path: Path) -> str:
     return f"{header}.{payload}.{signature}"
 
 
-def get_installation_token(org: str | None = None) -> str | None:
+def get_installation_token(
+    org: str | None = None, *, require_installation: bool = False
+) -> str | None:
     """Return a GitHub App installation token, or ``None`` if not in App mode.
 
     Resolves the installation ID dynamically by calling
     ``GET /app/installations`` and matching the org. If *org* is
     ``None``, detects it from the current repo's git remote.
     Tokens are cached per-org for 55 minutes.
+
+    With *require_installation*, an org that has no App installation
+    raises :class:`NoInstallationError` instead of returning ``None``
+    — an App token minted for a different installation cannot reach
+    the requested owner's private repos, so silently falling back
+    would mask the failure as a missing grant. Without App
+    credentials configured, ``None`` is still returned (ambient gh
+    auth is not installation-scoped).
     """
     if org is None:
         org = _detect_org()
@@ -180,6 +199,8 @@ def get_installation_token(org: str | None = None) -> str | None:
         installations = _resolve_installations(jwt_token)
         installation_id = installations.get(org)
         if not installation_id:
+            if require_installation:
+                raise NoInstallationError(org, sorted(installations))
             return None
 
         data = _jwt_api_request(

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -1123,6 +1123,42 @@ class TestGetInstallationToken:
         ):
             assert github.get_installation_token(org="missing-org") is None
 
+    def test_raises_when_required_and_org_has_no_installation(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+        monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
+        config_dir = tmp_path / ".config" / "vergil"
+        config_dir.mkdir(parents=True)
+        (config_dir / "app.env").write_text("APP_ID=12345\n")
+        (config_dir / "app.pem").write_text("fake-key\n")
+        with (
+            patch("vergil_tooling.lib.github._generate_jwt", return_value="jwt"),
+            patch(
+                "vergil_tooling.lib.github._resolve_installations",
+                return_value={"org-b": "222", "org-a": "111"},
+            ),
+            pytest.raises(github.NoInstallationError) as excinfo,
+        ):
+            github.get_installation_token(org="missing-org", require_installation=True)
+        assert excinfo.value.org == "missing-org"
+        assert excinfo.value.known == ["org-a", "org-b"]
+
+    def test_require_installation_returns_none_without_app_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # No App credentials -> ambient gh auth applies, which is not
+        # installation-scoped; requiring an installation must not raise.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+        monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
+        assert github.get_installation_token(org="some-org", require_installation=True) is None
+
     def test_caches_token_per_org(
         self,
         tmp_path: Path,

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_gh import main
+from vergil_tooling.lib import github
 
 
 def _completed(
@@ -190,6 +191,106 @@ def test_no_env_injection_when_no_app_token() -> None:
         main(["issue", "list"])
     _, kwargs = mock_run.call_args
     assert "env" not in kwargs or kwargs.get("env") is None
+
+
+# -- installation selection via -R/--repo (#1413) -----------------------------
+
+
+class TestRepoFlagInstallationSelection:
+    """The -R/--repo owner, not the cwd, selects the App installation."""
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            ["-R", "other-owner/repo"],
+            ["--repo", "other-owner/repo"],
+            ["--repo=other-owner/repo"],
+            ["-Rother-owner/repo"],
+            ["-R", "github.com/other-owner/repo"],
+            ["-R", "https://github.com/other-owner/repo"],
+        ],
+    )
+    def test_repo_flag_selects_target_owner_installation(self, extra: list[str]) -> None:
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value="ghs_other_token",
+            ) as mock_token,
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "list", *extra])
+        assert rc == 0
+        kwargs = mock_token.call_args.kwargs
+        assert kwargs.get("org") == "other-owner"
+        assert kwargs.get("require_installation") is True
+
+    def test_no_repo_flag_keeps_cwd_detection(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ) as mock_token,
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "list"])
+        assert rc == 0
+        kwargs = mock_token.call_args.kwargs
+        assert kwargs.get("org") is None
+        assert not kwargs.get("require_installation")
+
+    def test_last_repo_flag_wins(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value="ghs_token",
+            ) as mock_token,
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "list", "-R", "first-owner/repo", "-R", "second-owner/repo"])
+        assert rc == 0
+        assert mock_token.call_args.kwargs.get("org") == "second-owner"
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            ["-R"],  # dangling flag: gh itself rejects it downstream
+            ["-R", "not-a-repo"],  # unparseable value: gh rejects it downstream
+        ],
+    )
+    def test_unusable_repo_flag_falls_back_to_cwd_detection(self, extra: list[str]) -> None:
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ) as mock_token,
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "list", *extra])
+        assert rc == 0
+        kwargs = mock_token.call_args.kwargs
+        assert kwargs.get("org") is None
+        assert not kwargs.get("require_installation")
+
+    def test_unknown_owner_fails_loudly(self, capsys: pytest.CaptureFixture[str]) -> None:
+        err = github.NoInstallationError("unknown-owner", ["vergil-project", "wphillipmoore"])
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                side_effect=err,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            rc = main(["issue", "list", "-R", "unknown-owner/repo"])
+        assert rc != 0
+        mock_run.assert_not_called()
+        captured = capsys.readouterr().err
+        assert "unknown-owner" in captured
+        assert "vergil-project" in captured
+        assert "wphillipmoore" in captured
 
 
 # -- subprocess passthrough ---------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-gh mints the installation token for the -R/--repo owner instead of the cwd remote's owner, and fails loudly when that owner has no App installation.

## Issue Linkage

- Ref #1413

## Notes

- TDD: tests cover all -R value forms (OWNER/REPO, HOST/OWNER/REPO, URL), the unchanged no-flag path, last-flag-wins, unusable-flag fallback, and the loud unknown-owner failure. NoInstallationError raises only when App credentials are configured; ambient-auth setups still return None.