### PR TITLE
fix(release): unblock close-finalize by making the release cleanup path non-interactive

### DIFF
--- a/docs/site/docs/reference/dev/finalize-pr.md
+++ b/docs/site/docs/reference/dev/finalize-pr.md
@@ -5,18 +5,23 @@
 **Source:** `src/vergil_tooling/bin/vrg_finalize_pr.py`
 
 Finalizes a pull request and reconciles local state afterwards. Has
-two modes, keyed on whether a PR argument is given:
+three modes:
 
 - **`vrg-finalize-pr <PR>`** — runs the pre-merge provenance check,
   waits for checks to go green, merges the PR (or confirms it is
   already merged), then runs the cleanup below. This replaces a
   manual web merge followed by a separate cleanup step.
-- **`vrg-finalize-pr`** (no PR) — infers the PR from the
+- **`vrg-finalize-pr`** (no PR) — interactive: infers the PR from the
   `.worktrees/` worktrees and always confirms before acting (see
   *Choosing the PR* below). With no candidates, cleanup-only after
   confirmation: switch to the target branch, fast-forward pull,
   delete merged local branches, and prune stale remote-tracking
   references.
+- **`vrg-finalize-pr --cleanup-only`** — non-interactive release path:
+  skips inference and merge entirely, never reads stdin, and runs only
+  the cleanup. This is what `vrg-release` invokes during its
+  close-finalize phase (issue #1448). Mutually exclusive with a PR
+  argument.
 
 Must be run from the **main worktree** — the cleanup removes
 worktrees, which is unsafe when the calling shell's CWD is inside one.
@@ -32,7 +37,11 @@ worktrees, which is unsafe when the calling shell's CWD is inside one.
   several present a menu; none asks before running cleanup-only.
   Worktrees without an open PR are listed with the reason they were
   skipped. Inference mode requires an interactive terminal and fails
-  fast when stdin is not a TTY.
+  fast unless both stdin and stdout are TTYs — a captured stdout would
+  make the prompts invisible (issue #1448).
+- `vrg-finalize-pr --cleanup-only` — no prompts and no merge; the
+  scriptable path for callers (like `vrg-release`) that only want the
+  cleanup.
 
 ## Waiting for green
 
@@ -50,7 +59,8 @@ followed by the usual sweep, pull, and prune.
 ## Usage
 
 ```bash
-vrg-finalize-pr [PR] [--target-branch BRANCH] [--strategy {merge,squash,rebase}]
+vrg-finalize-pr [PR | --cleanup-only] [--target-branch BRANCH]
+                [--strategy {merge,squash,rebase}]
                 [--allow-provenance-violation] [--dry-run]
 ```
 
@@ -58,7 +68,8 @@ vrg-finalize-pr [PR] [--target-branch BRANCH] [--strategy {merge,squash,rebase}]
 
 | Argument | Description |
 | -------- | ----------- |
-| `PR` | PR number or URL to merge and finalize. Omit for cleanup-only (release path). |
+| `PR` | PR number or URL to merge and finalize. Omit to infer interactively. |
+| `--cleanup-only` | Skip PR inference and merge; run cleanup without prompting or reading stdin (non-interactive release path). Mutually exclusive with `PR`. |
 | `--target-branch` | Branch to switch to (default: `develop`) |
 | `--strategy` | Merge strategy when a PR is given (default: `squash`) |
 | `--allow-provenance-violation` | Proceed despite provenance violations (conscious human override) |
@@ -152,4 +163,4 @@ silently (issue #303).
 | Code | Meaning |
 | ---- | ------- |
 | 0 | Finalization complete, or declined at a confirmation prompt |
-| 1 | Provenance violation, unmergeable PR (draft, conflicts, failed checks, stuck behind), not run from main worktree, non-interactive stdin in inference mode, dirty working tree, failed validation, or failed CD run |
+| 1 | Provenance violation, unmergeable PR (draft, conflicts, failed checks, stuck behind), not run from main worktree, non-TTY stdin or stdout in inference mode, dirty working tree, failed validation, or failed CD run |

--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -1,13 +1,18 @@
 """Finalize a pull request: provenance check, merge, and cleanup.
 
-Two modes, keyed on whether a PR argument is given:
+Three modes:
 
 - ``vrg-finalize-pr <PR>`` — run the pre-merge provenance check, merge
   the PR (or confirm it is already merged), then run the cleanup below.
   This replaces the manual web merge + post-merge repo cleanup.
-- ``vrg-finalize-pr`` (no PR) — cleanup only, the backward-compatible
-  release path: switch to the target branch, fast-forward pull, delete
+- ``vrg-finalize-pr`` (no PR) — interactive: infer which PR to finalize
+  from open PRs in ``.worktrees/`` worktrees, confirm via prompts, then
+  run the cleanup. Requires a real terminal on both stdin and stdout.
+- ``vrg-finalize-pr --cleanup-only`` — non-interactive release path:
+  skip inference and merge entirely, never read stdin, and run only the
+  cleanup: switch to the target branch, fast-forward pull, delete
   merged local branches, and prune stale remote-tracking references.
+  This is what ``vrg-release`` invokes (issue #1448).
 
 After validation succeeds, also checks the most recent CD workflow run
 on the target branch and fails if it did not succeed (issue #303 — docs
@@ -38,11 +43,20 @@ _ETERNAL_BY_MODEL: dict[str, list[str]] = {
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Finalize a pull request.")
-    parser.add_argument(
+    # A PR argument and --cleanup-only contradict each other: the flag
+    # promises no merge and no prompts, the argument requests a merge.
+    target = parser.add_mutually_exclusive_group()
+    target.add_argument(
         "pr",
         nargs="?",
         default=None,
-        help="PR number or URL to merge and finalize. Omit for cleanup-only (release path).",
+        help="PR number or URL to merge and finalize. Omit to infer interactively.",
+    )
+    target.add_argument(
+        "--cleanup-only",
+        action="store_true",
+        help="Skip PR inference and merge; run cleanup without prompting "
+        "or reading stdin (non-interactive release path).",
     )
     parser.add_argument("--target-branch", default="develop", help="Target branch to switch to")
     parser.add_argument(
@@ -281,7 +295,10 @@ def main(argv: list[str] | None = None) -> int:
 
     root = git.repo_root()
 
-    if args.pr is None:
+    # --cleanup-only is the scriptable release path: no inference, no
+    # prompts, no stdin reads — args.pr stays None and only the cleanup
+    # below runs (issue #1448).
+    if args.pr is None and not args.cleanup_only:
         try:
             args.pr = _infer_pr(root, args.target_branch)
         except SystemExit as exc:

--- a/src/vergil_tooling/lib/release/finalize.py
+++ b/src/vergil_tooling/lib/release/finalize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.release.context import ReleaseError
@@ -19,20 +20,27 @@ def close_and_finalize(ctx: ReleaseContext) -> None:
     print("Tracking issue closed.")
 
     print("Running vrg-finalize-pr...")
+    # --cleanup-only is the non-interactive release path: no PR
+    # inference, no prompts (issue #1448). stdout is inherited so the
+    # slow finalize phases (validation takes ~a minute) stream live;
+    # stdin is closed so the child can never block on a terminal read;
+    # stderr is captured for ReleaseError.detail and replayed below so
+    # warnings are never silently swallowed.
     result = subprocess.run(  # noqa: S603
-        ("vrg-finalize-pr",),  # noqa: S607
+        ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
         check=False,
-        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
         text=True,
     )
-    if result.stdout:
-        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
     if result.returncode != 0:
         raise ReleaseError(
             phase="close-finalize",
-            command="vrg-finalize-pr",
+            command="vrg-finalize-pr --cleanup-only",
             message="vrg-finalize-pr failed.",
-            detail=result.stderr or result.stdout,
+            detail=result.stderr,
         )
     print("Finalization complete.")
 

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -60,13 +60,18 @@ def worktree_for_branch(branch: str, repo_root: Path) -> Path | None:
 
 
 def require_tty(context: str) -> None:
-    """Fail fast when an interactive prompt would read from non-TTY stdin.
+    """Fail fast when an interactive prompt cannot reach the human.
 
     These tools are human touch points by design: a human is assumed to
     be present, and EOF-as-default would be a silent failure. Scripted
     use is served by explicit arguments, not by piping into prompts.
+
+    Both stdin and stdout must be terminals: a non-TTY stdin means the
+    answer cannot be typed; a non-TTY stdout means the prompt text is
+    written into a pipe the human never sees — the prompt blocks
+    invisibly instead of failing fast (issue #1448).
     """
-    if not sys.stdin.isatty():
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
         msg = (
             f"{context} requires an interactive terminal.\n"
             "  Pass the target explicitly to run non-interactively."

--- a/tests/vergil_tooling/test_release_finalize.py
+++ b/tests/vergil_tooling/test_release_finalize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import patch
@@ -43,16 +44,43 @@ def test_close_and_finalize_succeeds() -> None:
     mock_close.assert_called_once()
 
 
-def test_close_and_finalize_prints_stdout() -> None:
+def test_close_and_finalize_streams_cleanup_only() -> None:
+    """Issue #1448: invoke the non-interactive flag, stream stdout to the
+    user, never hand the child the TTY stdin, and capture only stderr
+    (for ReleaseError.detail)."""
     ctx = _ctx()
     with (
         patch(_MOD + ".close_tracking_issue"),
         patch(
             _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stdout="cleaned up"),
+            return_value=CompletedProcess(args=(), returncode=0, stderr=""),
+        ) as run,
+    ):
+        close_and_finalize(ctx)
+    (cmd,) = run.call_args.args
+    assert cmd == ("vrg-finalize-pr", "--cleanup-only")
+    kwargs = run.call_args.kwargs
+    assert "capture_output" not in kwargs
+    assert "stdout" not in kwargs  # stdout streams to the user
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["stderr"] == subprocess.PIPE
+
+
+def test_close_and_finalize_relays_child_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Captured child stderr is replayed on success so warnings are
+    never silently swallowed."""
+    ctx = _ctx()
+    with (
+        patch(_MOD + ".close_tracking_issue"),
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(args=(), returncode=0, stderr="WARNING: x"),
         ),
     ):
         close_and_finalize(ctx)
+    assert "WARNING: x" in capsys.readouterr().err
 
 
 def test_build_summary_omits_none_fields() -> None:
@@ -91,6 +119,7 @@ def test_close_and_finalize_fails_on_finalize_error() -> None:
             _MOD + ".subprocess.run",
             return_value=CompletedProcess(args=(), returncode=1, stderr="validation failed"),
         ),
-        pytest.raises(ReleaseError, match="vrg-finalize-pr"),
+        pytest.raises(ReleaseError, match="vrg-finalize-pr") as excinfo,
     ):
         close_and_finalize(ctx)
+    assert excinfo.value.detail == "validation failed"

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -938,6 +938,50 @@ def test_explicit_pr_skips_inference_and_prompts() -> None:
     fin.assert_called_once()
 
 
+# -- --cleanup-only: non-interactive release path (issue #1448) ----------------
+
+
+def test_parse_args_cleanup_only_defaults_false() -> None:
+    assert parse_args([]).cleanup_only is False
+
+
+def test_parse_args_cleanup_only_flag() -> None:
+    assert parse_args(["--cleanup-only"]).cleanup_only is True
+
+
+def test_cleanup_only_rejects_pr_argument(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A PR argument and --cleanup-only contradict each other: the flag
+    promises no merge and no prompts, the argument requests a merge."""
+    with pytest.raises(SystemExit):
+        parse_args(["123", "--cleanup-only"])
+    err = capsys.readouterr().err
+    assert "--cleanup-only" in err
+    assert "not allowed with" in err
+
+
+def test_cleanup_only_skips_inference_and_prompts() -> None:
+    """--cleanup-only is the scriptable release path: no TTY guard, no
+    worktree enumeration, no prompts, no merge — straight to cleanup."""
+    with (
+        patch(_MOD + ".worktrees.require_tty") as guard,
+        patch(_MOD + ".worktrees.list_worktrees") as listing,
+        patch(_MOD + ".prompt_yes_no") as confirm,
+        patch(_MOD + "._finalize_specific_pr") as fin,
+        patch(_MOD + ".config.read_config", side_effect=FileNotFoundError),
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+    ):
+        rc = main(["--cleanup-only", "--dry-run"])
+    assert rc == 0
+    guard.assert_not_called()
+    listing.assert_not_called()
+    confirm.assert_not_called()
+    fin.assert_not_called()
+
+
 # -- engine swap + explicit-target cleanup (issue #1423) -----------------------
 
 _CLEAN_PROVENANCE = ProvenanceResult(violations=[], advisories=[])

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -68,14 +68,31 @@ def test_worktree_for_branch_ignores_non_canonical() -> None:
 
 
 def test_require_tty_passes_on_tty() -> None:
-    with patch(_MOD + ".sys.stdin") as stdin:
+    with (
+        patch(_MOD + ".sys.stdin") as stdin,
+        patch(_MOD + ".sys.stdout") as stdout,
+    ):
         stdin.isatty.return_value = True
+        stdout.isatty.return_value = True
         require_tty("test context")  # no raise
 
 
 def test_require_tty_fails_fast_on_non_tty() -> None:
     with patch(_MOD + ".sys.stdin") as stdin:
         stdin.isatty.return_value = False
+        with pytest.raises(SystemExit, match="interactive terminal"):
+            require_tty("test context")
+
+
+def test_require_tty_fails_fast_on_non_tty_stdout() -> None:
+    """Issue #1448: when stdout is captured, prompts are written into the
+    void — a TTY stdin alone must not pass the guard."""
+    with (
+        patch(_MOD + ".sys.stdin") as stdin,
+        patch(_MOD + ".sys.stdout") as stdout,
+    ):
+        stdin.isatty.return_value = True
+        stdout.isatty.return_value = False
         with pytest.raises(SystemExit, match="interactive terminal"):
             require_tty("test context")
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add vrg-finalize-pr --cleanup-only, invoke it from close_and_finalize with streamed stdout and closed stdin, and harden require_tty to check both stdin and stdout TTYs.

## Issue Linkage

- Ref #1448

## Notes

- Fix items 1-4 from the issue: new mutually-exclusive --cleanup-only flag (no inference, no prompts, no stdin); orchestrator streams finalize output live and captures only stderr for ReleaseError.detail, replaying it so warnings are not swallowed; require_tty now fails fast when either stdin or stdout is not a TTY; module docstring and reference doc updated to describe the three modes.