### PR TITLE
feat(repo-config): marker-delimited CLAUDE.md template region check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working in
 this repository.
 
+<!-- vergil:template:claude-md:begin -->
 ## Memory management
 
 Memory is allowed with human approval. The authoritative policy is in
@@ -104,6 +105,7 @@ vrg-container-run -- vrg-validate
 This is the **only** validation command. Do not run individual linters,
 formatters, or other tools outside of `vrg-validate`. If a tool is not
 invoked by `vrg-validate`, it is not part of the validation pipeline.
+<!-- vergil:template:claude-md:end -->
 
 > **Note:** This repository uses
 > `vrg-container-run -- uv run vrg-validate` because it runs its own

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -71,6 +71,15 @@ def _check_vergil_toml(repo_root: Path, items: list[DiffItem]) -> None:
         )
 
 
+#: Markers delimiting the canonical-template region in a consuming
+#: repo's CLAUDE.md. Exactly one begin/end pair; the lines between
+#: them (ignoring leading/trailing blank lines) must equal the
+#: template verbatim. Repo-local content outside the markers never
+#: affects compliance. Issue #1439.
+CLAUDE_MD_MARKER_BEGIN = "<!-- vergil:template:claude-md:begin -->"
+CLAUDE_MD_MARKER_END = "<!-- vergil:template:claude-md:end -->"
+
+
 def _check_claude_md(repo_root: Path, items: list[DiffItem]) -> None:
     claude_md = repo_root / "CLAUDE.md"
     if not claude_md.is_file():
@@ -85,14 +94,94 @@ def _check_claude_md(repo_root: Path, items: list[DiffItem]) -> None:
 
     content = claude_md.read_text(encoding="utf-8")
     template = _load_template()
-    if template not in content:
+    lines = content.splitlines()
+    begins = [i for i, line in enumerate(lines) if line.strip() == CLAUDE_MD_MARKER_BEGIN]
+    ends = [i for i, line in enumerate(lines) if line.strip() == CLAUDE_MD_MARKER_END]
+
+    if not begins and not ends:
+        # Legacy form (transition window): no markers, require the
+        # template as a contiguous verbatim substring.
+        if template not in content:
+            items.append(
+                DiffItem(
+                    field="local.claude_md",
+                    expected="template present",
+                    actual="template not found",
+                )
+            )
+        return
+
+    malformed = _marker_structure_error(begins, ends)
+    if malformed is not None:
         items.append(
             DiffItem(
                 field="local.claude_md",
-                expected="template present",
-                actual="template not found",
+                expected="well-formed template markers",
+                actual=malformed,
             )
         )
+        return
+
+    _compare_marked_region(lines, begins[0], ends[0], template, items)
+
+
+def _marker_structure_error(begins: list[int], ends: list[int]) -> str | None:
+    """Return a diagnostic for malformed markers, or None if well-formed."""
+    if len(begins) > 1:
+        return "multiple begin markers"
+    if len(ends) > 1:
+        return "multiple end markers"
+    if not ends:
+        return "begin marker without end marker"
+    if not begins:
+        return "end marker without begin marker"
+    if ends[0] < begins[0]:
+        return "end marker before begin marker"
+    return None
+
+
+def _compare_marked_region(
+    lines: list[str],
+    begin: int,
+    end: int,
+    template: str,
+    items: list[DiffItem],
+) -> None:
+    """Compare the marked region against the template line by line.
+
+    Reports the first divergent line with both the template line number
+    and the absolute CLAUDE.md line number, so drift is fixable without
+    manual diffing. Leading/trailing blank lines inside the region are
+    tolerated.
+    """
+    start = begin + 1
+    stop = end
+    while start < stop and not lines[start].strip():
+        start += 1
+    while stop > start and not lines[stop - 1].strip():
+        stop -= 1
+    region = lines[start:stop]
+    template_lines = template.splitlines()
+
+    for offset in range(max(len(region), len(template_lines))):
+        actual_line = region[offset] if offset < len(region) else None
+        template_line = template_lines[offset] if offset < len(template_lines) else None
+        if actual_line == template_line:
+            continue
+        expected = (
+            f"template line {offset + 1}: {template_line}"
+            if template_line is not None
+            else "end of template"
+        )
+        actual = (
+            f"CLAUDE.md line {start + offset + 1}: {actual_line}"
+            if actual_line is not None
+            else f"CLAUDE.md line {stop + 1}: end of marked region"
+        )
+        items.append(
+            DiffItem(field="local.claude_md", expected=expected, actual=actual)
+        )
+        return
 
 
 def _check_hook_guard_shim(repo_root: Path, items: list[DiffItem]) -> None:

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -178,9 +178,7 @@ def _compare_marked_region(
             if actual_line is not None
             else f"CLAUDE.md line {stop + 1}: end of marked region"
         )
