### PR TITLE
feat(progress): stage-aware progress framework for long-running CLI commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "VERGIL — Validation Engine for Repository Governance, Integrati
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
-dependencies = []
+dependencies = ["rich>=13.0"]
 
 [project.scripts]
 vrg-audit-approve = "vergil_tooling.bin.vrg_audit_approve:main"

--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -9,7 +9,7 @@ import time
 from vergil_tooling.lib import git
 from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.orchestrator import _format_elapsed, run_release
-from vergil_tooling.lib.release.preflight import preflight
+from vergil_tooling.lib.release.preflight import preflight, run_audit
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -52,10 +52,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         print("\n=== Phase: preflight ===")
         start = time.monotonic()
+        if not args.skip_audit:
+            run_audit()
         ctx = preflight(
             version_override=args.version_override,
             repo_root=repo_root,
-            skip_audit=args.skip_audit,
         )
         ctx.promote = not args.no_promote
         ctx.skip_cd_docs = args.skip_cd_docs

--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import argparse
 import sys
-import time
 
-from vergil_tooling.lib import git
-from vergil_tooling.lib.release.context import ReleaseError
-from vergil_tooling.lib.release.orchestrator import _format_elapsed, run_release
-from vergil_tooling.lib.release.preflight import preflight, run_audit
+from vergil_tooling.lib import git, progress
+from vergil_tooling.lib.release.orchestrator import ReleaseState, build_stages
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -30,50 +27,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         help="Skip rolling-tag promotion after release.",
     )
-    parser.add_argument(
-        "--skip-cd-docs",
-        action="store_true",
-        default=False,
-        help="Skip docs job verification in CD workflows (release job still verified).",
-    )
-    parser.add_argument(
-        "--skip-audit",
-        action="store_true",
-        default=False,
-        help="Skip the repo config audit in preflight.",
-    )
+    progress.add_progress_args(parser, build_stages())
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo_root = git.repo_root()
-
-    try:
-        print("\n=== Phase: preflight ===")
-        start = time.monotonic()
-        if not args.skip_audit:
-            run_audit()
-        ctx = preflight(
-            version_override=args.version_override,
-            repo_root=repo_root,
-        )
-        ctx.promote = not args.no_promote
-        ctx.skip_cd_docs = args.skip_cd_docs
-        elapsed = time.monotonic() - start
-        print(f"=== preflight: done ({_format_elapsed(elapsed)}) ===")
-        run_release(ctx)
-    except ReleaseError as exc:
-        print(f"\nRelease failed in phase '{exc.phase}'.", file=sys.stderr)
-        print(f"Command: {exc.command}", file=sys.stderr)
-        print(f"Error: {exc}", file=sys.stderr)
-        if exc.detail:
-            print(f"Detail: {exc.detail}", file=sys.stderr)
-        return 1
-    except Exception as exc:
-        print(f"\nUnexpected error: {exc}", file=sys.stderr)
-        return 1
-    return 0
+    state = ReleaseState(
+        version_override=args.version_override,
+        repo_root=repo_root,
+        promote=not args.no_promote,
+    )
+    return progress.run_pipeline(
+        state,
+        build_stages(),
+        command="vrg-release",
+        label="vrg-release",
+        args=args,
+        repo_root=repo_root,
+    )
 
 
 if __name__ == "__main__":

--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -25,13 +25,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Bump to next minor or major before releasing (default: release current version).",
     )
     parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        default=False,
