### PR TITLE
feat(vrg-vm): port vrg-vm lifecycle commands to the progress framework

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import os
 import shlex
+import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -57,6 +58,8 @@ from vergil_tooling.lib.lima import (
     vm_spec_status,
     vm_status,
 )
+from vergil_tooling.lib import progress
+from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.session import list_rows, make_name
 from vergil_tooling.lib.vm_spec import (
     ComposedSpec,
@@ -230,6 +233,135 @@ def _nested_preflight(target: Target) -> int:
     return 1
 
 
+@dataclass
+class _LifecycleState:
+    """Pipeline context for the long-running lifecycle commands.
+
+    ``template`` is populated by the fetch-template stage and cleaned up by
+    ``_run_lifecycle`` after the pipeline finishes, success or failure.
+    """
+
+    target: Target
+    tag: str = ""
+    vergil_version: str = ""
+    timeout: str = "30m"
+    template: Path | None = None
+
+
+def _log_root() -> Path:
+    """Where the .vergil run log lives: the enclosing repo, else the home dir.
+
+    vrg-vm is a host command runnable from anywhere; when invoked outside a
+    git checkout there is no project-local scratch dir to use.
+    """
+    result = subprocess.run(  # noqa: S603
+        ("git", "rev-parse", "--show-toplevel"),  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path.home()
+
+
+def _st_destroy(state: _LifecycleState) -> None:
+    delete_vm(state.target.instance)
+
+
+def _st_fetch_template(state: _LifecycleState) -> None:
+    print(f"Fetching template ({state.tag})...")
+    state.template = fetch_template(state.tag)
+
+
+def _st_create(state: _LifecycleState) -> None:
+    if state.template is None:
+        msg = "template missing — fetch-template did not run"
+        raise RuntimeError(msg)
+    print(f"Creating VM with projects mount: {state.target.identity.projects_dir}")
+    _create_from_target(state.target, state.template)
+
+
+def _st_start(state: _LifecycleState) -> None:
+    start_vm(state.target.instance, timeout=state.timeout)
+
+
+def _st_link_config(state: _LifecycleState) -> None:
+    link_claude_dirs(state.target.instance, Path.home() / ".claude")
+
+
+def _st_credentials(state: _LifecycleState) -> None:
+    inject_credentials(state.target.instance, state.target.identity)
+
+
+def _st_install_tooling(state: _LifecycleState) -> None:
+    install_tooling(state.target.instance, state.vergil_version)
+
+
+def _st_copy_config(state: _LifecycleState) -> None:
+    claude_dir = Path.home() / ".claude"
+    copy_claude_config(state.target.instance, claude_dir)
+    link_claude_dirs(state.target.instance, claude_dir)
+
+
+def _st_update_tooling(state: _LifecycleState) -> None:
+    # Runs as a warn-mode stage: a failed update surfaces as ⚠ in the summary
+    # and the start continues — the same warn-and-continue contract
+    # try_update_tooling provided before the pipeline port.
+    fallback = resolve_vergil_version(state.target.config, state.target.identity)
+    update_tooling(state.target.instance, fallback_tag=fallback)
+
+
+def _create_stages() -> list[Stage]:
+    return [
+        Stage("fetch-template", _st_fetch_template, mode="fail_fast"),
+        Stage("create", _st_create, mode="fail_fast"),
+        Stage("start", _st_start, mode="fail_fast"),
+        Stage("link-config", _st_link_config, mode="fail_fast"),
+        Stage("credentials", _st_credentials, mode="fail_fast"),
+        Stage("tooling", _st_install_tooling, mode="fail_fast"),
+    ]
+
+
+def _start_stages() -> list[Stage]:
+    return [
+        Stage("start", _st_start, mode="fail_fast"),
+        Stage("credentials", _st_credentials, mode="fail_fast"),
+        Stage("copy-config", _st_copy_config, mode="fail_fast"),
+        Stage("update-tooling", _st_update_tooling, mode="warn"),
+    ]
+
+
+def _rebuild_stages() -> list[Stage]:
+    return [
+        Stage("destroy", _st_destroy, mode="fail_fast"),
+        Stage("fetch-template", _st_fetch_template, mode="fail_fast"),
+        Stage("create", _st_create, mode="fail_fast"),
+        Stage("start", _st_start, mode="fail_fast"),
+        Stage("credentials", _st_credentials, mode="fail_fast"),
+        Stage("tooling", _st_install_tooling, mode="fail_fast"),
+        Stage("copy-config", _st_copy_config, mode="fail_fast"),
+    ]
+
+
+def _run_lifecycle(
+    verb: str, state: _LifecycleState, stages: list[Stage], args: argparse.Namespace
+) -> int:
+    """Run a lifecycle pipeline, always cleaning up the fetched template."""
+    try:
+        return progress.run_pipeline(
+            state,
+            stages,
+            command="vrg-vm",
+            label=f"vrg-vm {verb} '{state.target.instance}'",
+            args=args,
+            repo_root=_log_root(),
+        )
+    finally:
+        if state.template is not None:
+            state.template.unlink(missing_ok=True)
+
+
 def _create_from_target(target: Target, template: Path) -> None:
     """Build the VM for a target: dedicated boxes carry the composed spec, base is unchanged."""
     if target.spec.dedicated:
@@ -282,29 +414,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
         return 1
 
     print(f"Creating VM '{target.instance}' for identity '{name}'...")
-
-    print(f"  Fetching template ({tag})...")
-    template = fetch_template(tag)
-
-    try:
-        print(f"  Creating VM with projects mount: {identity.projects_dir}")
-        _create_from_target(target, template)
-
-        print("  Starting VM...")
-        start_vm(target.instance)
-
-        print("  Linking Claude config directories...")
-        link_claude_dirs(target.instance, Path.home() / ".claude")
-
-        print("Injecting credentials...")
-        inject_credentials(target.instance, identity)
-
-        install_tooling(target.instance, vergil_version)
-    finally:
-        template.unlink(missing_ok=True)
-
-    print(f"\nVM '{target.instance}' is ready.")
-    return 0
+    state = _LifecycleState(target=target, tag=tag, vergil_version=vergil_version)
+    return _run_lifecycle("create", state, _create_stages(), args)
 
 
 def _cmd_start(args: argparse.Namespace) -> int:
@@ -337,22 +448,8 @@ def _cmd_start(args: argparse.Namespace) -> int:
             return 1
 
     print(f"Starting VM '{target.instance}' (identity: {name})...")
-    start_vm(target.instance, timeout=args.timeout)
-
-    print("Injecting credentials...")
-    inject_credentials(target.instance, identity)
-
-    claude_dir = Path.home() / ".claude"
-    print("Copying Claude Code config...")
-    copy_claude_config(target.instance, claude_dir)
-    link_claude_dirs(target.instance, claude_dir)
-
-    fallback = resolve_vergil_version(config, identity)
-    print("Updating vergil-tooling...")
-    try_update_tooling(target.instance, fallback_tag=fallback)
-
-    print(f"VM '{target.instance}' is running.")
-    return 0
+    state = _LifecycleState(target=target, timeout=args.timeout)
+    return _run_lifecycle("start", state, _start_stages(), args)
 
 
 def _cmd_stop(args: argparse.Namespace) -> int:
@@ -455,34 +552,10 @@ def _cmd_rebuild(args: argparse.Namespace) -> int:
     tag = args.tag if args.tag else resolve_vm_tag(config, identity)
 
     print(f"Rebuilding VM '{target.instance}' (identity: {name})...")
-
-    print("  Destroying old VM...")
-    delete_vm(target.instance)
-
-    print(f"  Fetching template ({tag})...")
-    template = fetch_template(tag)
-
-    try:
-        print(f"  Creating VM with projects mount: {identity.projects_dir}")
-        _create_from_target(target, template)
-
-        print("  Starting VM...")
-        start_vm(target.instance, timeout=args.timeout)
-
-        print("  Injecting credentials...")
-        inject_credentials(target.instance, identity)
-
-        install_tooling(target.instance, vergil_version)
-
-        claude_dir = Path.home() / ".claude"
-        print("  Copying Claude Code config...")
-        copy_claude_config(target.instance, claude_dir)
-        link_claude_dirs(target.instance, claude_dir)
-    finally:
-        template.unlink(missing_ok=True)
-
-    print(f"\nVM '{target.instance}' rebuilt and ready.")
-    return 0
+    state = _LifecycleState(
+        target=target, tag=tag, vergil_version=vergil_version, timeout=args.timeout
+    )
+    return _run_lifecycle("rebuild", state, _rebuild_stages(), args)
 
 
 @dataclass
@@ -915,6 +988,7 @@ def main(argv: list[str] | None = None) -> int:
     p_create.add_argument(
         "--tag", default="", help="VM template version tag (default: vergil version from config)"
     )
+    progress.add_progress_args(p_create, ())
 
     p_start = sub.add_parser("start", help="Start VM and inject credentials")
     _add_identity_args(p_start)
@@ -929,6 +1003,7 @@ def main(argv: list[str] | None = None) -> int:
         default="30m",
         help="How long to wait for VM to reach running status (default: 30m)",
     )
+    progress.add_progress_args(p_start, ())
 
     p_stop = sub.add_parser("stop", help="Stop VM")
     _add_identity_args(p_stop)
@@ -960,6 +1035,7 @@ def main(argv: list[str] | None = None) -> int:
         default="30m",
         help="How long to wait for VM to reach running status (default: 30m)",
     )
