### PR TITLE
fix(release): keep consumer-refresh commands visible after the summary

### DIFF
--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -39,7 +39,7 @@ def main(argv: list[str] | None = None) -> int:
         repo_root=repo_root,
         promote=not args.no_promote,
     )
-    return progress.run_pipeline(
+    rc = progress.run_pipeline(
         state,
         build_stages(),
         command="vrg-release",
@@ -47,6 +47,13 @@ def main(argv: list[str] | None = None) -> int:
         args=args,
         repo_root=repo_root,
     )
+    # The progress renderer collapses each finished stage to a one-line
+    # summary, which erases the consumer-refresh commands — the one piece
+    # of output the human must act on. Re-print them below the summary.
+    if state.ctx is not None and state.ctx.consumer_refresh_message:
+        print()
+        print(state.ctx.consumer_refresh_message)
+    return rc
 
 
 if __name__ == "__main__":

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -37,6 +37,8 @@ class ReleaseContext:
     develop_cd_run_id: str | None = None
     develop_cd_run_url: str | None = None
 
+    consumer_refresh_message: str | None = None
+
     promote: bool = True
 
 

--- a/src/vergil_tooling/lib/release/handoff.py
+++ b/src/vergil_tooling/lib/release/handoff.py
@@ -11,19 +11,24 @@ if TYPE_CHECKING:
 
 
 def consumer_refresh(ctx: ReleaseContext) -> None:
-    """Read and display the consumer-refresh message from vergil.toml."""
+    """Read and display the consumer-refresh message from vergil.toml.
+
+    The message is also stored on ``ctx.consumer_refresh_message`` so
+    ``vrg-release`` can re-print it after the progress renderer collapses
+    this stage's output (the commands are for the human to act on).
+    """
     cfg = config.read_config(ctx.repo_root)
     template = cfg.publish.consumer_refresh
 
     if template is None:
-        print(
+        message = (
             f"No consumer-refresh sequence is configured for {ctx.repo}. "
             f"Add [publish].consumer-refresh to vergil.toml."
         )
-        return
+    else:
+        commands = template.replace("<VERSION>", ctx.version)
+        message = f"Consumer refresh commands:\n\n{commands}"
 
-    message = template.replace("<VERSION>", ctx.version)
-    print()
-    print("Consumer refresh commands:")
+    ctx.consumer_refresh_message = message
     print()
     print(message)

--- a/tests/vergil_tooling/test_release_handoff.py
+++ b/tests/vergil_tooling/test_release_handoff.py
@@ -38,3 +38,22 @@ def test_consumer_refresh_none(capsys: pytest.CaptureFixture[str]) -> None:
         consumer_refresh(ctx)
     captured = capsys.readouterr()
     assert "no consumer-refresh" in captured.out.lower()
+
+
+def test_consumer_refresh_stores_message_on_ctx() -> None:
+    ctx = _ctx()
+    with patch(_MOD + ".config.read_config") as mock_config:
+        mock_config.return_value.publish.consumer_refresh = "uv tool install pkg@v<VERSION>"
+        consumer_refresh(ctx)
+    assert ctx.consumer_refresh_message is not None
+    assert "Consumer refresh commands:" in ctx.consumer_refresh_message
+    assert "uv tool install pkg@v2.1.0" in ctx.consumer_refresh_message
+
+
+def test_consumer_refresh_none_stores_notice_on_ctx() -> None:
+    ctx = _ctx()
+    with patch(_MOD + ".config.read_config") as mock_config:
+        mock_config.return_value.publish.consumer_refresh = None
+        consumer_refresh(ctx)
+    assert ctx.consumer_refresh_message is not None
+    assert "no consumer-refresh" in ctx.consumer_refresh_message.lower()

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_release import main, parse_args
+from vergil_tooling.lib.release.context import ReleaseContext
+
+if TYPE_CHECKING:
+    import pytest
+
+    from vergil_tooling.lib.release.orchestrator import ReleaseState
 
 _MOD = "vergil_tooling.bin.vrg_release"
 
@@ -69,6 +77,42 @@ def test_main_returns_pipeline_exit_code() -> None:
         patch(_MOD + ".progress.run_pipeline", return_value=1),
     ):
         assert main([]) == 1
+
+
+def test_main_prints_consumer_refresh_message_after_pipeline(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    message = "Consumer refresh commands:\n\nuv tool install pkg@v2.1.0"
+
+    def fake_pipeline(state: ReleaseState, *args: object, **kwargs: object) -> int:
+        state.ctx = ReleaseContext(
+            repo="owner/repo",
+            version="2.1.0",
+            repo_root=Path("/tmp/repo"),  # noqa: S108
+            version_override=None,
+            consumer_refresh_message=message,
+        )
+        return 1
+
+    with (
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", side_effect=fake_pipeline),
+    ):
+        assert main([]) == 1
+    captured = capsys.readouterr()
+    assert "Consumer refresh commands:" in captured.out
+    assert "uv tool install pkg@v2.1.0" in captured.out
+
+
+def test_main_prints_nothing_when_no_consumer_refresh_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", return_value=0),
+    ):
+        assert main([]) == 0
+    assert capsys.readouterr().out == ""
 
 
 def test_main_passes_version_override() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Store the consumer-refresh message on ReleaseContext and re-print it after the vrg-release pipeline summary, so the commands survive the progress renderer's stage collapse.

## Issue Linkage

- Ref #1477

## Notes

- Behavior notes and approved design in issue #1477. In plain/gha formats the message appears twice (in-stream and at the end) by design.