### PR TITLE
fix(vrg-hook-guard): adopt canonical quote-strip + command-position matcher

### DIFF
--- a/src/vergil_tooling/bin/vrg_hook_guard.py
+++ b/src/vergil_tooling/bin/vrg_hook_guard.py
@@ -5,6 +5,13 @@ Blocks raw ``git`` and ``gh`` commands, directing agents to use
 hook JSON from stdin and outputs a deny decision on stdout when
 a raw invocation is detected.
 
+Matching follows the canonical quote-strip + command-position rule
+shared with the vergil-claude-plugin hook scripts (spec:
+vergil-claude-plugin
+``docs/specs/2026-06-05-450-command-matcher-quoting-design.md``):
+quoted spans are replaced with ``""``, then tool names match only
+at command position in the stripped text.
+
 Gated on managed-repo detection: no-op in repos without
 ``vergil.toml``.
 """
@@ -16,21 +23,39 @@ import re
 import sys
 from pathlib import Path
 
-_RAW_GIT_RE = re.compile(
-    r"(?<![a-zA-Z0-9_-])"
-    r"git"
-    r"(?:\s|$)",
-)
+# Canonical command-position anchor (spec section 2.2): the tool name
+# matches only at line start or after a command separator, applied per
+# line of the quote-stripped text.
+_RAW_GIT_RE = re.compile(r"(?:^|[;&|({]\s*)git(?:\s|$)", re.MULTILINE)
 
-_RAW_GH_RE = re.compile(
-    r"(?<![a-zA-Z0-9_-])"
-    r"gh"
-    r"(?:\s|$)",
-)
+_RAW_GH_RE = re.compile(r"(?:^|[;&|({]\s*)gh(?:\s|$)", re.MULTILINE)
 
-_QUOTED_STR_RE = re.compile(r""""[^"]*"|'[^']*'""")
+# Canonical quote-stripping alternation (spec section 2.1): an
+# escape-aware double-quoted span or a single-quoted span, combined as
+# one alternation so leftmost-match-wins mirrors shell scanning.
+_QUOTED_STR_RE = re.compile(r"\"(?:\\.|[^\"\\])*\"|'[^']*'")
 
 _SH_EXEC_RE = re.compile(r"(?:^|\s)(?:bash|sh)\s+-c\s")
+
+# The quoted span immediately following ``bash -c``/``sh -c`` in the
+# raw command text (spec section 4.3): the recheck runs against this
+# extracted content only, never the whole raw command.
+_SH_EXEC_ARG_RE = re.compile(
+    r"(?:^|\s)(?:bash|sh)\s+-c\s+"
+    r"(\"(?:\\.|[^\"\\])*\"|'[^']*')"
+)
+
+_GIT_DENY_REASON = (
+    "Raw git is blocked in Vergil-managed repos. "
+    "Use vrg-git instead. All git operations must go "
+    "through the vrg-git wrapper."
+)
+
+_GH_DENY_REASON = (
+    "Raw gh is blocked in Vergil-managed repos. "
+    "Use vrg-gh instead. All GitHub CLI operations must "
+    "go through the vrg-gh wrapper."
+)
 
 
 def _find_vergil_toml(start: Path) -> Path | None:
@@ -76,36 +101,21 @@ def main() -> int:
     stripped = _QUOTED_STR_RE.sub('""', command)
 
     if _RAW_GIT_RE.search(stripped):
-        _deny(
-            "Raw git is blocked in Vergil-managed repos. "
-            "Use vrg-git instead. All git operations must go "
-            "through the vrg-git wrapper."
-        )
+        _deny(_GIT_DENY_REASON)
         return 0
 
     if _RAW_GH_RE.search(stripped):
-        _deny(
-            "Raw gh is blocked in Vergil-managed repos. "
-            "Use vrg-gh instead. All GitHub CLI operations must "
-            "go through the vrg-gh wrapper."
-        )
+        _deny(_GH_DENY_REASON)
         return 0
 
     if _SH_EXEC_RE.search(stripped):
-        if _RAW_GIT_RE.search(command):
-            _deny(
-                "Raw git is blocked in Vergil-managed repos. "
-                "Use vrg-git instead. All git operations must go "
-                "through the vrg-git wrapper."
-            )
-            return 0
-
-        if _RAW_GH_RE.search(command):
-            _deny(
-                "Raw gh is blocked in Vergil-managed repos. "
-                "Use vrg-gh instead. All GitHub CLI operations must "
-                "go through the vrg-gh wrapper."
-            )
-            return 0
+        for match in _SH_EXEC_ARG_RE.finditer(command):
+            arg = match.group(1)[1:-1]
+            if _RAW_GIT_RE.search(arg):
+                _deny(_GIT_DENY_REASON)
+                return 0
+            if _RAW_GH_RE.search(arg):
+                _deny(_GH_DENY_REASON)
+                return 0
 
     return 0

--- a/tests/vergil_tooling/test_vrg_hook_guard.py
+++ b/tests/vergil_tooling/test_vrg_hook_guard.py
@@ -7,6 +7,8 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from vergil_tooling.bin.vrg_hook_guard import _find_vergil_toml, main
 
 
@@ -100,26 +102,6 @@ class TestRawGitDetection:
         result = json.loads(out)
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-    def test_env_var_prefix(self) -> None:
-        rc, out = _run("VRG_COMMIT_CONTEXT=1 git commit -m 'test'")
-        result = json.loads(out)
-        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-
-    def test_multiple_env_vars(self) -> None:
-        rc, out = _run("FOO=bar BAZ=1 git commit -m 'test'")
-        result = json.loads(out)
-        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-
-    def test_env_command_wrapper(self) -> None:
-        rc, out = _run("env git commit -m 'test'")
-        result = json.loads(out)
-        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-
-    def test_command_wrapper(self) -> None:
-        rc, out = _run("command git commit -m 'test'")
-        result = json.loads(out)
-        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-
     def test_bash_c_subshell(self) -> None:
         rc, out = _run('bash -c "git commit -m test"')
         result = json.loads(out)
