### PR TITLE
fix(vrg-submit-pr): template mode bypasses ALLOWED_LINKAGES validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,12 @@ Identity-aware tools (`vrg-git`, `vrg-gh`, `vrg-submit-pr`) read
 finalization are human actions. The PR handoff is:
 
 1. The agent writes `.vergil/pr-template.yml` with `issue`, `title`,
-   and `summary` fields (optional: `linkage`, `notes`).
+   and `summary` fields (optional: `linkage`, `notes`). If `linkage`
+   is present it must be `Ref` — GitHub auto-close keywords
+   (`Closes`/`Fixes`/`Resolves`) are banned repo-wide because issues
+   stay open until post-merge workflows succeed. Both
+   `pr_template.write_template()` and `vrg-submit-pr` reject any
+   other value.
 2. The human runs `vrg-submit-pr` with no arguments, which reads the
    template, previews the PR, and submits after confirmation.
 3. The human merges and runs post-merge cleanup (`vrg-finalize-pr`).

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -26,8 +26,8 @@ import tempfile
 from pathlib import Path
 
 from vergil_tooling.lib import git, github, identity_mode, pr_template, worktrees
+from vergil_tooling.lib.linkage import ALLOWED_LINKAGES
 
-ALLOWED_LINKAGES = ("Ref",)
 _ISSUE_PLAIN_RE = re.compile(r"^[1-9]\d*$")
 _ISSUE_CROSS_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[1-9]\d*$")
 
@@ -194,6 +194,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
         os.chdir(wt_path)
         root = wt_path
 
+    template_path = root / ".vergil" / "pr-template.yml"
     try:
         fields = pr_template.read_template(root)
     except FileNotFoundError:
