### PR TITLE
fix(release): replace FETCH_HEAD-dependent pull with fetch + ff-merge of remote-tracking ref

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -10,7 +10,7 @@ Three modes:
   run the cleanup. Requires a real terminal on both stdin and stdout.
 - ``vrg-finalize-pr --cleanup-only`` — non-interactive release path:
   skip inference and merge entirely, never read stdin, and run only the
-  cleanup: switch to the target branch, fast-forward pull, delete
+  cleanup: switch to the target branch, fast-forward sync, delete
   merged local branches, and prune stale remote-tracking references.
   This is what ``vrg-release`` invokes (issue #1448).
 
@@ -196,7 +196,7 @@ def _infer_pr(root: Path, target_branch: str) -> str | None:
     if not pairs:
         confirmed = prompt_yes_no(
             f"No open PRs found in worktrees. Run cleanup only (switch to "
-            f"{target_branch}, pull, prune branches/worktrees)?",
+            f"{target_branch}, sync, prune branches/worktrees)?",
             default=False,
         )
         if not confirmed:
@@ -319,7 +319,7 @@ def _stage_merge(ctx: FinalizeContext) -> None:
 
 
 def _stage_cleanup(ctx: FinalizeContext) -> None:
-    """Switch to the target branch, pull, and prune merged branches,
+    """Switch to the target branch, sync, and prune merged branches,
     worktrees, and remote-tracking references."""
     args = ctx.args
     root = ctx.root
@@ -348,7 +348,11 @@ def _stage_cleanup(ctx: FinalizeContext) -> None:
 
     print(f"Pulling latest from origin/{args.target_branch}...")
     _run(["fetch", "--tags", "--force", "origin", args.target_branch], dry_run=args.dry_run)
-    _run(["pull", "--ff-only", "origin", args.target_branch], dry_run=args.dry_run)
+    # ff-merge the remote-tracking ref instead of `pull`: FETCH_HEAD is
+    # written non-atomically, so a `pull` racing a concurrent fetch can
+    # see two merge candidates and abort (issue #1499). The
+    # remote-tracking ref is updated atomically.
+    _run(["merge", "--ff-only", f"origin/{args.target_branch}"], dry_run=args.dry_run)
 
     deleted = ctx.deleted
 

--- a/src/vergil_tooling/lib/release/bump.py
+++ b/src/vergil_tooling/lib/release/bump.py
@@ -36,7 +36,12 @@ def back_merge_and_bump(ctx: ReleaseContext) -> None:
     wait_and_merge(pr_url, phase="back-merge-bump")
 
     git.run("checkout", "develop")
-    git.run("pull", "--ff-only", "origin", "develop")
+    # Fetch then ff-merge the remote-tracking ref instead of `pull`:
+    # FETCH_HEAD is written non-atomically, so a `pull` racing a
+    # concurrent fetch can see two merge candidates and abort
+    # (issue #1499). origin/develop is updated atomically.
+    git.run("fetch", "origin", "develop")
+    git.run("merge", "--ff-only", "origin/develop")
 
     ctx.bump_pr_url = pr_url
     ctx.next_version = next_ver

--- a/tests/vergil_tooling/test_release_bump.py
+++ b/tests/vergil_tooling/test_release_bump.py
@@ -118,7 +118,10 @@ def test_back_merge_waits_and_merges() -> None:
     )
 
 
-def test_back_merge_pulls_develop_after_merge() -> None:
+def test_back_merge_syncs_develop_after_merge() -> None:
+    """The final develop sync must fetch then ff-merge the remote-tracking
+    ref — never `pull`, whose FETCH_HEAD dependence races concurrent
+    fetches (issue #1499)."""
     ctx = _ctx()
     git_run_calls: list[tuple[str, ...]] = []
 
@@ -139,6 +142,9 @@ def test_back_merge_pulls_develop_after_merge() -> None:
     develop_checkout_idx = next(
         i for i, c in enumerate(git_run_calls) if c == ("checkout", "develop")
     )
-    pull_idx = next(i for i, c in enumerate(git_run_calls) if c[:2] == ("pull", "--ff-only"))
-    assert git_run_calls[pull_idx] == ("pull", "--ff-only", "origin", "develop")
-    assert pull_idx > develop_checkout_idx
+    fetch_idx = next(i for i, c in enumerate(git_run_calls) if c == ("fetch", "origin", "develop"))
+    merge_idx = next(
+        i for i, c in enumerate(git_run_calls) if c == ("merge", "--ff-only", "origin/develop")
+    )
+    assert develop_checkout_idx < fetch_idx < merge_idx
+    assert not any(c[0] == "pull" for c in git_run_calls)

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -163,6 +163,44 @@ def test_main_library_release(tmp_path: Path) -> None:
     mock_run.assert_any_call("branch", "-D", "feature/x")
 
 
+def test_main_cleanup_syncs_target_without_pull(tmp_path: Path) -> None:
+    """Cleanup must fetch then ff-merge the remote-tracking ref — never
+    `pull`, whose FETCH_HEAD dependence races concurrent fetches
+    (issue #1499)."""
+    _make_profile(tmp_path, "library-release")
+    git_run_calls: list[tuple[str, ...]] = []
+
+    def capture_git_run(*args: str) -> None:
+        git_run_calls.append(args)
+
+    with (
+        _sweep_guards_pass(),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        patch(_MOD + ".git.run", side_effect=capture_git_run),
+        patch(
+            "vergil_tooling.bin.vrg_finalize_pr.git.merged_branches",
+            return_value=["feature/x", "develop"],
+        ),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+    ):
+        result = main([])
+
+    assert result == 0
+    fetch_idx = next(
+        i
+        for i, c in enumerate(git_run_calls)
+        if c == ("fetch", "--tags", "--force", "origin", "develop")
+    )
+    merge_idx = next(
+        i for i, c in enumerate(git_run_calls) if c == ("merge", "--ff-only", "origin/develop")
+    )
+    assert fetch_idx < merge_idx
+    assert not any(c[0] == "pull" for c in git_run_calls)
+
+
 def test_main_already_on_target(tmp_path: Path) -> None:
     _make_profile(tmp_path, "library-release")
     with (


### PR DESCRIPTION
# Pull Request

## Summary

- Replace 'pull --ff-only' with fetch + 'merge --ff-only origin/<branch>' in release bump and finalize-pr cleanup, eliminating the FETCH_HEAD interleaving race under concurrent fetches.

## Issue Linkage

- Ref #1499

## Notes

- Both call sites from the issue are covered (bump.py back-merge sync, vrg_finalize_pr.py cleanup). Tests assert the fetch-then-merge order and that no 'pull' is issued.