-        help="Show full subprocess output (default: summarized).",
-    )
-    parser.add_argument(
         "--no-promote",
         action="store_true",
         default=False,
@@ -62,7 +55,6 @@ def main(argv: list[str] | None = None) -> int:
         ctx = preflight(
             version_override=args.version_override,
             repo_root=repo_root,
-            verbose=args.verbose,
             skip_audit=args.skip_audit,
         )
         ctx.promote = not args.no_promote

--- a/src/vergil_tooling/bin/vrg_validate.py
+++ b/src/vergil_tooling/bin/vrg_validate.py
@@ -3,6 +3,9 @@
 Reads primary_language from vergil.toml, then either runs a
 specific check type (--check) or all checks in sequence:
   common -> install -> lint -> typecheck -> test -> audit -> custom
+
+Checks run as progress-framework stages: install is fail_fast,
+everything else is fail_defer so all failures are reported in one run.
 """
 
 from __future__ import annotations
@@ -10,12 +13,12 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
-from vergil_tooling.lib import config, git
+from vergil_tooling.lib import config, git, progress
 from vergil_tooling.lib.languages import CheckKind, language_commands
+from vergil_tooling.lib.progress import Stage, StageMode
 
 _CHECK_KINDS = {
     "common": None,
@@ -47,18 +50,6 @@ def _in_dev_container() -> bool:
     return False
 
 
-def _run_commands(cmds: list[list[str]], label: str, *, fail_fast: bool = False) -> int:
-    worst = 0
-    for cmd in cmds:
-        print(f"Running ({label}): {' '.join(cmd)}")
-        result = subprocess.run(cmd, check=False)  # noqa: S603
-        if result.returncode != 0:
-            if fail_fast:
-                return result.returncode
-            worst = result.returncode
-    return worst
-
-
 def _run_common_checks(repo_root: Path) -> int:  # noqa: ARG001
     from vergil_tooling.bin.validate_common import main as common_main
 
@@ -76,10 +67,71 @@ def _find_custom_validator(repo_root: Path) -> str | None:
     return None
 
 
-def _run_custom_validator(path: str) -> int:
-    print(f"Running: {path}")
-    result = subprocess.run((path,), check=False)  # noqa: S603
-    return result.returncode
+class ValidationFailure(Exception):
+    """One or more validation commands failed."""
+
+
+def _command_stage(label: str, cmds: list[list[str]], *, mode: StageMode) -> Stage:
+    def fn(_ctx: object) -> None:
+        failed = 0
+        for cmd in cmds:
+            print(f"Running ({label}): {' '.join(cmd)}")
+            rc = progress.run(cmd, check=False)
+            if rc != 0:
+                failed += 1
+                if mode == "fail_fast":
+                    break
+        if failed:
+            msg = f"{failed} of {len(cmds)} {label} command(s) failed"
+            raise ValidationFailure(msg)
+
+    return Stage(label, fn, mode=mode)
+
+
+def _build_stages(check: str | None, language: str | None, repo_root: Path) -> list[Stage]:
+    stages: list[Stage] = []
+
+    if check in (None, "common"):
+
+        def common_fn(_ctx: object) -> None:
+            rc = _run_common_checks(repo_root)
+            if rc != 0:
+                msg = f"common checks exited {rc}"
+                raise ValidationFailure(msg)
+
+        stages.append(Stage("common", common_fn, mode="fail_defer"))
+
+    if language is not None and check != "common":
+        kinds = [
+            kind
+            for kind in _LANGUAGE_CHECK_ORDER
+            if check is None or check == kind.value
+        ]
+        kind_cmds = [(kind, language_commands(language, kind)) for kind in kinds]
+        kind_cmds = [(kind, cmds) for kind, cmds in kind_cmds if cmds]
+        if kind_cmds:
+            install_cmds = language_commands(language, CheckKind.INSTALL)
+            if install_cmds:
+                stages.append(_command_stage("install", install_cmds, mode="fail_fast"))
+            stages.extend(
+                _command_stage(kind.value, cmds, mode="fail_defer")
+                for kind, cmds in kind_cmds
+            )
+
+    if check is None:
+        custom = _find_custom_validator(repo_root)
+        if custom is not None:
+
+            def custom_fn(_ctx: object) -> None:
+                print(f"Running: {custom}")
+                rc = progress.run((custom,), check=False)
+                if rc != 0:
+                    msg = f"custom validator exited {rc}"
+                    raise ValidationFailure(msg)
+
+            stages.append(Stage("custom", custom_fn, mode="fail_defer"))
+
+    return stages
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -93,6 +145,7 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Run only this check type. Omit to run all.",
     )
+    progress.add_progress_args(parser, ())
     args = parser.parse_args(argv)
 
     if not _in_dev_container():
@@ -118,70 +171,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    if args.check is not None:
-        return _run_single_check(args.check, language, repo_root)
-    return _run_all_checks(language, repo_root)
-
-
-def _run_single_check(check: str, language: str | None, repo_root: Path) -> int:
-    if check == "common":
-        return _run_common_checks(repo_root)
-
-    kind = _CHECK_KINDS[check]
-    assert kind is not None  # noqa: S101
-    cmds = language_commands(language, kind)
-    if not cmds:
-        print(f"No {check} commands for language '{language or '<not set>'}'")
+    stages = _build_stages(args.check, language, repo_root)
+    if not stages:
+        print(f"No {args.check} commands for language '{language or '<not set>'}'")
         return 0
 
-    install_cmds = language_commands(language, CheckKind.INSTALL)
-    if install_cmds:
-        rc = _run_commands(install_cmds, "install", fail_fast=True)
-        if rc != 0:
-            return rc
-
-    return _run_commands(cmds, check)
-
-
-def _run_all_checks(language: str | None, repo_root: Path) -> int:
-    print("=" * 40)
-    print("vrg-validate")
-    print(f"primary_language: {language or '<not set>'}")
-    print("=" * 40)
-    print()
-
-    rc = _run_common_checks(repo_root)
-    if rc != 0:
-        return rc
-
-    if language:
-        install_cmds = language_commands(language, CheckKind.INSTALL)
-        if install_cmds:
-            print()
-            rc = _run_commands(install_cmds, "install", fail_fast=True)
-            if rc != 0:
-                return rc
-
-        for kind in _LANGUAGE_CHECK_ORDER:
-            cmds = language_commands(language, kind)
-            if cmds:
-                print()
-                rc = _run_commands(cmds, kind.value)
-                if rc != 0:
-                    return rc
-
-    custom = _find_custom_validator(repo_root)
-    if custom is not None:
-        print()
-        rc = _run_custom_validator(custom)
-        if rc != 0:
-            return rc
-
-    print()
-    print("=" * 40)
-    print("vrg-validate: all checks passed")
-    print("=" * 40)
-    return 0
+    return progress.run_pipeline(
+        None,
+        stages,
+        command="vrg-validate",
+        label="vrg-validate",
+        args=args,
+        repo_root=repo_root,
+    )
 
 
 if __name__ == "__main__":

--- a/src/vergil_tooling/bin/vrg_validate.py
+++ b/src/vergil_tooling/bin/vrg_validate.py
@@ -67,7 +67,7 @@ def _find_custom_validator(repo_root: Path) -> str | None:
     return None
 
 
-class ValidationFailure(Exception):
+class ValidationError(Exception):
     """One or more validation commands failed."""
 
 
@@ -83,7 +83,7 @@ def _command_stage(label: str, cmds: list[list[str]], *, mode: StageMode) -> Sta
                     break
         if failed:
             msg = f"{failed} of {len(cmds)} {label} command(s) failed"
-            raise ValidationFailure(msg)
+            raise ValidationError(msg)
 
     return Stage(label, fn, mode=mode)
 
@@ -97,16 +97,12 @@ def _build_stages(check: str | None, language: str | None, repo_root: Path) -> l
             rc = _run_common_checks(repo_root)
             if rc != 0:
                 msg = f"common checks exited {rc}"
-                raise ValidationFailure(msg)
+                raise ValidationError(msg)
 
         stages.append(Stage("common", common_fn, mode="fail_defer"))
 
     if language is not None and check != "common":
-        kinds = [
-            kind
-            for kind in _LANGUAGE_CHECK_ORDER
-            if check is None or check == kind.value
-        ]
+        kinds = [kind for kind in _LANGUAGE_CHECK_ORDER if check is None or check == kind.value]
         kind_cmds = [(kind, language_commands(language, kind)) for kind in kinds]
         kind_cmds = [(kind, cmds) for kind, cmds in kind_cmds if cmds]
         if kind_cmds:
@@ -114,8 +110,7 @@ def _build_stages(check: str | None, language: str | None, repo_root: Path) -> l
             if install_cmds:
                 stages.append(_command_stage("install", install_cmds, mode="fail_fast"))
             stages.extend(
-                _command_stage(kind.value, cmds, mode="fail_defer")
-                for kind, cmds in kind_cmds
+                _command_stage(kind.value, cmds, mode="fail_defer") for kind, cmds in kind_cmds
             )
 
     if check is None:
@@ -127,7 +122,7 @@ def _build_stages(check: str | None, language: str | None, repo_root: Path) -> l
                 rc = progress.run((custom,), check=False)
                 if rc != 0:
                     msg = f"custom validator exited {rc}"
-                    raise ValidationFailure(msg)
+                    raise ValidationError(msg)
 
             stages.append(Stage("custom", custom_fn, mode="fail_defer"))
 

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from vergil_tooling.lib import github
+from vergil_tooling.lib import github, progress
 
 _REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote"}
 
@@ -34,26 +34,9 @@ def _remote_env(args: tuple[str, ...]) -> dict[str, str] | None:
 
 
 def run(*args: str) -> None:
-    """Run a git command and raise on failure."""
+    """Run a git command, streaming output, and raise on failure."""
     env = _remote_env(args)
-    try:
-        result = subprocess.run(  # noqa: S603
-            ("git", *args),  # noqa: S607
-            check=True,
-            capture_output=True,
-            text=True,
-            env=env,
-        )
-    except subprocess.CalledProcessError as exc:
-        if exc.stdout:
-            print(exc.stdout, end="")
-        if exc.stderr:
-            print(exc.stderr, end="", file=sys.stderr)
-        raise
-    if result.stdout:
-        print(result.stdout, end="")
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
+    progress.run(("git", *args), env=env)
 
 
 def read_output(*args: str) -> str:

--- a/src/vergil_tooling/lib/output.py
+++ b/src/vergil_tooling/lib/output.py
@@ -1,8 +1,8 @@
-"""TTY-aware output formatting for CI and interactive use.
+"""CI-aware output formatting for CI and interactive use.
 
-Detection: ``sys.stdout.isatty()``. When stdout is a TTY, output is
-formatted for human reading. When not (CI, piped), output uses
-GitHub Actions workflow commands.
+Detection: ``$GITHUB_ACTIONS == "true"`` (owned by ``lib/progress.py``).
+When actually running under GitHub Actions, output uses GitHub Actions
+workflow commands; otherwise output is formatted for human reading.
 """
 
 from __future__ import annotations
@@ -11,9 +11,16 @@ import os
 import sys
 from pathlib import Path
 
+from vergil_tooling.lib.progress import is_github_actions
+
 
 def is_ci() -> bool:
-    return not sys.stdout.isatty()
+    """True when actually running under GitHub Actions.
+
+    Detection is owned by lib/progress.py; this fixes the old behavior where
+    merely piped output (local pipes, agent runs) got ::error:: annotations.
+    """
+    return is_github_actions()
 
 
 def emit_error(msg: str, *, file: str | None = None, line: int | None = None) -> None:

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -5,9 +5,12 @@ Design: docs/specs/2026-06-05-progress-framework-design.md
 
 from __future__ import annotations
 
+import io
 import os
 import re
+import subprocess
 import sys
+import threading
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
@@ -265,3 +268,104 @@ class RichRenderer:
     def close(self) -> None:
         if self._live.is_started:
             self._live.stop()
+
+
+@dataclass
+class _Session:
+    """Active pipeline state: routes output lines to the renderer and the log."""
+
+    renderer: Any
+    log: RunLog
+
+    def __post_init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def handle_line(self, line: str) -> None:
+        with self._lock:
+            self.log.write(line)
+            self.renderer.stage_line(line)
+
+
+_session: _Session | None = None
+
+
+def emit(line: str) -> None:
+    """Route one line of output through the active pipeline, or print it."""
+    session = _session
+    if session is not None:
+        session.handle_line(line)
+    else:
+        print(line)
+
+
+class _EmitWriter(io.TextIOBase):
+    """File-like sink that forwards complete lines to ``emit``.
+
+    Used to redirect sys.stdout/sys.stderr during stage execution so bare
+    ``print()`` calls deep in stage code join the renderer and log.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+
+    def write(self, s: str) -> int:
+        self._buf += s
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            emit(line)
+        return len(s)
+
+    def flush(self) -> None:
+        if self._buf:
+            emit(self._buf)
+            self._buf = ""
+
+
+def run(
+    cmd: Sequence[str],
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> int:
+    """Run *cmd*, streaming each output line through the active pipeline.
+
+    Raises CalledProcessError (carrying captured stdout/stderr) on nonzero
+    exit when ``check`` is true; otherwise returns the exit code.
+    """
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    captured: dict[str, list[str]] = {"stdout": [], "stderr": []}
+
+    def _pump(stream: IO[str], name: str) -> None:
+        for raw in stream:
+            line = raw.rstrip("\n")
+            captured[name].append(line)
+            emit(line)
+
+    threads = [
+        threading.Thread(target=_pump, args=(proc.stdout, "stdout"), daemon=True),
+        threading.Thread(target=_pump, args=(proc.stderr, "stderr"), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    try:
+        returncode = proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        proc.wait()
+        raise
+    for thread in threads:
+        thread.join()
+    if check and returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode,
+            tuple(cmd),
+            output="\n".join(captured["stdout"]),
+            stderr="\n".join(captured["stderr"]),
+        )
+    return returncode

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -5,12 +5,16 @@ Design: docs/specs/2026-06-05-progress-framework-design.md
 
 from __future__ import annotations
 
+import argparse
+import contextlib
 import io
 import os
 import re
 import subprocess
 import sys
 import threading
+import time
+import traceback
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
@@ -369,3 +373,119 @@ def run(
             stderr="\n".join(captured["stderr"]),
         )
     return returncode
+
+
+def add_progress_args(parser: argparse.ArgumentParser, stages: Sequence[Stage]) -> None:
+    """Add the framework's CLI flags, including per-stage --skip-* escape hatches."""
+    parser.add_argument(
+        "--output-window",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Rolling window size for the TTY renderer. 0 = full stream then collapse.",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=("rich", "gha", "plain"),
+        default=None,
+        help="Override renderer auto-detection.",
+    )
+    for stage in stages:
+        if stage.skip_flag is not None:
+            if stage.mode != "fail_fast":
+                msg = f"skip_flag is only supported on fail_fast stages: {stage.name}"
+                raise ValueError(msg)
+            parser.add_argument(
+                "--" + stage.skip_flag.replace("_", "-"),
+                action="store_true",
+                default=False,
+                help=f"Skip the {stage.name} stage entirely.",
+            )
+
+
+def _make_renderer(fmt: str, out: IO[str], window: int) -> Any:
+    if fmt == "rich":
+        return RichRenderer(out, window)
+    if fmt == "gha":
+        return GhaRenderer(out)
+    return PlainRenderer(out)
+
+
+def run_pipeline(
+    ctx: Any,
+    stages: Sequence[Stage],
+    *,
+    command: str,
+    label: str,
+    args: argparse.Namespace,
+    repo_root: Path,
+) -> int:
+    """Run *stages* in order with progress rendering and full logging.
+
+    Returns 0 on success, 1 if any fail_defer/fail_fast stage failed,
+    130 on KeyboardInterrupt.
+    """
+    global _session  # noqa: PLW0603
+    out = sys.stdout
+    log = RunLog(command, repo_root)
+    fmt = args.output_format or detect_format()
+    renderer = _make_renderer(fmt, out, args.output_window)
+    _session = _Session(renderer=renderer, log=log)
+    results: list[StageResult] = []
+    interrupted = False
+    start_total = time.monotonic()
+    try:
+        for stage in stages:
+            if stage.skip_flag is not None and getattr(args, stage.skip_flag, False):
+                flag = "--" + stage.skip_flag.replace("_", "-")
+                result = StageResult(stage.name, "skipped", 0.0, f"skipped via {flag}")
+                log.write(f"=== {stage.name}: skipped via {flag} ===")
+                renderer.end_stage(result)
+                results.append(result)
+                continue
+            renderer.start_stage(stage.name)
+            log.write(f"=== {stage.name}: started ===")
+            start = time.monotonic()
+            try:
+                with (
+                    contextlib.redirect_stdout(_EmitWriter()),
+                    contextlib.redirect_stderr(_EmitWriter()),
+                ):
+                    stage.fn(ctx)
+            except KeyboardInterrupt:
+                result = StageResult(
+                    stage.name, "interrupted", time.monotonic() - start, "interrupted"
+                )
+                log.write(f"=== {stage.name}: interrupted ===")
+                renderer.end_stage(result)
+                results.append(result)
+                interrupted = True
+                break
+            except Exception as exc:  # noqa: BLE001 — the pipeline is the failure boundary
+                cause = f"{type(exc).__name__}: {exc}"
+                status: StageStatus = "warn" if stage.mode == "warn" else "failed"
+                result = StageResult(stage.name, status, time.monotonic() - start, cause)
+                log.write(f"=== {stage.name}: {status} ({cause}) ===")
+                log.write(traceback.format_exc())
+                renderer.end_stage(result)
+                results.append(result)
+                if stage.mode == "fail_fast":
+                    break
+            else:
+                elapsed = time.monotonic() - start
+                result = StageResult(stage.name, "ok", elapsed)
+                log.write(f"=== {stage.name}: ok ({format_elapsed(elapsed)}) ===")
+                renderer.end_stage(result)
+                results.append(result)
+    finally:
+        _session = None
+        text = build_summary(label, results, time.monotonic() - start_total, log.path)
+        renderer.summary(text)
+        renderer.close()
+        log.write(text)
+        log.close()
+    if interrupted:
+        return 130
+    if any(r.status == "failed" for r in results):
+        return 1
+    return 0

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -5,7 +5,6 @@ Design: docs/specs/2026-06-05-progress-framework-design.md
 
 from __future__ import annotations
 
-import argparse
 import contextlib
 import io
 import os
@@ -18,7 +17,6 @@ import traceback
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Literal
 
 from rich.console import Console, Group
@@ -27,7 +25,9 @@ from rich.spinner import Spinner
 from rich.text import Text
 
 if TYPE_CHECKING:
+    import argparse
     from collections.abc import Callable, Sequence
+    from pathlib import Path
 
 LOG_RETAIN = 20
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
@@ -239,9 +239,7 @@ class RichRenderer:
         if self._active is not None:
             parts.append(Spinner("dots", text=Text(f" {self._active}")))
             if self._window > 0:
-                parts.extend(
-                    Text.from_ansi(f"   {line}", style="dim") for line in self._tail
-                )
+                parts.extend(Text.from_ansi(f"   {line}", style="dim") for line in self._tail)
         return Group(*parts)
 
     def start_stage(self, name: str) -> None:
@@ -257,9 +255,7 @@ class RichRenderer:
         self._live.update(self._renderable())
 
     def end_stage(self, result: StageResult) -> None:
-        self._completed.append(
-            Text(_status_line(result), style=_STATUS_STYLES[result.status])
-        )
+        self._completed.append(Text(_status_line(result), style=_STATUS_STYLES[result.status]))
         self._active = None
         self._tail.clear()
         self._live.update(self._renderable())

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -9,6 +9,8 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -86,3 +88,34 @@ def detect_format() -> str:
     if is_github_actions():
         return "gha"
     return "plain"
+
+
+class RunLog:
+    """Full verbose log for one run of a progress-aware command.
+
+    Lives at ``.vergil/<command>-YYYYMMDD-HHMMSS.log``. On creation, prunes
+    older logs for the same command so at most ``LOG_RETAIN`` remain.
+    """
+
+    def __init__(self, command: str, repo_root: Path) -> None:
+        log_dir = repo_root / ".vergil"
+        log_dir.mkdir(exist_ok=True)
+        _prune_logs(log_dir, command)
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")  # noqa: DTZ005
+        self.path = log_dir / f"{command}-{stamp}.log"
+        self._fh = self.path.open("a", encoding="utf-8")
+
+    def write(self, line: str) -> None:
+        """Append one line, with ANSI escapes stripped, and flush."""
+        self._fh.write(_ANSI_RE.sub("", line) + "\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        self._fh.close()
+
+
+def _prune_logs(log_dir: Path, command: str) -> None:
+    logs = sorted(log_dir.glob(f"{command}-*.log"))
+    excess = len(logs) - (LOG_RETAIN - 1)
+    for stale in logs[: max(0, excess)]:
+        stale.unlink(missing_ok=True)

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -11,10 +11,10 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 LOG_RETAIN = 20
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
@@ -119,3 +119,81 @@ def _prune_logs(log_dir: Path, command: str) -> None:
     excess = len(logs) - (LOG_RETAIN - 1)
     for stale in logs[: max(0, excess)]:
         stale.unlink(missing_ok=True)
+
+
+_RULE = "─" * 45
+
+
+def build_summary(
+    label: str,
+    results: Sequence[StageResult],
+    total_elapsed: float,
+    log_path: Path,
+) -> str:
+    """Build the plain-text final summary shared by all renderers."""
+    warnings = [r for r in results if r.status in ("warn", "skipped")]
+    failures = [r for r in results if r.status in ("failed", "interrupted")]
+    lines = [_RULE]
+    if warnings:
+        lines.append("⚠  warnings (non-fatal):")
+        lines.extend(f"   {r.name} — {r.error}" for r in warnings)
+        lines.append("")
+    if failures:
+        lines.append("✗  failures:")
+        lines.extend(f"   {r.name} — {r.error}" for r in failures)
+        lines.append("")
+        lines.append(f"{label} completed with errors  (total: {format_total(total_elapsed)})")
+        lines.append(f"PipelineError: {PipelineError(failures)} · exit 1")
+    else:
+        lines.append(f"✓  {label} complete  (total: {format_total(total_elapsed)})")
+    lines.append(f"   full log → {log_path}")
+    return "\n".join(lines)
+
+
+def _status_line(result: StageResult) -> str:
+    symbol = _SYMBOLS[result.status]
+    if result.status == "skipped":
+        return f"{symbol} {result.name} — {result.error}"
+    detail = f" — {result.error}" if result.error else ""
+    return f"{symbol} {result.name}  {format_elapsed(result.elapsed)}{detail}"
+
+
+class PlainRenderer:
+    """Sequential flat output for piped / non-GHA-CI contexts."""
+
+    def __init__(self, out: IO[str]) -> None:
+        self._out = out
+
+    def start_stage(self, name: str) -> None:
+        self._print(f"→ {name}  starting...")
+
+    def stage_line(self, line: str) -> None:
+        self._print(line)
+
+    def end_stage(self, result: StageResult) -> None:
+        self._print(_status_line(result))
+        self._print("")
+
+    def summary(self, text: str) -> None:
+        self._print(text)
+
+    def close(self) -> None:
+        pass
+
+    def _print(self, line: str) -> None:
+        self._out.write(line + "\n")
+        self._out.flush()
+
+
+class GhaRenderer(PlainRenderer):
+    """GitHub Actions ::group:: rendering; one collapsible section per stage."""
+
+    def start_stage(self, name: str) -> None:
+        self._print(f"::group::{name}")
+
+    def end_stage(self, result: StageResult) -> None:
+        self._print("::endgroup::")
+        self._print(_status_line(result))
+        if result.status in ("failed", "interrupted"):
+            self._print(f"::error title={result.name} failed::{result.error}")
+        self._print("")

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -8,10 +8,16 @@ from __future__ import annotations
 import os
 import re
 import sys
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Literal
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.spinner import Spinner
+from rich.text import Text
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -197,3 +203,65 @@ class GhaRenderer(PlainRenderer):
         if result.status in ("failed", "interrupted"):
             self._print(f"::error title={result.name} failed::{result.error}")
         self._print("")
+
+
+_STATUS_STYLES: dict[str, str] = {
+    "ok": "green",
+    "warn": "yellow",
+    "failed": "red",
+    "skipped": "yellow",
+    "interrupted": "red",
+}
+
+
+class RichRenderer:
+    """Live TTY display: completed stages collapse to one line, the active stage
+    shows a spinner plus a rolling window of its last N output lines."""
+
+    def __init__(self, out: IO[str], window: int, *, force_terminal: bool | None = None) -> None:
+        self._console = Console(file=out, highlight=False, force_terminal=force_terminal)
+        self._window = window
+        self._completed: list[Text] = []
+        self._tail: deque[str] = deque(maxlen=window if window > 0 else 1)
+        self._active: str | None = None
+        self._live = Live(console=self._console, refresh_per_second=8)
+        self._live.start()
+
+    def _renderable(self) -> Group:
+        parts: list[Text | Spinner] = list(self._completed)
+        if self._active is not None:
+            parts.append(Spinner("dots", text=Text(f" {self._active}")))
+            if self._window > 0:
+                parts.extend(
+                    Text.from_ansi(f"   {line}", style="dim") for line in self._tail
+                )
+        return Group(*parts)
+
+    def start_stage(self, name: str) -> None:
+        self._active = name
+        self._tail.clear()
+        self._live.update(self._renderable())
+
+    def stage_line(self, line: str) -> None:
+        if self._window == 0:
+            self._console.print(Text.from_ansi(line))
+        else:
+            self._tail.append(line)
+        self._live.update(self._renderable())
+
+    def end_stage(self, result: StageResult) -> None:
+        self._completed.append(
+            Text(_status_line(result), style=_STATUS_STYLES[result.status])
+        )
+        self._active = None
+        self._tail.clear()
+        self._live.update(self._renderable())
+
+    def summary(self, text: str) -> None:
+        self._live.update(self._renderable())
+        self._live.stop()
+        self._console.print(Text(text))
+
+    def close(self) -> None:
+        if self._live.is_started:
+            self._live.stop()

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -1,0 +1,88 @@
+"""Stage-aware progress framework for long-running, human-invoked commands.
+
+Design: docs/specs/2026-06-05-progress-framework-design.md
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+LOG_RETAIN = 20
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+StageMode = Literal["warn", "fail_defer", "fail_fast"]
+StageStatus = Literal["ok", "warn", "failed", "skipped", "interrupted"]
+
+_SYMBOLS: dict[str, str] = {
+    "ok": "✓",
+    "warn": "⚠",
+    "failed": "✗",
+    "skipped": "⚠",
+    "interrupted": "✗",
+}
+
+
+@dataclass
+class Stage:
+    """One step of a procedural pipeline. Failure is signaled by ``fn`` raising."""
+
+    name: str
+    fn: Callable[[Any], None]
+    mode: StageMode
+    skip_flag: str | None = None
+
+
+@dataclass
+class StageResult:
+    """Outcome of one stage."""
+
+    name: str
+    status: StageStatus
+    elapsed: float = 0.0
+    error: str | None = None
+
+
+class PipelineError(Exception):
+    """One or more pipeline stages failed."""
+
+    def __init__(self, failures: list[StageResult]) -> None:
+        self.failures = failures
+        names = ", ".join(f.name for f in failures)
+        plural = "" if len(failures) == 1 else "s"
+        super().__init__(f"{len(failures)} stage{plural} failed ({names})")
+
+
+def format_elapsed(seconds: float) -> str:
+    """Format a per-stage duration: ``3.2s`` or ``1m01s``."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    return f"{minutes}m{secs:02d}s"
+
+
+def format_total(seconds: float) -> str:
+    """Format a pipeline total as ``MM:SS``."""
+    minutes, secs = divmod(int(seconds), 60)
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def is_github_actions() -> bool:
+    """True when actually running under GitHub Actions."""
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def detect_format() -> str:
+    """Auto-detect the renderer: TTY -> rich, GHA -> gha, else plain."""
+    if sys.stdout.isatty():
+        return "rich"
+    if is_github_actions():
+        return "gha"
+    return "plain"

--- a/src/vergil_tooling/lib/release/bump.py
+++ b/src/vergil_tooling/lib/release/bump.py
@@ -33,7 +33,7 @@ def back_merge_and_bump(ctx: ReleaseContext) -> None:
     pr_url = _create_bump_pr(ctx, next_ver)
     print(f"Back-merge PR created: {pr_url}")
 
-    wait_and_merge(pr_url, phase="back-merge-bump", verbose=ctx.verbose)
+    wait_and_merge(pr_url, phase="back-merge-bump")
 
     git.run("checkout", "develop")
     git.run("pull", "--ff-only", "origin", "develop")

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -21,13 +21,8 @@ _CD_POLL_ATTEMPTS = 30
 
 def confirm_main(ctx: ReleaseContext) -> None:
     """Watch CD on main and verify publish artifacts."""
-    skip_docs = ctx.skip_cd_docs
-    run_id, run_url = _watch_cd(ctx, branch="main", check_status=not skip_docs)
-    expected: tuple[str, ...] = _MAIN_EXPECTED_JOBS
-    if skip_docs:
-        expected = tuple(j for j in expected if j != "docs")
-        print("  Skipping docs job verification (--skip-cd-docs).")
-    _verify_jobs(ctx, run_id, expected, phase="confirm-main")
+    run_id, run_url = _watch_cd(ctx, branch="main", check_status=True)
+    _verify_jobs(ctx, run_id, _MAIN_EXPECTED_JOBS, phase="confirm-main")
 
     ctx.cd_run_id = run_id
     ctx.cd_run_url = run_url
@@ -38,14 +33,8 @@ def confirm_main(ctx: ReleaseContext) -> None:
 
 def confirm_develop(ctx: ReleaseContext) -> None:
     """Watch CD on develop after back-merge."""
-    skip_docs = ctx.skip_cd_docs
-    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=not skip_docs)
-    expected: tuple[str, ...] = _DEVELOP_EXPECTED_JOBS
-    if skip_docs:
-        expected = tuple(j for j in expected if j != "docs")
-        print("  Skipping docs job verification (--skip-cd-docs).")
-    if expected:
-        _verify_jobs(ctx, run_id, expected, phase="confirm-develop")
+    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=True)
+    _verify_jobs(ctx, run_id, _DEVELOP_EXPECTED_JOBS, phase="confirm-develop")
 
     ctx.develop_cd_run_id = run_id
     ctx.develop_cd_run_url = run_url

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -77,7 +77,7 @@ def _watch_cd(
     )
     print(f"  Workflow run: {run_url}")
 
-    watch_workflow(ctx.repo, run_id, verbose=ctx.verbose, check_status=check_status)
+    watch_workflow(ctx.repo, run_id, check_status=check_status)
 
     if check_status:
         print(f"  CD workflow succeeded: {run_url}")

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -17,7 +17,6 @@ class ReleaseContext:
     version: str
     repo_root: Path
     version_override: str | None
-    verbose: bool = False
 
     issue_number: int | None = None
     issue_url: str | None = None

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -38,7 +38,6 @@ class ReleaseContext:
     develop_cd_run_url: str | None = None
 
     promote: bool = True
-    skip_cd_docs: bool = False
 
 
 class ReleaseError(Exception):

