### PR TITLE
feat(progress): auto-size the RichRenderer rolling window to terminal height

### DIFF
--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -32,6 +32,14 @@ if TYPE_CHECKING:
 LOG_RETAIN = 20
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
+# Auto-sized rolling window (--output-window omitted): the visible tail is
+# computed per render from the live terminal height. The cap bounds redraw
+# churn on very tall terminals; the margin leaves headroom for the summary
+# line and shell prompt; the floor keeps degenerate terminals usable.
+AUTO_WINDOW_CAP = 40
+AUTO_WINDOW_MARGIN = 2
+AUTO_WINDOW_FLOOR = 3
+
 StageMode = Literal["warn", "fail_defer", "fail_fast"]
 StageStatus = Literal["ok", "warn", "failed", "skipped", "interrupted"]
 
@@ -223,22 +231,51 @@ _STATUS_STYLES: dict[str, str] = {
 
 class RichRenderer:
     """Live TTY display: completed stages collapse to one line, the active stage
-    shows a spinner plus a rolling window of its last N output lines."""
+    shows a spinner plus a rolling window of its last N output lines.
 
-    def __init__(self, out: IO[str], window: int, *, force_terminal: bool | None = None) -> None:
-        self._console = Console(file=out, highlight=False, force_terminal=force_terminal)
+    ``window=None`` (the default) auto-sizes the window to the terminal:
+    each render shows as many tail lines as fit the current console height
+    after the completed-stage lines and spinner, clamped to
+    [AUTO_WINDOW_FLOOR, AUTO_WINDOW_CAP]. Querying ``console.size`` per
+    render makes the window resize-aware."""
+
+    def __init__(
+        self,
+        out: IO[str],
+        window: int | None,
+        *,
+        force_terminal: bool | None = None,
+        width: int | None = None,
+        height: int | None = None,
+    ) -> None:
+        self._console = Console(
+            file=out, highlight=False, force_terminal=force_terminal, width=width, height=height
+        )
         self._window = window
         self._completed: list[Text] = []
-        self._tail: deque[str] = deque(maxlen=window if window > 0 else 1)
+        # In auto mode the visible slice never exceeds the cap, so buffering
+        # more than AUTO_WINDOW_CAP lines is pointless.
+        maxlen = AUTO_WINDOW_CAP if window is None else window if window > 0 else 1
+        self._tail: deque[str] = deque(maxlen=maxlen)
         self._active: str | None = None
         self._live = Live(console=self._console, refresh_per_second=8)
         self._live.start()
+
+    def _visible_window(self) -> int:
+        """Tail size for auto mode, computed from the live terminal height."""
+        available = (
+            self._console.size.height - len(self._completed) - 1 - AUTO_WINDOW_MARGIN
+        )  # − 1 for the spinner line
+        return max(AUTO_WINDOW_FLOOR, min(AUTO_WINDOW_CAP, available))
 
     def _renderable(self) -> Group:
         parts: list[Text | Spinner] = list(self._completed)
         if self._active is not None:
             parts.append(Spinner("dots", text=Text(f" {self._active}")))
-            if self._window > 0:
+            if self._window is None:
+                visible = list(self._tail)[-self._visible_window() :]
+                parts.extend(Text.from_ansi(f"   {line}", style="dim") for line in visible)
+            elif self._window > 0:
                 parts.extend(Text.from_ansi(f"   {line}", style="dim") for line in self._tail)
         return Group(*parts)
 
@@ -376,9 +413,13 @@ def add_progress_args(parser: argparse.ArgumentParser, stages: Sequence[Stage]) 
     parser.add_argument(
         "--output-window",
         type=int,
-        default=5,
+        default=None,
         metavar="N",
-        help="Rolling window size for the TTY renderer. 0 = full stream then collapse.",
+        help=(
+            "Rolling window size for the TTY renderer. Default: auto-size to the "
+            f"terminal height (max {AUTO_WINDOW_CAP} lines, resize-aware). "
+            "N = fixed window. 0 = full stream then collapse."
+        ),
     )
     parser.add_argument(
         "--output-format",
@@ -399,7 +440,7 @@ def add_progress_args(parser: argparse.ArgumentParser, stages: Sequence[Stage]) 
             )
 
 
-def _make_renderer(fmt: str, out: IO[str], window: int) -> Any:
+def _make_renderer(fmt: str, out: IO[str], window: int | None) -> Any:
     if fmt == "rich":
         return RichRenderer(out, window)
     if fmt == "gha":

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rich.spinner import Spinner
+from rich.text import Text
 
 from vergil_tooling.lib import progress
 from vergil_tooling.lib.progress import PipelineError, Stage, StageResult
@@ -204,6 +206,73 @@ def test_rich_renderer_window_zero_streams() -> None:
     r.summary("S")
     r.close()
     assert "streamed line" in out.getvalue()
+
+
+def _auto_renderer(height: int) -> progress.RichRenderer:
+    out = io.StringIO()
+    return progress.RichRenderer(out, window=None, force_terminal=True, width=80, height=height)
+
+
+def _rendered_tail_lines(r: progress.RichRenderer) -> list[str]:
+    """Extract the dim tail lines from the current renderable (after the spinner)."""
+    parts = list(r._renderable().renderables)
+    spinner_idx = next(i for i, p in enumerate(parts) if isinstance(p, Spinner))
+    return [part.plain for part in parts[spinner_idx + 1 :] if isinstance(part, Text)]
+
+
+def test_rich_renderer_auto_window_caps_on_tall_terminal() -> None:
+    r = _auto_renderer(height=100)
+    r.start_stage("build")
+    for i in range(progress.AUTO_WINDOW_CAP + 20):
+        r.stage_line(f"line {i}")
+    tail = _rendered_tail_lines(r)
+    assert len(tail) == progress.AUTO_WINDOW_CAP
+    # most recent lines, not the oldest
+    assert tail[-1].strip() == f"line {progress.AUTO_WINDOW_CAP + 19}"
+    r.close()
+
+
+def test_rich_renderer_auto_window_fits_short_terminal() -> None:
+    r = _auto_renderer(height=24)
+    for name in ("one", "two", "three"):
+        r.end_stage(StageResult(name, "ok", 1.0))
+    r.start_stage("build")
+    for i in range(50):
+        r.stage_line(f"line {i}")
+    # height − completed(3) − spinner(1) − margin = visible
+    expected = 24 - 3 - 1 - progress.AUTO_WINDOW_MARGIN
+    assert len(_rendered_tail_lines(r)) == expected
+    r.close()
+
+
+def test_rich_renderer_auto_window_shrinks_as_stages_complete() -> None:
+    r = _auto_renderer(height=24)
+    r.start_stage("first")
+    for i in range(50):
+        r.stage_line(f"line {i}")
+    before = len(_rendered_tail_lines(r))
+    r.end_stage(StageResult("first", "ok", 1.0))
+    r.start_stage("second")
+    for i in range(50):
+        r.stage_line(f"line {i}")
+    after = len(_rendered_tail_lines(r))
+    assert after == before - 1
+    r.close()
+
+
+def test_rich_renderer_auto_window_floor_on_degenerate_terminal() -> None:
+    r = _auto_renderer(height=4)
+    r.start_stage("build")
+    for i in range(50):
+        r.stage_line(f"line {i}")
+    assert len(_rendered_tail_lines(r)) == progress.AUTO_WINDOW_FLOOR
+    r.close()
+
+
+def test_rich_renderer_auto_buffers_only_up_to_cap() -> None:
+    r = _auto_renderer(height=100)
+    assert r._tail.maxlen == progress.AUTO_WINDOW_CAP
+    r.close()
 
 
 class _FakeRenderer:
@@ -426,7 +495,7 @@ def test_add_progress_args_generates_flags() -> None:
     assert args.output_format is None
     args = parser.parse_args([])
     assert args.skip_audit is False
-    assert args.output_window == 5
+    assert args.output_window is None  # auto-size to terminal height
 
 
 def test_add_progress_args_rejects_skip_on_non_fail_fast() -> None:
@@ -460,6 +529,9 @@ def test_make_renderer_selects_by_format() -> None:
     rich_renderer = progress._make_renderer("rich", out, 5)
     assert isinstance(rich_renderer, progress.RichRenderer)
     rich_renderer.close()
+    auto_renderer = progress._make_renderer("rich", out, None)
+    assert isinstance(auto_renderer, progress.RichRenderer)
+    auto_renderer.close()
     assert isinstance(progress._make_renderer("gha", out, 5), progress.GhaRenderer)
     plain = progress._make_renderer("plain", out, 5)
     assert isinstance(plain, progress.PlainRenderer)

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -48,7 +48,7 @@ def test_parse_args_has_progress_flags() -> None:
 def test_parse_args_default_skip_audit() -> None:
     args = parse_args([])
     assert args.skip_audit is False
-    assert args.output_window == 5
+    assert args.output_window is None  # auto-size to terminal height
     assert args.output_format is None
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Default --output-window becomes auto: per-render visible tail computed from console height, clamped to [3, 40], resize-aware; explicit N and 0 behavior unchanged.

## Issue Linkage

- Ref #1461

## Notes

- Constants AUTO_WINDOW_CAP=40, AUTO_WINDOW_MARGIN=2, AUTO_WINDOW_FLOOR=3 per the issue design. RichRenderer gains width/height kwargs so tests can pin the console size.