### PR TITLE
fix(ci): grant actions: read to the security job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # Requested by ci-security.yml@v2.1.3: codeql-action/upload-sarif
+      # needs it on private repos. See vergil-project/vergil-actions#698.
+      actions: read
     with:
       language: python
       run-standards: ${{ inputs.run-release != 'false' }}


### PR DESCRIPTION
# Pull Request

## Summary

- Grant actions: read on the security job ahead of the ci-security.yml v2.1.3 re-promote.

## Issue Linkage

- Ref #1472

## Notes

- >-