--- a/src/vergil_tooling/lib/release/merge.py
+++ b/src/vergil_tooling/lib/release/merge.py
@@ -2,7 +2,7 @@
 
 Thin wrapper over the shared engine in ``vergil_tooling.lib.pr_merge``
 — release keeps its public interface (``ReleaseError`` on failure,
-verbose-aware check waiting, merge-commit strategy) while the loop
+streamed check waiting, merge-commit strategy) while the loop
 logic lives in one place.
 """
 
@@ -13,13 +13,13 @@ from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.subprocess import wait_for_checks
 
 
-def wait_and_merge(pr_url: str, *, phase: str, verbose: bool = False) -> None:
+def wait_and_merge(pr_url: str, *, phase: str) -> None:
     """Wait for checks, handle behind-base, then merge with a merge commit."""
     try:
         pr_merge.wait_and_merge(
             pr_url,
             strategy="merge",
-            wait_checks=lambda pr: wait_for_checks(pr, verbose=verbose),
+            wait_checks=wait_for_checks,
         )
     except pr_merge.MergeAbortError as exc:
         raise ReleaseError(

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -1,10 +1,13 @@
-"""Sequential phase runner for vrg-release."""
+"""Declarative stage list for the vrg-release pipeline."""
 
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.promote import promote
 from vergil_tooling.lib.release.bump import back_merge_and_bump
 from vergil_tooling.lib.release.confirm import confirm_develop, confirm_main
@@ -12,6 +15,7 @@ from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.finalize import close_and_finalize
 from vergil_tooling.lib.release.handoff import consumer_refresh
 from vergil_tooling.lib.release.merge import wait_and_merge
+from vergil_tooling.lib.release.preflight import preflight, run_audit
 from vergil_tooling.lib.release.prepare import prepare
 from vergil_tooling.lib.release.tracking import (
     comment_phase_complete,
@@ -30,6 +34,91 @@ def _format_elapsed(seconds: float) -> str:
     minutes = int(seconds // 60)
     secs = int(seconds % 60)
     return f"{minutes}m{secs:02d}s"
+
+
+@dataclass
+class ReleaseState:
+    """Pipeline context for vrg-release; ctx is populated by the preflight stage."""
+
+    version_override: str | None
+    repo_root: Path
+    promote: bool
+    ctx: ReleaseContext | None = None
+
+
+def _audit_stage(state: ReleaseState) -> None:
+    run_audit()
+
+
+def _preflight_stage(state: ReleaseState) -> None:
+    ctx = preflight(
+        version_override=state.version_override,
+        repo_root=state.repo_root,
+    )
+    ctx.promote = state.promote
+    state.ctx = ctx
+
+
+def _tracked(name: str, fn: Callable[[ReleaseContext], None]) -> Callable[[ReleaseState], None]:
+    """Wrap a phase fn with tracking-issue comments (command-local, per spec)."""
+
+    def stage(state: ReleaseState) -> None:
+        ctx = state.ctx
+        if ctx is None:
+            raise ReleaseError(
+                phase=name,
+                command=name,
+                message="release context missing — preflight did not run",
+            )
+        try:
+            fn(ctx)
+        except ReleaseError as exc:
+            comment_phase_failed(ctx, name, exc)
+            raise
+        except Exception as exc:
+            wrapped = ReleaseError(
+                phase=name,
+                command=str(getattr(exc, "cmd", type(exc).__name__)),
+                message=str(exc),
+                detail=(getattr(exc, "stderr", None) or getattr(exc, "stdout", None)),
+            )
+            comment_phase_failed(ctx, name, wrapped)
+            raise wrapped from exc
+        comment_phase_complete(ctx, name, _phase_details(ctx, name))
+
+    return stage
+
+
+def build_stages() -> list[Stage]:
+    """The vrg-release pipeline, in execution order."""
+    return [
+        Stage("audit", _audit_stage, mode="fail_fast", skip_flag="skip_audit"),
+        Stage("preflight", _preflight_stage, mode="fail_fast"),
+        Stage("prepare", _tracked("prepare", prepare), mode="fail_fast"),
+        Stage("merge-release", _tracked("merge-release", merge_release), mode="fail_fast"),
+        Stage("confirm-main", _tracked("confirm-main", confirm_main), mode="fail_fast"),
+        Stage(
+            "back-merge-bump",
+            _tracked("back-merge-bump", back_merge_and_bump),
+            mode="fail_fast",
+        ),
+        Stage(
+            "confirm-develop",
+            _tracked("confirm-develop", confirm_develop),
+            mode="fail_defer",
+        ),
+        Stage("promote", _tracked("promote", _promote_phase), mode="fail_defer"),
+        Stage(
+            "close-finalize",
+            _tracked("close-finalize", close_and_finalize),
+            mode="fail_defer",
+        ),
+        Stage(
+            "consumer-refresh",
+            _tracked("consumer-refresh", consumer_refresh),
+            mode="fail_defer",
+        ),
+    ]
 
 
 def merge_release(ctx: ReleaseContext) -> None:

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.progress import Stage
@@ -23,6 +22,7 @@ from vergil_tooling.lib.release.tracking import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from vergil_tooling.lib.release.context import ReleaseContext
 
@@ -37,7 +37,7 @@ class ReleaseState:
     ctx: ReleaseContext | None = None
 
 
-def _audit_stage(state: ReleaseState) -> None:
+def _audit_stage(_state: ReleaseState) -> None:
     run_audit()
 
 

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -26,14 +25,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from vergil_tooling.lib.release.context import ReleaseContext
-
-
-def _format_elapsed(seconds: float) -> str:
-    if seconds < 60:
-        return f"{seconds:.0f}s"
-    minutes = int(seconds // 60)
-    secs = int(seconds % 60)
-    return f"{minutes}m{secs:02d}s"
 
 
 @dataclass
@@ -180,54 +171,3 @@ def _phase_details(ctx: ReleaseContext, phase: str) -> str:
     elif phase == "consumer-refresh":
         lines.append("Consumer refresh instructions displayed.")
     return "\n".join(lines)
-
-
-def run_release(ctx: ReleaseContext) -> None:
-    """Execute the release workflow phase by phase."""
-    phases: list[tuple[str, Callable[[ReleaseContext], None]]] = [
-        ("prepare", prepare),
-        ("merge-release", merge_release),
-        ("confirm-main", confirm_main),
-        ("back-merge-bump", back_merge_and_bump),
-        ("confirm-develop", confirm_develop),
-        ("promote", _promote_phase),
-        ("close-finalize", close_and_finalize),
-        ("consumer-refresh", consumer_refresh),
-    ]
-
-    for phase_name, phase_fn in phases:
-        print(f"\n=== Phase: {phase_name} ===")
-        start = time.monotonic()
-        try:
-            phase_fn(ctx)
-        except ReleaseError as exc:
-            elapsed = time.monotonic() - start
-            print(f"=== {phase_name}: FAILED ({_format_elapsed(elapsed)}) ===")
-            comment_phase_failed(ctx, phase_name, exc)
-            raise
-        except Exception as exc:
-            elapsed = time.monotonic() - start
-            print(f"=== {phase_name}: FAILED ({_format_elapsed(elapsed)}) ===")
-            wrapped = ReleaseError(
-                phase=phase_name,
-                command=str(getattr(exc, "cmd", type(exc).__name__)),
-                message=str(exc),
-                detail=(getattr(exc, "stderr", None) or getattr(exc, "stdout", None)),
-            )
-            comment_phase_failed(ctx, phase_name, wrapped)
-            raise wrapped from exc
-        elapsed = time.monotonic() - start
-        print(f"=== {phase_name}: done ({_format_elapsed(elapsed)}) ===")
-        try:
-            comment_phase_complete(
-                ctx,
-                phase_name,
-                _phase_details(ctx, phase_name),
-            )
-        except Exception as exc:
-            raise ReleaseError(
-                phase=f"comment({phase_name})",
-                command="comment_phase_complete",
-                message=str(exc),
-                detail=(getattr(exc, "stderr", None) or getattr(exc, "stdout", None)),
-            ) from exc

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -40,11 +40,7 @@ def merge_release(ctx: ReleaseContext) -> None:
             command="merge_release",
             message=("release_pr_url is not set — prepare phase may not have run."),
         )
-    wait_and_merge(
-        ctx.release_pr_url,
-        phase="merge-release",
-        verbose=ctx.verbose,
-    )
+    wait_and_merge(ctx.release_pr_url, phase="merge-release")
     ctx.release_merge_sha = "merged"
 
 

--- a/src/vergil_tooling/lib/release/preflight.py
+++ b/src/vergil_tooling/lib/release/preflight.py
@@ -20,7 +20,6 @@ def preflight(
     *,
     version_override: str | None,
     repo_root: Path,
-    verbose: bool = False,
     skip_audit: bool = False,
 ) -> ReleaseContext:
     """Run all preflight checks and return an initialized ReleaseContext."""
@@ -54,7 +53,6 @@ def preflight(
         version=release_version,
         repo_root=repo_root,
         version_override=version_override,
-        verbose=verbose,
     )
 
 

--- a/src/vergil_tooling/lib/release/preflight.py
+++ b/src/vergil_tooling/lib/release/preflight.py
@@ -20,15 +20,12 @@ def preflight(
     *,
     version_override: str | None,
     repo_root: Path,
-    skip_audit: bool = False,
 ) -> ReleaseContext:
     """Run all preflight checks and return an initialized ReleaseContext."""
     _check_host_prerequisites()
-    repo = _check_gh_auth()
+    repo = check_gh_auth()
     _read_and_validate_config(repo_root)
     _check_branch_and_tree()
-    if not skip_audit:
-        _audit_repo_config(repo)
 
     try:
         current_version = version.show(repo_root)
@@ -73,7 +70,12 @@ def _check_host_prerequisites() -> None:
         )
 
 
-def _check_gh_auth() -> str:
+def run_audit() -> None:
+    """Standalone audit stage: resolve the repo and audit its GitHub config."""
+    audit_repo_config(check_gh_auth())
+
+
+def check_gh_auth() -> str:
     try:
         return github.read_output(
             "repo",
@@ -126,7 +128,7 @@ def _check_branch_and_tree() -> None:
         )
 
 
-def _audit_repo_config(repo: str) -> None:
+def audit_repo_config(repo: str) -> None:
     result = subprocess.run(  # noqa: S603
         ("vrg-github-repo-config", "audit", "--repo", repo),  # noqa: S607
         check=False,

--- a/src/vergil_tooling/lib/release/subprocess.py
+++ b/src/vergil_tooling/lib/release/subprocess.py
@@ -1,15 +1,15 @@
-"""Verbose-aware subprocess wrappers for noisy release commands."""
+"""Subprocess wrappers for noisy release commands (streamed via progress)."""
 
 from __future__ import annotations
 
-import subprocess as _subprocess
-import sys
+import subprocess
 import time
 
+from vergil_tooling.lib import progress, retry
 from vergil_tooling.lib.github import (
     GitHubAPIError,
     _checks_registered,
-    _run_with_retry,
+    _gh_env,
     current_repo,
     head_sha,
 )
@@ -18,26 +18,33 @@ _POLL_INTERVAL_SECS = 5
 _POLL_TIMEOUT_SECS = 180
 
 
-def _run_verbose(cmd: tuple[str, ...], *, verbose: bool) -> None:
-    """Run *cmd* through the GitHub retry wrapper, printing output if verbose."""
-    try:
-        result = _run_with_retry(cmd, capture_output=True, text=True, check=True)
-    except _subprocess.CalledProcessError as exc:
-        if verbose:
-            if exc.stdout:
-                print(exc.stdout, end="")
-            if exc.stderr:
-                print(exc.stderr, end="", file=sys.stderr)
-        raise
-    if verbose:
-        if result.stdout:
-            print(result.stdout, end="")
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr)
+def _stream_with_retry(cmd: tuple[str, ...]) -> None:
+    """Stream *cmd* via progress.run, retrying transient GitHub failures.
+
+    Streaming-compatible analogue of github._run_with_retry: progress.run
+    raises CalledProcessError carrying captured output, which is what
+    retry.is_retryable inspects. Preserves _gh_env credential injection.
+    """
+    env = _gh_env()
+    for attempt in range(retry.MAX_RETRIES + 1):
+        try:
+            progress.run(cmd, env=env)
+        except subprocess.CalledProcessError as exc:
+            if attempt == retry.MAX_RETRIES or not retry.is_retryable(exc):
+                raise
+            delay = retry.compute_delay(attempt)
+            progress.emit(
+                f"transient GitHub failure, retrying in {delay:.1f}s"
+                f" (attempt {attempt + 1}/{retry.MAX_RETRIES + 1})"
+            )
+            time.sleep(delay)
+        else:
+            return
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
-def wait_for_checks(pr: str, *, verbose: bool) -> None:
-    """Block until CI checks on *pr* pass. Verbose controls output."""
+def wait_for_checks(pr: str) -> None:
+    """Block until CI checks on *pr* pass, streaming watch output."""
     repo = current_repo()
     sha = head_sha(pr)
 
@@ -57,22 +64,13 @@ def wait_for_checks(pr: str, *, verbose: bool) -> None:
             ),
         )
 
-    _run_verbose(
-        ("gh", "pr", "checks", pr, "--watch"),  # noqa: S607
-        verbose=verbose,
-    )
+    _stream_with_retry(("gh", "pr", "checks", pr, "--watch"))  # noqa: S607
 
 
-def watch_workflow(
-    repo: str,
-    run_id: str,
-    *,
-    verbose: bool,
-    check_status: bool = True,
-) -> None:
-    """Block until a workflow run completes. Verbose controls output."""
+def watch_workflow(repo: str, run_id: str, *, check_status: bool = True) -> None:
+    """Block until a workflow run completes, streaming watch output."""
     cmd: tuple[str, ...] = ("gh", "run", "watch", "--repo", repo)
     if check_status:
         cmd = (*cmd, "--exit-status")
     cmd = (*cmd, run_id)
-    _run_verbose(cmd, verbose=verbose)  # noqa: S607
+    _stream_with_retry(cmd)  # noqa: S607

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -15,72 +15,32 @@ def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedPro
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
 
 
-def test_run_delegates_to_subprocess() -> None:
-    with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
-        mock_run.return_value = _completed()
+def test_run_delegates_to_progress_run() -> None:
+    with patch("vergil_tooling.lib.git.progress") as m_progress:
         git.run("status")
-    mock_run.assert_called_once_with(
-        ("git", "status"), check=True, capture_output=True, text=True, env=None
-    )
+    m_progress.run.assert_called_once_with(("git", "status"), env=None)
 
 
 def test_run_commit_no_env_var_gate() -> None:
     """Commit calls no longer set VRG_COMMIT_CONTEXT — the git hook
     has been replaced by a Claude Code PreToolUse hook (#1135).
     """
-    with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
-        mock_run.return_value = _completed()
+    with patch("vergil_tooling.lib.git.progress") as m_progress:
         git.run("commit", "-m", "msg")
-    _args, kwargs = mock_run.call_args
-    assert "env" not in kwargs or kwargs.get("env") is None
+    _args, kwargs = m_progress.run.call_args
+    assert kwargs.get("env") is None
 
 
-def test_run_prints_captured_output(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
-        result = _completed(stdout="branch created\n")
-        result.stderr = "warning: refname\n"
-        mock_run.return_value = result
-        git.run("checkout", "-b", "test")
-    captured = capsys.readouterr()
-    assert "branch created" in captured.out
-    assert "warning: refname" in captured.err
-
-
-def test_run_error_carries_output() -> None:
-    err = subprocess.CalledProcessError(1, "git push", output="out", stderr="err")
+def test_run_raises_on_failure() -> None:
+    err = subprocess.CalledProcessError(1, ("git", "status"), output="so", stderr="se")
     with (
-        patch("vergil_tooling.lib.git.subprocess.run", side_effect=err),
-        pytest.raises(subprocess.CalledProcessError) as exc_info,
+        patch("vergil_tooling.lib.git.progress") as m_progress,
+        pytest.raises(subprocess.CalledProcessError) as excinfo,
     ):
-        git.run("push", "origin", "main")
-    assert exc_info.value.stdout == "out"
-    assert exc_info.value.stderr == "err"
-
-
-def test_run_prints_stderr_on_error(capsys: pytest.CaptureFixture[str]) -> None:
-    err = subprocess.CalledProcessError(1, "git push", output="partial\n", stderr="fatal: error\n")
-    with (
-        patch("vergil_tooling.lib.git.subprocess.run", side_effect=err),
-        pytest.raises(subprocess.CalledProcessError),
-    ):
-        git.run("push", "origin", "main")
-    captured = capsys.readouterr()
-    assert "partial" in captured.out
-    assert "fatal: error" in captured.err
-
-
-def test_run_error_no_output(capsys: pytest.CaptureFixture[str]) -> None:
-    err = subprocess.CalledProcessError(1, "git status")
-    err.stderr = ""
-    err.stdout = ""
-    with (
-        patch("vergil_tooling.lib.git.subprocess.run", side_effect=err),
-        pytest.raises(subprocess.CalledProcessError),
-    ):
+        m_progress.run.side_effect = err
         git.run("status")
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err == ""
+    assert excinfo.value.output == "so"
+    assert excinfo.value.stderr == "se"
 
 
 def test_read_output_prints_stderr_on_error(capsys: pytest.CaptureFixture[str]) -> None:
@@ -228,11 +188,10 @@ class TestRunRemoteCredentialInjection:
                 "vergil_tooling.lib.git.github.get_installation_token",
                 return_value="ghs_test_token",
             ),
-            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+            patch("vergil_tooling.lib.git.progress") as mock_progress,
         ):
-            mock_run.return_value = _completed()
             git.run(subcmd, "origin", "main")
-        _, kwargs = mock_run.call_args
+        _, kwargs = mock_progress.run.call_args
         env = kwargs.get("env")
         assert env is not None
         assert env["GIT_CONFIG_COUNT"] == "1"
@@ -246,11 +205,10 @@ class TestRunRemoteCredentialInjection:
                 "vergil_tooling.lib.git.github.get_installation_token",
                 return_value="ghs_test_token",
             ),
-            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+            patch("vergil_tooling.lib.git.progress") as mock_progress,
         ):
-            mock_run.return_value = _completed()
             git.run(subcmd)
-        _, kwargs = mock_run.call_args
+        _, kwargs = mock_progress.run.call_args
         assert "env" not in kwargs or kwargs.get("env") is None
 
     def test_no_injection_when_no_token(self) -> None:
@@ -259,11 +217,10 @@ class TestRunRemoteCredentialInjection:
                 "vergil_tooling.lib.git.github.get_installation_token",
                 return_value=None,
             ),
-            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+            patch("vergil_tooling.lib.git.progress") as mock_progress,
         ):
-            mock_run.return_value = _completed()
             git.run("push", "origin", "main")
-        _, kwargs = mock_run.call_args
+        _, kwargs = mock_progress.run.call_args
         assert "env" not in kwargs or kwargs.get("env") is None
 
     def test_token_encodes_as_basic_auth(self) -> None:
@@ -274,11 +231,10 @@ class TestRunRemoteCredentialInjection:
                 "vergil_tooling.lib.git.github.get_installation_token",
                 return_value="ghs_test_token",
             ),
-            patch("vergil_tooling.lib.git.subprocess.run") as mock_run,
+            patch("vergil_tooling.lib.git.progress") as mock_progress,
         ):
-            mock_run.return_value = _completed()
             git.run("push", "origin", "main")
-        _, kwargs = mock_run.call_args
+        _, kwargs = mock_progress.run.call_args
         header_value = kwargs["env"]["GIT_CONFIG_VALUE_0"]
         expected = base64.b64encode(b"x-access-token:ghs_test_token").decode()
         assert expected in header_value

--- a/tests/vergil_tooling/test_output.py
+++ b/tests/vergil_tooling/test_output.py
@@ -20,15 +20,15 @@ if TYPE_CHECKING:
     import pytest
 
 
-def test_is_ci_returns_true_when_not_a_tty() -> None:
+def test_is_ci_true_under_github_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert is_ci() is True
+
+
+def test_is_ci_false_when_merely_piped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     with patch("sys.stdout") as mock_stdout:
         mock_stdout.isatty.return_value = False
-        assert is_ci() is True
-
-
-def test_is_ci_returns_false_when_tty() -> None:
-    with patch("sys.stdout") as mock_stdout:
-        mock_stdout.isatty.return_value = True
         assert is_ci() is False
 
 

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -7,7 +7,7 @@ import io
 import subprocess
 import sys
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -331,9 +331,7 @@ def _boom(ctx: object) -> None:
     raise RuntimeError(msg)
 
 
-def test_pipeline_fail_defer_continues(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_pipeline_fail_defer_continues(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
     stages = [
         Stage("bad", _boom, mode="fail_defer"),
@@ -367,9 +365,7 @@ def test_pipeline_warn_does_not_affect_exit(
 def test_pipeline_skip_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
     stages = [
-        Stage(
-            "audit", lambda ctx: calls.append("audit"), mode="fail_fast", skip_flag="skip_audit"
-        ),
+        Stage("audit", lambda ctx: calls.append("audit"), mode="fail_fast", skip_flag="skip_audit"),
         Stage("after", lambda ctx: calls.append("after"), mode="fail_defer"),
     ]
     assert _pipeline(tmp_path, stages, _args(skip_audit=True)) == 0
@@ -381,9 +377,7 @@ def _interrupt(ctx: object) -> None:
     raise KeyboardInterrupt
 
 
-def test_pipeline_interrupt_exits_130(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_pipeline_interrupt_exits_130(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
     stages = [
         Stage("slow", _interrupt, mode="fail_defer"),
@@ -421,3 +415,48 @@ def test_add_progress_args_rejects_skip_on_non_fail_fast() -> None:
     stages = [Stage("docs", lambda ctx: None, mode="fail_defer", skip_flag="skip_docs")]
     with pytest.raises(ValueError, match="skip_flag is only supported on fail_fast stages"):
         progress.add_progress_args(parser, stages)
+
+
+def test_gha_renderer_ok_stage_no_error_annotation() -> None:
+    out = io.StringIO()
+    r = progress.GhaRenderer(out)
+    r.start_stage("lint")
+    r.end_stage(StageResult("lint", "ok", 1.0))
+    r.close()
+    text = out.getvalue()
+    assert "::endgroup::" in text
+    assert "::error" not in text
+
+
+def test_rich_renderer_close_without_summary_stops_live() -> None:
+    out = io.StringIO()
+    r = progress.RichRenderer(out, window=2, force_terminal=True)
+    r.start_stage("build")
+    r.close()  # live still started — close() must stop it
+    assert r._live.is_started is False
+
+
+def test_make_renderer_selects_by_format() -> None:
+    out = io.StringIO()
+    rich_renderer = progress._make_renderer("rich", out, 5)
+    assert isinstance(rich_renderer, progress.RichRenderer)
+    rich_renderer.close()
+    assert isinstance(progress._make_renderer("gha", out, 5), progress.GhaRenderer)
+    plain = progress._make_renderer("plain", out, 5)
+    assert isinstance(plain, progress.PlainRenderer)
+    assert not isinstance(plain, progress.GhaRenderer)
+
+
+def test_run_keyboard_interrupt_terminates_child() -> None:
+    progress._session = None
+    fake_proc = MagicMock()
+    fake_proc.stdout = io.StringIO("")
+    fake_proc.stderr = io.StringIO("")
+    fake_proc.wait.side_effect = [KeyboardInterrupt, 130]
+    with (
+        patch(_MOD + ".subprocess.Popen", return_value=fake_proc),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        progress.run(("sleep", "60"))
+    fake_proc.terminate.assert_called_once_with()
+    assert fake_proc.wait.call_count == 2

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import io
 import subprocess
 import sys
@@ -290,3 +291,133 @@ def test_run_check_false_returns_code() -> None:
     progress._session = None
     rc = progress.run((sys.executable, "-c", "import sys; sys.exit(2)"), check=False)
     assert rc == 2
+
+
+def _args(**skips: bool) -> argparse.Namespace:
+    return argparse.Namespace(output_window=5, output_format="plain", **skips)
+
+
+def _pipeline(tmp_path: Path, stages: list[Stage], args: argparse.Namespace) -> int:
+    return progress.run_pipeline(
+        None, stages, command="test-cmd", label="test", args=args, repo_root=tmp_path
+    )
+
+
+def test_pipeline_success_exit_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[str] = []
+    stages = [
+        Stage("one", lambda ctx: calls.append("one"), mode="fail_fast"),
+        Stage("two", lambda ctx: calls.append("two"), mode="fail_defer"),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 0
+    assert calls == ["one", "two"]
+    out = capsys.readouterr().out
+    assert "✓  test complete" in out
+
+
+def test_pipeline_stage_print_is_captured(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    stages = [Stage("noisy", lambda ctx: print("deep print"), mode="fail_defer")]
+    _pipeline(tmp_path, stages, _args())
+    assert "deep print" in capsys.readouterr().out
+    logs = list((tmp_path / ".vergil").glob("test-cmd-*.log"))
+    assert len(logs) == 1
+    assert "deep print" in logs[0].read_text()
+
+
+def _boom(ctx: object) -> None:
+    msg = "boom"
+    raise RuntimeError(msg)
+
+
+def test_pipeline_fail_defer_continues(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[str] = []
+    stages = [
+        Stage("bad", _boom, mode="fail_defer"),
+        Stage("after", lambda ctx: calls.append("after"), mode="fail_defer"),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 1
+    assert calls == ["after"]
+    out = capsys.readouterr().out
+    assert "✗  failures:" in out
+    assert "bad — RuntimeError: boom" in out
+
+
+def test_pipeline_fail_fast_stops(tmp_path: Path) -> None:
+    calls: list[str] = []
+    stages = [
+        Stage("bad", _boom, mode="fail_fast"),
+        Stage("after", lambda ctx: calls.append("after"), mode="fail_fast"),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 1
+    assert calls == []
+
+
+def test_pipeline_warn_does_not_affect_exit(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    stages = [Stage("meh", _boom, mode="warn")]
+    assert _pipeline(tmp_path, stages, _args()) == 0
+    assert "⚠  warnings (non-fatal):" in capsys.readouterr().out
+
+
+def test_pipeline_skip_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[str] = []
+    stages = [
+        Stage(
+            "audit", lambda ctx: calls.append("audit"), mode="fail_fast", skip_flag="skip_audit"
+        ),
+        Stage("after", lambda ctx: calls.append("after"), mode="fail_defer"),
+    ]
+    assert _pipeline(tmp_path, stages, _args(skip_audit=True)) == 0
+    assert calls == ["after"]  # audit never ran
+    assert "audit — skipped via --skip-audit" in capsys.readouterr().out
+
+
+def _interrupt(ctx: object) -> None:
+    raise KeyboardInterrupt
+
+
+def test_pipeline_interrupt_exits_130(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[str] = []
+    stages = [
+        Stage("slow", _interrupt, mode="fail_defer"),
+        Stage("after", lambda ctx: calls.append("after"), mode="fail_defer"),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 130
+    assert calls == []
+    out = capsys.readouterr().out
+    assert "slow — interrupted" in out
+    assert "full log →" in out
+
+
+def test_pipeline_traceback_in_log(tmp_path: Path) -> None:
+    stages = [Stage("bad", _boom, mode="fail_defer")]
+    _pipeline(tmp_path, stages, _args())
+    log = next((tmp_path / ".vergil").glob("test-cmd-*.log"))
+    assert "Traceback" in log.read_text()
+
+
+def test_add_progress_args_generates_flags() -> None:
+    parser = argparse.ArgumentParser()
+    stages = [Stage("audit", lambda ctx: None, mode="fail_fast", skip_flag="skip_audit")]
+    progress.add_progress_args(parser, stages)
+    args = parser.parse_args(["--skip-audit", "--output-window", "3"])
+    assert args.skip_audit is True
+    assert args.output_window == 3
+    assert args.output_format is None
+    args = parser.parse_args([])
+    assert args.skip_audit is False
+    assert args.output_window == 5
+
+
+def test_add_progress_args_rejects_skip_on_non_fail_fast() -> None:
+    parser = argparse.ArgumentParser()
+    stages = [Stage("docs", lambda ctx: None, mode="fail_defer", skip_flag="skip_docs")]
+    with pytest.raises(ValueError, match="skip_flag is only supported on fail_fast stages"):
+        progress.add_progress_args(parser, stages)

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -78,3 +78,34 @@ def test_detect_format_plain(monkeypatch: pytest.MonkeyPatch) -> None:
     with patch("sys.stdout") as mock_stdout:
         mock_stdout.isatty.return_value = False
         assert progress.detect_format() == "plain"
+
+
+def test_runlog_creates_timestamped_file(tmp_path: Path) -> None:
+    log = progress.RunLog("vrg-release", tmp_path)
+    assert log.path.parent == tmp_path / ".vergil"
+    assert log.path.name.startswith("vrg-release-")
+    assert log.path.name.endswith(".log")
+    log.close()
+
+
+def test_runlog_write_strips_ansi(tmp_path: Path) -> None:
+    log = progress.RunLog("vrg-release", tmp_path)
+    log.write("\x1b[32mgreen\x1b[0m line")
+    log.close()
+    assert log.path.read_text() == "green line\n"
+
+
+def test_runlog_prunes_to_retain_count(tmp_path: Path) -> None:
+    log_dir = tmp_path / ".vergil"
+    log_dir.mkdir()
+    for i in range(25):
+        (log_dir / f"vrg-release-20260101-{i:06d}.log").write_text("old")
+    (log_dir / "vrg-validate-20260101-000000.log").write_text("other command")
+    log = progress.RunLog("vrg-release", tmp_path)
+    log.close()
+    release_logs = sorted(log_dir.glob("vrg-release-*.log"))
+    assert len(release_logs) == progress.LOG_RETAIN
+    # newest survives, oldest pruned, other commands untouched
+    assert log.path in release_logs
+    assert (log_dir / "vrg-validate-20260101-000000.log").exists()
+    assert not (log_dir / "vrg-release-20260101-000000.log").exists()

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import io
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+import pytest
 
 from vergil_tooling.lib import progress
 from vergil_tooling.lib.progress import PipelineError, Stage, StageResult
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 _MOD = "vergil_tooling.lib.progress"
 
@@ -201,3 +203,90 @@ def test_rich_renderer_window_zero_streams() -> None:
     r.summary("S")
     r.close()
     assert "streamed line" in out.getvalue()
+
+
+class _FakeRenderer:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def start_stage(self, name: str) -> None:
+        pass
+
+    def stage_line(self, line: str) -> None:
+        self.lines.append(line)
+
+    def end_stage(self, result: StageResult) -> None:
+        pass
+
+    def summary(self, text: str) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _fake_session(tmp_path: Path) -> tuple[_FakeRenderer, progress.RunLog]:
+    renderer = _FakeRenderer()
+    log = progress.RunLog("test-cmd", tmp_path)
+    progress._session = progress._Session(renderer=renderer, log=log)
+    return renderer, log
+
+
+def test_emit_without_session_prints(capsys: pytest.CaptureFixture[str]) -> None:
+    progress._session = None
+    progress.emit("hello")
+    assert capsys.readouterr().out == "hello\n"
+
+
+def test_emit_with_session_routes_to_renderer_and_log(tmp_path: Path) -> None:
+    renderer, log = _fake_session(tmp_path)
+    try:
+        progress.emit("\x1b[31mred\x1b[0m line")
+    finally:
+        progress._session = None
+        log.close()
+    assert renderer.lines == ["\x1b[31mred\x1b[0m line"]  # raw to renderer
+    assert log.path.read_text() == "red line\n"  # stripped in log
+
+
+def test_emit_writer_buffers_partial_lines(tmp_path: Path) -> None:
+    renderer, log = _fake_session(tmp_path)
+    try:
+        w = progress._EmitWriter()
+        w.write("par")
+        w.write("tial\nsecond\nthi")
+        w.flush()  # flushes the partial third line
+    finally:
+        progress._session = None
+        log.close()
+    assert renderer.lines == ["partial", "second", "thi"]
+
+
+def test_run_streams_lines_to_session(tmp_path: Path) -> None:
+    renderer, log = _fake_session(tmp_path)
+    try:
+        rc = progress.run(
+            (sys.executable, "-c", "import sys; print('out1'); print('err1', file=sys.stderr)")
+        )
+    finally:
+        progress._session = None
+        log.close()
+    assert rc == 0
+    assert "out1" in renderer.lines
+    assert "err1" in renderer.lines
+
+
+def test_run_raises_with_captured_output(tmp_path: Path) -> None:
+    progress._session = None
+    code = "import sys; print('so long'); print('bad', file=sys.stderr); sys.exit(3)"
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        progress.run((sys.executable, "-c", code))
+    assert excinfo.value.returncode == 3
+    assert "so long" in excinfo.value.output
+    assert "bad" in excinfo.value.stderr
+
+
+def test_run_check_false_returns_code() -> None:
+    progress._session = None
+    rc = progress.run((sys.executable, "-c", "import sys; sys.exit(2)"), check=False)
+    assert rc == 2

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -1,0 +1,80 @@
+"""Tests for vergil_tooling.lib.progress."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from vergil_tooling.lib import progress
+from vergil_tooling.lib.progress import PipelineError, Stage, StageResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+_MOD = "vergil_tooling.lib.progress"
+
+
+def test_stage_defaults() -> None:
+    stage = Stage("audit", lambda ctx: None, mode="fail_fast")
+    assert stage.skip_flag is None
+
+
+def test_pipeline_error_message_single() -> None:
+    failures = [StageResult("build-images", "failed", 4.0, "boom")]
+    err = PipelineError(failures)
+    assert str(err) == "1 stage failed (build-images)"
+    assert err.failures == failures
+
+
+def test_pipeline_error_message_plural() -> None:
+    failures = [
+        StageResult("a", "failed", 1.0, "x"),
+        StageResult("b", "failed", 2.0, "y"),
+    ]
+    assert str(PipelineError(failures)) == "2 stages failed (a, b)"
+
+
+def test_format_elapsed_seconds() -> None:
+    assert progress.format_elapsed(3.21) == "3.2s"
+
+
+def test_format_elapsed_minutes() -> None:
+    assert progress.format_elapsed(61) == "1m01s"
+
+
+def test_format_total() -> None:
+    assert progress.format_total(61) == "01:01"
+    assert progress.format_total(58) == "00:58"
+
+
+def test_is_github_actions_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert progress.is_github_actions() is True
+
+
+def test_is_github_actions_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    assert progress.is_github_actions() is False
+
+
+def test_detect_format_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    with patch("sys.stdout") as mock_stdout:
+        mock_stdout.isatty.return_value = True
+        assert progress.detect_format() == "rich"
+
+
+def test_detect_format_gha(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    with patch("sys.stdout") as mock_stdout:
+        mock_stdout.isatty.return_value = False
+        assert progress.detect_format() == "gha"
+
+
+def test_detect_format_plain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    with patch("sys.stdout") as mock_stdout:
+        mock_stdout.isatty.return_value = False
+        assert progress.detect_format() == "plain"

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -170,3 +170,34 @@ def test_gha_renderer_groups_and_error() -> None:
     assert "::endgroup::\n" in text
     assert "::error title=audit failed::boom" in text
     assert "SUMMARY" in text
+
+
+def _rich_renderer() -> tuple[progress.RichRenderer, io.StringIO]:
+    out = io.StringIO()
+    return progress.RichRenderer(out, window=2, force_terminal=True), out
+
+
+def test_rich_renderer_lifecycle_and_window() -> None:
+    r, out = _rich_renderer()
+    r.start_stage("build")
+    for i in range(5):
+        r.stage_line(f"line {i}")
+    assert list(r._tail) == ["line 3", "line 4"]  # window of 2
+    r.end_stage(StageResult("build", "ok", 2.1))
+    assert r._active is None
+    assert not r._tail
+    r.summary("SUMMARY TEXT")
+    r.close()
+    assert "SUMMARY TEXT" in out.getvalue()
+    assert "build" in out.getvalue()
+
+
+def test_rich_renderer_window_zero_streams() -> None:
+    out = io.StringIO()
+    r = progress.RichRenderer(out, window=0, force_terminal=True)
+    r.start_stage("build")
+    r.stage_line("streamed line")
+    r.end_stage(StageResult("build", "ok", 1.0))
+    r.summary("S")
+    r.close()
+    assert "streamed line" in out.getvalue()

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -109,3 +110,63 @@ def test_runlog_prunes_to_retain_count(tmp_path: Path) -> None:
     assert log.path in release_logs
     assert (log_dir / "vrg-validate-20260101-000000.log").exists()
     assert not (log_dir / "vrg-release-20260101-000000.log").exists()
+
+
+def _results_mixed() -> list[StageResult]:
+    return [
+        StageResult("audit", "skipped", 0.0, "skipped via --skip-audit"),
+        StageResult("changelog", "ok", 3.2),
+        StageResult("build-images", "failed", 65.0, "docker build exited 1"),
+    ]
+
+
+def test_build_summary_with_failures(tmp_path: Path) -> None:
+    text = progress.build_summary("release 2.1.2", _results_mixed(), 61.0, tmp_path / "x.log")
+    assert "⚠  warnings (non-fatal):" in text
+    assert "audit — skipped via --skip-audit" in text
+    assert "✗  failures:" in text
+    assert "build-images — docker build exited 1" in text
+    assert "release 2.1.2 completed with errors  (total: 01:01)" in text
+    assert "PipelineError: 1 stage failed (build-images) · exit 1" in text
+    assert str(tmp_path / "x.log") in text
+
+
+def test_build_summary_success(tmp_path: Path) -> None:
+    text = progress.build_summary(
+        "release 2.1.2", [StageResult("changelog", "ok", 3.2)], 58.0, tmp_path / "x.log"
+    )
+    assert "✓  release 2.1.2 complete  (total: 00:58)" in text
+    assert "PipelineError" not in text
+
+
+def test_plain_renderer_lifecycle() -> None:
+    out = io.StringIO()
+    r = progress.PlainRenderer(out)
+    r.start_stage("audit")
+    r.stage_line("checking things")
+    r.end_stage(StageResult("audit", "ok", 2.1))
+    r.end_stage(StageResult("docs", "skipped", 0.0, "skipped via --skip-docs"))
+    r.summary("SUMMARY")
+    r.close()
+    text = out.getvalue()
+    assert "→ audit  starting..." in text
+    assert "checking things" in text
+    assert "✓ audit  2.1s" in text
+    assert "⚠ docs — skipped via --skip-docs" in text
+    assert "SUMMARY" in text
+
+
+def test_gha_renderer_groups_and_error() -> None:
+    out = io.StringIO()
+    r = progress.GhaRenderer(out)
+    r.start_stage("audit")
+    r.stage_line("checking")
+    r.end_stage(StageResult("audit", "failed", 2.0, "boom"))
+    r.summary("SUMMARY")
+    r.close()
+    text = out.getvalue()
+    assert "::group::audit\n" in text
+    assert "checking\n" in text
+    assert "::endgroup::\n" in text
+    assert "::error title=audit failed::boom" in text
+    assert "SUMMARY" in text

--- a/tests/vergil_tooling/test_release_bump.py
+++ b/tests/vergil_tooling/test_release_bump.py
@@ -115,7 +115,6 @@ def test_back_merge_waits_and_merges() -> None:
     mock_wm.assert_called_once_with(
         "https://github.com/owner/repo/pull/101",
         phase="back-merge-bump",
-        verbose=False,
     )
 
 

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -259,7 +259,6 @@ def test_confirm_main_skip_cd_docs_skips_docs_job() -> None:
     m_watch.assert_called_once_with(
         "owner/repo",
         "12345",
-        verbose=False,
         check_status=False,
     )
     assert ctx.tag == "v2.1.0"
@@ -285,7 +284,6 @@ def test_confirm_develop_skip_cd_docs_skips_verify() -> None:
     m_watch.assert_called_once_with(
         "owner/repo",
         "67890",
-        verbose=False,
         check_status=False,
     )
     assert ctx.develop_cd_run_id == "67890"

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -29,6 +29,28 @@ def _ctx() -> ReleaseContext:
     return ctx
 
 
+def test_watch_cd_check_status_false_reports_completed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from vergil_tooling.lib.release.confirm import _watch_cd
+
+    ctx = _ctx()
+    with (
+        patch(
+            _MOD + ".github.read_output",
+            side_effect=["12345", "https://github.com/o/r/actions/runs/12345"],
+        ),
+        patch(_MOD + ".watch_workflow"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.read_output", return_value=_SHA),
+    ):
+        run_id, run_url = _watch_cd(ctx, branch="main", check_status=False)
+    assert run_id == "12345"
+    out = capsys.readouterr().out
+    assert "CD workflow completed" in out
+    assert "CD workflow succeeded" not in out
+
+
 def test_main_expected_jobs() -> None:
     assert _MAIN_EXPECTED_JOBS == ("docs", "release")
 

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -236,59 +236,6 @@ def test_confirm_develop_fails_job_not_success() -> None:
         confirm_develop(ctx)
 
 
-def test_confirm_main_skip_cd_docs_skips_docs_job() -> None:
-    ctx = _ctx()
-    ctx.skip_cd_docs = True
-    with (
-        patch(
-            _MOD + ".github.read_output",
-            side_effect=[
-                "12345",
-                "https://github.com/o/r/actions/runs/12345",
-                "success",
-                "https://github.com/o/r/releases/tag/v2.1.0",
-            ],
-        ),
-        patch(_MOD + ".watch_workflow") as m_watch,
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.read_output", return_value=_SHA),
-        patch(_MOD + ".git.ref_exists", return_value=True),
-    ):
-        confirm_main(ctx)
-
-    m_watch.assert_called_once_with(
-        "owner/repo",
-        "12345",
-        check_status=False,
-    )
-    assert ctx.tag == "v2.1.0"
-
-
-def test_confirm_develop_skip_cd_docs_skips_verify() -> None:
-    ctx = _ctx()
-    ctx.skip_cd_docs = True
-    with (
-        patch(
-            _MOD + ".github.read_output",
-            side_effect=[
-                "67890",
-                "https://github.com/o/r/actions/runs/67890",
-            ],
-        ),
-        patch(_MOD + ".watch_workflow") as m_watch,
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.read_output", return_value=_SHA),
-    ):
-        confirm_develop(ctx)
-
-    m_watch.assert_called_once_with(
-        "owner/repo",
-        "67890",
-        check_status=False,
-    )
-    assert ctx.develop_cd_run_id == "67890"
-
-
 def test_poll_attempts_constant() -> None:
     assert _CD_POLL_ATTEMPTS == 30
 

--- a/tests/vergil_tooling/test_release_merge.py
+++ b/tests/vergil_tooling/test_release_merge.py
@@ -15,7 +15,7 @@ _MOD = "vergil_tooling.lib.release.merge"
 
 def test_delegates_with_merge_strategy() -> None:
     with patch(_MOD + ".pr_merge.wait_and_merge") as engine:
-        wait_and_merge("https://github.com/o/r/pull/5", phase="phase-2", verbose=True)
+        wait_and_merge("https://github.com/o/r/pull/5", phase="phase-2")
     engine.assert_called_once()
     args, kwargs = engine.call_args
     assert args == ("https://github.com/o/r/pull/5",)
@@ -32,11 +32,11 @@ def test_wraps_merge_abort_in_release_error() -> None:
     assert excinfo.value.phase == "phase-3"
 
 
-def test_injected_waiter_carries_verbose_flag() -> None:
+def test_injected_waiter_is_wait_for_checks() -> None:
     with (
         patch(_MOD + ".pr_merge.wait_and_merge") as engine,
         patch(_MOD + ".wait_for_checks") as waiter,
     ):
-        wait_and_merge("https://github.com/o/r/pull/5", phase="phase-2", verbose=True)
+        wait_and_merge("https://github.com/o/r/pull/5", phase="phase-2")
         engine.call_args.kwargs["wait_checks"]("https://github.com/o/r/pull/5")
-    waiter.assert_called_once_with("https://github.com/o/r/pull/5", verbose=True)
+    waiter.assert_called_once_with("https://github.com/o/r/pull/5")

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -240,7 +240,6 @@ def test_merge_release_calls_wait_and_merge() -> None:
     m_wm.assert_called_once_with(
         "https://github.com/o/r/pull/100",
         phase="merge-release",
-        verbose=False,
     )
     assert ctx.release_merge_sha == "merged"
 

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -226,6 +226,20 @@ def test_phase_details_unknown_phase() -> None:
     assert details == ""
 
 
+def test_phase_details_unset_fields_yield_empty() -> None:
+    from vergil_tooling.lib.release.orchestrator import _phase_details
+
+    ctx = _ctx()  # all URL/tag/version fields unset
+    for phase in (
+        "prepare",
+        "merge-release",
+        "confirm-main",
+        "back-merge-bump",
+        "confirm-develop",
+    ):
+        assert _phase_details(ctx, phase) == ""
+
+
 def test_merge_release_raises_if_no_pr_url() -> None:
     from vergil_tooling.lib.release.orchestrator import merge_release
 

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vergil_tooling.lib.release.context import ReleaseContext, ReleaseError
-from vergil_tooling.lib.release.orchestrator import run_release
+from vergil_tooling.lib.release.orchestrator import (
+    ReleaseState,
+    _preflight_stage,
+    _tracked,
+    build_stages,
+)
 
 _MOD = "vergil_tooling.lib.release.orchestrator"
 
@@ -24,28 +28,90 @@ def _ctx(*, promote: bool = True) -> ReleaseContext:
     return ctx
 
 
-def test_orchestrator_runs_all_phases() -> None:
+def test_build_stages_order_and_modes() -> None:
+    stages = build_stages()
+    assert [s.name for s in stages] == [
+        "audit",
+        "preflight",
+        "prepare",
+        "merge-release",
+        "confirm-main",
+        "back-merge-bump",
+        "confirm-develop",
+        "promote",
+        "close-finalize",
+        "consumer-refresh",
+    ]
+    assert stages[0].skip_flag == "skip_audit"
+    fail_fast = {s.name for s in stages if s.mode == "fail_fast"}
+    assert fail_fast == {
+        "audit",
+        "preflight",
+        "prepare",
+        "merge-release",
+        "confirm-main",
+        "back-merge-bump",
+    }
+
+
+def test_preflight_stage_populates_ctx() -> None:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/repo"), promote=False)  # noqa: S108
     ctx = _ctx()
+    with patch(_MOD + ".preflight", return_value=ctx) as m_preflight:
+        _preflight_stage(state)
+    m_preflight.assert_called_once_with(version_override=None, repo_root=Path("/tmp/repo"))  # noqa: S108
+    assert state.ctx is ctx
+    assert ctx.promote is False
+
+
+def test_audit_stage_runs_audit() -> None:
+    from vergil_tooling.lib.release.orchestrator import _audit_stage
+
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/repo"), promote=True)  # noqa: S108
+    with patch(_MOD + ".run_audit") as m_audit:
+        _audit_stage(state)
+    m_audit.assert_called_once_with()
+
+
+def test_tracked_stage_comments_on_success() -> None:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/repo"), promote=True)  # noqa: S108
+    state.ctx = _ctx()
+    fn = MagicMock()
+    with patch(_MOD + ".comment_phase_complete") as m_comment:
+        _tracked("prepare", fn)(state)
+    fn.assert_called_once_with(state.ctx)
+    m_comment.assert_called_once()
+
+
+def test_tracked_stage_comments_release_error_on_failure() -> None:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/repo"), promote=True)  # noqa: S108
+    state.ctx = _ctx()
+    exc = ReleaseError(phase="prepare", command="git checkout", message="branch exists")
+    fn = MagicMock(side_effect=exc)
     with (
-        patch(_MOD + ".prepare") as m_prepare,
-        patch(_MOD + ".merge_release") as m_merge_release,
-        patch(_MOD + ".confirm_main") as m_confirm_main,
-        patch(_MOD + ".back_merge_and_bump") as m_bump,
-        patch(_MOD + ".confirm_develop") as m_confirm_develop,
-        patch(_MOD + "._promote_phase") as m_promote,
-        patch(_MOD + ".close_and_finalize") as m_finalize,
-        patch(_MOD + ".consumer_refresh") as m_handoff,
-        patch(_MOD + ".comment_phase_complete"),
+        patch(_MOD + ".comment_phase_failed") as m_failed,
+        pytest.raises(ReleaseError, match="branch exists"),
     ):
-        run_release(ctx)
-    m_prepare.assert_called_once_with(ctx)
-    m_merge_release.assert_called_once_with(ctx)
-    m_confirm_main.assert_called_once_with(ctx)
-    m_bump.assert_called_once_with(ctx)
-    m_confirm_develop.assert_called_once_with(ctx)
-    m_promote.assert_called_once_with(ctx)
-    m_finalize.assert_called_once_with(ctx)
-    m_handoff.assert_called_once_with(ctx)
+        _tracked("prepare", fn)(state)
+    m_failed.assert_called_once_with(state.ctx, "prepare", exc)
+
+
+def test_tracked_stage_wraps_and_comments_on_failure() -> None:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/repo"), promote=True)  # noqa: S108
+    state.ctx = _ctx()
+    fn = MagicMock(side_effect=RuntimeError("boom"))
+    with (
+        patch(_MOD + ".comment_phase_failed") as m_failed,
+        pytest.raises(ReleaseError, match="boom"),
+    ):
+        _tracked("prepare", fn)(state)
+    m_failed.assert_called_once()
+
+
+def test_tracked_stage_requires_ctx() -> None:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/repo"), promote=True)  # noqa: S108
+    with pytest.raises(ReleaseError, match="preflight did not run"):
+        _tracked("prepare", MagicMock())(state)
 
 
 def test_promote_phase_calls_promote_when_enabled() -> None:
@@ -64,13 +130,6 @@ def test_promote_phase_skips_when_disabled() -> None:
     with patch(_MOD + ".promote") as mock_promote:
         _promote_phase(ctx)
     mock_promote.assert_not_called()
-
-
-def test_format_elapsed_minutes() -> None:
-    from vergil_tooling.lib.release.orchestrator import _format_elapsed
-
-    assert _format_elapsed(90) == "1m30s"
-    assert _format_elapsed(125) == "2m05s"
 
 
 def test_phase_details_prepare() -> None:
@@ -167,61 +226,6 @@ def test_phase_details_unknown_phase() -> None:
     assert details == ""
 
 
-def test_orchestrator_stops_on_failure_and_comments() -> None:
-    ctx = _ctx()
-    exc = ReleaseError(
-        phase="merge-release",
-        command="gh pr merge",
-        message="CI failed",
-    )
-    with (
-        patch(_MOD + ".prepare"),
-        patch(_MOD + ".merge_release", side_effect=exc),
-        patch(_MOD + ".comment_phase_complete"),
-        patch(_MOD + ".comment_phase_failed") as m_failed,
-        pytest.raises(ReleaseError),
-    ):
-        run_release(ctx)
-    m_failed.assert_called_once_with(ctx, "merge-release", exc)
-
-
-def test_orchestrator_wraps_non_release_error() -> None:
-    ctx = _ctx()
-    with (
-        patch(
-            _MOD + ".prepare",
-            side_effect=subprocess.CalledProcessError(1, "git push"),
-        ),
-        patch(_MOD + ".comment_phase_complete"),
-        patch(_MOD + ".comment_phase_failed") as m_failed,
-        pytest.raises(ReleaseError),
-    ):
-        run_release(ctx)
-    wrapped = m_failed.call_args[0][2]
-    assert wrapped.phase == "prepare"
-    assert "git push" in wrapped.command
-
-
-def test_orchestrator_does_not_run_later_phases_on_failure() -> None:
-    ctx = _ctx()
-    with (
-        patch(
-            _MOD + ".prepare",
-            side_effect=ReleaseError(
-                phase="prepare",
-                command="git checkout",
-                message="branch exists",
-            ),
-        ),
-        patch(_MOD + ".merge_release") as m_merge,
-        patch(_MOD + ".comment_phase_complete"),
-        patch(_MOD + ".comment_phase_failed"),
-        pytest.raises(ReleaseError),
-    ):
-        run_release(ctx)
-    m_merge.assert_not_called()
-
-
 def test_merge_release_raises_if_no_pr_url() -> None:
     from vergil_tooling.lib.release.orchestrator import merge_release
 
@@ -242,18 +246,3 @@ def test_merge_release_calls_wait_and_merge() -> None:
         phase="merge-release",
     )
     assert ctx.release_merge_sha == "merged"
-
-
-def test_comment_failure_raises_with_comment_phase() -> None:
-    ctx = _ctx()
-    with (
-        patch(_MOD + ".prepare"),
-        patch(
-            _MOD + ".comment_phase_complete",
-            side_effect=Exception("GitHub 502"),
-        ),
-        pytest.raises(ReleaseError) as exc_info,
-    ):
-        run_release(ctx)
-    assert exc_info.value.phase == "comment(prepare)"
-    assert exc_info.value.command == "comment_phase_complete"

--- a/tests/vergil_tooling/test_release_preflight.py
+++ b/tests/vergil_tooling/test_release_preflight.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from vergil_tooling.lib.release import preflight as preflight_module
 from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.preflight import (
     _compute_release_version,
@@ -19,10 +20,10 @@ def test_preflight_success() -> None:
     root = Path("/tmp/repo")  # noqa: S108
     with (
         patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo"),
         patch(_MOD + "._read_and_validate_config"),
         patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config"),
+        patch(_MOD + ".audit_repo_config"),
         patch(_MOD + ".version.show", return_value="2.1.0"),
         patch(_MOD + "._check_version_not_tagged"),
         patch(_MOD + "._check_no_existing_tracking_issue"),
@@ -37,10 +38,10 @@ def test_preflight_with_minor_override() -> None:
     root = Path("/tmp/repo")  # noqa: S108
     with (
         patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo"),
         patch(_MOD + "._read_and_validate_config"),
         patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config"),
+        patch(_MOD + ".audit_repo_config"),
         patch(_MOD + ".version.show", return_value="2.0.34"),
         patch(_MOD + "._check_version_not_tagged"),
         patch(_MOD + "._check_no_existing_tracking_issue"),
@@ -54,10 +55,10 @@ def test_preflight_with_major_override() -> None:
     root = Path("/tmp/repo")  # noqa: S108
     with (
         patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo"),
         patch(_MOD + "._read_and_validate_config"),
         patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config"),
+        patch(_MOD + ".audit_repo_config"),
         patch(_MOD + ".version.show", return_value="2.0.34"),
         patch(_MOD + "._check_version_not_tagged"),
         patch(_MOD + "._check_no_existing_tracking_issue"),
@@ -71,10 +72,10 @@ def test_preflight_wraps_version_error() -> None:
     root = Path("/tmp/repo")  # noqa: S108
     with (
         patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo"),
         patch(_MOD + "._read_and_validate_config"),
         patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config"),
+        patch(_MOD + ".audit_repo_config"),
         patch(
             _MOD + ".version.show",
             side_effect=FileNotFoundError("VERSION file not found"),
@@ -102,14 +103,14 @@ def test_check_host_prerequisites_fails() -> None:
         _check_host_prerequisites()
 
 
-def test_check_gh_auth_fails() -> None:
-    from vergil_tooling.lib.release.preflight import _check_gh_auth
+def testcheck_gh_auth_fails() -> None:
+    from vergil_tooling.lib.release.preflight import check_gh_auth
 
     with (
         patch(_MOD + ".github.read_output", side_effect=Exception("auth failed")),
         pytest.raises(ReleaseError, match="authentication failed"),
     ):
-        _check_gh_auth()
+        check_gh_auth()
 
 
 def test_check_branch_wrong_branch() -> None:
@@ -145,10 +146,10 @@ def test_check_branch_not_synced() -> None:
         _check_branch_and_tree()
 
 
-def test_audit_repo_config_fails() -> None:
+def testaudit_repo_config_fails() -> None:
     from subprocess import CompletedProcess
 
-    from vergil_tooling.lib.release.preflight import _audit_repo_config
+    from vergil_tooling.lib.release.preflight import audit_repo_config
 
     with (
         patch(
@@ -162,7 +163,7 @@ def test_audit_repo_config_fails() -> None:
         ),
         pytest.raises(ReleaseError, match="non-compliant"),
     ):
-        _audit_repo_config("owner/repo")
+        audit_repo_config("owner/repo")
 
 
 def test_check_version_not_tagged_passes() -> None:
@@ -219,11 +220,11 @@ def test_check_host_prerequisites_success() -> None:
         _check_host_prerequisites()
 
 
-def test_check_gh_auth_success() -> None:
-    from vergil_tooling.lib.release.preflight import _check_gh_auth
+def testcheck_gh_auth_success() -> None:
+    from vergil_tooling.lib.release.preflight import check_gh_auth
 
     with patch(_MOD + ".github.read_output", return_value="owner/repo"):
-        assert _check_gh_auth() == "owner/repo"
+        assert check_gh_auth() == "owner/repo"
 
 
 def test_read_and_validate_config(tmp_path: Path) -> None:
@@ -258,49 +259,44 @@ def test_check_branch_and_tree_success() -> None:
         _check_branch_and_tree()
 
 
-def test_audit_repo_config_success() -> None:
+def testaudit_repo_config_success() -> None:
     from subprocess import CompletedProcess
 
-    from vergil_tooling.lib.release.preflight import _audit_repo_config
+    from vergil_tooling.lib.release.preflight import audit_repo_config
 
     with patch(
         _MOD + ".subprocess.run",
         return_value=CompletedProcess(args=(), returncode=0, stdout="", stderr=""),
     ):
-        _audit_repo_config("owner/repo")
+        audit_repo_config("owner/repo")
 
 
-def test_preflight_skips_audit_when_requested() -> None:
+def test_preflight_never_audits() -> None:
+    """The audit is its own pipeline stage now — preflight never runs it."""
     root = Path("/tmp/repo")  # noqa: S108
     with (
         patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo"),
         patch(_MOD + "._read_and_validate_config"),
         patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config") as mock_audit,
+        patch(_MOD + ".audit_repo_config") as mock_audit,
         patch(_MOD + ".version.show", return_value="2.1.0"),
         patch(_MOD + "._check_version_not_tagged"),
         patch(_MOD + "._check_no_existing_tracking_issue"),
     ):
-        ctx = preflight(version_override=None, repo_root=root, skip_audit=True)
+        ctx = preflight(version_override=None, repo_root=root)
     assert ctx.repo == "owner/repo"
     mock_audit.assert_not_called()
 
 
-def test_preflight_runs_audit_by_default() -> None:
-    root = Path("/tmp/repo")  # noqa: S108
+def test_run_audit_resolves_repo_and_audits() -> None:
     with (
-        patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
-        patch(_MOD + "._read_and_validate_config"),
-        patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config") as mock_audit,
-        patch(_MOD + ".version.show", return_value="2.1.0"),
-        patch(_MOD + "._check_version_not_tagged"),
-        patch(_MOD + "._check_no_existing_tracking_issue"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo") as m_auth,
+        patch(_MOD + ".audit_repo_config") as m_audit,
     ):
-        preflight(version_override=None, repo_root=root)
-    mock_audit.assert_called_once_with("owner/repo")
+        preflight_module.run_audit()
+    m_auth.assert_called_once_with()
+    m_audit.assert_called_once_with("owner/repo")
 
 
 def test_preflight_wraps_version_sync_error() -> None:
@@ -309,10 +305,10 @@ def test_preflight_wraps_version_sync_error() -> None:
     root = Path("/tmp/repo")  # noqa: S108
     with (
         patch(_MOD + "._check_host_prerequisites"),
-        patch(_MOD + "._check_gh_auth", return_value="owner/repo"),
+        patch(_MOD + ".check_gh_auth", return_value="owner/repo"),
         patch(_MOD + "._read_and_validate_config"),
         patch(_MOD + "._check_branch_and_tree"),
-        patch(_MOD + "._audit_repo_config"),
+        patch(_MOD + ".audit_repo_config"),
         patch(
             _MOD + ".version.show",
             side_effect=VersionSyncError("VERSION", "1.0.0", {"pyproject.toml": "1.0.1"}),

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -7,15 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
+from vergil_tooling.lib import retry
+from vergil_tooling.lib.release import subprocess as release_subprocess
 from vergil_tooling.lib.release.subprocess import wait_for_checks, watch_workflow
 
 _MOD = "vergil_tooling.lib.release.subprocess"
-
-
-def _completed(
-    returncode: int = 0, stdout: str = "", stderr: str = ""
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 def _cpe(stdout: str = "", stderr: str = "") -> subprocess.CalledProcessError:
@@ -23,94 +19,74 @@ def _cpe(stdout: str = "", stderr: str = "") -> subprocess.CalledProcessError:
     return exc
 
 
-class TestWaitForChecks:
-    def test_verbose_prints_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+class TestStreamWithRetry:
+    def test_passes_gh_env(self) -> None:
         with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._run_with_retry", return_value=_completed(stdout="all passed\n")),
+            patch(_MOD + ".progress") as m_progress,
+            patch(_MOD + "._gh_env", return_value={"GH_TOKEN": "x"}),
         ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
-        captured = capsys.readouterr()
-        assert "all passed" in captured.out
+            release_subprocess._stream_with_retry(("gh", "run", "watch"))
+        m_progress.run.assert_called_once_with(("gh", "run", "watch"), env={"GH_TOKEN": "x"})
 
-    def test_quiet_suppresses_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_retries_transient_then_succeeds(self) -> None:
+        transient = subprocess.CalledProcessError(1, ("gh",), output="", stderr="HTTP 502")
+        with (
+            patch(_MOD + ".progress") as m_progress,
+            patch(_MOD + "._gh_env", return_value=None),
+            patch(_MOD + ".time"),
+        ):
+            m_progress.run.side_effect = [transient, None]
+            release_subprocess._stream_with_retry(("gh", "run", "watch"))
+        assert m_progress.run.call_count == 2
+
+    def test_propagates_non_transient(self) -> None:
+        fatal = subprocess.CalledProcessError(1, ("gh",), output="", stderr="not found")
+        with (
+            patch(_MOD + ".progress") as m_progress,
+            patch(_MOD + "._gh_env", return_value=None),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            m_progress.run.side_effect = fatal
+            release_subprocess._stream_with_retry(("gh", "run", "watch"))
+        assert m_progress.run.call_count == 1
+
+    def test_gives_up_after_max(self) -> None:
+        transient = subprocess.CalledProcessError(1, ("gh",), output="", stderr="HTTP 502")
+        with (
+            patch(_MOD + ".progress") as m_progress,
+            patch(_MOD + "._gh_env", return_value=None),
+            patch(_MOD + ".time"),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            m_progress.run.side_effect = transient
+            release_subprocess._stream_with_retry(("gh", "run", "watch"))
+        assert m_progress.run.call_count == retry.MAX_RETRIES + 1
+
+
+class TestWaitForChecks:
+    def test_streams_watch_command(self) -> None:
         with (
             patch(_MOD + ".current_repo", return_value="o/r"),
             patch(_MOD + ".head_sha", return_value="abc123"),
             patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._run_with_retry", return_value=_completed(stdout="all passed\n")),
+            patch(_MOD + "._stream_with_retry") as m_stream,
         ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
-        captured = capsys.readouterr()
-        assert captured.out == ""
+            wait_for_checks("https://github.com/o/r/pull/1")
+        m_stream.assert_called_once_with(
+            ("gh", "pr", "checks", "https://github.com/o/r/pull/1", "--watch")
+        )
 
     def test_failure_raises_with_output(self) -> None:
         with (
             patch(_MOD + ".current_repo", return_value="o/r"),
             patch(_MOD + ".head_sha", return_value="abc123"),
             patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
+            patch(_MOD + "._stream_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
             pytest.raises(subprocess.CalledProcessError) as exc_info,
         ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
+            wait_for_checks("https://github.com/o/r/pull/1")
         assert exc_info.value.stdout == "fail"
         assert exc_info.value.stderr == "err"
-
-    def test_verbose_failure_prints_then_raises(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
-            patch(
-                _MOD + "._run_with_retry",
-                side_effect=_cpe(stdout="check output\n", stderr="error\n"),
-            ),
-            pytest.raises(subprocess.CalledProcessError),
-        ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
-        captured = capsys.readouterr()
-        assert "check output" in captured.out
-        assert "error" in captured.err
-
-    def test_verbose_failure_no_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="fail\n", stderr="")),
-            pytest.raises(subprocess.CalledProcessError),
-        ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
-        captured = capsys.readouterr()
-        assert "fail" in captured.out
-        assert captured.err == ""
-
-    def test_verbose_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._run_with_retry", return_value=_completed(stdout="", stderr="warn\n")),
-        ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
-        captured = capsys.readouterr()
-        assert captured.out == ""
-        assert "warn" in captured.err
-
-    def test_verbose_failure_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
-            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="", stderr="error\n")),
-            pytest.raises(subprocess.CalledProcessError),
-        ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=True)
-        captured = capsys.readouterr()
-        assert captured.out == ""
-        assert "error" in captured.err
 
     def test_polls_until_checks_registered(self) -> None:
         registered_calls = iter([False, False, True, True])
@@ -118,86 +94,44 @@ class TestWaitForChecks:
             patch(_MOD + ".current_repo", return_value="o/r"),
             patch(_MOD + ".head_sha", return_value="abc123"),
             patch(_MOD + "._checks_registered", side_effect=registered_calls),
-            patch(_MOD + "._run_with_retry", return_value=_completed()),
+            patch(_MOD + "._stream_with_retry"),
             patch(_MOD + ".time.sleep"),
             patch(_MOD + ".time.monotonic", side_effect=[0, 1, 2, 3]),
         ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
+            wait_for_checks("https://github.com/o/r/pull/1")
 
     def test_polls_timeout_raises(self) -> None:
         with (
             patch(_MOD + ".current_repo", return_value="o/r"),
             patch(_MOD + ".head_sha", return_value="abc123def456"),
             patch(_MOD + "._checks_registered", return_value=False),
-            patch(_MOD + "._run_with_retry") as mock_run,
+            patch(_MOD + "._stream_with_retry") as m_stream,
             patch(_MOD + ".time.sleep"),
             patch(_MOD + ".time.monotonic", side_effect=[0, 200]),
             pytest.raises(subprocess.CalledProcessError, match="no checks reported"),
         ):
-            wait_for_checks("https://github.com/o/r/pull/1", verbose=False)
-        mock_run.assert_not_called()
+            wait_for_checks("https://github.com/o/r/pull/1")
+        m_stream.assert_not_called()
 
 
 class TestWatchWorkflow:
-    def test_verbose_prints_output(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with patch(_MOD + "._run_with_retry", return_value=_completed(stdout="workflow done\n")):
-            watch_workflow("owner/repo", "12345", verbose=True)
-        captured = capsys.readouterr()
-        assert "workflow done" in captured.out
-
-    def test_quiet_suppresses_output(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with patch(_MOD + "._run_with_retry", return_value=_completed(stdout="workflow done\n")):
-            watch_workflow("owner/repo", "12345", verbose=False)
-        captured = capsys.readouterr()
-        assert captured.out == ""
-
     def test_failure_raises_with_output(self) -> None:
         with (
-            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
+            patch(_MOD + "._stream_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
             pytest.raises(subprocess.CalledProcessError) as exc_info,
         ):
-            watch_workflow("owner/repo", "12345", verbose=False)
+            watch_workflow("owner/repo", "12345")
         assert exc_info.value.stdout == "fail"
         assert exc_info.value.stderr == "err"
 
-    def test_verbose_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with patch(_MOD + "._run_with_retry", return_value=_completed(stdout="", stderr="warn\n")):
-            watch_workflow("owner/repo", "12345", verbose=True)
-        captured = capsys.readouterr()
-        assert captured.out == ""
-        assert "warn" in captured.err
-
-    def test_verbose_failure_prints_then_raises(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with (
-            patch(
-                _MOD + "._run_with_retry",
-                side_effect=_cpe(stdout="run log\n", stderr="error\n"),
-            ),
-            pytest.raises(subprocess.CalledProcessError),
-        ):
-            watch_workflow("owner/repo", "12345", verbose=True)
-        captured = capsys.readouterr()
-        assert "run log" in captured.out
-        assert "error" in captured.err
-
-    def test_verbose_failure_empty_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
-        with (
-            patch(_MOD + "._run_with_retry", side_effect=_cpe(stdout="", stderr="error\n")),
-            pytest.raises(subprocess.CalledProcessError),
-        ):
-            watch_workflow("owner/repo", "12345", verbose=True)
-        captured = capsys.readouterr()
-        assert captured.out == ""
-        assert "error" in captured.err
-
     def test_check_status_false_omits_exit_status(self) -> None:
-        with patch(_MOD + "._run_with_retry", return_value=_completed()) as m:
-            watch_workflow("owner/repo", "12345", verbose=False, check_status=False)
+        with patch(_MOD + "._stream_with_retry") as m:
+            watch_workflow("owner/repo", "12345", check_status=False)
         cmd = m.call_args[0][0]
         assert "--exit-status" not in cmd
 
     def test_check_status_true_includes_exit_status(self) -> None:
-        with patch(_MOD + "._run_with_retry", return_value=_completed()) as m:
-            watch_workflow("owner/repo", "12345", verbose=False, check_status=True)
+        with patch(_MOD + "._stream_with_retry") as m:
+            watch_workflow("owner/repo", "12345", check_status=True)
         cmd = m.call_args[0][0]
         assert "--exit-status" in cmd

--- a/tests/vergil_tooling/test_vrg_ecosystem_resolve.py
+++ b/tests/vergil_tooling/test_vrg_ecosystem_resolve.py
@@ -29,6 +29,7 @@ def test_python_ecosystem_ci_mode(capsys: pytest.CaptureFixture[str], tmp_path: 
     output_file.write_text("")
     with (
         patch("vergil_tooling.bin.vrg_ecosystem_resolve.is_ci", return_value=True),
+        patch("vergil_tooling.lib.output.is_ci", return_value=True),
         patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}),
     ):
         rc = main(["python"])
@@ -44,6 +45,7 @@ def test_go_ecosystem_ci_mode(tmp_path: Path) -> None:
     output_file.write_text("")
     with (
         patch("vergil_tooling.bin.vrg_ecosystem_resolve.is_ci", return_value=True),
+        patch("vergil_tooling.lib.output.is_ci", return_value=True),
         patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}),
     ):
         rc = main(["go"])
@@ -68,6 +70,7 @@ def test_rust_ecosystem_ci_mode(tmp_path: Path) -> None:
     output_file.write_text("")
     with (
         patch("vergil_tooling.bin.vrg_ecosystem_resolve.is_ci", return_value=True),
+        patch("vergil_tooling.lib.output.is_ci", return_value=True),
         patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}),
     ):
         rc = main(["rust"])

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_release import main, parse_args
-from vergil_tooling.lib.release.context import ReleaseContext
 
 _MOD = "vergil_tooling.bin.vrg_release"
 
@@ -35,152 +33,53 @@ def test_parse_args_default_promote() -> None:
     assert args.no_promote is False
 
 
-def test_parse_args_skip_cd_docs() -> None:
-    args = parse_args(["--skip-cd-docs"])
-    assert args.skip_cd_docs is True
-    assert args.version_override is None
-
-
-def test_parse_args_default_skip_cd_docs() -> None:
-    args = parse_args([])
-    assert args.skip_cd_docs is False
-
-
-def test_parse_args_skip_audit() -> None:
-    args = parse_args(["--skip-audit"])
-    assert args.skip_audit is True
-    assert args.version_override is None
-
-
-def test_parse_args_default_skip_audit() -> None:
-    args = parse_args([])
-    assert args.skip_audit is False
-
-
 def test_parse_args_no_promote_with_minor() -> None:
     args = parse_args(["--no-promote", "minor"])
     assert args.no_promote is True
     assert args.version_override == "minor"
 
 
-def test_main_skip_audit_skips_run_audit() -> None:
-    mock_root = Path("/tmp/repo")  # noqa: S108
+def test_parse_args_has_progress_flags() -> None:
+    args = parse_args(["--skip-audit", "--output-format", "plain"])
+    assert args.skip_audit is True
+    assert args.output_format == "plain"
+
+
+def test_parse_args_default_skip_audit() -> None:
+    args = parse_args([])
+    assert args.skip_audit is False
+    assert args.output_window == 5
+    assert args.output_format is None
+
+
+def test_main_runs_pipeline() -> None:
     with (
-        patch(_MOD + ".run_audit") as mock_audit,
-        patch(_MOD + ".preflight") as mock_pf,
-        patch(_MOD + ".run_release"),
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
+        patch(_MOD + ".git") as m_git,
+        patch(_MOD + ".progress.run_pipeline", return_value=0) as m_pipeline,
     ):
-        mock_pf.return_value = ReleaseContext(
-            repo="o/r",
-            version="1.0.0",
-            repo_root=mock_root,
-            version_override=None,
-        )
-        main(["--skip-audit"])
-    mock_audit.assert_not_called()
+        assert main(["--no-promote", "--output-format", "plain"]) == 0
+    state = m_pipeline.call_args.args[0]
+    assert state.promote is False
+    assert state.repo_root is m_git.repo_root.return_value
 
 
-def test_main_runs_audit_by_default() -> None:
-    mock_root = Path("/tmp/repo")  # noqa: S108
+def test_main_returns_pipeline_exit_code() -> None:
     with (
-        patch(_MOD + ".run_audit") as mock_audit,
-        patch(_MOD + ".preflight") as mock_pf,
-        patch(_MOD + ".run_release"),
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", return_value=1),
     ):
-        mock_pf.return_value = ReleaseContext(
-            repo="o/r",
-            version="1.0.0",
-            repo_root=mock_root,
-            version_override=None,
-        )
-        main([])
-    mock_audit.assert_called_once_with()
+        assert main([]) == 1
 
 
-def test_main_sets_promote_on_context() -> None:
-    mock_root = Path("/tmp/repo")  # noqa: S108
+def test_main_passes_version_override() -> None:
     with (
-        patch(_MOD + ".run_audit"),
-        patch(_MOD + ".preflight") as mock_pf,
-        patch(_MOD + ".run_release") as mock_run,
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", return_value=0) as m_pipeline,
     ):
-        ctx = ReleaseContext(
-            repo="o/r",
-            version="1.0.0",
-            repo_root=mock_root,
-            version_override=None,
-        )
-        mock_pf.return_value = ctx
-        main(["--no-promote"])
-    assert ctx.promote is False
-    mock_run.assert_called_once_with(ctx)
-
-
-def test_main_returns_zero_on_success() -> None:
-    mock_root = Path("/tmp/repo")  # noqa: S108
-    with (
-        patch(_MOD + ".run_audit"),
-        patch(_MOD + ".preflight") as mock_pf,
-        patch(_MOD + ".run_release"),
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
-    ):
-        mock_pf.return_value = ReleaseContext(
-            repo="o/r",
-            version="1.0.0",
-            repo_root=mock_root,
-            version_override=None,
-        )
-        result = main([])
-    assert result == 0
-
-
-def test_main_returns_one_on_release_error() -> None:
-    from vergil_tooling.lib.release.context import ReleaseError
-
-    mock_root = Path("/tmp/repo")  # noqa: S108
-    with (
-        patch(
-            _MOD + ".preflight",
-            side_effect=ReleaseError(
-                phase="preflight",
-                command="test",
-                message="test failure",
-            ),
-        ),
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
-    ):
-        result = main([])
-    assert result == 1
-
-
-def test_main_returns_one_on_release_error_with_detail() -> None:
-    from vergil_tooling.lib.release.context import ReleaseError
-
-    mock_root = Path("/tmp/repo")  # noqa: S108
-    with (
-        patch(
-            _MOD + ".preflight",
-            side_effect=ReleaseError(
-                phase="preflight",
-                command="test",
-                message="test failure",
-                detail="extra detail",
-            ),
-        ),
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
-    ):
-        result = main([])
-    assert result == 1
-
-
-def test_main_returns_one_on_unexpected_error() -> None:
-    mock_root = Path("/tmp/repo")  # noqa: S108
-    with (
-        patch(_MOD + ".preflight", side_effect=RuntimeError("boom")),
-        patch(_MOD + ".git.repo_root", return_value=mock_root),
-    ):
-        result = main([])
-    assert result == 1
+        main(["minor"])
+    state = m_pipeline.call_args.args[0]
+    assert state.version_override == "minor"
+    assert state.promote is True
+    kwargs = m_pipeline.call_args.kwargs
+    assert kwargs["command"] == "vrg-release"
+    assert kwargs["label"] == "vrg-release"

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -63,9 +63,10 @@ def test_parse_args_no_promote_with_minor() -> None:
     assert args.version_override == "minor"
 
 
-def test_main_passes_skip_audit_to_preflight() -> None:
+def test_main_skip_audit_skips_run_audit() -> None:
     mock_root = Path("/tmp/repo")  # noqa: S108
     with (
+        patch(_MOD + ".run_audit") as mock_audit,
         patch(_MOD + ".preflight") as mock_pf,
         patch(_MOD + ".run_release"),
         patch(_MOD + ".git.repo_root", return_value=mock_root),
@@ -77,14 +78,31 @@ def test_main_passes_skip_audit_to_preflight() -> None:
             version_override=None,
         )
         main(["--skip-audit"])
-    mock_pf.assert_called_once()
-    _, kwargs = mock_pf.call_args
-    assert kwargs["skip_audit"] is True
+    mock_audit.assert_not_called()
+
+
+def test_main_runs_audit_by_default() -> None:
+    mock_root = Path("/tmp/repo")  # noqa: S108
+    with (
+        patch(_MOD + ".run_audit") as mock_audit,
+        patch(_MOD + ".preflight") as mock_pf,
+        patch(_MOD + ".run_release"),
+        patch(_MOD + ".git.repo_root", return_value=mock_root),
+    ):
+        mock_pf.return_value = ReleaseContext(
+            repo="o/r",
+            version="1.0.0",
+            repo_root=mock_root,
+            version_override=None,
+        )
+        main([])
+    mock_audit.assert_called_once_with()
 
 
 def test_main_sets_promote_on_context() -> None:
     mock_root = Path("/tmp/repo")  # noqa: S108
     with (
+        patch(_MOD + ".run_audit"),
         patch(_MOD + ".preflight") as mock_pf,
         patch(_MOD + ".run_release") as mock_run,
         patch(_MOD + ".git.repo_root", return_value=mock_root),
@@ -104,6 +122,7 @@ def test_main_sets_promote_on_context() -> None:
 def test_main_returns_zero_on_success() -> None:
     mock_root = Path("/tmp/repo")  # noqa: S108
     with (
+        patch(_MOD + ".run_audit"),
         patch(_MOD + ".preflight") as mock_pf,
         patch(_MOD + ".run_release"),
         patch(_MOD + ".git.repo_root", return_value=mock_root),

--- a/tests/vergil_tooling/test_vrg_validate.py
+++ b/tests/vergil_tooling/test_vrg_validate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import mock_open, patch
@@ -14,19 +13,22 @@ if TYPE_CHECKING:
 import pytest
 
 from vergil_tooling.bin.vrg_validate import (
+    ValidationFailure,
+    _build_stages,
+    _command_stage,
     _find_custom_validator,
     _in_dev_container,
-    _run_commands,
     _run_common_checks,
-    _run_custom_validator,
     main,
 )
 from vergil_tooling.lib.languages import CheckKind
 
+_MOD = "vergil_tooling.bin.vrg_validate"
+
 
 @pytest.fixture(autouse=True)
 def _container_env() -> Iterator[None]:
-    with patch("vergil_tooling.bin.vrg_validate._in_dev_container", return_value=True):
+    with patch(_MOD + "._in_dev_container", return_value=True):
         yield
 
 
@@ -44,57 +46,146 @@ def _write_config(tmp_path: Path, language: str = "") -> None:
 
 
 def test_rejects_host_execution() -> None:
-    with patch("vergil_tooling.bin.vrg_validate._in_dev_container", return_value=False):
+    with patch(_MOD + "._in_dev_container", return_value=False):
         assert main([]) == 1
 
 
-# -- --check common -----------------------------------------------------------
+# -- Stage construction --------------------------------------------------------
+
+
+def test_build_stages_full_run_order() -> None:
+    with (
+        patch(_MOD + ".language_commands") as m_cmds,
+        patch(_MOD + "._find_custom_validator", return_value=None),
+    ):
+        m_cmds.side_effect = lambda lang, kind: [["echo", kind.value]]
+        stages = _build_stages(None, "python", Path("/tmp/r"))  # noqa: S108
+    assert [s.name for s in stages] == [
+        "common",
+        "install",
+        "lint",
+        "typecheck",
+        "test",
+        "audit",
+    ]
+    assert stages[1].mode == "fail_fast"
+    assert all(s.mode == "fail_defer" for s in stages if s.name != "install")
+
+
+def test_build_stages_full_run_includes_custom() -> None:
+    with (
+        patch(_MOD + ".language_commands") as m_cmds,
+        patch(_MOD + "._find_custom_validator", return_value="/path/to/custom"),
+    ):
+        m_cmds.side_effect = lambda lang, kind: [["echo", kind.value]]
+        stages = _build_stages(None, "python", Path("/tmp/r"))  # noqa: S108
+    assert stages[-1].name == "custom"
+    assert stages[-1].mode == "fail_defer"
+
+
+def test_build_stages_check_common_only() -> None:
+    stages = _build_stages("common", "python", Path("/tmp/r"))  # noqa: S108
+    assert [s.name for s in stages] == ["common"]
+
+
+def test_build_stages_check_lint_runs_install_then_lint() -> None:
+    with patch(_MOD + ".language_commands") as m_cmds:
+        m_cmds.side_effect = lambda lang, kind: [["echo", kind.value]]
+        stages = _build_stages("lint", "python", Path("/tmp/r"))  # noqa: S108
+    assert [s.name for s in stages] == ["install", "lint"]
+    assert stages[0].mode == "fail_fast"
+
+
+def test_build_stages_check_lint_no_install_commands() -> None:
+    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+        if kind == CheckKind.INSTALL:
+            return []
+        if kind == CheckKind.LINT:
+            return [["ruff", "check", "src/"]]
+        return []
+
+    with patch(_MOD + ".language_commands", side_effect=mock_lang_cmds):
+        stages = _build_stages("lint", "python", Path("/tmp/r"))  # noqa: S108
+    assert [s.name for s in stages] == ["lint"]
+
+
+def test_build_stages_no_language_skips_language_checks() -> None:
+    with patch(_MOD + "._find_custom_validator", return_value=None):
+        stages = _build_stages(None, None, Path("/tmp/r"))  # noqa: S108
+    assert [s.name for s in stages] == ["common"]
+
+
+def test_build_stages_no_commands_for_check() -> None:
+    with patch(_MOD + ".language_commands", return_value=[]):
+        stages = _build_stages("lint", "python", Path("/tmp/r"))  # noqa: S108
+    assert stages == []
+
+
+# -- _command_stage ------------------------------------------------------------
+
+
+def test_command_stage_fail_defer_runs_all_commands() -> None:
+    with patch(_MOD + ".progress.run", side_effect=[1, 0, 2]) as m_run:
+        stage = _command_stage("test", [["cmd1"], ["cmd2"], ["cmd3"]], mode="fail_defer")
+        with pytest.raises(ValidationFailure, match="2 of 3 test command"):
+            stage.fn(None)
+    assert m_run.call_count == 3
+
+
+def test_command_stage_fail_fast_stops_on_first_failure() -> None:
+    with patch(_MOD + ".progress.run", return_value=1) as m_run:
+        stage = _command_stage("install", [["cmd1"], ["cmd2"]], mode="fail_fast")
+        with pytest.raises(ValidationFailure, match="1 of 2 install command"):
+            stage.fn(None)
+    assert m_run.call_count == 1
+
+
+def test_command_stage_success_no_raise() -> None:
+    with patch(_MOD + ".progress.run", return_value=0):
+        stage = _command_stage("lint", [["cmd1"]], mode="fail_defer")
+        stage.fn(None)  # does not raise
+
+
+# -- main() wiring -------------------------------------------------------------
 
 
 def test_check_common_runs_common_checks(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0) as mock,
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=0) as mock,
     ):
         result = main(["--check", "common"])
     assert result == 0
     mock.assert_called_once()
 
 
-# -- --check lint (language-specific) -----------------------------------------
-
-
 def test_check_lint_runs_install_then_lint(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
-    calls: list[list[str]] = []
+    calls: list[str] = []
 
-    def mock_run_commands(cmds: list[list[str]], label: str, **kwargs: bool) -> int:
-        calls.extend(cmds)
+    def mock_run(cmd: list[str], *, check: bool = True) -> int:
+        calls.append(" ".join(cmd))
         return 0
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", side_effect=mock_run_commands),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
     ):
         result = main(["--check", "lint"])
     assert result == 0
-    joined = [" ".join(c) for c in calls]
-    assert "uv sync --frozen --group dev" in joined
-    assert "ruff check src/ tests/" in joined
+    assert "uv sync --frozen --group dev" in calls
+    assert "ruff check src/ tests/" in calls
 
 
 def test_check_lint_no_commands_without_language(tmp_path: Path) -> None:
     _write_config(tmp_path)
-    with patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path):
+    with patch(_MOD + ".git.repo_root", return_value=tmp_path):
         result = main(["--check", "lint"])
     assert result == 0
 
 
-# -- No --check (run all) ----------------------------------------------------
-
-
-def test_run_all_calls_common_then_language_checks(tmp_path: Path) -> None:
+def test_run_all_executes_stages_in_order(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
     order: list[str] = []
 
@@ -102,78 +193,152 @@ def test_run_all_calls_common_then_language_checks(tmp_path: Path) -> None:
         order.append("common")
         return 0
 
-    def mock_commands(cmds: list[list[str]], label: str, **kwargs: bool) -> int:
-        order.append(label)
+    def mock_run(cmd: list[str], *, check: bool = True) -> int:
+        order.append(cmd[-1])
         return 0
 
+    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+        return [["echo", kind.value]]
+
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", side_effect=mock_common),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", side_effect=mock_commands),
-        patch("vergil_tooling.bin.vrg_validate._find_custom_validator", return_value=None),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", side_effect=mock_common),
+        patch(_MOD + ".language_commands", side_effect=mock_lang_cmds),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
+        patch(_MOD + "._find_custom_validator", return_value=None),
     ):
         result = main([])
     assert result == 0
-    assert order[0] == "common"
-    assert "install" in order
-    assert "lint" in order
-    assert "typecheck" in order
-    assert "test" in order
-    assert "audit" in order
+    assert order == ["common", "install", "lint", "typecheck", "test", "audit"]
 
 
-def test_run_all_stops_on_failure(tmp_path: Path) -> None:
+def test_run_all_common_failure_reported(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
 
-    def mock_common(repo_root: Path) -> int:
-        return 1
+    def mock_run(cmd: list[str], *, check: bool = True) -> int:
+        return 0
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", side_effect=mock_common),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=1),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
+        patch(_MOD + "._find_custom_validator", return_value=None),
     ):
         result = main([])
     assert result == 1
 
 
-def test_run_all_includes_custom_validator(tmp_path: Path) -> None:
+def test_run_all_language_failure_does_not_stop_later_checks(tmp_path: Path) -> None:
+    """Intentional behavior change: lint failure no longer prevents typecheck/test/audit."""
     _write_config(tmp_path, "python")
+    ran: list[str] = []
+
+    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+        return [["echo", kind.value]]
+
+    def mock_run(cmd: list[str], *, check: bool = True) -> int:
+        ran.append(cmd[-1])
+        return 1 if cmd[-1] == "lint" else 0
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", return_value=0),
-        patch(
-            "vergil_tooling.bin.vrg_validate._find_custom_validator",
-            return_value="/path/to/custom",
-        ),
-        patch(
-            "vergil_tooling.bin.vrg_validate._run_custom_validator",
-            return_value=0,
-        ) as mock_custom,
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=0),
+        patch(_MOD + ".language_commands", side_effect=mock_lang_cmds),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
+        patch(_MOD + "._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 1
+    assert "typecheck" in ran
+    assert "test" in ran
+    assert "audit" in ran
+
+
+def test_run_all_install_failure_stops_later_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    ran: list[str] = []
+
+    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+        return [["echo", kind.value]]
+
+    def mock_run(cmd: list[str], *, check: bool = True) -> int:
+        ran.append(cmd[-1])
+        return 1 if cmd[-1] == "install" else 0
+
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=0),
+        patch(_MOD + ".language_commands", side_effect=mock_lang_cmds),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
+        patch(_MOD + "._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 1
+    assert "lint" not in ran
+
+
+def test_run_all_includes_custom_validator(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+    ran: list[str] = []
+
+    def mock_run(cmd: tuple[str, ...], *, check: bool = True) -> int:
+        ran.append(cmd[0])
+        return 0
+
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=0),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
+        patch(_MOD + "._find_custom_validator", return_value="/path/to/custom"),
     ):
         result = main([])
     assert result == 0
-    mock_custom.assert_called_once()
+    assert ran == ["/path/to/custom"]
+
+
+def test_run_all_custom_validator_failure(tmp_path: Path) -> None:
+    _write_config(tmp_path)
+
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=0),
+        patch(_MOD + ".progress.run", return_value=1),
+        patch(_MOD + "._find_custom_validator", return_value="/path/to/custom"),
+    ):
+        result = main([])
+    assert result == 1
 
 
 def test_run_all_language_none_skips_language_checks(tmp_path: Path) -> None:
     _write_config(tmp_path)
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0),
-        patch("vergil_tooling.bin.vrg_validate._find_custom_validator", return_value=None),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + "._run_common_checks", return_value=0),
+        patch(_MOD + "._find_custom_validator", return_value=None),
     ):
         result = main([])
     assert result == 0
+
+
+def test_main_runs_pipeline_with_command_name(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".progress.run_pipeline", return_value=0) as m_pipeline,
+    ):
+        result = main(["--check", "common"])
+    assert result == 0
+    kwargs = m_pipeline.call_args.kwargs
+    assert kwargs["command"] == "vrg-validate"
+    assert kwargs["repo_root"] == tmp_path
 
 
 # -- Unit tests for internal functions ----------------------------------------
 
 
 def test_in_dev_container_dockerenv() -> None:
-    with patch("vergil_tooling.bin.vrg_validate.Path.exists", return_value=True):
+    with patch(_MOD + ".Path.exists", return_value=True):
         assert _in_dev_container() is True
 
 
@@ -190,7 +355,7 @@ _HOST_MOUNTINFO = (
 
 def test_in_dev_container_overlay_mountinfo() -> None:
     with (
-        patch("vergil_tooling.bin.vrg_validate.Path.exists", return_value=False),
+        patch(_MOD + ".Path.exists", return_value=False),
         patch.object(Path, "open", mock_open(read_data=_OVERLAY_MOUNTINFO)),
     ):
         assert _in_dev_container() is True
@@ -198,7 +363,7 @@ def test_in_dev_container_overlay_mountinfo() -> None:
 
 def test_in_dev_container_host_mountinfo() -> None:
     with (
-        patch("vergil_tooling.bin.vrg_validate.Path.exists", return_value=False),
+        patch(_MOD + ".Path.exists", return_value=False),
         patch.object(Path, "open", mock_open(read_data=_HOST_MOUNTINFO)),
     ):
         assert _in_dev_container() is False
@@ -206,7 +371,7 @@ def test_in_dev_container_host_mountinfo() -> None:
 
 def test_in_dev_container_no_mountinfo() -> None:
     with (
-        patch("vergil_tooling.bin.vrg_validate.Path.exists", return_value=False),
+        patch(_MOD + ".Path.exists", return_value=False),
         patch.object(Path, "open", side_effect=OSError),
     ):
         assert _in_dev_container() is False
@@ -217,44 +382,14 @@ def test_in_dev_container_env_var_no_longer_used(
 ) -> None:
     monkeypatch.setenv("ST_IN_DEV_CONTAINER", "1")
     with (
-        patch("vergil_tooling.bin.vrg_validate.Path.exists", return_value=False),
+        patch(_MOD + ".Path.exists", return_value=False),
         patch.object(Path, "open", side_effect=OSError),
     ):
         assert _in_dev_container() is False
 
 
-def test_run_commands_success() -> None:
-    with patch(
-        "vergil_tooling.bin.vrg_validate.subprocess.run",
-        return_value=subprocess.CompletedProcess(args=[], returncode=0),
-    ):
-        assert _run_commands([["echo", "hello"]], "test") == 0
-
-
-def test_run_commands_failure_runs_all_by_default() -> None:
-    results: Iterator[subprocess.CompletedProcess[bytes]] = iter(
-        [
-            subprocess.CompletedProcess(args=[], returncode=1),
-            subprocess.CompletedProcess(args=[], returncode=0),
-            subprocess.CompletedProcess(args=[], returncode=2),
-        ]
-    )
-    with patch("vergil_tooling.bin.vrg_validate.subprocess.run", side_effect=results) as mock:
-        assert _run_commands([["cmd1"], ["cmd2"], ["cmd3"]], "test") == 2
-    assert mock.call_count == 3
-
-
-def test_run_commands_fail_fast_stops_on_first() -> None:
-    with patch(
-        "vergil_tooling.bin.vrg_validate.subprocess.run",
-        return_value=subprocess.CompletedProcess(args=[], returncode=1),
-    ) as mock:
-        assert _run_commands([["cmd1"], ["cmd2"]], "test", fail_fast=True) == 1
-    assert mock.call_count == 1
-
-
 def test_find_custom_validator_entry_point() -> None:
-    with patch("vergil_tooling.bin.vrg_validate.shutil.which", return_value="/usr/bin/custom"):
+    with patch(_MOD + ".shutil.which", return_value="/usr/bin/custom"):
         assert _find_custom_validator(Path("/fake")) == "/usr/bin/custom"
 
 
@@ -264,29 +399,13 @@ def test_find_custom_validator_local_script(tmp_path: Path) -> None:
     script = scripts_bin / "validate-custom"
     script.write_text("#!/bin/bash\n")
     script.chmod(0o755)
-    with patch("vergil_tooling.bin.vrg_validate.shutil.which", return_value=None):
+    with patch(_MOD + ".shutil.which", return_value=None):
         assert _find_custom_validator(tmp_path) == str(script)
 
 
 def test_find_custom_validator_none(tmp_path: Path) -> None:
-    with patch("vergil_tooling.bin.vrg_validate.shutil.which", return_value=None):
+    with patch(_MOD + ".shutil.which", return_value=None):
         assert _find_custom_validator(tmp_path) is None
-
-
-def test_run_custom_validator() -> None:
-    with patch(
-        "vergil_tooling.bin.vrg_validate.subprocess.run",
-        return_value=subprocess.CompletedProcess(args=[], returncode=0),
-    ):
-        assert _run_custom_validator("/path/to/script") == 0
-
-
-def test_run_custom_validator_failure() -> None:
-    with patch(
-        "vergil_tooling.bin.vrg_validate.subprocess.run",
-        return_value=subprocess.CompletedProcess(args=[], returncode=1),
-    ):
-        assert _run_custom_validator("/path/to/script") == 1
 
 
 # -- Config error handling ---------------------------------------------------
@@ -294,7 +413,7 @@ def test_run_custom_validator_failure() -> None:
 
 def test_missing_config_uses_empty_language(tmp_path: Path) -> None:
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
     ):
         result = main(["--check", "lint"])
     assert result == 0
@@ -304,9 +423,9 @@ def test_config_error_returns_1(tmp_path: Path) -> None:
     from vergil_tooling.lib.config import ConfigError
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
         patch(
-            "vergil_tooling.bin.vrg_validate.config.read_config",
+            _MOD + ".config.read_config",
             side_effect=ConfigError("bad config"),
         ),
     ):
@@ -319,81 +438,19 @@ def test_config_error_returns_1(tmp_path: Path) -> None:
 
 def test_check_lint_install_failure_stops(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
-    call_count = 0
+    ran: list[str] = []
 
-    def mock_run_commands(cmds: list[list[str]], label: str, **kwargs: bool) -> int:
-        nonlocal call_count
-        call_count += 1
-        if label == "install":
-            return 1
-        return 0
+    def mock_run(cmd: list[str], *, check: bool = True) -> int:
+        ran.append(" ".join(cmd))
+        return 1 if "uv sync" in " ".join(cmd) else 0
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", side_effect=mock_run_commands),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".progress.run", side_effect=mock_run),
     ):
         result = main(["--check", "lint"])
     assert result == 1
-    assert call_count == 1
-
-
-# -- Run all: language check failure stops -----------------------------------
-
-
-def test_run_all_language_check_failure_stops(tmp_path: Path) -> None:
-    _write_config(tmp_path, "python")
-
-    def mock_commands(cmds: list[list[str]], label: str, **kwargs: bool) -> int:
-        if label == "lint":
-            return 1
-        return 0
-
-    with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", side_effect=mock_commands),
-    ):
-        result = main([])
-    assert result == 1
-
-
-# -- Run all: custom validator failure stops ---------------------------------
-
-
-def test_run_all_custom_validator_failure(tmp_path: Path) -> None:
-    _write_config(tmp_path)
-
-    with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0),
-        patch(
-            "vergil_tooling.bin.vrg_validate._find_custom_validator",
-            return_value="/path/to/custom",
-        ),
-        patch("vergil_tooling.bin.vrg_validate._run_custom_validator", return_value=1),
-    ):
-        result = main([])
-    assert result == 1
-
-
-# -- Run all: install failure stops ------------------------------------------
-
-
-def test_run_all_install_failure_stops(tmp_path: Path) -> None:
-    _write_config(tmp_path, "python")
-
-    def mock_commands(cmds: list[list[str]], label: str, **kwargs: bool) -> int:
-        if label == "install":
-            return 1
-        return 0
-
-    with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", side_effect=mock_commands),
-    ):
-        result = main([])
-    assert result == 1
+    assert all("ruff" not in cmd for cmd in ran)
 
 
 # -- _run_common_checks body --------------------------------------------------
