### PR TITLE
fix(release): stream vrg-finalize-pr output through the progress session

### DIFF
--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -363,14 +363,19 @@ def run(
     *,
     env: dict[str, str] | None = None,
     check: bool = True,
+    stdin: int | None = None,
 ) -> int:
     """Run *cmd*, streaming each output line through the active pipeline.
+
+    ``stdin`` is forwarded to Popen — pass ``subprocess.DEVNULL`` for
+    children that must never block on a terminal read.
 
     Raises CalledProcessError (carrying captured stdout/stderr) on nonzero
     exit when ``check`` is true; otherwise returns the exit code.
     """
     proc = subprocess.Popen(  # noqa: S603
         cmd,
+        stdin=stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/src/vergil_tooling/lib/release/finalize.py
+++ b/src/vergil_tooling/lib/release/finalize.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from typing import TYPE_CHECKING
 
+from vergil_tooling.lib import progress
 from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.tracking import close_tracking_issue
 
@@ -21,27 +21,23 @@ def close_and_finalize(ctx: ReleaseContext) -> None:
 
     print("Running vrg-finalize-pr...")
     # --cleanup-only is the non-interactive release path: no PR
-    # inference, no prompts (issue #1448). stdout is inherited so the
-    # slow finalize phases (validation takes ~a minute) stream live;
-    # stdin is closed so the child can never block on a terminal read;
-    # stderr is captured for ReleaseError.detail and replayed below so
-    # warnings are never silently swallowed.
-    result = subprocess.run(  # noqa: S603
-        ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
-        check=False,
-        stdin=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    if result.stderr:
-        print(result.stderr, file=sys.stderr, end="")
-    if result.returncode != 0:
+    # inference, no prompts (issue #1448). Output streams through the
+    # progress session so the live display stays intact and the run log
+    # captures the cleanup narration (issue #1470) — the child must not
+    # inherit the TTY: raw writes under the live display strand stale
+    # frames on screen. stdin is closed so the child can never block on
+    # a terminal read. Captured stderr rides on CalledProcessError for
+    # ReleaseError.detail; the streamed lines mean warnings are never
+    # silently swallowed.
+    try:
+        progress.run(("vrg-finalize-pr", "--cleanup-only"), stdin=subprocess.DEVNULL)  # noqa: S607
+    except subprocess.CalledProcessError as exc:
         raise ReleaseError(
             phase="close-finalize",
             command="vrg-finalize-pr --cleanup-only",
             message="vrg-finalize-pr failed.",
-            detail=result.stderr,
-        )
+            detail=exc.stderr,
+        ) from exc
     print("Finalization complete.")
 
 

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -362,6 +362,16 @@ def test_run_check_false_returns_code() -> None:
     assert rc == 2
 
 
+def test_run_stdin_devnull_gives_child_eof() -> None:
+    """Issue #1470: ``stdin=subprocess.DEVNULL`` reaches the child, which
+    sees immediate EOF instead of inheriting (and potentially blocking on)
+    the parent's stdin."""
+    progress._session = None
+    code = "import sys; sys.exit(0 if sys.stdin.read() == '' else 1)"
+    rc = progress.run((sys.executable, "-c", code), check=False, stdin=subprocess.DEVNULL)
+    assert rc == 0
+
+
 def _args(**skips: bool) -> argparse.Namespace:
     return argparse.Namespace(output_window=5, output_format="plain", **skips)
 

--- a/tests/vergil_tooling/test_release_finalize.py
+++ b/tests/vergil_tooling/test_release_finalize.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import pytest
@@ -35,52 +34,26 @@ def test_close_and_finalize_succeeds() -> None:
     ctx = _ctx()
     with (
         patch(_MOD + ".close_tracking_issue") as mock_close,
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0),
-        ),
+        patch(_MOD + ".progress.run", return_value=0),
     ):
         close_and_finalize(ctx)
     mock_close.assert_called_once()
 
 
-def test_close_and_finalize_streams_cleanup_only() -> None:
-    """Issue #1448: invoke the non-interactive flag, stream stdout to the
-    user, never hand the child the TTY stdin, and capture only stderr
-    (for ReleaseError.detail)."""
+def test_close_and_finalize_streams_through_progress() -> None:
+    """Issue #1470: the cleanup child must not inherit the TTY — raw writes
+    under the live display strand stale frames on screen. Its output streams
+    through the progress session (live display + run log) instead; stdin is
+    closed so the child can never block on a terminal read (issue #1448)."""
     ctx = _ctx()
     with (
         patch(_MOD + ".close_tracking_issue"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stderr=""),
-        ) as run,
+        patch(_MOD + ".progress.run", return_value=0) as run,
     ):
         close_and_finalize(ctx)
     (cmd,) = run.call_args.args
     assert cmd == ("vrg-finalize-pr", "--cleanup-only")
-    kwargs = run.call_args.kwargs
-    assert "capture_output" not in kwargs
-    assert "stdout" not in kwargs  # stdout streams to the user
-    assert kwargs["stdin"] == subprocess.DEVNULL
-    assert kwargs["stderr"] == subprocess.PIPE
-
-
-def test_close_and_finalize_relays_child_stderr(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Captured child stderr is replayed on success so warnings are
-    never silently swallowed."""
-    ctx = _ctx()
-    with (
-        patch(_MOD + ".close_tracking_issue"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=0, stderr="WARNING: x"),
-        ),
-    ):
-        close_and_finalize(ctx)
-    assert "WARNING: x" in capsys.readouterr().err
+    assert run.call_args.kwargs["stdin"] == subprocess.DEVNULL
 
 
 def test_build_summary_omits_none_fields() -> None:
@@ -113,12 +86,15 @@ def test_build_summary_labels_back_merge_pr() -> None:
 
 def test_close_and_finalize_fails_on_finalize_error() -> None:
     ctx = _ctx()
+    err = subprocess.CalledProcessError(
+        1,
+        ("vrg-finalize-pr", "--cleanup-only"),
+        output="",
+        stderr="validation failed",
+    )
     with (
         patch(_MOD + ".close_tracking_issue"),
-        patch(
-            _MOD + ".subprocess.run",
-            return_value=CompletedProcess(args=(), returncode=1, stderr="validation failed"),
-        ),
+        patch(_MOD + ".progress.run", side_effect=err),
         pytest.raises(ReleaseError, match="vrg-finalize-pr") as excinfo,
     ):
         close_and_finalize(ctx)


### PR DESCRIPTION
# Pull Request

## Summary

- Route the close-finalize cleanup child through progress.run so it no longer inherits the TTY and corrupts the rich.Live display; its output now reaches the rolling window and the run log, and progress.run gains stdin passthrough to preserve the non-interactive DEVNULL guarantee.

## Issue Linkage

- Ref #1470

## Notes

- >