### PR TITLE
fix(github): make wait_for_checks resilient to PR head movement

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -17,9 +17,12 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vergil_tooling.lib import retry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 log = logging.getLogger(__name__)
 
@@ -385,6 +388,64 @@ def _checks_registered(repo: str, sha: str) -> bool:
     return int(result.stdout.strip()) > 0
 
 
+# gh pr checks exits 1 with this stderr when the current head has no
+# registered checks — transient right after the head moves, fatal only
+# once the registration deadline has passed.
+_NO_CHECKS_MARKER = "no checks reported"
+
+
+def _is_no_checks_error(exc: subprocess.CalledProcessError) -> bool:
+    """True if a watch failure means zero checks on the PR's current head."""
+    return _NO_CHECKS_MARKER in (exc.stderr or "").lower()
+
+
+def _poll_and_watch_checks(
+    pr: str,
+    watch: Callable[[], None],
+    *,
+    poll_interval: int,
+    poll_timeout: int,
+) -> None:
+    """Wait until checks register on the PR's *current* head, then run *watch*.
+
+    The head can move while waiting — ``update-branch`` or a push creates
+    a new head commit whose CI run takes seconds to register — so the SHA
+    is re-resolved on every poll rather than pinned once.  ``gh pr checks
+    --watch`` likewise re-resolves the head on every refresh and exits 1
+    with "no checks reported" the moment it sees a head with zero
+    registered checks; that failure is transient (head moved mid-watch),
+    so it re-enters the registration poll and restarts the watch instead
+    of raising (#1490).  All waiting shares one deadline; every other
+    watch failure propagates unchanged.
+    """
+    repo = current_repo()
+    deadline = time.monotonic() + poll_timeout
+
+    while True:
+        sha = head_sha(pr)
+        while not _checks_registered(repo, sha):
+            if time.monotonic() >= deadline:
+                raise GitHubAPIError(
+                    1,
+                    ("gh", "pr", "checks", pr, "--watch"),
+                    stderr=(
+                        f"no checks reported for {sha[:8]} after {poll_timeout}s"
+                        " — GitHub may be experiencing delays"
+                    ),
+                )
+            time.sleep(poll_interval)
+            sha = head_sha(pr)
+        try:
+            watch()
+        except subprocess.CalledProcessError as exc:
+            if not _is_no_checks_error(exc) or time.monotonic() >= deadline:
+                raise
+            print("Watch lost the checks (PR head likely moved) — re-polling...")
+            time.sleep(poll_interval)
+        else:
+            return
+
+
 def wait_for_checks(
     pr: str,
     *,
@@ -393,35 +454,20 @@ def wait_for_checks(
 ) -> None:
     """Block until all checks on *pr* reach a terminal state.
 
-    Resolves the PR's HEAD commit SHA and polls the GitHub REST API
-    until at least one check run exists for that commit.  Then hands
-    off to ``gh pr checks --watch`` which blocks until every check
-    completes.
+    Polls the GitHub REST API until at least one check run exists for
+    the PR's current head commit, then hands off to ``gh pr checks
+    --watch`` which blocks until every check completes.  Resilient to
+    the head moving mid-wait (see ``_poll_and_watch_checks``).
 
     Transient GitHub API errors (502/503/504/429) are retried
     automatically via the library-level retry wrapper.
     """
-    repo = current_repo()
-    sha = head_sha(pr)
-
-    deadline = time.monotonic() + poll_timeout
-    while not _checks_registered(repo, sha):
-        if time.monotonic() >= deadline:
-            break
-        time.sleep(poll_interval)
-
-    if not _checks_registered(repo, sha):
-        cmd = ("gh", "pr", "checks", pr, "--watch")
-        raise GitHubAPIError(
-            1,
-            cmd,
-            stderr=(
-                f"no checks reported for {sha[:8]} after {poll_timeout}s"
-                " — GitHub may be experiencing delays"
-            ),
-        )
-
-    run("pr", "checks", pr, "--watch")
+    _poll_and_watch_checks(
+        pr,
+        lambda: run("pr", "checks", pr, "--watch"),
+        poll_interval=poll_interval,
+        poll_timeout=poll_timeout,
+    )
 
 
 _FAILED_BUCKETS = frozenset({"fail", "cancel"})

--- a/src/vergil_tooling/lib/release/subprocess.py
+++ b/src/vergil_tooling/lib/release/subprocess.py
@@ -6,13 +6,7 @@ import subprocess
 import time
 
 from vergil_tooling.lib import progress, retry
-from vergil_tooling.lib.github import (
-    GitHubAPIError,
-    _checks_registered,
-    _gh_env,
-    current_repo,
-    head_sha,
-)
+from vergil_tooling.lib.github import _gh_env, _poll_and_watch_checks
 
 _POLL_INTERVAL_SECS = 5
 _POLL_TIMEOUT_SECS = 180
@@ -44,27 +38,17 @@ def _stream_with_retry(cmd: tuple[str, ...]) -> None:
 
 
 def wait_for_checks(pr: str) -> None:
-    """Block until CI checks on *pr* pass, streaming watch output."""
-    repo = current_repo()
-    sha = head_sha(pr)
+    """Block until CI checks on *pr* pass, streaming watch output.
 
-    deadline = time.monotonic() + _POLL_TIMEOUT_SECS
-    while not _checks_registered(repo, sha):
-        if time.monotonic() >= deadline:
-            break
-        time.sleep(_POLL_INTERVAL_SECS)
-
-    if not _checks_registered(repo, sha):
-        raise GitHubAPIError(
-            1,
-            ("gh", "pr", "checks", pr, "--watch"),
-            stderr=(
-                f"no checks reported for {sha[:8]} after {_POLL_TIMEOUT_SECS}s"
-                " — GitHub may be experiencing delays"
-            ),
-        )
-
-    _stream_with_retry(("gh", "pr", "checks", pr, "--watch"))  # noqa: S607
+    Delegates to the shared poll-and-watch engine — resilient to the PR
+    head moving mid-wait (#1490) — with the streaming watch runner.
+    """
+    _poll_and_watch_checks(
+        pr,
+        lambda: _stream_with_retry(("gh", "pr", "checks", pr, "--watch")),  # noqa: S607
+        poll_interval=_POLL_INTERVAL_SECS,
+        poll_timeout=_POLL_TIMEOUT_SECS,
+    )
 
 
 def watch_workflow(repo: str, run_id: str, *, check_status: bool = True) -> None:

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -171,6 +171,79 @@ def test_wait_for_checks_does_not_use_fail_fast() -> None:
     assert "--fail-fast" not in call_args
 
 
+def test_wait_for_checks_reresolves_head_while_polling() -> None:
+    """The head SHA is re-resolved each poll — update-branch can move it (#1490)."""
+
+    def registered(_repo: str, sha: str) -> bool:
+        return sha == "new"
+
+    with (
+        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
+        patch("vergil_tooling.lib.github.head_sha", side_effect=["old", "new"]) as mock_sha,
+        patch("vergil_tooling.lib.github._checks_registered", side_effect=registered) as mock_reg,
+        patch("vergil_tooling.lib.github.time.sleep"),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
+    assert mock_sha.call_count == 2
+    assert mock_reg.call_args[0] == ("owner/repo", "new")
+    mock_run.assert_called_once_with("pr", "checks", "https://github.com/pr/1", "--watch")
+
+
+def test_wait_for_checks_restarts_watch_on_no_checks_reported() -> None:
+    """A watch killed by "no checks reported" (head moved mid-watch) restarts (#1490)."""
+    no_checks = github.GitHubAPIError(
+        1,
+        ("gh", "pr", "checks", "1", "--watch"),
+        None,
+        "no checks reported on the 'feature/x' branch",
+    )
+    with (
+        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
+        patch("vergil_tooling.lib.github.head_sha", side_effect=["old", "new"]),
+        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
+        patch("vergil_tooling.lib.github.time.sleep"),
+        patch("vergil_tooling.lib.github.run", side_effect=[no_checks, None]) as mock_run,
+    ):
+        github.wait_for_checks("https://github.com/pr/1")
+    assert mock_run.call_count == 2
+
+
+def test_wait_for_checks_propagates_other_watch_failures() -> None:
+    """Only the "no checks reported" watch failure is transient; the rest raise."""
+    boom = github.GitHubAPIError(1, ("gh",), None, "HTTP 401: Bad credentials")
+    with (
+        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
+        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
+        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
+        patch("vergil_tooling.lib.github.run", side_effect=boom) as mock_run,
+        pytest.raises(github.GitHubAPIError, match="Bad credentials"),
+    ):
+        github.wait_for_checks("https://github.com/pr/1")
+    mock_run.assert_called_once()
+
+
+def test_wait_for_checks_watch_restart_bounded_by_deadline() -> None:
+    """The no-checks restart shares the poll deadline — past it, the error raises (#1490)."""
+    no_checks = github.GitHubAPIError(
+        1,
+        ("gh", "pr", "checks", "1", "--watch"),
+        None,
+        "no checks reported on the 'feature/x' branch",
+    )
+    with (
+        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
+        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
+        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
+        patch("vergil_tooling.lib.github.time.monotonic", side_effect=[0.0, 61.0]),
+        patch("vergil_tooling.lib.github.time.sleep"),
+        patch("vergil_tooling.lib.github.run", side_effect=no_checks) as mock_run,
+        pytest.raises(github.GitHubAPIError, match="no checks reported"),
+    ):
+        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
+    mock_run.assert_called_once()
+
+
 def test_failed_check_names_returns_failing_checks() -> None:
     payload = json.dumps(
         [

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -12,6 +12,7 @@ from vergil_tooling.lib.release import subprocess as release_subprocess
 from vergil_tooling.lib.release.subprocess import wait_for_checks, watch_workflow
 
 _MOD = "vergil_tooling.lib.release.subprocess"
+_GH = "vergil_tooling.lib.github"
 
 
 def _cpe(stdout: str = "", stderr: str = "") -> subprocess.CalledProcessError:
@@ -64,11 +65,13 @@ class TestStreamWithRetry:
 
 
 class TestWaitForChecks:
+    """The shared poll-and-watch engine lives in lib.github (#1490)."""
+
     def test_streams_watch_command(self) -> None:
         with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
+            patch(_GH + ".current_repo", return_value="o/r"),
+            patch(_GH + ".head_sha", return_value="abc123"),
+            patch(_GH + "._checks_registered", return_value=True),
             patch(_MOD + "._stream_with_retry") as m_stream,
         ):
             wait_for_checks("https://github.com/o/r/pull/1")
@@ -78,9 +81,9 @@ class TestWaitForChecks:
 
     def test_failure_raises_with_output(self) -> None:
         with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", return_value=True),
+            patch(_GH + ".current_repo", return_value="o/r"),
+            patch(_GH + ".head_sha", return_value="abc123"),
+            patch(_GH + "._checks_registered", return_value=True),
             patch(_MOD + "._stream_with_retry", side_effect=_cpe(stdout="fail", stderr="err")),
             pytest.raises(subprocess.CalledProcessError) as exc_info,
         ):
@@ -91,27 +94,40 @@ class TestWaitForChecks:
     def test_polls_until_checks_registered(self) -> None:
         registered_calls = iter([False, False, True, True])
         with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123"),
-            patch(_MOD + "._checks_registered", side_effect=registered_calls),
+            patch(_GH + ".current_repo", return_value="o/r"),
+            patch(_GH + ".head_sha", return_value="abc123"),
+            patch(_GH + "._checks_registered", side_effect=registered_calls),
             patch(_MOD + "._stream_with_retry"),
-            patch(_MOD + ".time.sleep"),
-            patch(_MOD + ".time.monotonic", side_effect=[0, 1, 2, 3]),
+            patch(_GH + ".time.sleep"),
+            patch(_GH + ".time.monotonic", side_effect=[0, 1, 2, 3]),
         ):
             wait_for_checks("https://github.com/o/r/pull/1")
 
     def test_polls_timeout_raises(self) -> None:
         with (
-            patch(_MOD + ".current_repo", return_value="o/r"),
-            patch(_MOD + ".head_sha", return_value="abc123def456"),
-            patch(_MOD + "._checks_registered", return_value=False),
+            patch(_GH + ".current_repo", return_value="o/r"),
+            patch(_GH + ".head_sha", return_value="abc123def456"),
+            patch(_GH + "._checks_registered", return_value=False),
             patch(_MOD + "._stream_with_retry") as m_stream,
-            patch(_MOD + ".time.sleep"),
-            patch(_MOD + ".time.monotonic", side_effect=[0, 200]),
+            patch(_GH + ".time.sleep"),
+            patch(_GH + ".time.monotonic", side_effect=[0, 200]),
             pytest.raises(subprocess.CalledProcessError, match="no checks reported"),
         ):
             wait_for_checks("https://github.com/o/r/pull/1")
         m_stream.assert_not_called()
+
+    def test_restarts_watch_on_no_checks_reported(self) -> None:
+        """Head movement mid-watch re-polls registration and restarts the watch (#1490)."""
+        no_checks = _cpe(stderr="no checks reported on the 'feature/x' branch")
+        with (
+            patch(_GH + ".current_repo", return_value="o/r"),
+            patch(_GH + ".head_sha", side_effect=["old", "new"]),
+            patch(_GH + "._checks_registered", return_value=True),
+            patch(_GH + ".time.sleep"),
+            patch(_MOD + "._stream_with_retry", side_effect=[no_checks, None]) as m_stream,
+        ):
+            wait_for_checks("https://github.com/o/r/pull/1")
+        assert m_stream.call_count == 2
 
 
 class TestWatchWorkflow:


### PR DESCRIPTION
# Pull Request

## Summary

- Re-resolve the PR head SHA on every registration poll and restart gh pr checks --watch when it dies with 'no checks reported' (head moved mid-watch), bounded by the existing 180s deadline; unify the duplicated wait loop in lib/github.py and lib/release/subprocess.py into one shared engine.

## Issue Linkage

- Ref #1490

## Notes

- Root cause observed on PR #1486: finalize's update-branch moved the head, the registration guard validated the stale SHA, and the watch hard-failed when a refresh saw the new head before its CI run registered. Five new tests cover head re-resolution, watch restart, deadline bounding, and non-transient propagation.