@@ -137,11 +119,6 @@ class TestRawGitDetection:
 
     def test_dollar_paren(self) -> None:
         rc, out = _run("echo $(git log --oneline)")
-        result = json.loads(out)
-        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-
-    def test_backtick(self) -> None:
-        rc, out = _run("echo `git log --oneline`")
         result = json.loads(out)
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
@@ -243,6 +220,107 @@ class TestQuotedArgumentExclusion:
 
     def test_bash_c_vrg_git_allowed(self) -> None:
         rc, out = _run('bash -c "vrg-git push origin main"')
+        assert rc == 0
+        assert out == ""
+
+
+# -- canonical case table (spec section 6.1) -----------------------------------
+#
+# Encoded verbatim from the command-matcher quoting design spec,
+# section 6.1 (vergil-claude-plugin,
+# docs/specs/2026-06-05-450-command-matcher-quoting-design.md). The
+# rule is implemented twice (jq/Oniguruma in the plugin scripts,
+# Python re here); drift between the implementations requires editing
+# the spec table — a visible act. Verdicts are for the raw-git
+# predicate. Rows 11-12 apply only to vrg-hook-guard.
+
+_SPEC_TABLE = [
+    # columns: row number, command, denies, exercises
+    (1, "git commit -m x", True, "plain invocation"),
+    (2, "cd foo && git commit", True, "separator"),
+    (3, "x=$(git commit -m x)", True, "( separator"),
+    (4, "{ git commit -m x; }", True, "{ separator"),
+    (
+        5,
+        'vrg-commit --body "line one\ngit commit prose"',
+        False,
+        "#450 repro",
+    ),
+    (6, "find . -path ./.git -prune", False, "position anchor"),
+    (7, 'echo "git commit"', False, "quoted span stripped"),
+    (8, "echo 'say \"git commit\"'", False, "nesting"),
+    (9, 'echo "he said \\"git commit\\""', False, "escape handling"),
+    (
+        10,
+        'echo "; git commit',
+        True,
+        "unbalanced quote with a separator inside the span (spec 2.1)",
+    ),
+    (11, 'bash -c "git commit"', True, "recheck path"),
+    (
+        12,
+        "bash -c 'true' && vrg-commit --body \"git commit prose\"",
+        False,
+        "recheck confinement (spec 4.3)",
+    ),
+    (13, "if git commit; then :; fi", False, "keyword position (spec 2.4)"),
+    (
+        14,
+        'echo "git commit',
+        False,
+        "unbalanced quote; the unstripped quote is not a separator",
+    ),
+]
+
+
+class TestSpecCanonicalTable:
+    @pytest.mark.parametrize(
+        ("command", "denies"),
+        [(command, denies) for _, command, denies, _ in _SPEC_TABLE],
+        ids=[f"row-{row}" for row, _, _, _ in _SPEC_TABLE],
+    )
+    def test_spec_vector(self, command: str, denies: bool) -> None:
+        rc, out = _run(command)
+        assert rc == 0
+        if denies:
+            result = json.loads(out)
+            assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        else:
+            assert out == ""
+
+
+# -- accepted false-negative gaps (spec section 2.4) ---------------------------
+#
+# The canonical anchor (spec section 2.2) matches a tool name only at
+# line start or after a command separator. These shapes place the tool
+# name elsewhere and are accepted false negatives: the hook guards
+# against agent slip-ups, and the vrg-git/vrg-gh wrappers remain the
+# real enforcement layer.
+
+
+class TestAcceptedGaps:
+    def test_env_var_prefix(self) -> None:
+        rc, out = _run("VRG_COMMIT_CONTEXT=1 git commit -m 'test'")
+        assert rc == 0
+        assert out == ""
+
+    def test_multiple_env_vars(self) -> None:
+        rc, out = _run("FOO=bar BAZ=1 git commit -m 'test'")
+        assert rc == 0
+        assert out == ""
+
+    def test_env_command_wrapper(self) -> None:
+        rc, out = _run("env git commit -m 'test'")
+        assert rc == 0
+        assert out == ""
+
+    def test_command_wrapper(self) -> None:
+        rc, out = _run("command git commit -m 'test'")
+        assert rc == 0
+        assert out == ""
+
+    def test_backtick_substitution(self) -> None:
+        rc, out = _run("echo `git log --oneline`")
         assert rc == 0
         assert out == ""
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the lookbehind anchor with the canonical quote-strip + command-position matcher rule, fixing false denies on path-prefixed hits like 'find . -path ./.git -prune'.

## Issue Linkage

- Ref #1443

## Notes

- Implements vergil-claude-plugin
docs/specs/2026-06-05-450-command-matcher-quoting-design.md
sections 2 and 4 (the vrg-hook-guard half of
vergil-claude-plugin#450). The bash -c recheck is confined to the
extracted quoted argument (spec 4.3), and the test module encodes
the spec 6.1 table verbatim including rows 11-12.

Behavior note for review: the canonical anchor drops some deny
shapes the old lookbehind caught — env-assignment prefixes
(FOO=1 git ...), env/command wrappers, and backtick substitution.
These are the same accepted false-negative class as spec 2.4's
keyword-position gap (slip-up guard, not adversarial; the
vrg-git/vrg-gh wrappers remain the real enforcement layer). They
are encoded as documented accepted-gap tests rather than removed
silently.