-        items.append(
-            DiffItem(field="local.claude_md", expected=expected, actual=actual)
-        )
+        items.append(DiffItem(field="local.claude_md", expected=expected, actual=actual))
         return
 
 

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -11,7 +11,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Any
 
-from vergil_tooling.lib import git, github
+from vergil_tooling.lib import git, github, repo_config
 from vergil_tooling.lib.config import _ENUMS
 
 _CHECKPOINT_RE = re.compile(r"chore\(init\): step (\d+) -")
@@ -157,7 +157,7 @@ def render_vergil_toml(ctx: RepoInitContext) -> str:
 
 
 def render_claude_md(ctx: RepoInitContext) -> str:
-    """Render CLAUDE.md with project header + consumer template."""
+    """Render CLAUDE.md with project header + marker-delimited consumer template."""
     consumer = _load_data_file("claude_md_consumer.md")
     header = (
         "# CLAUDE.md\n"
@@ -173,7 +173,14 @@ def render_claude_md(ctx: RepoInitContext) -> str:
         "```\n"
         "\n"
     )
-    return header + consumer
+    return (
+        header
+        + repo_config.CLAUDE_MD_MARKER_BEGIN
+        + "\n"
+        + consumer
+        + repo_config.CLAUDE_MD_MARKER_END
+        + "\n"
+    )
 
 
 def render_readme(ctx: RepoInitContext) -> str:

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -140,9 +140,7 @@ class TestClaudeMdMarkers:
         assert _claude_md_items(tmp_path) == []
 
     def test_divergent_line_reports_both_line_numbers(self, tmp_path: Path) -> None:
-        mutated = _TEMPLATE_TEXT.replace(
-            "## Memory management", "## Memory mismanagement", 1
-        )
+        mutated = _TEMPLATE_TEXT.replace("## Memory management", "## Memory mismanagement", 1)
         # _BEGIN is line 1, so template line 1 lands on CLAUDE.md line 2.
         content = f"{_BEGIN}\n{mutated}{_END}\n"
         (tmp_path / "CLAUDE.md").write_text(content)
@@ -191,6 +189,13 @@ class TestClaudeMdMarkers:
         items = _claude_md_items(tmp_path)
         assert len(items) == 1
         assert "multiple begin markers" in str(items[0].actual)
+
+    def test_multiple_end_markers_fail(self, tmp_path: Path) -> None:
+        content = f"{_BEGIN}\n{_TEMPLATE_TEXT}{_END}\n{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "multiple end markers" in str(items[0].actual)
 
     def test_end_before_begin_fails(self, tmp_path: Path) -> None:
         content = f"{_END}\n{_TEMPLATE_TEXT}{_BEGIN}\n"

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -110,6 +110,106 @@ class TestClaudeMd:
         assert "local.claude_md" not in fields
 
 
