### PR TITLE
fix(github-config): compare ruleset required checks by set, not list order

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -7,6 +7,8 @@ against the actual GitHub API state to produce audit diffs.
 
 from __future__ import annotations
 
+import copy
+import json
 import subprocess
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
@@ -644,6 +646,47 @@ class ConfigDiff:
         return len(self.items) == 0
 
 
+def _canonical_key(obj: object) -> str:
+    """Stable, order-independent sort key for a rule or check dict."""
+    return json.dumps(obj, sort_keys=True, default=str)
+
+
+def _canonicalize_rules(rules: Sequence[object]) -> list[object]:
+    """Normalize a ruleset's ``rules`` for order-independent comparison.
+
+    GitHub does not assign meaning to the order of rules within a ruleset,
+    nor to the order of contexts within a ``required_status_checks`` rule.
+    Comparing the raw lists with ``!=`` therefore reports spurious drift on
+    a pure reordering while a genuine added/removed required check is the
+    real concern (issue #1368).  Sorting both the outer rule list and the
+    nested check list makes the comparison reflect set membership: an
+    extra or missing required check always differs, a reordering never does.
+    """
+    canonical: list[object] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            canonical.append(rule)
+            continue
+        rule_copy = copy.deepcopy(cast("dict[str, object]", rule))
+        params = rule_copy.get("parameters")
+        if isinstance(params, dict):
+            params_dict = cast("dict[str, object]", params)
+            checks = params_dict.get("required_status_checks")
+            if isinstance(checks, list):
+                params_dict["required_status_checks"] = sorted(
+                    cast("list[object]", checks), key=_canonical_key
+                )
+        canonical.append(rule_copy)
+    return sorted(canonical, key=_canonical_key)
+
+
+def _values_differ(prefix: str, desired: object, actual: object) -> bool:
+    """Compare two leaf values, using set semantics for ruleset rules."""
+    if prefix.endswith(".rules") and isinstance(desired, list) and isinstance(actual, list):
+        return _canonicalize_rules(desired) != _canonicalize_rules(actual)
+    return desired != actual
+
+
 def _diff_dataclass(
     prefix: str,
     desired: object,
@@ -655,7 +698,7 @@ def _diff_dataclass(
         if desired is None:
             skipped.append(prefix)
             return
-        if desired != actual:
+        if _values_differ(prefix, desired, actual):
             items.append(DiffItem(field=prefix, expected=desired, actual=actual))
         return
     for field_name in cast("dict[str, object]", desired.__dataclass_fields__):

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -21,6 +21,7 @@ from vergil_tooling.lib.github_config import (
     _apply_repo_settings,
     _apply_rulesets,
     _apply_security_settings,
+    _canonicalize_rules,
     _cleanup_classic_branch_protection,
     _fetch_vulnerability_alerts,
     _lang_has_check,
@@ -1011,6 +1012,73 @@ def test_diff_public_repo_has_no_security_skipped() -> None:
     diff = compute_diff(desired=state, actual=state)
     assert diff.is_compliant()
     assert not any(s.startswith("security.") for s in diff.skipped)
+
+
+# -- Issue #1368: required-status-check drift must never read as compliant ----
+
+
+def test_diff_detects_extra_required_check() -> None:
+    """A required check on the live ruleset but absent from desired is drift.
+
+    This is the issue #1368 scenario: release-model ``none`` drops
+    ``version / version-bump`` from desired, but the live ruleset still
+    requires it.  The audit must not report compliant.
+    """
+    desired = compute_desired_state(
+        _vergil_config(release_model="none"), visibility="public", is_org=True
+    )
+    actual = compute_desired_state(
+        _vergil_config(release_model="none"), visibility="public", is_org=True
+    )
+    actual_gates = next(r for r in actual.rulesets if r.name == "CI gates")
+    _checks(actual_gates).append({"context": "version / version-bump", "integration_id": 15368})
+
+    diff = compute_diff(desired=desired, actual=actual)
+
+    assert not diff.is_compliant()
+    assert any(d.field == "rulesets.CI gates.rules" for d in diff.items)
+
+
+def test_diff_detects_missing_required_check() -> None:
+    """A required check desired but absent from the live ruleset is drift."""
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual_gates = next(r for r in actual.rulesets if r.name == "CI gates")
+    _checks(actual_gates).pop()
+
+    diff = compute_diff(desired=desired, actual=actual)
+
+    assert not diff.is_compliant()
+    assert any(d.field == "rulesets.CI gates.rules" for d in diff.items)
+
+
+def test_diff_ignores_required_check_ordering() -> None:
+    """Reordered-but-identical check sets are not drift (no false positive)."""
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual_gates = next(r for r in actual.rulesets if r.name == "CI gates")
+    _checks(actual_gates).reverse()
+
+    diff = compute_diff(desired=desired, actual=actual)
+
+    assert diff.is_compliant()
+
+
+def test_diff_ignores_rule_ordering() -> None:
+    """Reordered-but-identical rule lists are not drift (no false positive)."""
+    desired = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    actual_bp = next(r for r in actual.rulesets if r.name == "Branch protection")
+    actual_bp.rules.reverse()
+
+    diff = compute_diff(desired=desired, actual=actual)
+
+    assert diff.is_compliant()
+
+
+def test_canonicalize_rules_preserves_non_dict_entries() -> None:
+    """Non-dict rule entries are passed through unchanged before sorting."""
+    assert _canonicalize_rules(["z", "a"]) == ["a", "z"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Make ruleset required-status-check comparison order-independent so required-check drift is detected and reordering is not flagged.

## Issue Linkage

- Ref #1368

## Notes

- Investigation finding (verified against current develop, real parser +
compute_desired_state + compute_diff): the reported false-*negative*
(audit reports compliant despite required-check drift) does NOT reproduce.
The plain list `!=` already catches an added or removed required check
because a superset/subset always differs in length. Likely already fixed
by #1210, or the original trigger was outside the rulesets API the tool
reads (e.g. classic branch protection, or an app-installation token
returning incomplete ruleset data).

What DID reproduce is a real, opposite defect in the same code: the
order-sensitive `!=` flags a reordered-but-identical check set as
NON-COMPLIANT with a confusing `extra (0) / missing (0)` delta.

Fix (per the issue's Expected section — set-based comparison keyed like
format_rules_delta): route the ruleset `rules` leaf comparison through
`_canonicalize_rules`/`_values_differ`, sorting the outer rule list and
each `required_status_checks` list before comparing. This makes a
silent false-green on required-check drift structurally impossible and
removes the reorder false-positive. Detection now matches the existing
delta presentation.

Tests: added compute_diff coverage for extra/missing required checks
(the issue's stated concern) and for check/rule reordering (the defect
found). 147 passed; github_config.py at 100% coverage; vrg-validate green.