### PR TITLE
feat(vm-spec): per-profile nested virtualization via the [vm] cascade

### DIFF
--- a/docs/site/docs/reference/vm-spec.md
+++ b/docs/site/docs/reference/vm-spec.md
@@ -1,0 +1,95 @@
+# VM Spec Reference (`[vm]`)
+
+A repo declares the VM it needs in the `[vm]` section of its
+`vergil.toml`. `vrg-vm` composes that declaration with the identity's
+base footprint and any host override into the effective spec for each
+(identity, repo) pair, then builds a **dedicated VM** whenever the repo
+customizes anything.
+
+The composition model and rationale live in the per-repo VM profiles
+design spec
+([vergil-vm `docs/specs/2026-06-04-per-repo-vm-profiles-design.md`](https://github.com/vergil-project/vergil-vm/blob/main/docs/specs/2026-06-04-per-repo-vm-profiles-design.md));
+this page is the key-by-key reference.
+
+## Structure
+
+```toml
+[vm]                      # applies to every identity
+packages = ["qemu-system-x86", "libvirt-clients"]
+
+[[vm.apt_repos]]          # extra apt repositories (list of tables)
+name = "hashicorp"
+key_url = "https://apt.releases.hashicorp.com/gpg"
+uri = "https://apt.releases.hashicorp.com"
+suite = "noble"
+components = "main"
+
+[vm.vergil-user]          # role overlay: only the vergil-user identity
+cpus = 12
+memory = "64GiB"
+disk = "300GiB"
+stale_days = 7
+vagrant_plugins = ["vagrant-libvirt"]
+nested = true
+```
+
+## Precedence
+
+Five tiers, later wins:
+
+1. Built-in base footprint
+2. Identity footprint (`identities.toml`)
+3. Repo `[vm]` (all identities)
+4. Repo `[vm.<role>]` (one identity)
+5. Host override (`identities.toml` per-repo override; scalars pushed
+   below the repo-declared floor are flagged loudly)
+
+Scalars are **last-wins**; list keys (`packages`, `apt_repos`,
+`vagrant_plugins`) **accumulate** across tiers. Declaring any `[vm]`
+key marks the spec customized, which gives the repo a dedicated VM.
+
+## Keys
+
+| Key | Type | Default | Semantics |
+|---|---|---|---|
+| `cpus` | int | identity/base footprint | vCPUs (last-wins scalar) |
+| `memory` | string `"<N>GiB"` | identity/base footprint | RAM (last-wins scalar) |
+| `disk` | string `"<N>GiB"` | identity/base footprint | Disk size (last-wins scalar) |
+| `stale_days` | int | 3 | Age threshold before `vrg-vm` prompts to rebuild |
+| `packages` | list of strings | `[]` | Extra apt packages (accumulates) |
+| `apt_repos` | list of tables | `[]` | Extra apt repositories — `name`, `key_url`, `uri`, `suite`, `components` (accumulates) |
+| `vagrant_plugins` | list of strings | `[]` | Vagrant plugins to install (accumulates) |
+| `nested` | bool | `false` | Nested virtualization (last-wins scalar; see below) |
+
+The vergil-vm template owns *how* declarative installs happen — repos
+never supply scripts.
+
+## Nested virtualization (`nested`)
+
+`nested = true` requests `/dev/kvm` inside the VM
+(vergil-project/vergil-vm#131). At create time `vrg-vm` applies both
+halves together:
+
+- `--set='.nestedVirtualization = true'` — the Lima config knob
+- `--set='.param.NESTED_VIRT = "true"'` — turns on the template's
+  in-guest verification, which fails the build loudly when `/dev/kvm`
+  did not appear
+
+Three-layer defense, outermost first:
+
+1. **Host preflight** — `vrg-vm create`/`rebuild` abort before any
+   build (and before the destroy half of a rebuild) unless the host is
+   macOS 15+ on M3-or-later Apple silicon.
+2. **Lima** — rejects `nestedVirtualization` on unsupported hosts.
+3. **In-guest check** — the template verifies `/dev/kvm` exists and
+   fails the build rather than degrading silently to TCG emulation.
+
+## Fingerprint and `NEEDS-REBUILD`
+
+The composed spec is fingerprinted (SHA-256 over the declaration) and
+stamped into the VM at create time. `vrg-vm list` compares the stored
+fingerprint against the freshly composed one and shows `NEEDS-REBUILD`
+on any drift. Editing any declarative key — including toggling
+`nested` — flips the fingerprint. `nested` enters the fingerprint
+payload only when true, so profiles that never set it kept their
+fingerprints when the knob was introduced.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
   - Script Reference:
       - Overview: reference/index.md
       - CLI Tools Overview: reference/cli-tools-overview.md
+      - VM Spec ([vm]): reference/vm-spec.md
       - Hook Guard:
           - Claude Code Hook Guard: reference/hooks/pre-commit.md
       - Validators:

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -46,6 +46,7 @@ from vergil_tooling.lib.lima import (
     install_tooling,
     link_claude_dirs,
     list_vms,
+    nested_virt_unsupported_reason,
     shell_run,
     start_vm,
     stop_vm,
@@ -209,6 +210,26 @@ def _preflight_target(target: Target) -> int:
     return 0
 
 
+def _nested_preflight(target: Target) -> int:
+    """Abort (nonzero) when the target wants nested virt the host cannot provide.
+
+    Runs before any build step — and before the destroy half of a rebuild —
+    so an unsupported host never eats a VM it cannot recreate. Lima's own
+    rejection is the backstop; the template's in-guest /dev/kvm check is the
+    last line (no-silent-failures).
+    """
+    if not target.spec.nested:
+        return 0
+    reason = nested_virt_unsupported_reason()
+    if reason is None:
+        return 0
+    print(
+        f"ERROR: cannot build VM '{target.instance}': {reason}",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def _create_from_target(target: Target, template: Path) -> None:
     """Build the VM for a target: dedicated boxes carry the composed spec, base is unchanged."""
     if target.spec.dedicated:
@@ -223,6 +244,7 @@ def _create_from_target(target: Target, template: Path) -> None:
             apt_repos=list(target.spec.apt_repos),
             vagrant_plugins=list(target.spec.vagrant_plugins),
             fingerprint=target.fingerprint,
+            nested=target.spec.nested,
         )
     else:
         create_vm(
@@ -254,6 +276,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             f"ERROR: identity '{name}' has no projects_dir configured",
             file=sys.stderr,
         )
+        return 1
+
+    if _nested_preflight(target) != 0:
         return 1
 
     print(f"Creating VM '{target.instance}' for identity '{name}'...")
@@ -421,6 +446,9 @@ def _cmd_rebuild(args: argparse.Namespace) -> int:
             f"ERROR: identity '{name}' has no projects_dir configured",
             file=sys.stderr,
         )
+        return 1
+
+    if _nested_preflight(target) != 0:
         return 1
 
     vergil_version = resolve_vergil_version(config, identity)

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -100,6 +100,7 @@ class RoleOverlay:
     stale_days: int | None
     apt_repos: list[dict[str, str]]
     vagrant_plugins: list[str]
+    nested: bool | None = None
 
 
 @dataclass
@@ -112,13 +113,16 @@ class VmStanza:
     apt_repos: list[dict[str, str]]
     vagrant_plugins: list[str]
     roles: dict[str, RoleOverlay]
+    nested: bool | None = None
 
 
 # Recognized keys in a [vm] / [vm.<role>] table. apt_repos is a list of tables
 # (key + apt source line); vagrant_plugins is a list of plugin names. The
 # vergil-vm template owns *how* these install — repos never supply a script.
+# nested enables Lima nested virtualization for the profile (issue #1447);
+# default off, requires macOS 15+ on M3-or-later Apple silicon at create time.
 _VM_KEYS = frozenset(
-    {"cpus", "memory", "disk", "stale_days", "packages", "apt_repos", "vagrant_plugins"}
+    {"cpus", "memory", "disk", "stale_days", "packages", "apt_repos", "vagrant_plugins", "nested"}
 )
 
 
@@ -134,6 +138,7 @@ def _parse_role_overlay(name: str, raw: dict[str, Any], source: str = CONFIG_FIL
         stale_days=raw.get("stale_days"),
         apt_repos=list(raw.get("apt_repos", [])),
         vagrant_plugins=list(raw.get("vagrant_plugins", [])),
+        nested=raw.get("nested"),
     )
 
 
@@ -160,6 +165,7 @@ def parse_vm_stanza(raw: dict[str, Any], source: str = CONFIG_FILE) -> VmStanza 
         apt_repos=list(fields.get("apt_repos", [])),
         vagrant_plugins=list(fields.get("vagrant_plugins", [])),
         roles=roles,
+        nested=fields.get("nested"),
     )
 
 

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import platform
 import re
 import shlex
 import subprocess
@@ -145,6 +146,45 @@ def fetch_template(tag: str) -> Path:
     return Path(tmp.name)
 
 
+_NESTED_VIRT_REQUIREMENT = "nested virtualization requires macOS 15+ on M3-or-later Apple silicon"
+_NESTED_VIRT_MIN_MACOS_MAJOR = 15
+_NESTED_VIRT_MIN_APPLE_M = 3
+
+
+def _nested_virt_unsupported_reason(system: str, mac_ver: str, cpu_brand: str) -> str | None:
+    """Pure-logic core of nested_virt_unsupported_reason (testable without a host)."""
+    if system != "Darwin":
+        return f"{_NESTED_VIRT_REQUIREMENT}; host OS is {system or 'unknown'}"
+    major = mac_ver.split(".", 1)[0]
+    if not major.isdigit() or int(major) < _NESTED_VIRT_MIN_MACOS_MAJOR:
+        return f"{_NESTED_VIRT_REQUIREMENT}; host macOS is {mac_ver or 'unknown'}"
+    match = re.search(r"\bApple M(\d+)\b", cpu_brand)
+    if match is None or int(match.group(1)) < _NESTED_VIRT_MIN_APPLE_M:
+        return f"{_NESTED_VIRT_REQUIREMENT}; host CPU is {cpu_brand or 'unknown'}"
+    return None
+
+
+def nested_virt_unsupported_reason() -> str | None:
+    """Return why this host cannot do nested virtualization, or None if it can.
+
+    First line of the three-layer defense for the per-profile ``nested`` knob
+    (issue #1447): abort before any build starts. Lima's own rejection is the
+    backstop; the template's in-guest /dev/kvm check is the last line.
+    """
+    system = platform.system()
+    if system != "Darwin":
+        return _nested_virt_unsupported_reason(system, "", "")
+    result = subprocess.run(  # noqa: S603
+        ["sysctl", "-n", "machdep.cpu.brand_string"],  # noqa: S607
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    # An unreadable brand string yields a reason (abort), never a silent pass.
+    cpu_brand = result.stdout.strip() if result.returncode == 0 else ""
+    return _nested_virt_unsupported_reason(system, platform.mac_ver()[0], cpu_brand)
+
+
 def create_vm(
     instance: str,
     template: Path,
@@ -157,6 +197,7 @@ def create_vm(
     apt_repos: list[dict[str, str]] | None = None,
     vagrant_plugins: list[str] | None = None,
     fingerprint: str | None = None,
+    nested: bool = False,
 ) -> None:
     claude_projects_path = Path.home() / ".claude" / "projects"
     claude_skills_path = Path.home() / ".claude" / "skills"
@@ -203,6 +244,12 @@ def create_vm(
         args.append(f'--set=.param.VAGRANT_PLUGINS = "{" ".join(vagrant_plugins)}"')
     if fingerprint:
         args.append(f'--set=.param.SPEC_FINGERPRINT = "{fingerprint}"')
+    if nested:
+        # Both halves together (vergil-vm#131): the Lima config knob exposes
+        # /dev/kvm, the template param turns on the in-guest verification that
+        # fails the build loudly when it didn't appear.
+        args.append("--set=.nestedVirtualization = true")
+        args.append('--set=.param.NESTED_VIRT = "true"')
     args.append(str(template))
     _limactl(*args)
 

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -32,6 +32,9 @@ class ComposedSpec:
     vagrant_plugins: tuple[str, ...]
     dedicated: bool
     under: tuple[str, ...]
+    # Per-profile nested virtualization (issue #1447): default off, last-wins
+    # through the [vm]/[vm.<role>] cascade like the footprint scalars.
+    nested: bool = False
 
 
 @dataclass
@@ -46,6 +49,7 @@ class _Acc:
     apt_repos: list[dict[str, str]]
     vagrant_plugins: list[str]
     customized: bool
+    nested: bool
     # Repo-declared footprint (tiers 3+4 only) — the floor an override is measured
     # against. None means the repo never declared that scalar, so no floor applies.
     declared_cpus: int | None
@@ -78,6 +82,9 @@ def _apply_overlay(acc: _Acc, overlay: VmStanza | RoleOverlay) -> None:
     if overlay.stale_days is not None:
         acc.stale_days = overlay.stale_days
         acc.customized = True
+    if overlay.nested is not None:
+        acc.nested = overlay.nested
+        acc.customized = True
 
 
 def compose_vm_spec(
@@ -98,6 +105,7 @@ def compose_vm_spec(
         apt_repos=[],
         vagrant_plugins=[],
         customized=False,
+        nested=False,
         declared_cpus=None,
         declared_mem=None,
         declared_disk=None,
@@ -139,6 +147,7 @@ def compose_vm_spec(
         vagrant_plugins=tuple(sorted(set(acc.vagrant_plugins))),
         dedicated=acc.customized,
         under=tuple(under),
+        nested=acc.nested,
     )
 
 
@@ -185,15 +194,19 @@ def spec_fingerprint(spec: ComposedSpec) -> str:
     what the VM is built from. Packages, apt repos, and vagrant plugins are sorted so
     order cannot change the hash. Editing any declarative field flips the fingerprint.
     """
-    payload = "\n".join(
-        (
-            f"cpus={spec.cpus}",
-            f"memory={spec.memory}",
-            f"disk={spec.disk}",
-            f"stale_days={spec.stale_days}",
-            "packages=" + ",".join(sorted(spec.packages)),
-            "apt_repos=" + ",".join(sorted(_repo_key(r) for r in spec.apt_repos)),
-            "vagrant_plugins=" + ",".join(sorted(spec.vagrant_plugins)),
-        )
-    )
+    fields = [
+        f"cpus={spec.cpus}",
+        f"memory={spec.memory}",
+        f"disk={spec.disk}",
+        f"stale_days={spec.stale_days}",
+        "packages=" + ",".join(sorted(spec.packages)),
+        "apt_repos=" + ",".join(sorted(_repo_key(r) for r in spec.apt_repos)),
+        "vagrant_plugins=" + ",".join(sorted(spec.vagrant_plugins)),
+    ]
+    # nested enters the payload only when true: profiles that never set it keep
+    # the fingerprint they had before the knob existed (no spurious NEEDS-REBUILD
+    # on upgrade), while toggling it flips the hash in both directions.
+    if spec.nested:
+        fields.append("nested=true")
+    payload = "\n".join(fields)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -658,6 +658,22 @@ class TestParseVmStanza:
         assert overlay.stale_days == 7
         assert overlay.packages == []
 
+    def test_nested_parsed_at_vm_and_role_tiers(self) -> None:
+        raw = {"vm": {"nested": True, "vergil-user": {"nested": False}}}
+        stanza = parse_vm_stanza(raw)
+        assert stanza is not None
+        assert stanza.nested is True
+        assert stanza.roles["vergil-user"].nested is False
+
+    def test_nested_absent_is_none(self) -> None:
+        stanza = parse_vm_stanza({"vm": {"packages": []}})
+        assert stanza is not None
+        assert stanza.nested is None
+
+    def test_nested_not_flagged_unrecognized(self, capsys: pytest.CaptureFixture[str]) -> None:
+        parse_vm_stanza({"vm": {"nested": True, "vergil-user": {"nested": True}}})
+        assert "unrecognized" not in capsys.readouterr().err
+
     def test_vm_section_not_flagged_unrecognized(self, capsys: pytest.CaptureFixture[str]) -> None:
         _warn_unrecognized_keys({"vm": {"packages": [], "vergil-user": {"cpus": 4}}})
         err = capsys.readouterr().err

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -12,6 +12,7 @@ from vergil_tooling.lib.identity import Identity
 from vergil_tooling.lib.lima import (
     _inject_host_git_identity,
     _limactl,
+    _nested_virt_unsupported_reason,
     _read_host_git_config,
     copy_claude_config,
     create_vm,
@@ -22,6 +23,7 @@ from vergil_tooling.lib.lima import (
     install_tooling,
     link_claude_dirs,
     list_vms,
+    nested_virt_unsupported_reason,
     read_fingerprint,
     shell_pipe,
     shell_run,
@@ -379,6 +381,90 @@ class TestCreateVm:
         assert '--set=.memory = "24GiB"' in args
         assert '--set=.disk = "100GiB"' in args
         assert str(tpl) == args[-1]
+
+    @patch("vergil_tooling.lib.lima.Path.home")
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_nested_sets_both_lima_halves(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects", nested=True)
+        args = mock.call_args[0]
+        assert "--set=.nestedVirtualization = true" in args
+        assert '--set=.param.NESTED_VIRT = "true"' in args
+
+    @patch("vergil_tooling.lib.lima.Path.home")
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_no_nested_flags_by_default(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects")
+        args = mock.call_args[0]
+        assert not any("nestedVirtualization" in a for a in args)
+        assert not any("NESTED_VIRT" in a for a in args)
+
+
+class TestNestedVirtSupport:
+    """Host-support preflight for nested virtualization (macOS 15+, M3+)."""
+
+    def test_non_darwin_host_unsupported(self) -> None:
+        reason = _nested_virt_unsupported_reason("Linux", "", "")
+        assert reason is not None
+        assert "macOS 15" in reason
+        assert "Linux" in reason
+
+    def test_old_macos_unsupported(self) -> None:
+        reason = _nested_virt_unsupported_reason("Darwin", "14.7.1", "Apple M3 Pro")
+        assert reason is not None
+        assert "14.7.1" in reason
+
+    def test_pre_m3_chip_unsupported(self) -> None:
+        reason = _nested_virt_unsupported_reason("Darwin", "15.2", "Apple M2 Max")
+        assert reason is not None
+        assert "Apple M2 Max" in reason
+
+    def test_unknown_cpu_brand_unsupported(self) -> None:
+        reason = _nested_virt_unsupported_reason("Darwin", "15.2", "")
+        assert reason is not None
+
+    def test_intel_mac_unsupported(self) -> None:
+        reason = _nested_virt_unsupported_reason(
+            "Darwin", "15.2", "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz"
+        )
+        assert reason is not None
+
+    def test_m3_on_macos_15_supported(self) -> None:
+        assert _nested_virt_unsupported_reason("Darwin", "15.2", "Apple M3 Pro") is None
+
+    def test_m4_on_macos_26_supported(self) -> None:
+        assert _nested_virt_unsupported_reason("Darwin", "26.0", "Apple M4") is None
+
+    @patch("vergil_tooling.lib.lima.subprocess.run")
+    @patch("vergil_tooling.lib.lima.platform.mac_ver", return_value=("15.2", ("", "", ""), ""))
+    @patch("vergil_tooling.lib.lima.platform.system", return_value="Darwin")
+    def test_wrapper_gathers_host_facts(
+        self, _system: MagicMock, _ver: MagicMock, mock_run: MagicMock
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="Apple M3 Pro\n")
+        assert nested_virt_unsupported_reason() is None
+        assert mock_run.call_args.args[0] == ["sysctl", "-n", "machdep.cpu.brand_string"]
+
+    @patch("vergil_tooling.lib.lima.subprocess.run")
+    @patch("vergil_tooling.lib.lima.platform.mac_ver", return_value=("15.2", ("", "", ""), ""))
+    @patch("vergil_tooling.lib.lima.platform.system", return_value="Darwin")
+    def test_wrapper_sysctl_failure_is_unsupported(
+        self, _system: MagicMock, _ver: MagicMock, mock_run: MagicMock
+    ) -> None:
+        # No silent failures: an unreadable CPU brand aborts rather than guessing.
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert nested_virt_unsupported_reason() is not None
+
+    @patch("vergil_tooling.lib.lima.platform.system", return_value="Linux")
+    def test_wrapper_non_darwin_short_circuits(self, _system: MagicMock) -> None:
+        assert nested_virt_unsupported_reason() is not None
 
 
 class TestStartStopVm:

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 
 import pytest
@@ -121,6 +122,83 @@ class TestComposeVmSpec:
         assert spec.memory == "2GiB"
         assert spec.under == ()
 
+    def test_nested_defaults_false(self) -> None:
+        base_spec = compose_vm_spec(identity="vergil-user", base=BASE, stanza=None, override=None)
+        assert base_spec.nested is False
+        mq_spec = compose_vm_spec(
+            identity="vergil-user", base=BASE, stanza=_mq_stanza(), override=None
+        )
+        assert mq_spec.nested is False
+
+    def test_nested_true_at_vm_tier_applies_and_dedicates(self) -> None:
+        stanza = VmStanza(
+            packages=[],
+            cpus=None,
+            memory=None,
+            disk=None,
+            stale_days=None,
+            apt_repos=[],
+            vagrant_plugins=[],
+            roles={},
+            nested=True,
+        )
+        spec = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+        assert spec.nested is True
+        assert spec.dedicated is True
+
+    def test_role_nested_overrides_vm_tier_last_wins(self) -> None:
+        stanza = VmStanza(
+            packages=[],
+            cpus=None,
+            memory=None,
+            disk=None,
+            stale_days=None,
+            apt_repos=[],
+            vagrant_plugins=[],
+            nested=True,
+            roles={
+                "vergil-user": RoleOverlay(
+                    packages=[],
+                    cpus=None,
+                    memory=None,
+                    disk=None,
+                    stale_days=None,
+                    apt_repos=[],
+                    vagrant_plugins=[],
+                    nested=False,
+                ),
+            },
+        )
+        spec = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+        assert spec.nested is False
+
+    def test_role_nested_alone_applies_only_to_that_role(self) -> None:
+        stanza = VmStanza(
+            packages=[],
+            cpus=None,
+            memory=None,
+            disk=None,
+            stale_days=None,
+            apt_repos=[],
+            vagrant_plugins=[],
+            roles={
+                "vergil-user": RoleOverlay(
+                    packages=[],
+                    cpus=None,
+                    memory=None,
+                    disk=None,
+                    stale_days=None,
+                    apt_repos=[],
+                    vagrant_plugins=[],
+                    nested=True,
+                ),
+            },
+        )
+        user = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+        audit = compose_vm_spec(identity="vergil-audit", base=BASE, stanza=stanza, override=None)
+        assert user.nested is True
+        assert audit.nested is False
+
     def test_override_above_declared_not_flagged(self) -> None:
         # An override that raises a scalar above the repo-declared value is not "under".
         spec = compose_vm_spec(
@@ -230,3 +308,28 @@ class TestFingerprint:
         assert spec_fingerprint(self._spec(vagrant_plugins=("a",))) != spec_fingerprint(
             self._spec(vagrant_plugins=("a", "b"))
         )
+
+    def test_nested_toggle_changes_fingerprint(self) -> None:
+        assert spec_fingerprint(self._spec(nested=True)) != spec_fingerprint(
+            self._spec(nested=False)
+        )
+
+    def test_nested_false_keeps_legacy_fingerprint(self) -> None:
+        """Profiles that never set nested must not flip to NEEDS-REBUILD on upgrade.
+
+        Pins the encoding: ``nested`` enters the payload only when true, so
+        every fingerprint stored before the knob existed stays valid.
+        """
+        legacy_payload = "\n".join(
+            (
+                "cpus=12",
+                "memory=64GiB",
+                "disk=300GiB",
+                "stale_days=7",
+                "packages=a,b",
+                "apt_repos=" + "|".join(f"{k}={_REPO[k]}" for k in sorted(_REPO)),
+                "vagrant_plugins=vagrant-libvirt",
+            )
+        )
+        expected = hashlib.sha256(legacy_payload.encode("utf-8")).hexdigest()
+        assert spec_fingerprint(self._spec(nested=False)) == expected

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+from typing import Any
 
 import pytest
 
@@ -265,8 +266,8 @@ class TestInstanceName:
 
 
 class TestFingerprint:
-    def _spec(self, **over: object) -> ComposedSpec:
-        base: dict[str, object] = {
+    def _spec(self, **over: Any) -> ComposedSpec:
+        base: dict[str, Any] = {
             "cpus": 12,
             "memory": "64GiB",
             "disk": "300GiB",
@@ -278,7 +279,7 @@ class TestFingerprint:
             "under": (),
         }
         base.update(over)
-        return ComposedSpec(**base)  # type: ignore[arg-type]
+        return ComposedSpec(**base)
 
     def test_stable_for_same_declaration(self) -> None:
         assert spec_fingerprint(self._spec()) == spec_fingerprint(self._spec())

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1384,6 +1384,143 @@ class TestCreateDedicated:
         assert kwargs["apt_repos"] == []
         assert kwargs["vagrant_plugins"] == []
 
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.nested_virt_unsupported_reason", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_dedicated_create_passes_nested(
+        self,
+        _status: MagicMock,
+        mock_support: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        _start: MagicMock,
+        _link: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION + "\nnested = true\n")
+        cfg = _identities(tmp_path, projects)
+        template = tmp_path / "tpl.yaml"
+        template.write_text("x")
+        mock_fetch.return_value = template
+
+        assert main(["create", "lmf/mq", "--config", str(cfg)]) == 0
+        mock_support.assert_called_once()
+        assert mock_create.call_args.kwargs["nested"] is True
+
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch(
+        "vergil_tooling.bin.vrg_vm.nested_virt_unsupported_reason",
+        return_value="macOS 15+ on M3-or-later Apple silicon required",
+    )
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_create_aborts_on_unsupported_host_before_build(
+        self,
+        _status: MagicMock,
+        _support: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        _start: MagicMock,
+        _link: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION + "\nnested = true\n")
+        cfg = _identities(tmp_path, projects)
+
+        assert main(["create", "lmf/mq", "--config", str(cfg)]) == 1
+        assert "M3-or-later" in capsys.readouterr().err
+        mock_fetch.assert_not_called()
+        mock_create.assert_not_called()
+
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch(
+        "vergil_tooling.bin.vrg_vm.nested_virt_unsupported_reason",
+        return_value="unsupported host",
+    )
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
+    def test_create_without_nested_skips_host_check(
+        self,
+        _status: MagicMock,
+        mock_support: MagicMock,
+        mock_fetch: MagicMock,
+        _create: MagicMock,
+        _start: MagicMock,
+        _link: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # An unsupported host must not block profiles that never asked for nested.
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
+        cfg = _identities(tmp_path, projects)
+        template = tmp_path / "tpl.yaml"
+        template.write_text("x")
+        mock_fetch.return_value = template
+
+        assert main(["create", "lmf/mq", "--config", str(cfg)]) == 0
+        mock_support.assert_not_called()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch(
+        "vergil_tooling.bin.vrg_vm.nested_virt_unsupported_reason",
+        return_value="unsupported host",
+    )
+    @patch("vergil_tooling.bin.vrg_vm.delete_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_rebuild_aborts_on_unsupported_host_before_destroy(
+        self,
+        _status: MagicMock,
+        mock_delete: MagicMock,
+        _support: MagicMock,
+        mock_fetch: MagicMock,
+        _create: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _install: MagicMock,
+        _link: MagicMock,
+        _copy: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The preflight must fire before the old VM is destroyed, or an
+        # unsupported host turns a rebuild into a destroy-only operation.
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION + "\nnested = true\n")
+        cfg = _identities(tmp_path, projects)
+
+        assert main(["rebuild", "lmf/mq", "--config", str(cfg)]) == 1
+        assert "unsupported host" in capsys.readouterr().err
+        mock_delete.assert_not_called()
+        mock_fetch.assert_not_called()
+
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")


### PR DESCRIPTION
# Pull Request

## Summary

- Parse 'nested' in the [vm]/[vm.<role>] cascade (last-wins, default false), fold it into the spec fingerprint only when true, drive both Lima halves at create time (.nestedVirtualization + NESTED_VIRT param), and abort create/rebuild on hosts below macOS 15 / Apple M3 before any build or destroy.

## Issue Linkage

- Ref #1447

## Notes

- Docs: the [vm] spec reference named in the issue didn't exist, so this adds docs/site/docs/reference/vm-spec.md (human chose new-reference-page when asked). Fingerprint encodes nested only when true so pre-existing profiles keep their fingerprints (no spurious NEEDS-REBUILD on upgrade). Tooling half of vergil-project/vergil-vm#131.