+_BEGIN = "<!-- vergil:template:claude-md:begin -->"
+_END = "<!-- vergil:template:claude-md:end -->"
+
+
+def _claude_md_items(tmp_path: Path) -> list:
+    diff = audit_local_config(tmp_path)
+    return [i for i in diff.items if i.field == "local.claude_md"]
+
+
+class TestClaudeMdMarkers:
+    def test_marked_region_matching_template_is_compliant(self, tmp_path: Path) -> None:
+        content = f"# CLAUDE.md\n\n{_BEGIN}\n{_TEMPLATE_TEXT}{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        assert _claude_md_items(tmp_path) == []
+
+    def test_repo_local_content_outside_markers_is_ignored(self, tmp_path: Path) -> None:
+        content = (
+            f"# CLAUDE.md\n\nIntro prose.\n\n{_BEGIN}\n{_TEMPLATE_TEXT}{_END}\n"
+            "\n## Identity modes\n\nRepo-local guidance, including the words\n"
+            "template not found, which must not confuse the check.\n"
+        )
+        (tmp_path / "CLAUDE.md").write_text(content)
+        assert _claude_md_items(tmp_path) == []
+
+    def test_blank_lines_around_region_are_tolerated(self, tmp_path: Path) -> None:
+        content = f"# CLAUDE.md\n\n{_BEGIN}\n\n\n{_TEMPLATE_TEXT}\n\n{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        assert _claude_md_items(tmp_path) == []
+
+    def test_divergent_line_reports_both_line_numbers(self, tmp_path: Path) -> None:
+        mutated = _TEMPLATE_TEXT.replace(
+            "## Memory management", "## Memory mismanagement", 1
+        )
+        # _BEGIN is line 1, so template line 1 lands on CLAUDE.md line 2.
+        content = f"{_BEGIN}\n{mutated}{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "template line 1" in str(items[0].expected)
+        assert "## Memory management" in str(items[0].expected)
+        assert "line 2" in str(items[0].actual)
+        assert "## Memory mismanagement" in str(items[0].actual)
+
+    def test_truncated_region_reports_missing_template_line(self, tmp_path: Path) -> None:
+        template_lines = _TEMPLATE_TEXT.splitlines()
+        truncated = "\n".join(template_lines[:-1]) + "\n"
+        content = f"{_BEGIN}\n{truncated}{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert f"template line {len(template_lines)}" in str(items[0].expected)
+        assert "end of marked region" in str(items[0].actual)
+
+    def test_extra_region_content_after_template_fails(self, tmp_path: Path) -> None:
+        content = f"{_BEGIN}\n{_TEMPLATE_TEXT}## Extra section\n{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "end of template" in str(items[0].expected)
+        assert "## Extra section" in str(items[0].actual)
+
+    def test_begin_without_end_fails(self, tmp_path: Path) -> None:
+        content = f"{_BEGIN}\n{_TEMPLATE_TEXT}"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "end marker" in str(items[0].actual)
+
+    def test_end_without_begin_fails(self, tmp_path: Path) -> None:
+        content = f"{_TEMPLATE_TEXT}{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "begin marker" in str(items[0].actual)
+
+    def test_multiple_begin_markers_fail(self, tmp_path: Path) -> None:
+        content = f"{_BEGIN}\n{_BEGIN}\n{_TEMPLATE_TEXT}{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "multiple begin markers" in str(items[0].actual)
+
+    def test_end_before_begin_fails(self, tmp_path: Path) -> None:
+        content = f"{_END}\n{_TEMPLATE_TEXT}{_BEGIN}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+        assert "before begin marker" in str(items[0].actual)
+
+    def test_markers_take_precedence_over_legacy_substring(self, tmp_path: Path) -> None:
+        mutated = _TEMPLATE_TEXT.replace("vrg-git", "vrg-Git", 1)
+        # The verbatim template appears outside the marked region, but the
+        # marked region itself diverges — markers must win over the legacy
+        # contiguous-substring fallback.
+        content = f"{_TEMPLATE_TEXT}\n{_BEGIN}\n{mutated}{_END}\n"
+        (tmp_path / "CLAUDE.md").write_text(content)
+        items = _claude_md_items(tmp_path)
+        assert len(items) == 1
+
+
 _MINIMAL_SETTINGS = {
     "extraKnownMarketplaces": {
         "vergil-marketplace": {

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -200,6 +200,16 @@ class TestRenderClaudeMd:
         assert "## Shell command policy" in content
         assert "## Validation" in content
 
+    def test_wraps_consumer_template_in_markers(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        content = render_claude_md(ctx)
+        begin = "<!-- vergil:template:claude-md:begin -->"
+        end = "<!-- vergil:template:claude-md:end -->"
+        assert content.count(begin) == 1
+        assert content.count(end) == 1
+        assert content.index(begin) < content.index("## Memory management")
+        assert content.rstrip().endswith(end)
+
 
 class TestRenderReadme:
     def test_contains_project_name(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the contiguous-substring CLAUDE.md compliance check with a single marker-delimited region (exact template match, first-divergent-line diagnostics), keep a legacy-substring fallback for unmigrated repos, scaffold markers in vrg-repo-init, and adopt the markers in this repo's CLAUDE.md.

## Issue Linkage

- Ref #1439

## Notes

- Design choices confirmed with the human: single begin/end marker block (not per-section), legacy contiguous-substring fallback during the migration window. Related: worktree/branch cleanup race observed during this work is tracked as #1445.