+    progress.add_progress_args(p_rebuild, ())
 
     p_list = sub.add_parser(
         "list",

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -23,6 +23,7 @@ from vergil_tooling.bin.vrg_vm_resolve import (
     name_by_session,
     projects_glob,
 )
+from vergil_tooling.lib import progress
 from vergil_tooling.lib.config import ConfigError, VmStanza, read_config
 from vergil_tooling.lib.identity import (
     Identity,
@@ -58,7 +59,6 @@ from vergil_tooling.lib.lima import (
     vm_spec_status,
     vm_status,
 )
-from vergil_tooling.lib import progress
 from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.session import list_rows, make_name
 from vergil_tooling.lib.vm_spec import (
@@ -420,7 +420,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
 
 def _cmd_start(args: argparse.Namespace) -> int:
     target = _resolve_target(args)
-    name, identity, config = target.identity_name, target.identity, target.config
+    name = target.identity_name
 
     if _preflight_target(target) != 0:
         return 1

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -9,11 +9,14 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from vergil_tooling.lib import progress
 
 if TYPE_CHECKING:
     from vergil_tooling.lib.identity import Identity
@@ -37,6 +40,16 @@ def _limactl(*args: str) -> subprocess.CompletedProcess[str]:
         if exc.stderr:
             print(exc.stderr, end="", file=sys.stderr)
         raise
+
+
+def _limactl_stream(*args: str) -> None:
+    """Run limactl, streaming output through the progress framework.
+
+    Used for the long-running lifecycle verbs whose output is the only
+    progress signal (issue #1454); quick query verbs stay on ``_limactl``'s
+    captured model.
+    """
+    progress.run(("limactl", *args))
 
 
 def shell_run(
@@ -254,11 +267,97 @@ def create_vm(
     _limactl(*args)
 
 
+_GUEST_LOG_POLL_SECS = 2.0
+_HEARTBEAT_SECS = 30.0
+
+_DURATION_RE = re.compile(r"(\d+(?:\.\d+)?)([hms])")
+
+
+def _parse_duration_secs(value: str) -> float | None:
+    """Parse a Go-style duration ('30m', '1h30m', '90s') to seconds, or None."""
+    parts = _DURATION_RE.findall(value)
+    if not parts or "".join(f"{n}{u}" for n, u in parts) != value:
+        return None
+    scale = {"h": 3600.0, "m": 60.0, "s": 1.0}
+    return sum(float(n) * scale[u] for n, u in parts)
+
+
+def _serial_dir(instance: str) -> Path:
+    return Path.home() / ".lima" / instance
+
+
+def _drain_serial_logs(serial_dir: Path, offsets: dict[Path, int]) -> None:
+    """Emit complete new lines appended to the instance's serial logs.
+
+    The serial console carries the in-guest provision output (cloud-init,
+    extra-package installs, vagrant plugin builds) that ``limactl start``
+    itself never prints. Partial trailing lines are held back until the
+    newline arrives; *offsets* tracks per-file progress between calls.
+    """
+    for path in sorted(serial_dir.glob("serial*.log")):
+        try:
+            start = offsets.get(path, 0)
+            with path.open("rb") as fh:
+                fh.seek(start)
+                chunk = fh.read()
+        except OSError:
+            continue
+        cut = chunk.rfind(b"\n")
+        if cut == -1:
+            continue
+        offsets[path] = start + cut + 1
+        for raw in chunk[: cut + 1].decode("utf-8", errors="replace").splitlines():
+            line = raw.strip()
+            if line:
+                progress.emit(f"[guest] {line}")
+
+
+def _heartbeat(elapsed: float, timeout: str, budget: float | None) -> str:
+    """One elapsed-vs-budget line, so an approaching timeout cliff is visible."""
+    if budget:
+        return f"[elapsed] {progress.format_elapsed(elapsed)} of {timeout} timeout budget"
+    return f"[elapsed] {progress.format_elapsed(elapsed)}"
+
+
+def _provision_monitor(
+    serial_dir: Path,
+    timeout: str,
+    stop: threading.Event,
+    *,
+    poll_secs: float = _GUEST_LOG_POLL_SECS,
+    heartbeat_secs: float = _HEARTBEAT_SECS,
+) -> None:
+    """Tail serial logs and emit a periodic heartbeat until *stop* is set."""
+    offsets: dict[Path, int] = {}
+    budget = _parse_duration_secs(timeout)
+    started = time.monotonic()
+    next_beat = heartbeat_secs
+    while not stop.wait(poll_secs):
+        _drain_serial_logs(serial_dir, offsets)
+        elapsed = time.monotonic() - started
+        if elapsed >= next_beat:
+            progress.emit(_heartbeat(elapsed, timeout, budget))
+            next_beat = elapsed + heartbeat_secs
+    _drain_serial_logs(serial_dir, offsets)
+
+
 def start_vm(instance: str, *, timeout: str = "30m") -> None:
+    """Start the VM, streaming limactl output and in-guest provision progress."""
     status = vm_status(instance)
     if status == "Running":
         return
-    _limactl("start", f"--timeout={timeout}", instance)
+    stop = threading.Event()
+    monitor = threading.Thread(
+        target=_provision_monitor,
+        args=(_serial_dir(instance), timeout, stop),
+        daemon=True,
+    )
+    monitor.start()
+    try:
+        _limactl_stream("start", f"--timeout={timeout}", instance)
+    finally:
+        stop.set()
+        monitor.join()
 
 
 def stop_vm(instance: str) -> None:

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -457,7 +457,9 @@ def run_pipeline(
                 results.append(result)
                 interrupted = True
                 break
-            except Exception as exc:  # noqa: BLE001 — the pipeline is the failure boundary
+            # SystemExit included: a stage calling sys.exit() is a stage
+            # failure to record and summarize, not a silent process exit.
+            except (Exception, SystemExit) as exc:  # noqa: BLE001 — the pipeline is the failure boundary
                 cause = f"{type(exc).__name__}: {exc}"
                 status: StageStatus = "warn" if stage.mode == "warn" else "failed"
                 result = StageResult(stage.name, status, time.monotonic() - start, cause)

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -468,25 +468,33 @@ class TestNestedVirtSupport:
 
 
 class TestStartStopVm:
-    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima._limactl_stream")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Stopped")
-    def test_start_calls_limactl_with_default_timeout(
+    def test_start_streams_limactl_with_default_timeout(
         self, _status: MagicMock, mock: MagicMock
     ) -> None:
         start_vm("vergil-agent")
         mock.assert_called_once_with("start", "--timeout=30m", "vergil-agent")
 
-    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima._limactl_stream")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Stopped")
     def test_start_passes_custom_timeout(self, _status: MagicMock, mock: MagicMock) -> None:
         start_vm("vergil-agent", timeout="1h")
         mock.assert_called_once_with("start", "--timeout=1h", "vergil-agent")
 
-    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima._limactl_stream")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Running")
     def test_start_skips_if_running(self, _status: MagicMock, mock: MagicMock) -> None:
         start_vm("vergil-agent")
         mock.assert_not_called()
+
+    @patch("vergil_tooling.lib.lima._limactl_stream", side_effect=RuntimeError("boom"))
+    @patch("vergil_tooling.lib.lima.vm_status", return_value="Stopped")
+    def test_start_stops_monitor_on_failure(self, _status: MagicMock, mock: MagicMock) -> None:
+        # The monitor thread must be stopped and joined even when limactl fails.
+        with pytest.raises(RuntimeError, match="boom"):
+            start_vm("vergil-agent")
+        mock.assert_called_once()
 
     @patch("vergil_tooling.lib.lima._limactl")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Running")
@@ -1255,3 +1263,160 @@ class TestVmProbe:
     def test_exec_failure_is_zeros_and_none(self, mock_shell: MagicMock) -> None:
         mock_shell.side_effect = subprocess.CalledProcessError(1, "limactl")
         assert vm_probe("inst", fingerprint=True) == (0, 0, None)
+
+
+class TestLimactlStream:
+    @patch("vergil_tooling.lib.lima.progress")
+    def test_delegates_to_progress_run(self, m_progress: MagicMock) -> None:
+        from vergil_tooling.lib.lima import _limactl_stream
+
+        _limactl_stream("start", "--timeout=30m", "vergil-agent")
+        m_progress.run.assert_called_once_with(
+            ("limactl", "start", "--timeout=30m", "vergil-agent")
+        )
+
+
+class TestParseDurationSecs:
+    def test_minutes(self) -> None:
+        from vergil_tooling.lib.lima import _parse_duration_secs
+
+        assert _parse_duration_secs("30m") == 1800
+
+    def test_compound(self) -> None:
+        from vergil_tooling.lib.lima import _parse_duration_secs
+
+        assert _parse_duration_secs("1h30m") == 5400
+
+    def test_seconds(self) -> None:
+        from vergil_tooling.lib.lima import _parse_duration_secs
+
+        assert _parse_duration_secs("90s") == 90
+
+    def test_invalid(self) -> None:
+        from vergil_tooling.lib.lima import _parse_duration_secs
+
+        assert _parse_duration_secs("soon") is None
+
+    def test_empty(self) -> None:
+        from vergil_tooling.lib.lima import _parse_duration_secs
+
+        assert _parse_duration_secs("") is None
+
+    def test_trailing_garbage(self) -> None:
+        from vergil_tooling.lib.lima import _parse_duration_secs
+
+        assert _parse_duration_secs("30mxx") is None
+
+
+class TestDrainSerialLogs:
+    def test_emits_new_complete_lines(self, tmp_path: Path) -> None:
+        from vergil_tooling.lib.lima import _drain_serial_logs
+
+        (tmp_path / "serial.log").write_bytes(b"boot one\nboot two\npartial")
+        offsets: dict[Path, int] = {}
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            _drain_serial_logs(tmp_path, offsets)
+        assert [c.args[0] for c in m_emit.call_args_list] == [
+            "[guest] boot one",
+            "[guest] boot two",
+        ]
+        # partial line held back; offset stops at the last newline
+        assert offsets[tmp_path / "serial.log"] == len(b"boot one\nboot two\n")
+
+    def test_second_drain_emits_only_appended(self, tmp_path: Path) -> None:
+        from vergil_tooling.lib.lima import _drain_serial_logs
+
+        log = tmp_path / "serial.log"
+        log.write_bytes(b"first\n")
+        offsets: dict[Path, int] = {}
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            _drain_serial_logs(tmp_path, offsets)
+            log.write_bytes(b"first\nsecond\n")
+            _drain_serial_logs(tmp_path, offsets)
+        assert [c.args[0] for c in m_emit.call_args_list] == [
+            "[guest] first",
+            "[guest] second",
+        ]
+
+    def test_no_complete_line_is_silent(self, tmp_path: Path) -> None:
+        from vergil_tooling.lib.lima import _drain_serial_logs
+
+        (tmp_path / "serial.log").write_bytes(b"no newline yet")
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            _drain_serial_logs(tmp_path, {})
+        m_emit.assert_not_called()
+
+    def test_missing_dir_is_noop(self, tmp_path: Path) -> None:
+        from vergil_tooling.lib.lima import _drain_serial_logs
+
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            _drain_serial_logs(tmp_path / "absent", {})
+        m_emit.assert_not_called()
+
+    def test_unreadable_file_is_skipped(self, tmp_path: Path) -> None:
+        from vergil_tooling.lib.lima import _drain_serial_logs
+
+        (tmp_path / "serial.log").write_bytes(b"line\n")
+        with (
+            patch("vergil_tooling.lib.lima.progress.emit") as m_emit,
+            patch.object(Path, "open", side_effect=OSError),
+        ):
+            _drain_serial_logs(tmp_path, {})
+        m_emit.assert_not_called()
+
+    def test_blank_lines_not_emitted(self, tmp_path: Path) -> None:
+        from vergil_tooling.lib.lima import _drain_serial_logs
+
+        (tmp_path / "serial.log").write_bytes(b"\r\n\nreal line\r\n")
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            _drain_serial_logs(tmp_path, {})
+        assert [c.args[0] for c in m_emit.call_args_list] == ["[guest] real line"]
+
+
+class TestHeartbeat:
+    def test_with_budget(self) -> None:
+        from vergil_tooling.lib.lima import _heartbeat
+
+        line = _heartbeat(125.0, "30m", 1800.0)
+        assert line == "[elapsed] 2m05s of 30m timeout budget"
+
+    def test_without_budget(self) -> None:
+        from vergil_tooling.lib.lima import _heartbeat
+
+        assert _heartbeat(3.0, "soon", None) == "[elapsed] 3.0s"
+
+
+class TestProvisionMonitor:
+    def test_tails_and_emits_heartbeat(self, tmp_path: Path) -> None:
+        import threading
+        import time as _time
+
+        from vergil_tooling.lib.lima import _provision_monitor
+
+        (tmp_path / "serial.log").write_bytes(b"boot line\n")
+        stop = threading.Event()
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            thread = threading.Thread(
+                target=_provision_monitor,
+                args=(tmp_path, "30m", stop),
+                kwargs={"poll_secs": 0.01, "heartbeat_secs": 0.03},
+            )
+            thread.start()
+            _time.sleep(0.2)
+            stop.set()
+            thread.join()
+        emitted = [c.args[0] for c in m_emit.call_args_list]
+        assert "[guest] boot line" in emitted
+        assert any(e.startswith("[elapsed]") for e in emitted)
+
+    def test_stop_preset_drains_once_and_exits(self, tmp_path: Path) -> None:
+        import threading
+
+        from vergil_tooling.lib.lima import _provision_monitor
+
+        (tmp_path / "serial.log").write_bytes(b"final line\n")
+        stop = threading.Event()
+        stop.set()
+        with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
+            _provision_monitor(tmp_path, "30m", stop, poll_secs=0.01, heartbeat_secs=0.03)
+        assert [c.args[0] for c in m_emit.call_args_list] == ["[guest] final line"]

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -373,6 +373,25 @@ def test_pipeline_skip_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert "audit — skipped via --skip-audit" in capsys.readouterr().out
 
 
+def _exit_one(ctx: object) -> None:
+    raise SystemExit(1)
+
+
+def test_pipeline_systemexit_is_stage_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A stage calling sys.exit() is a recorded failure, not a silent process exit."""
+    calls: list[str] = []
+    stages = [
+        Stage("bad", _exit_one, mode="fail_defer"),
+        Stage("after", lambda ctx: calls.append("after"), mode="fail_defer"),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 1
+    assert calls == ["after"]
+    out = capsys.readouterr().out
+    assert "bad — SystemExit: 1" in out
+
+
 def _interrupt(ctx: object) -> None:
     raise KeyboardInterrupt
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1990,9 +1990,7 @@ class TestRunLifecycle:
         template = tmp_path / "template.yaml"
         template.write_text("cpus: 4")
         state = _LifecycleState(target=_lifecycle_target(tmp_path), template=template)
-        rc = _run_lifecycle(
-            "create", state, [Stage("bad", _boom, mode="fail_fast")], self._args()
-        )
+        rc = _run_lifecycle("create", state, [Stage("bad", _boom, mode="fail_fast")], self._args())
         assert rc == 1
         assert not template.exists()
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import textwrap
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,7 @@ from vergil_tooling.bin.vrg_vm import (
     DedicatedRow,
     Target,
     _list_rows,
+    _log_root,
     _preflight_target,
     _probe_running,
     _resolve_target,
@@ -25,8 +27,19 @@ from vergil_tooling.lib.identity import Identity, IdentityConfig
 from vergil_tooling.lib.vm_spec import ComposedSpec
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Iterator
     from typing import Any
+
+# Bound at import time, before the autouse _vm_log_root fixture patches the
+# module attribute — TestLogRoot exercises the real implementation.
+_REAL_LOG_ROOT = _log_root
+
+
+@pytest.fixture(autouse=True)
+def _vm_log_root(tmp_path: Path) -> Iterator[None]:
+    """Keep pipeline run logs out of the real repo's .vergil directory."""
+    with patch("vergil_tooling.bin.vrg_vm._log_root", return_value=tmp_path):
+        yield
 
 
 @pytest.fixture()
@@ -292,7 +305,7 @@ class TestCreate:
 
 class TestStart:
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
@@ -315,7 +328,7 @@ class TestStart:
         mock_copy.assert_called_once()
 
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
@@ -342,7 +355,7 @@ class TestStart:
 
 class TestStartStaleness:
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
@@ -365,7 +378,7 @@ class TestStartStaleness:
         assert "--allow-stale-vm" in captured.err
 
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
@@ -385,7 +398,7 @@ class TestStartStaleness:
         mock_start.assert_called_once()
 
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
@@ -405,7 +418,7 @@ class TestStartStaleness:
         mock_start.assert_called_once()
 
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
@@ -424,7 +437,7 @@ class TestStartStaleness:
         mock_update.assert_called_once()
 
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
@@ -1859,3 +1872,165 @@ class TestProbeRunning:
         discovered: dict[str, list[DedicatedRow]] = {"vergil-user": []}
         with pytest.raises(RuntimeError, match="boom"):
             _probe_running(identities, discovered, {"vergil-user": "Running"})
+
+
+def _lifecycle_target(tmp_path: Path) -> Any:
+    from vergil_tooling.lib.identity import load_config
+    from vergil_tooling.lib.vm_spec import compose_vm_spec
+
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        default_identity = "vergil"
+        vergil = "v2.0"
+
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        projects_dir = "/home/user/projects"
+    """)
+    )
+    config = load_config(p)
+    identity = config.identities["vergil"]
+    spec = compose_vm_spec(
+        identity="vergil",
+        base={"cpus": 4, "memory": "4GiB", "disk": "50GiB"},
+        stanza=None,
+        override=None,
+    )
+    return Target("vergil", identity, config, None, None, spec, "vergil-agent", "")
+
+
+class TestLifecycleStages:
+    def test_create_stage_order_and_modes(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _create_stages
+
+        stages = _create_stages()
+        assert [s.name for s in stages] == [
+            "fetch-template",
+            "create",
+            "start",
+            "link-config",
+            "credentials",
+            "tooling",
+        ]
+        assert all(s.mode == "fail_fast" for s in stages)
+
+    def test_start_stage_order_and_modes(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _start_stages
+
+        stages = _start_stages()
+        assert [s.name for s in stages] == [
+            "start",
+            "credentials",
+            "copy-config",
+            "update-tooling",
+        ]
+        assert stages[-1].mode == "warn"
+        assert all(s.mode == "fail_fast" for s in stages[:-1])
+
+    def test_rebuild_stage_order_and_modes(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _rebuild_stages
+
+        stages = _rebuild_stages()
+        assert [s.name for s in stages] == [
+            "destroy",
+            "fetch-template",
+            "create",
+            "start",
+            "credentials",
+            "tooling",
+            "copy-config",
+        ]
+        assert all(s.mode == "fail_fast" for s in stages)
+
+    def test_st_create_requires_template(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _LifecycleState, _st_create
+
+        state = _LifecycleState(target=_lifecycle_target(tmp_path))
+        with pytest.raises(RuntimeError, match="fetch-template did not run"):
+            _st_create(state)
+
+    def test_st_update_tooling_resolves_fallback(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _LifecycleState, _st_update_tooling
+
+        state = _LifecycleState(target=_lifecycle_target(tmp_path))
+        with patch("vergil_tooling.bin.vrg_vm.update_tooling") as m_update:
+            _st_update_tooling(state)
+        m_update.assert_called_once_with("vergil-agent", fallback_tag="v2.0")
+
+
+class TestRunLifecycle:
+    def _args(self) -> argparse.Namespace:
+        return argparse.Namespace(output_window=5, output_format="plain")
+
+    def test_cleans_up_template_on_success(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _LifecycleState, _run_lifecycle
+        from vergil_tooling.lib.progress import Stage
+
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        state = _LifecycleState(target=_lifecycle_target(tmp_path), template=template)
+        rc = _run_lifecycle(
+            "create",
+            state,
+            [Stage("noop", lambda ctx: None, mode="fail_fast")],
+            self._args(),
+        )
+        assert rc == 0
+        assert not template.exists()
+
+    def test_cleans_up_template_on_failure(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _LifecycleState, _run_lifecycle
+        from vergil_tooling.lib.progress import Stage
+
+        def _boom(ctx: object) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        state = _LifecycleState(target=_lifecycle_target(tmp_path), template=template)
+        rc = _run_lifecycle(
+            "create", state, [Stage("bad", _boom, mode="fail_fast")], self._args()
+        )
+        assert rc == 1
+        assert not template.exists()
+
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch(
+        "vergil_tooling.bin.vrg_vm.update_tooling",
+        side_effect=RuntimeError("update failed"),
+    )
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_update_failure_is_warning_not_error(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        _start: MagicMock,
+        _inject: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # warn-mode stage: a failed tooling update must not fail the start.
+        result = main(["start", "--config", str(config_file), "--output-format", "plain"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "⚠  warnings (non-fatal):" in out
+        assert "update-tooling — RuntimeError: update failed" in out
+
+
+class TestLogRoot:
+    def test_inside_repo_uses_toplevel(self, tmp_path: Path) -> None:
+        completed = MagicMock(returncode=0, stdout=f"{tmp_path}\n")
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run", return_value=completed):
+            assert _REAL_LOG_ROOT() == tmp_path
+
+    def test_outside_repo_falls_back_to_home(self) -> None:
+        completed = MagicMock(returncode=128, stdout="")
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run", return_value=completed):
+            assert _REAL_LOG_ROOT() == Path.home()


### PR DESCRIPTION
# Pull Request

## Summary

- Ports `vrg-vm create` / `rebuild` / `start` onto the #1419 progress
framework and fixes the silence during long provisions.

- **Stage pipelines:** the three lifecycle commands become declarative
  `Stage` lists run by `run_pipeline` (create: fetch-template → create
  → start → link-config → credentials → tooling; rebuild adds destroy
  up front and copy-config at the end; start: start → credentials →
  copy-config → update-tooling). All stages are fail_fast except
  start's update-tooling, which is a warn-mode stage preserving
  `try_update_tooling`'s warn-and-continue contract.
- **`limactl start` streams** through `progress.run` instead of being
  captured (`_limactl_stream`); quick query verbs keep the captured
  model.
- **In-guest provision visibility:** a monitor thread tails the
  host-side serial logs (`~/.lima/<instance>/serial*.log`) during the
  start stage, emitting `[guest]` lines into the rolling window and
  run log, plus a periodic `[elapsed] … of <timeout> timeout budget`
  heartbeat so an approaching 30-minute cliff is visible.
- **Run log:** every create/rebuild/start writes
  `.vergil/vrg-vm-*.log` (enclosing repo, else `~/.vergil` since
  vrg-vm is host-scoped), so a failed provision is diagnosable
  without re-running.
- **Framework fix:** `run_pipeline` now records `SystemExit` from a
  stage as a stage failure — lima helpers signal fatal errors with
  `SystemExit`, which previously would have bypassed the summary.

Full suite green (2,412 tests, 100% coverage);
`vrg-container-run -- uv run vrg-validate` passes end-to-end.

## Issue Linkage

- Ref #1454

## Notes

- stop/restart/update/destroy/list/session are untouched — they are
quick commands per the #1419 scope rule. The serial-log tail covers
the cloud-init/extra-package/vagrant-plugin output named in the
issue's motivating case without requiring SSH to be up.