@@ -204,6 +205,9 @@ def _run_template_mode(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+    except pr_template.TemplateError as exc:
+        print(f"vrg-submit-pr: invalid PR template at {template_path}:\n  {exc}", file=sys.stderr)
+        return 1
 
     issue_ref = _resolve_issue_ref(fields["issue"])
     branch = git.current_branch()
@@ -211,6 +215,17 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     title = fields["title"]
     linkage = fields.get("linkage", "Ref")
     notes = fields.get("notes", "")
+
+    # Belt-and-suspenders: read_template validates linkage, but guard the
+    # value used to build the PR body so a forbidden auto-close keyword can
+    # never reach the PR regardless of how the fields were obtained.
+    if linkage not in ALLOWED_LINKAGES:
+        print(
+            f"vrg-submit-pr: linkage '{linkage}' in {template_path} is not allowed; "
+            f"use: {', '.join(ALLOWED_LINKAGES)}.",
+            file=sys.stderr,
+        )
+        return 1
     pr_body = _build_pr_body(
         summary=fields["summary"],
         linkage=linkage,

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -8,6 +8,11 @@ from __future__ import annotations
 
 import re
 
+# The only linkage keywords allowed in PR bodies and templates.
+# Auto-close keywords (Closes/Fixes/Resolves) are banned repo-wide —
+# issues stay open until post-merge workflows succeed.
+ALLOWED_LINKAGES = ("Ref",)
+
 LINKAGE_RE = re.compile(
     r"^\s*[-*]?\s*Ref:?\s+"
     r"([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#([0-9]+)",

--- a/src/vergil_tooling/lib/pr_template.py
+++ b/src/vergil_tooling/lib/pr_template.py
@@ -11,6 +11,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.await_file import atomic_write
+from vergil_tooling.lib.linkage import ALLOWED_LINKAGES
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -21,7 +22,19 @@ _REQUIRED_FIELDS = ("issue", "title", "summary")
 
 
 class TemplateError(Exception):
-    """Raised when a template file is malformed or missing required fields."""
+    """Raised when a template file is malformed or carries invalid field values."""
+
+
+def _validate_linkage(linkage: str) -> None:
+    """Raise ``TemplateError`` if the linkage keyword is not allowed."""
+    if linkage not in ALLOWED_LINKAGES:
+        allowed = ", ".join(ALLOWED_LINKAGES)
+        msg = (
+            f"PR template linkage '{linkage}' is not allowed; use: {allowed}. "
+            "GitHub auto-close keywords (Closes/Fixes/Resolves) are banned "
+            "repo-wide — issues stay open until post-merge workflows succeed."
+        )
+        raise TemplateError(msg)
 
 
 def _parse(text: str) -> dict[str, str]:
@@ -65,7 +78,8 @@ def read_template(worktree_root: Path) -> dict[str, str]:
     """Read and validate ``.vergil/pr-template.yml``.
 
     Raises ``FileNotFoundError`` if the file does not exist.
-    Raises ``TemplateError`` if required fields are missing.
+    Raises ``TemplateError`` if required fields are missing or the
+    linkage keyword is not allowed.
     """
     path = _template_path(worktree_root)
     if not path.exists():
@@ -76,6 +90,8 @@ def read_template(worktree_root: Path) -> dict[str, str]:
         if field not in fields:
             msg = f"PR template is missing required field: {field}"
             raise TemplateError(msg)
+    if "linkage" in fields:
+        _validate_linkage(fields["linkage"])
     return fields
 
 
@@ -88,7 +104,13 @@ def write_template(
     linkage: str = "Ref",
     notes: str = "",
 ) -> Path:
-    """Write ``.vergil/pr-template.yml``, warning if it already exists."""
+    """Write ``.vergil/pr-template.yml``, warning if it already exists.
+
+    Raises ``TemplateError`` if the linkage keyword is not allowed —
+    the producer fails loudly before a forbidden auto-close linkage
+    can reach the template file.
+    """
+    _validate_linkage(linkage)
     path = _template_path(worktree_root)
     if path.exists():
         print(

--- a/tests/vergil_tooling/test_pr_template.py
+++ b/tests/vergil_tooling/test_pr_template.py
@@ -93,6 +93,39 @@ class TestParseAndRead:
             read_template(tmp_path)
 
 
+class TestLinkageValidation:
+    @pytest.mark.parametrize("forbidden", ["Closes", "Fixes", "Resolves", "closes", "ref"])
+    def test_read_rejects_forbidden_linkage(self, tmp_path: Path, forbidden: str) -> None:
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text(
+            f"issue: 42\ntitle: fix\nsummary: Fix\nlinkage: {forbidden}\n"
+        )
+        with pytest.raises(TemplateError, match="linkage"):
+            read_template(tmp_path)
+
+    def test_read_error_names_allowed_value(self, tmp_path: Path) -> None:
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text(
+            "issue: 42\ntitle: fix\nsummary: Fix\nlinkage: Closes\n"
+        )
+        with pytest.raises(TemplateError, match="Ref"):
+            read_template(tmp_path)
+
+    def test_read_accepts_absent_linkage(self, tmp_path: Path) -> None:
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text("issue: 42\ntitle: fix\nsummary: Fix\n")
+        result = read_template(tmp_path)
+        assert "linkage" not in result
+
+    def test_write_rejects_forbidden_linkage(self, tmp_path: Path) -> None:
+        with pytest.raises(TemplateError, match="linkage"):
+            write_template(tmp_path, issue="42", title="fix", summary="Fix", linkage="Closes")
+        assert not (tmp_path / ".vergil" / "pr-template.yml").exists()
+
+
 class TestWriteTemplate:
     def test_creates_vergil_dir_and_file(self, tmp_path: Path) -> None:
         path = write_template(tmp_path, issue="42", title="fix: bug", summary="Fix the bug")

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -395,6 +395,40 @@ class TestTemplateMode:
         assert result == 0
         assert "/vergil:pr-watch https://github.com/pr/7" in capsys.readouterr().out
 
+    def test_template_rejects_forbidden_linkage(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text(
+            "issue: 42\ntitle: fix\nsummary: Fix\nlinkage: Closes\n"
+        )
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        ):
+            result = main([])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "pr-template.yml" in err
+        assert "Ref" in err
+
+    def test_template_belt_and_suspenders_linkage_check(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Even if read_template returns a bad linkage, template mode rejects it."""
+        fields = {"issue": "42", "title": "fix", "summary": "Fix", "linkage": "Closes"}
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".pr_template.read_template", return_value=fields),
+        ):
+            result = main([])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "linkage" in err.lower()
+        assert "Ref" in err
+
     def test_template_aborts_on_decline(self, tmp_path: Path) -> None:
         vergil = tmp_path / ".vergil"
         vergil.mkdir()


### PR DESCRIPTION
# Pull Request

## Summary

- Validate PR-template linkage at producer, consumer, and submit layers so forbidden auto-close keywords fail loudly before PR creation

## Issue Linkage

- Ref #1458

## Notes

- ALLOWED_LINKAGES moved to lib/linkage.py as the shared source of truth.
read_template()/write_template() raise TemplateError with remediation;
_run_template_mode reports the template path and re-checks the body value.
CLAUDE.md PR-handoff section now documents that linkage must be Ref.