### PR TITLE
ci: add build-only docs verification job to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,6 @@ jobs:
       run-release: ${{ inputs.run-release != 'false' }}
       container-tag: '3.14'
       container-suffix: python
+
+  docs:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-docs.yml@v2.1


### PR DESCRIPTION
# Pull Request

## Summary

- Add the docs job calling ci-docs.yml so docs-build failures are caught pre-merge.

## Issue Linkage

- Ref #1362

## Notes

- The issue body specified ci-docs.yml@v2.0, but every other job in this
ci.yml pins @v2.1, so the docs job uses @v2.1 for consistency (confirmed
by the user). The reusable workflow exists at both tags. The caller job id
is exactly `docs` so the required check context resolves to `docs / docs`.