### PR TITLE
chore(gitignore): ignore .claude/scheduled_tasks.lock runtime lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build/
 .worktrees/
 .vergil/
 .superpowers/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
# Pull Request

## Summary

- The Claude Code scheduled-tasks subsystem (behind /schedule, /loop, and
cron agents) writes a per-session runtime lock at
.claude/scheduled_tasks.lock containing session id, pid, process start,
and acquisition timestamp. It is rewritten every session, so it
perpetually appeared as an untracked file in `git status`.

This adds a single, targeted line to .gitignore:

    .claude/scheduled_tasks.lock

A blanket `.claude/` ignore would be wrong — `.claude/settings.json` and
`.claude/hooks/` are intentionally tracked. The exact-path pattern ignores
only the runtime lock and leaves those tracked files untouched.

Validation: `vrg-container-run -- uv run vrg-validate` passed clean.

## Issue Linkage

- Ref #1501

## Notes

- Acceptance criteria from #1501:
- .claude/scheduled_tasks.lock no longer appears in `git status`
- .claude/settings.json and .claude/hooks/ remain tracked