### PR TITLE
fix(repo-config): verify claude_settings marketplace/plugin keys against canonical template

### DIFF
--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -25,6 +25,19 @@ def _load_template() -> str:
     )
 
 
+def _load_settings_template() -> dict[str, Any]:
+    raw = (
+        importlib.resources.files("vergil_tooling.data")
+        .joinpath("claude_settings.json")
+        .read_text(encoding="utf-8")
+    )
+    template = json.loads(raw)
+    if not isinstance(template, dict):  # pragma: no cover - packaging error
+        msg = "claude_settings.json template is not a JSON object"
+        raise TypeError(msg)
+    return template
+
+
 def audit_local_config(repo_root: Path) -> ConfigDiff:
     """Run all local config checks against a repo root directory."""
     items: list[DiffItem] = []
@@ -128,72 +141,61 @@ def _check_claude_settings(repo_root: Path, items: list[DiffItem]) -> None:
         )
         return
 
-    _check_marketplace(raw, items)
-    _check_plugin_enabled(raw, items)
+    template = _load_settings_template()
+    _check_settings_section(
+        raw,
+        template,
+        key="extraKnownMarketplaces",
+        field="local.claude_settings.marketplace",
+        items=items,
+    )
+    _check_settings_section(
+        raw,
+        template,
+        key="enabledPlugins",
+        field="local.claude_settings.plugin",
+        items=items,
+    )
 
 
-def _check_marketplace(raw: dict[str, Any], items: list[DiffItem]) -> None:
-    marketplaces = raw.get("extraKnownMarketplaces", {})
-    if not isinstance(marketplaces, dict):
+def _check_settings_section(
+    raw: dict[str, Any],
+    template: dict[str, Any],
+    *,
+    key: str,
+    field: str,
+    items: list[DiffItem],
+) -> None:
+    """Require every template entry under ``key`` to match exactly.
+
+    Same pattern as the CLAUDE.md template-presence check: the
+    canonical entries must be present and equal; repos may add extra
+    entries of their own. Catches plugin-manager clobbering of
+    ``enabledPlugins`` / ``extraKnownMarketplaces`` (issue #1427).
+    """
+    expected_entries = template.get(key, {})
+    actual_section = raw.get(key, {})
+    if not isinstance(actual_section, dict):
         items.append(
             DiffItem(
-                field="local.claude_settings.marketplace",
-                expected="vergil-marketplace configured",
-                actual="extraKnownMarketplaces is not an object",
+                field=field,
+                expected=f"{key} object",
+                actual=f"{key} is not an object",
             )
         )
         return
 
-    vergil_mp = marketplaces.get("vergil-marketplace")
-    if not isinstance(vergil_mp, dict):
-        items.append(
-            DiffItem(
-                field="local.claude_settings.marketplace",
-                expected="vergil-marketplace configured",
-                actual="missing",
+    for name, expected_value in expected_entries.items():
+        actual_value = actual_section.get(name)
+        if actual_value != expected_value:
+            items.append(
+                DiffItem(
+                    field=field,
+                    expected=f"{name} = {json.dumps(expected_value, sort_keys=True)}",
+                    actual=(
+                        "missing"
+                        if name not in actual_section
+                        else f"{name} = {json.dumps(actual_value, sort_keys=True)}"
+                    ),
+                )
             )
-        )
-        return
-
-    source = vergil_mp.get("source", {})
-    if not isinstance(source, dict):
-        items.append(
-            DiffItem(
-                field="local.claude_settings.marketplace",
-                expected="vergil-marketplace with source object",
-                actual="source is not an object",
-            )
-        )
-        return
-
-    repo = source.get("repo", "")
-    if repo != "vergil-project/vergil-claude-plugin":
-        items.append(
-            DiffItem(
-                field="local.claude_settings.marketplace_repo",
-                expected="vergil-project/vergil-claude-plugin",
-                actual=repo or "missing",
-            )
-        )
-
-
-def _check_plugin_enabled(raw: dict[str, Any], items: list[DiffItem]) -> None:
-    plugins = raw.get("enabledPlugins", {})
-    if not isinstance(plugins, dict):
-        items.append(
-            DiffItem(
-                field="local.claude_settings.plugin",
-                expected="vergil@vergil-marketplace enabled",
-                actual="enabledPlugins is not an object",
-            )
-        )
-        return
-
-    if not plugins.get("vergil@vergil-marketplace"):
-        items.append(
-            DiffItem(
-                field="local.claude_settings.plugin",
-                expected="vergil@vergil-marketplace enabled",
-                actual="not enabled",
-            )
-        )

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -124,6 +124,11 @@ _MINIMAL_SETTINGS = {
     },
 }
 
