### PR TITLE
fix(vrg-vm): read custom-title naming events and break slot collisions by recency

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -52,23 +52,38 @@ def _project_slug(cwd: str) -> str:
     return "".join(c if c.isalnum() else "-" for c in cwd)
 
 
-def _last_agent_name(transcript: Path) -> str | None:
-    """Return the last ``agent-name`` value in a transcript, or ``None``."""
+# Transcript event types that carry a session name, mapped to their value
+# field. Claude Code originally wrote ``agent-name`` events and renamed them
+# to ``custom-title`` (~2.1.16x); both forms must be read.
+_NAME_EVENT_FIELDS = {"agent-name": "agentName", "custom-title": "customTitle"}
+
+
+def _last_session_name(transcript: Path) -> str | None:
+    """Return the last session-name value in a transcript, or ``None``.
+
+    The last naming event in file order wins, regardless of which of the two
+    event types (``agent-name`` or ``custom-title``) carries it.
+    """
     last: str | None = None
     try:
         with transcript.open() as fh:
             for raw in fh:
                 line = raw.strip()
-                if not line or '"agent-name"' not in line:
+                if not line or ('"agent-name"' not in line and '"custom-title"' not in line):
                     continue
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if entry.get("type") == "agent-name":
-                    value = entry.get("agentName")
-                    if isinstance(value, str):
-                        last = value
+                event_type = entry.get("type")
+                if not isinstance(event_type, str):
+                    continue
+                field = _NAME_EVENT_FIELDS.get(event_type)
+                if field is None:
+                    continue
+                value = entry.get(field)
+                if isinstance(value, str):
+                    last = value
     except OSError:
         return None
     return last
