### PR TITLE
fix(vrg-pr-await): abort with an error when the target PR is already merged

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_await.py
+++ b/src/vergil_tooling/bin/vrg_pr_await.py
@@ -11,6 +11,11 @@ On settle it prints a JSON object (``reason``, ``head_sha``, ``review_count``,
 ``checks``, ``failed_checks``, ``all_checks_passed``) for the wrapping skill to
 reconcile, and exits 0. Like ``vrg-await`` it blocks patiently and
 indefinitely — a wait that never returns means the PR has not changed.
+
+If any poll (including the first) finds the PR already merged, it aborts with
+an error and exits 1: a merged PR can never settle into actionable output, and
+a merge observed mid-watch means the audit cycle was bypassed — failing loudly
+surfaces the short-circuit instead of leaving an orphaned poll loop running.
 """
 
 from __future__ import annotations
@@ -44,11 +49,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    state, reason = pr_await.wait_for_settle(
-        args.pr,
-        since_sha=args.since_sha,
-        since_reviews=args.since_reviews,
-    )
+    try:
+        state, reason = pr_await.wait_for_settle(
+            args.pr,
+            since_sha=args.since_sha,
+            since_reviews=args.since_reviews,
+        )
+    except pr_await.PrMergedError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     print(json.dumps(pr_await.to_output(state, reason), indent=2))
     return 0
 

--- a/src/vergil_tooling/lib/pr_await.py
+++ b/src/vergil_tooling/lib/pr_await.py
@@ -5,6 +5,12 @@ API. It blocks until the PR *settles*: all checks reach a terminal conclusion,
 **or** a new commit appears (the head SHA moves), **or** a new review appears.
 On settle it returns the observed state so the wrapping skill can reconcile.
 
+A merged PR can never settle into anything actionable — continued polling
+would just spin as an orphaned watcher — so every poll (including the first)
+checks the PR's state and raises :class:`PrMergedError` when it is merged.
+A merge observed mid-watch means the audit cycle was bypassed; failing loudly
+surfaces the short-circuit instead of silently spinning.
+
 The "is it settled?" decision lives here in deterministic code, not in agent
 tokens — the agent only acts on the returned verdict.
 """
@@ -20,6 +26,15 @@ _POLL_INTERVAL = 15.0
 
 _FAILED_BUCKETS = frozenset({"fail", "cancel"})
 _PENDING_BUCKET = "pending"
+_MERGED_STATE = "MERGED"
+
+
+class PrMergedError(Exception):
+    """The watched PR is already merged, so the watch can never settle."""
+
+    def __init__(self, pr: str) -> None:
+        self.pr = pr
+        super().__init__(f"PR {pr} is already merged; aborting watch")
 
 
 @dataclass(frozen=True)
@@ -29,6 +44,12 @@ class PrState:
     head_sha: str
     checks: list[dict[str, str]] = field(default_factory=list)
     reviews: list[dict[str, object]] = field(default_factory=list)
+    pr_state: str = "OPEN"
+
+    @property
+    def merged(self) -> bool:
+        """True when the PR has been merged."""
+        return self.pr_state == _MERGED_STATE
 
     @property
     def has_checks(self) -> bool:
@@ -52,11 +73,12 @@ class PrState:
 
 
 def gather_state(pr: str) -> PrState:
-    """Poll the GitHub API once for the PR's head SHA, checks, and reviews."""
+    """Poll the GitHub API once for the PR's head SHA, checks, reviews, and state."""
     return PrState(
         head_sha=github.head_sha(pr),
         checks=github.pr_checks(pr),
         reviews=github.pr_reviews(pr),
+        pr_state=github.pr_state(pr),
     )
 
 
@@ -87,9 +109,16 @@ def wait_for_settle(
     since_reviews: int | None,
     poll_interval: float = _POLL_INTERVAL,
 ) -> tuple[PrState, str]:
-    """Block until the PR settles; return the settled state and the reason."""
+    """Block until the PR settles; return the settled state and the reason.
+
+    Raises :class:`PrMergedError` as soon as any poll (including the first)
+    observes the PR merged — a merged PR aborts the watch even when a settle
+    reason exists, since no settle verdict on a merged PR is actionable.
+    """
     while True:
         state = gather_state(pr)