+_SETTINGS_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "vergil_tooling" / "data" / "claude_settings.json"
+)
+_SETTINGS_TEMPLATE = json.loads(_SETTINGS_TEMPLATE_PATH.read_text(encoding="utf-8"))
+
 
 def _write_settings(tmp_path: Path, settings: dict) -> None:
     (tmp_path / ".claude").mkdir(exist_ok=True)
@@ -169,7 +174,75 @@ class TestClaudeSettings:
         _write_settings(tmp_path, settings)
         diff = audit_local_config(tmp_path)
         fields = {i.field for i in diff.items}
-        assert "local.claude_settings.marketplace_repo" in fields
+        assert "local.claude_settings.marketplace" in fields
+
+    def test_marketplace_source_drift(self, tmp_path: Path) -> None:
+        settings = {
+            "extraKnownMarketplaces": {
+                "vergil-marketplace": {
+                    "source": {"source": "git", "repo": "vergil-project/vergil-claude-plugin"}
+                }
+            },
+            "enabledPlugins": {"vergil@vergil-marketplace": True},
+        }
+        _write_settings(tmp_path, settings)
+        diff = audit_local_config(tmp_path)
+        fields = {i.field for i in diff.items}
+        assert "local.claude_settings.marketplace" in fields
+
+    def test_plugin_truthy_but_not_true(self, tmp_path: Path) -> None:
+        settings = {
+            **_MINIMAL_SETTINGS,
+            "enabledPlugins": {"vergil@vergil-marketplace": "yes"},
+        }
+        _write_settings(tmp_path, settings)
+        diff = audit_local_config(tmp_path)
+        fields = {i.field for i in diff.items}
+        assert "local.claude_settings.plugin" in fields
+
+    def test_plugin_manager_clobber_detected(self, tmp_path: Path) -> None:
+        # Regression for issue #1427: Claude Code's plugin manager
+        # rewrote a checked-in settings.json, emptying both keys.
+        settings = {
+            "permissions": {"allow": ["Bash(vrg-*)"]},
+            "extraKnownMarketplaces": {},
+            "enabledPlugins": {},
+        }
+        _write_settings(tmp_path, settings)
+        diff = audit_local_config(tmp_path)
+        fields = {i.field for i in diff.items}
+        assert "local.claude_settings.marketplace" in fields
+        assert "local.claude_settings.plugin" in fields
+
+    def test_canonical_template_sections_compliant(self, tmp_path: Path) -> None:
+        settings = {
+            "extraKnownMarketplaces": _SETTINGS_TEMPLATE["extraKnownMarketplaces"],
+            "enabledPlugins": _SETTINGS_TEMPLATE["enabledPlugins"],
+        }
+        _write_settings(tmp_path, settings)
+        diff = audit_local_config(tmp_path)
+        settings_fields = {
+            i.field for i in diff.items if i.field.startswith("local.claude_settings")
+        }
+        assert not settings_fields
+
+    def test_extra_entries_allowed(self, tmp_path: Path) -> None:
+        settings = {
+            "extraKnownMarketplaces": {
+                **_SETTINGS_TEMPLATE["extraKnownMarketplaces"],
+                "other-marketplace": {"source": {"source": "github", "repo": "other/repo"}},
+            },
+            "enabledPlugins": {
+                **_SETTINGS_TEMPLATE["enabledPlugins"],
+                "other@other-marketplace": True,
+            },
+        }
+        _write_settings(tmp_path, settings)
+        diff = audit_local_config(tmp_path)
+        settings_fields = {
+            i.field for i in diff.items if i.field.startswith("local.claude_settings")
+        }
+        assert not settings_fields
 
     def test_plugin_not_enabled(self, tmp_path: Path) -> None:
         settings = {


### PR DESCRIPTION
# Pull Request

## Summary

- The local.claude_settings audit check now requires every marketplace/plugin entry in the canonical data/claude_settings.json template to be present and deep-equal in the repo's settings, single-sourcing the expected values and catching plugin-manager clobbering.

## Issue Linkage

- Ref #1427

## Notes

- The issue's premise ("the check only verifies the file exists") was
stale: presence checks for the marketplace/plugin keys have existed
since 2026-05-18 (64cd17fb), so the emptied-keys clobber was already
detectable. The remaining gap — implemented here per the issue's
Change section — was that the expected values were hand-rolled
literals duplicating the canonical template. The check is now
template-driven (same pattern as the CLAUDE.md template-presence
check): canonical entries must match exactly, extra entries remain
allowed. Newly detected drift: marketplace source changes and
non-true plugin values. The marketplace_repo diff field is folded
into local.claude_settings.marketplace. A regression test pins the
exact clobber scenario from the issue.