@@ -409,30 +466,7 @@ def test_run_common_checks_calls_common_main() -> None:
     mock.assert_called_once()
 
 
-# -- Branch: no install commands for single check -----------------------------
-
-
-def test_single_check_no_install_commands(tmp_path: Path) -> None:
-    _write_config(tmp_path, "python")
-
-    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
-        if kind == CheckKind.INSTALL:
-            return []
-        if kind == CheckKind.LINT:
-            return [["ruff", "check", "src/"]]
-        return []
-
-    with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate.language_commands", side_effect=mock_lang_cmds),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", return_value=0) as mock_run,
-    ):
-        result = main(["--check", "lint"])
-    assert result == 0
-    mock_run.assert_called_once_with([["ruff", "check", "src/"]], "lint")
-
-
-# -- Branch: no install commands in run-all mode ------------------------------
+# -- venv PATH handling --------------------------------------------------------
 
 
 def test_venv_bin_prepended_to_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -443,8 +477,8 @@ def test_venv_bin_prepended_to_path(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("PATH", "/usr/bin")
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", return_value=0),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".progress.run", return_value=0),
     ):
         result = main(["--check", "lint"])
     assert result == 0
@@ -461,30 +495,9 @@ def test_venv_bin_not_prepended_when_already_on_path(
     monkeypatch.setenv("PATH", f"{venv_bin}:/usr/bin")
 
     with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", return_value=0),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".progress.run", return_value=0),
     ):
         main(["--check", "lint"])
     count = os.environ["PATH"].split(os.pathsep).count(str(venv_bin))
     assert count == 1