+        if state.merged:
+            raise PrMergedError(pr)
         reason = settle_reason(state, since_sha=since_sha, since_reviews=since_reviews)
         if reason is not None:
             return state, reason

--- a/tests/vergil_tooling/test_pr_await.py
+++ b/tests/vergil_tooling/test_pr_await.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from vergil_tooling.lib import pr_await
-from vergil_tooling.lib.pr_await import PrState, settle_reason, to_output
+from vergil_tooling.lib.pr_await import PrMergedError, PrState, settle_reason, to_output
 
 _MOD = "vergil_tooling.lib.pr_await"
 
@@ -108,11 +110,48 @@ def test_gather_state_reads_github() -> None:
         patch(f"{_MOD}.github.head_sha", return_value="abc123"),
         patch(f"{_MOD}.github.pr_checks", return_value=checks),
         patch(f"{_MOD}.github.pr_reviews", return_value=reviews),
+        patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
     ):
         state = pr_await.gather_state("PR")
     assert state.head_sha == "abc123"
     assert state.checks == checks
     assert state.reviews == reviews
+    assert state.pr_state == "OPEN"
+
+
+def test_wait_for_settle_aborts_when_merged_at_start() -> None:
+    merged = PrState("sha", _checks("pass"), [], pr_state="MERGED")
+    with (
+        patch(f"{_MOD}.gather_state", return_value=merged),
+        patch(f"{_MOD}.time.sleep") as slept,
+        pytest.raises(PrMergedError, match="already merged"),
+    ):
+        pr_await.wait_for_settle("PR", since_sha=None, since_reviews=None)
+    slept.assert_not_called()
+
+
+def test_wait_for_settle_aborts_when_merged_mid_watch() -> None:
+    pending = PrState("sha", _checks("pending"), [])
+    merged = PrState("sha", _checks("pending"), [], pr_state="MERGED")
+    with (
+        patch(f"{_MOD}.gather_state", side_effect=[pending, merged]),
+        patch(f"{_MOD}.time.sleep") as slept,
+        pytest.raises(PrMergedError),
+    ):
+        pr_await.wait_for_settle("PR", since_sha=None, since_reviews=None)
+    slept.assert_called_once()
+
+
+def test_wait_for_settle_merged_abort_wins_over_settle() -> None:
+    # Even when a settle reason exists (new commit, checks terminal), a
+    # merged PR aborts instead of settling.
+    merged = PrState("new-sha", _checks("pass"), [], pr_state="MERGED")
+    with (
+        patch(f"{_MOD}.gather_state", return_value=merged),
+        patch(f"{_MOD}.time.sleep"),
+        pytest.raises(PrMergedError),
+    ):
+        pr_await.wait_for_settle("PR", since_sha="old-sha", since_reviews=0)
 
 
 def test_to_output_shape() -> None:

--- a/tests/vergil_tooling/test_vrg_pr_await.py
+++ b/tests/vergil_tooling/test_vrg_pr_await.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_pr_await import main, parse_args
-from vergil_tooling.lib.pr_await import PrState
+from vergil_tooling.lib.pr_await import PrMergedError, PrState
 
 if TYPE_CHECKING:
     import pytest
@@ -47,3 +47,13 @@ def test_main_passes_baselines_through() -> None:
     _, kwargs = waiter.call_args
     assert kwargs["since_sha"] == "old"
     assert kwargs["since_reviews"] == 3
+
+
+def test_main_errors_when_pr_already_merged(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.pr_await.wait_for_settle", side_effect=PrMergedError(_PR)):
+        result = main([_PR])
+    assert result == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("error:")
+    assert "already merged" in captured.err


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-pr-await now checks the PR state on every poll and exits 1 with a clear error when the PR is merged, instead of polling forever as an orphaned watcher.

## Issue Linkage

- Ref #1420

## Notes

- Merged-state check rides the existing github.pr_state() wrapper; abort wins over any settle reason since no settle verdict on a merged PR is actionable.