@@ -85,7 +100,7 @@ def name_by_session(projects_dir: Path, slug: str | None = None) -> dict[str, st
         return result
     pattern = f"{slug}/*.jsonl" if slug is not None else "*/*.jsonl"
     for transcript in sorted(projects_dir.glob(pattern)):
-        name = _last_agent_name(transcript)
+        name = _last_session_name(transcript)
         if name is not None:
             result[transcript.stem] = name
     return result
@@ -221,9 +236,9 @@ def roster_names(roster: list[dict[str, object]]) -> dict[str, str]:
     """Map session id to its roster ``name`` (authoritative for live sessions).
 
     The roster records each live session's current name directly, so a session
-    that has not yet written an ``agent-name`` event to its transcript — e.g. a
-    freshly created session with no turns, hence no transcript at all — is still
-    named here. Transcript names, by contrast, only cover sessions that have run.
+    that has not yet written a naming event to its transcript — e.g. a freshly
+    created session with no turns, hence no transcript at all — is still named
+    here. Transcript names, by contrast, only cover sessions that have run.
     """
     out: dict[str, str] = {}
     for entry in roster:
@@ -255,14 +270,18 @@ def _read_state(
 
 
 def _archive_session(session_id: str, timestamp: str) -> None:
-    """Relabel a cold session by appending an archived ``agent-name`` entry."""
+    """Relabel a cold session by appending an archived ``custom-title`` entry.
+
+    ``custom-title`` is the event type current Claude Code writes, so the
+    archived label also shows up in Claude's own resume picker.
+    """
     transcript = projects_glob(_claude_dir() / "projects", session_id)
-    current = _last_agent_name(transcript)
+    current = _last_session_name(transcript)
     if current is None:
         return
     entry = {
-        "type": "agent-name",
-        "agentName": make_archived_name(current, timestamp),
+        "type": "custom-title",
+        "customTitle": make_archived_name(current, timestamp),
         "sessionId": session_id,
     }
     try:

--- a/src/vergil_tooling/lib/session.py
+++ b/src/vergil_tooling/lib/session.py
@@ -123,12 +123,33 @@ class SessionRow:
     last_active: float | None = None  # epoch seconds; None when age is unknown
 
 
+def _displaces(
+    existing_active: bool,
+    existing_last_active: float | None,
+    active: bool,
+    last_active: float | None,
+) -> bool:
+    """True if a new claimant beats the existing holder of a name collision.
+
+    Liveness dominates: a live session always beats a dead one. Between
+    claimants of equal liveness the more recently active wins — a ``/clear``
+    rotation leaves the abandoned session id still claiming the slot name,
+    and recency is what picks the current id over it. Unknown ages and exact
+    ties keep the incumbent.
+    """
+    if active != existing_active:
+        return active
+    if last_active is None:
+        return False
+    return existing_last_active is None or last_active > existing_last_active
+
+
 def _merge_slot(
     slots: dict[int, Slot], slot: int, session_id: str, active: bool, last_active: float | None
 ) -> None:
-    """Insert/replace a slot, letting an active session win a slot collision."""
+    """Insert/replace a slot: liveness wins a collision, then recency."""
     existing = slots.get(slot)
-    if existing is None or (active and not existing.active):
+    if existing is None or _displaces(existing.active, existing.last_active, active, last_active):
         slots[slot] = Slot(slot, session_id, active, last_active)
 
 
@@ -141,11 +162,12 @@ def build_slots(
 ) -> dict[int, Slot]:
     """Build the slot map for one ``identity`` + ``path``.
 
-    ``name_by_session`` maps session id to its current name (last ``agent-name``
+    ``name_by_session`` maps session id to its current name (last naming event
     per transcript). ``active_sessions`` is the set of session ids with a live
     roster entry. ``last_active`` optionally maps session id to epoch seconds.
     Names that do not parse, or that belong to another identity or path, are
-    ignored. On a slot collision an active session wins.
+    ignored. On a slot collision an active session wins, then the most
+    recently active.
     """
     la = last_active or {}
     slots: dict[int, Slot] = {}
@@ -167,8 +189,9 @@ def list_rows(
 ) -> list[SessionRow]:
     """All named sessions as sorted rows, deduped per (identity, slot, path).
 
-    On a duplicate (identity, slot, path) an active session wins. Rows are
-    sorted by identity, then slot, then path for stable display.
+    On a duplicate (identity, slot, path) an active session wins, then the
+    most recently active. Rows are sorted by identity, then slot, then path
+    for stable display.
     """
     la = last_active or {}
     best: dict[tuple[str, int, str], SessionRow] = {}
@@ -180,7 +203,9 @@ def list_rows(
         active = session_id in active_sessions
         key = (identity, slot, path)
         existing = best.get(key)
-        if existing is None or (active and not existing.active):
+        if existing is None or _displaces(
+            existing.active, existing.last_active, active, la.get(session_id)
+        ):
             best[key] = SessionRow(identity, slot, path, session_id, active, la.get(session_id))
     return sorted(best.values(), key=lambda r: (r.identity, r.slot, r.path))
 

--- a/tests/vergil_tooling/test_session.py
+++ b/tests/vergil_tooling/test_session.py
@@ -259,6 +259,81 @@ def test_list_rows_attaches_last_active() -> None:
     assert rows[0].last_active == 5.0
 
 
+# --- recency-aware slot collisions (issue #1493) ---
+
+
+def test_build_slots_recent_idle_wins_collision() -> None:
+    # /clear rotates the session id, so both the abandoned and the current id
+    # claim the slot. With neither live, the most recently active must win.
+    name_by_session = {"old": "vergil:01:p", "new": "vergil:01:p"}
+    slots = build_slots(
+        "vergil",
+        "p",
+        name_by_session,
+        active_sessions=set(),
+        last_active={"old": 1000.0, "new": 2000.0},
+    )
+    assert slots[1].session_id == "new"
+
+
+def test_build_slots_recent_idle_wins_collision_either_order() -> None:
+    name_by_session = {"new": "vergil:01:p", "old": "vergil:01:p"}
+    slots = build_slots(
+        "vergil",
+        "p",
+        name_by_session,
+        active_sessions=set(),
+        last_active={"old": 1000.0, "new": 2000.0},
+    )
+    assert slots[1].session_id == "new"
+
+
+def test_build_slots_known_age_beats_unknown_in_collision() -> None:
+    name_by_session = {"unknown": "vergil:01:p", "known": "vergil:01:p"}
+    slots = build_slots(
+        "vergil",
+        "p",
+        name_by_session,
+        active_sessions=set(),
+        last_active={"known": 1000.0},
+    )
+    assert slots[1].session_id == "known"
+
+
+def test_build_slots_unknown_age_keeps_incumbent_in_collision() -> None:
+    name_by_session = {"known": "vergil:01:p", "unknown": "vergil:01:p"}
+    slots = build_slots(
+        "vergil",
+        "p",
+        name_by_session,
+        active_sessions=set(),
+        last_active={"known": 1000.0},
+    )
+    assert slots[1].session_id == "known"
+
+
+def test_build_slots_active_beats_recent_idle() -> None:
+    # Liveness still dominates recency.
+    name_by_session = {"idle": "vergil:01:p", "live": "vergil:01:p"}
+    slots = build_slots(
+        "vergil",
+        "p",
+        name_by_session,
+        active_sessions={"live"},
+        last_active={"idle": 9999.0, "live": 1.0},
+    )
+    assert slots[1] == Slot(1, "live", active=True, last_active=1.0)
+
+
+def test_list_rows_recent_idle_wins_duplicate() -> None:
+    rows = list_rows(
+        {"old": "vergil:01:p", "new": "vergil:01:p"},
+        active_sessions=set(),
+        last_active={"old": 1000.0, "new": 2000.0},
+    )
+    assert rows == [SessionRow("vergil", 1, "p", "new", active=False, last_active=2000.0)]
+
+
 DAY = 86400.0
 
 

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -78,7 +78,7 @@ def test_archive_session_append_oserror_is_swallowed(
     projects.mkdir(parents=True)
     (projects / "adir.jsonl").mkdir()  # a directory -> open("a") raises OSError
     monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
-    monkeypatch.setattr(r, "_last_agent_name", lambda _t: "vergil:01:p")
+    monkeypatch.setattr(r, "_last_session_name", lambda _t: "vergil:01:p")
     r._archive_session("adir", "2026-05-30T14:23:07Z")  # must not raise
 
 
@@ -91,7 +91,7 @@ def test_archive_session_appends_archived_name(
     t.write_text('{"type":"agent-name","agentName":"vergil:01:p","sessionId":"s1"}\n')
     monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
     r._archive_session("s1", "2026-05-30T14:23:07Z")
-    assert r._last_agent_name(t) == "archived@2026-05-30T14:23:07Z@vergil:01:p"
+    assert r._last_session_name(t) == "archived@2026-05-30T14:23:07Z@vergil:01:p"
 
 
 def test_archive_session_missing_transcript_is_noop(
@@ -102,10 +102,10 @@ def test_archive_session_missing_transcript_is_noop(
     r._archive_session("ghost", "2026-05-30T14:23:07Z")  # must not raise
 
 
-# --- _last_agent_name ---
+# --- _last_session_name ---
 
 
-def test_last_agent_name_last_wins(tmp_path: Path) -> None:
+def test_last_session_name_last_wins(tmp_path: Path) -> None:
     f = tmp_path / "s.jsonl"
     f.write_text(
         "\n".join(
@@ -118,30 +118,104 @@ def test_last_agent_name_last_wins(tmp_path: Path) -> None:
             ]
         )
     )
-    assert r._last_agent_name(f) == "id:02:b"
+    assert r._last_session_name(f) == "id:02:b"
 
 
-def test_last_agent_name_skips_malformed_json(tmp_path: Path) -> None:
+def test_last_session_name_skips_malformed_json(tmp_path: Path) -> None:
     f = tmp_path / "s.jsonl"
     f.write_text('{"type":"agent-name", BROKEN "agentName":"x"}\n')
-    assert r._last_agent_name(f) is None
+    assert r._last_session_name(f) is None
 
 
-def test_last_agent_name_ignores_non_string_value(tmp_path: Path) -> None:
+def test_last_session_name_ignores_non_string_value(tmp_path: Path) -> None:
     f = tmp_path / "s.jsonl"
     f.write_text('{"type":"agent-name","agentName":123}\n')
-    assert r._last_agent_name(f) is None
+    assert r._last_session_name(f) is None
 
 
-def test_last_agent_name_missing_file_returns_none(tmp_path: Path) -> None:
-    assert r._last_agent_name(tmp_path / "nope.jsonl") is None
+def test_last_session_name_missing_file_returns_none(tmp_path: Path) -> None:
+    assert r._last_session_name(tmp_path / "nope.jsonl") is None
 
 
-def test_last_agent_name_ignores_other_type_with_token(tmp_path: Path) -> None:
+def test_last_session_name_ignores_other_type_with_token(tmp_path: Path) -> None:
     # line carries the "agent-name" substring but is not an agent-name entry
     f = tmp_path / "s.jsonl"
     f.write_text('{"type":"user","agent-name":"not really"}\n')
-    assert r._last_agent_name(f) is None
+    assert r._last_session_name(f) is None
+
+
+# --- custom-title naming events (issue #1493) ---
+
+
+def test_last_session_name_reads_custom_title(tmp_path: Path) -> None:
+    # Claude Code >= 2.1.16x records session names as custom-title events.
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":"custom-title","customTitle":"id:01:a","sessionId":"s"}\n')
+    assert r._last_session_name(f) == "id:01:a"
+
+
+def test_last_session_name_mixed_event_types_last_wins(tmp_path: Path) -> None:
+    # A transcript spanning the Claude rename carries both event types; the
+    # last naming event in file order wins regardless of type.
+    f = tmp_path / "s.jsonl"
+    f.write_text(
+        '{"type":"agent-name","agentName":"id:01:a","sessionId":"s"}\n'
+        '{"type":"custom-title","customTitle":"id:02:b","sessionId":"s"}\n'
+    )
+    assert r._last_session_name(f) == "id:02:b"
+    f.write_text(
+        '{"type":"custom-title","customTitle":"id:02:b","sessionId":"s"}\n'
+        '{"type":"agent-name","agentName":"id:03:c","sessionId":"s"}\n'
+    )
+    assert r._last_session_name(f) == "id:03:c"
+
+
+def test_last_session_name_ignores_non_string_custom_title(tmp_path: Path) -> None:
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":"custom-title","customTitle":123}\n')
+    assert r._last_session_name(f) is None
+
+
+def test_last_session_name_ignores_non_string_type(tmp_path: Path) -> None:
+    # a non-string (unhashable) "type" carrying the token must not crash
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":["agent-name"],"agentName":"id:01:a"}\n')
+    assert r._last_session_name(f) is None
+
+
+def test_last_session_name_ignores_other_type_with_custom_title_token(
+    tmp_path: Path,
+) -> None:
+    # line carries the "custom-title" substring but is not a custom-title entry
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":"user","custom-title":"not really"}\n')
+    assert r._last_session_name(f) is None
+
+
+def test_name_by_session_reads_custom_title(tmp_path: Path) -> None:
+    slug = tmp_path / "slug"
+    slug.mkdir()
+    (slug / "s1.jsonl").write_text(
+        '{"type":"custom-title","customTitle":"id:01:a","sessionId":"s1"}\n'
+    )
+    assert r.name_by_session(tmp_path) == {"s1": "id:01:a"}
+
+
+def test_archive_session_archives_custom_title_named_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Archiving must work on transcripts named only via custom-title events
+    # (previously a silent no-op) and must append a custom-title event so
+    # Claude's own resume picker shows the archived label too.
+    projects = tmp_path / "projects" / "slug"
+    projects.mkdir(parents=True)
+    t = projects / "s1.jsonl"
+    t.write_text('{"type":"custom-title","customTitle":"vergil:01:p","sessionId":"s1"}\n')
+    monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
+    r._archive_session("s1", "2026-06-07T00:00:00Z")
+    assert r._last_session_name(t) == "archived@2026-06-07T00:00:00Z@vergil:01:p"
+    appended = json.loads(t.read_text().splitlines()[-1])
+    assert appended["type"] == "custom-title"
 
 
 def test_claude_dir_points_at_dot_claude() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Parse both agent-name and custom-title transcript events and resolve slot-name collisions by liveness then recency, so reconnection after a VM kill resumes the current session instead of a stale pre-clear one.

## Issue Linkage

- Ref #1493

## Notes

- Verified end-to-end against live VM state: post-kill slot resolution now picks the current session ids; the pre-rename squatter transcripts are demoted. Archiving now also works on (and emits) custom-title events. Both halves must land together: dual-type parsing alone would make the post-/clear winner order-dependent.