-
-
-def test_run_all_no_install_commands(tmp_path: Path) -> None:
-    _write_config(tmp_path, "python")
-
-    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
-        if kind == CheckKind.INSTALL:
-            return []
-        if kind == CheckKind.LINT:
-            return [["ruff", "check", "src/"]]
-        return []
-
-    with (
-        patch("vergil_tooling.bin.vrg_validate.git.repo_root", return_value=tmp_path),
-        patch("vergil_tooling.bin.vrg_validate._run_common_checks", return_value=0),
-        patch("vergil_tooling.bin.vrg_validate.language_commands", side_effect=mock_lang_cmds),
-        patch("vergil_tooling.bin.vrg_validate._run_commands", return_value=0),
-        patch("vergil_tooling.bin.vrg_validate._find_custom_validator", return_value=None),
-    ):
-        result = main([])
-    assert result == 0

--- a/tests/vergil_tooling/test_vrg_validate.py
+++ b/tests/vergil_tooling/test_vrg_validate.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 import pytest
 
 from vergil_tooling.bin.vrg_validate import (
-    ValidationFailure,
+    ValidationError,
     _build_stages,
     _command_stage,
     _find_custom_validator,
@@ -127,7 +127,7 @@ def test_build_stages_no_commands_for_check() -> None:
 def test_command_stage_fail_defer_runs_all_commands() -> None:
     with patch(_MOD + ".progress.run", side_effect=[1, 0, 2]) as m_run:
         stage = _command_stage("test", [["cmd1"], ["cmd2"], ["cmd3"]], mode="fail_defer")
-        with pytest.raises(ValidationFailure, match="2 of 3 test command"):
+        with pytest.raises(ValidationError, match="2 of 3 test command"):
             stage.fn(None)
     assert m_run.call_count == 3
 
@@ -135,7 +135,7 @@ def test_command_stage_fail_defer_runs_all_commands() -> None:
 def test_command_stage_fail_fast_stops_on_first_failure() -> None:
     with patch(_MOD + ".progress.run", return_value=1) as m_run:
         stage = _command_stage("install", [["cmd1"], ["cmd2"]], mode="fail_fast")
-        with pytest.raises(ValidationFailure, match="1 of 2 install command"):
+        with pytest.raises(ValidationError, match="1 of 2 install command"):
             stage.fn(None)
     assert m_run.call_count == 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -837,6 +837,9 @@ wheels = [
 name = "vergil-tooling"
 version = "2.1.11"
 source = { editable = "." }
+dependencies = [
+    { name = "rich" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -850,6 +853,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "rich", specifier = ">=13.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Pull Request

## Summary

- Implements the progress framework from
docs/specs/2026-06-05-progress-framework-design.md and migrates the
first two adopters.

## Framework (`lib/progress.py`)

- `Stage` / `run_pipeline` declarative pipeline API with three failure
  modes (`warn` / `fail_defer` / `fail_fast`) and per-stage
  `--skip-<stage>` escape hatches (fail_fast only, enforced at parser
  construction)
- Three auto-detected renderers: `RichRenderer` (TTY, rolling last-N
  window via rich Live), `GhaRenderer` (`::group::` annotations),
  `PlainRenderer` (piped / other CI); `--output-format` overrides
- Always-on run log at `.vergil/<command>-YYYYMMDD-HHMMSS.log` with
  ANSI stripping and prune-on-start (keep 20 per command)
- Streaming subprocess runner (`progress.run`) plus stdout/stderr
  redirection during stages, so bare `print()` calls deep in library
  code route through the renderer and log automatically
- Structured final summary listing warnings, failures, and log path;
  KeyboardInterrupt renders the summary and exits 130

## Migrations

- `vrg-release`: bespoke phase runner replaced by `build_stages()`;
  audit extracted as a skippable fail_fast stage; back half of the
  pipeline is fail_defer; `--verbose` and `--skip-cd-docs` removed
  (subsumed by the window + log and fail_defer reporting)
- `vrg-validate`: checks become stages — install is fail_fast,
  language checks and custom validator are fail_defer so all failures
  are reported in one run
- `git.run()` and the release CI pollers stream through the framework;
  the pollers retain transient-failure retry and credential injection
- `output.is_ci()` re-pointed at `$GITHUB_ACTIONS` (detection owned by
  `lib/progress.py`) — merely piped output no longer gets GHA
  annotations

`rich` becomes the repo's first external dependency. Full suite green
(2,366 tests, 100% coverage); `vrg-container-run -- uv run
vrg-validate` passes end-to-end and was used to live-smoke the plain
and GHA renderers.

## Issue Linkage

- Ref #1419

## Notes

- Rollout steps 1-3 of issue #1419 are complete (framework, vrg-release,
vrg-validate). Step 4 — remaining long-running commands
(vrg-finalize-pr, vrg-submit-pr) — is incremental follow-up per the
spec, so linkage defaults to Ref; change to Closes if you consider the
issue done. Plan: docs/plans/2026-06-05-progress-framework.md.