### PR TITLE
feat(container-run): resolve validation command from target repo's vergil.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,16 @@ formatters, or other tools outside of `vrg-validate`. If a tool is not
 invoked by `vrg-validate`, it is not part of the validation pipeline.
 <!-- vergil:template:claude-md:end -->
 
-> **Note:** This repository uses
-> `vrg-container-run -- uv run vrg-validate` because it runs its own
-> unreleased code rather than the pre-installed version.
+> **Note:** The command above works as-is here, even though this repo
+> dogfoods its own unreleased code (the cached dev image deliberately
+> skips `uv tool install`, so `vrg-validate` is not on `PATH` and must be
+> run via `uv run`). This repo declares a `[validation]` override in
+> `vergil.toml` (`container-command = "uv run vrg-validate"`), and
+> `vrg-container-run` reads it from the target repo at execution time, so
+> `vrg-container-run -- vrg-validate` is transparently expanded to
+> `vrg-container-run -- uv run vrg-validate`. The override lives in
+> `vergil.toml` (not just here) so cross-repo agents pick it up regardless
+> of which `CLAUDE.md` their session loaded (issues #1430, #1433).
 
 ## Identity modes and PR submission
 
@@ -177,9 +184,11 @@ above.
 Testing is split across two tiers with increasing scope and cost:
 
 **Tier 1 — Local pre-commit (seconds):** The single entry point
-`vrg-container-run -- uv run vrg-validate` runs everything
+`vrg-container-run -- vrg-validate` runs everything
 (lint, typecheck, tests, audit, common checks) inside one dev
-container.
+container. (Here that transparently expands to `uv run vrg-validate`
+via the `[validation]` override in `vergil.toml` — see
+[Validation](#validation).)
 
 **Tier 2 — PR CI (~5-8 min):** Triggers on `pull_request`. Python 3.12,
 all quality checks, security scanners (CodeQL, Trivy, Semgrep), standards
@@ -211,7 +220,8 @@ Dev container images are maintained in
 cd ../vergil-docker && docker/build.sh
 
 # Run the full validation pipeline in one container
-vrg-container-run -- uv run vrg-validate
+# (the [validation] override in vergil.toml expands this to `uv run vrg-validate`)
+vrg-container-run -- vrg-validate
 ```
 
 ## Architecture

--- a/src/vergil_tooling/bin/vrg_container_run.py
+++ b/src/vergil_tooling/bin/vrg_container_run.py
@@ -9,10 +9,16 @@ arguments after ``--``.
 from __future__ import annotations
 
 import os
+import shlex
 import sys
+from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import git
-from vergil_tooling.lib.config import container_env_prefixes
+from vergil_tooling.lib.config import (
+    DEFAULT_VALIDATION_COMMAND,
+    container_env_prefixes,
+    validation_container_command,
+)
 from vergil_tooling.lib.container import (
     assert_runtime_available,
     build_container_args,
@@ -22,7 +28,17 @@ from vergil_tooling.lib.container import (
 )
 from vergil_tooling.lib.container_cache import ensure_cached_image
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 _VALID_PREFIXES = {"dev", "prod"}
+
+# When the in-container command is the validation entry point, rewrite it using
+# the target repo's [validation].container-command override (issue #1433). This
+# lets the fleet-wide `vrg-container-run -- vrg-validate` keep working in repos
+# that need a different activation (e.g. the self-repo's "uv run vrg-validate"),
+# regardless of which repo the invoking agent's session started in.
+_VALIDATION_ENTRY = DEFAULT_VALIDATION_COMMAND
 
 _USAGE = """\
 usage: vrg-container-run [--prefix <dev|prod>] [--] <command> [args...]
@@ -47,6 +63,20 @@ examples:
   vrg-container-run -- uv run pytest tests/
   DOCKER_DEV_IMAGE=custom:img vrg-container-run -- make build
 """
+
+
+def _apply_validation_override(command: list[str], repo_root: Path) -> list[str]:
+    """Rewrite a ``vrg-validate`` invocation per the repo's override.
+
+    Only the validation entry point is rewritten; any other command passes
+    through unchanged. Trailing arguments (e.g. ``--check common``) are
+    preserved. The default override is ``vrg-validate`` itself, so repos
+    without a ``[validation]`` section are left untouched.
+    """
+    if not command or command[0] != _VALIDATION_ENTRY:
+        return command
+    override = validation_container_command(repo_root)
+    return shlex.split(override) + command[1:]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -84,6 +114,7 @@ def main(argv: list[str] | None = None) -> int:
     runtime = detect_runtime()
     repo_root = git.repo_root()
     lang = detect_language(repo_root)
+    command = _apply_validation_override(command, repo_root)
 
     env_image = os.environ.get("DOCKER_DEV_IMAGE")
     if env_image:

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -13,6 +13,13 @@ if TYPE_CHECKING:
 
 CONFIG_FILE = "vergil.toml"
 
+# The default in-container validation entry point. Repos may override this in
+# [validation].container-command (e.g. the self-repo, which activates its local
+# dev version via "uv run vrg-validate"). vrg-container-run resolves the
+# override from the target repo so cross-repo agents pick it up at execution
+# time, independent of which CLAUDE.md their session loaded (issue #1433).
+DEFAULT_VALIDATION_COMMAND = "vrg-validate"
+
 _ENUMS: dict[str, set[str]] = {
     "repository-type": {"library", "application", "infrastructure", "tooling", "documentation"},
     "versioning-scheme": {"library", "semver", "application", "none"},
@@ -31,7 +38,7 @@ _REQUIRED_PROJECT_FIELDS = (
 _PROJECT_FIELDS = (*_REQUIRED_PROJECT_FIELDS, "primary-language", "ghas")
 
 _KNOWN_SECTIONS = frozenset(
-    {"project", "dependencies", "markdownlint", "ci", "publish", "container", "vm"},
+    {"project", "dependencies", "markdownlint", "ci", "publish", "container", "validation", "vm"},
 )
 
 _KNOWN_KEYS: dict[str, frozenset[str]] = {
@@ -41,6 +48,7 @@ _KNOWN_KEYS: dict[str, frozenset[str]] = {
     "ci": frozenset({"versions", "integration-tests"}),
     "publish": frozenset({"release", "docs", "consumer-refresh"}),
     "container": frozenset({"env-prefixes"}),
+    "validation": frozenset({"container-command"}),
 }
 
 
@@ -82,6 +90,11 @@ class ContainerConfig:
 
 
 @dataclass
+class ValidationConfig:
+    container_command: str
+
+
+@dataclass
 class VergilConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
@@ -89,6 +102,7 @@ class VergilConfig:
     ci: CiConfig
     publish: PublishConfig
     container: ContainerConfig
+    validation: ValidationConfig
     vm: VmStanza | None = None
 
 
@@ -275,6 +289,19 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
     else:
         container = ContainerConfig(env_prefixes=[])
 
+    validation_raw = raw.get("validation")
+    if validation_raw is not None:
+        container_command = validation_raw.get("container-command")
+        if container_command is None:
+            msg = f"{source}: [validation] missing required field 'container-command'"
+            raise ConfigError(msg)
+        if not isinstance(container_command, str) or not container_command.strip():
+            msg = f"{source}: [validation].container-command must be a non-empty string"
+            raise ConfigError(msg)
+        validation = ValidationConfig(container_command=container_command)
+    else:
+        validation = ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND)
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -290,6 +317,7 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
         ci=ci,
         publish=publish,
         container=container,
+        validation=validation,
         vm=parse_vm_stanza(raw, source),
     )
 
@@ -330,3 +358,17 @@ def container_env_prefixes(repo_root: Path) -> list[str]:
     except FileNotFoundError:
         return []
     return cfg.container.env_prefixes
+
+
+def validation_container_command(repo_root: Path) -> str:
+    """Return ``[validation].container-command`` from vergil.toml.
+
+    Falls back to :data:`DEFAULT_VALIDATION_COMMAND` (``"vrg-validate"``) when
+    the repo declares no override or has no ``vergil.toml``. ``ConfigError``
+    from a malformed config propagates, matching :func:`container_env_prefixes`.
+    """
+    try:
+        cfg = read_config(repo_root)
+    except FileNotFoundError:
+        return DEFAULT_VALIDATION_COMMAND
+    return cfg.validation.container_command

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -8,15 +8,18 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.lib.config import (
+    DEFAULT_VALIDATION_COMMAND,
     CiConfig,
     ConfigError,
     ContainerConfig,
     MarkdownlintConfig,
+    ValidationConfig,
     VmStanza,
     _warn_unrecognized_keys,
     container_env_prefixes,
     parse_vm_stanza,
     read_config,
+    validation_container_command,
     vrg_install_tag,
 )
 
@@ -590,6 +593,70 @@ def test_container_env_prefixes_no_file(tmp_path: Path) -> None:
 def test_container_env_prefixes_no_section(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text(_VALID_TOML)
     assert container_env_prefixes(tmp_path) == []
+
+
+# -- [validation] section -----------------------------------------------------
+
+_VALIDATION_TOML = _VALID_TOML + '[validation]\ncontainer-command = "uv run vrg-validate"\n'
+
+
+def test_read_config_validation_section(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALIDATION_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.validation == ValidationConfig(container_command="uv run vrg-validate")
+
+
+def test_read_config_no_validation_section_defaults(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.validation == ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND)
+
+
+def test_read_config_validation_missing_container_command(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[validation]\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[validation\].*container-command"):
+        read_config(tmp_path)
+
+
+def test_read_config_validation_command_not_string(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[validation]\ncontainer-command = 42\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[validation\]\.container-command must be a non-empty"):
+        read_config(tmp_path)
+
+
+def test_read_config_validation_command_empty(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '[validation]\ncontainer-command = "   "\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[validation\]\.container-command must be a non-empty"):
+        read_config(tmp_path)
+
+
+def test_warns_unrecognized_validation_key(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    toml = _VALIDATION_TOML + "foo = true\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    read_config(tmp_path)
+    assert "unrecognized key 'foo' in [validation]" in capsys.readouterr().err
+
+
+# -- validation_container_command convenience function ------------------------
+
+
+def test_validation_container_command_with_override(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALIDATION_TOML)
+    assert validation_container_command(tmp_path) == "uv run vrg-validate"
+
+
+def test_validation_container_command_no_file(tmp_path: Path) -> None:
+    assert validation_container_command(tmp_path) == DEFAULT_VALIDATION_COMMAND
+
+
+def test_validation_container_command_no_section(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    assert validation_container_command(tmp_path) == DEFAULT_VALIDATION_COMMAND
 
 
 # -- [vm] cascade (issue #99) -------------------------------------------------

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -7,11 +7,13 @@ from typing import cast
 from unittest.mock import patch
 
 from vergil_tooling.lib.config import (
+    DEFAULT_VALIDATION_COMMAND,
     CiConfig,
     ContainerConfig,
     MarkdownlintConfig,
     ProjectConfig,
     PublishConfig,
+    ValidationConfig,
     VergilConfig,
 )
 from vergil_tooling.lib.github_config import (
@@ -343,6 +345,7 @@ def _vergil_config(
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
         publish=PublishConfig(release=False, docs=True, consumer_refresh=None),
         container=ContainerConfig(env_prefixes=[]),
+        validation=ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND),
     )
 
 
@@ -1457,6 +1460,7 @@ def test_compute_desired_state_publish_release_true() -> None:
         ci=_ci(),
         publish=PublishConfig(release=True, docs=True, consumer_refresh=None),
         container=ContainerConfig(env_prefixes=[]),
+        validation=ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND),
     )
     state = compute_desired_state(config, visibility="public", is_org=True)
     assert state.publish.release is True

--- a/tests/vergil_tooling/test_vrg_container_run.py
+++ b/tests/vergil_tooling/test_vrg_container_run.py
@@ -369,6 +369,107 @@ def test_registry_image_uses_pull_always(tmp_path: Path) -> None:
     assert "--pull=always" in args
 
 
+# -- validation-command override ([validation] in vergil.toml) ----------------
+
+
+def test_validate_command_rewritten_by_override(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="img:1"),
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_run.validation_container_command",
+            return_value="uv run vrg-validate",
+        ),
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "vrg-validate"])
+    args = mock_exec.call_args[0][1]
+    assert args[-3:] == ["uv", "run", "vrg-validate"]
+
+
+def test_validate_override_preserves_trailing_args(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="img:1"),
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_run.validation_container_command",
+            return_value="uv run vrg-validate",
+        ),
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "vrg-validate", "--check", "common"])
+    args = mock_exec.call_args[0][1]
+    assert args[-5:] == ["uv", "run", "vrg-validate", "--check", "common"]
+
+
+def test_validate_override_printed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="img:1"),
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_run.validation_container_command",
+            return_value="uv run vrg-validate",
+        ),
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp"),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "vrg-validate"])
+    assert "Command:  uv run vrg-validate" in capsys.readouterr().out
+
+
+def test_non_validate_command_not_rewritten(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="img:1"),
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_run.validation_container_command",
+            return_value="uv run vrg-validate",
+        ) as mock_override,
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "echo", "hi"])
+    args = mock_exec.call_args[0][1]
+    assert args[-2:] == ["echo", "hi"]
+    mock_override.assert_not_called()
+
+
+def test_validate_default_no_override_passthrough(tmp_path: Path) -> None:
+    # No vergil.toml in tmp_path: validation_container_command falls back to the
+    # default "vrg-validate", so the command is unchanged (real-helper path).
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="img:1"),
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp") as mock_exec,
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "vrg-validate"])
+    args = mock_exec.call_args[0][1]
+    assert args[-1] == "vrg-validate"
+
+
 def test_python_routes_through_cache(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text("[project]\n")
     env = {"GH_TOKEN": "tok"}

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -21,11 +21,13 @@ from vergil_tooling.bin.vrg_github_repo_config import (
     parse_args,
 )
 from vergil_tooling.lib.config import (
+    DEFAULT_VALIDATION_COMMAND,
     CiConfig,
     ContainerConfig,
     MarkdownlintConfig,
     ProjectConfig,
     PublishConfig,
+    ValidationConfig,
     VergilConfig,
 )
 from vergil_tooling.lib.github_config import ConfigDiff, DiffItem
@@ -386,6 +388,7 @@ def _make_config() -> VergilConfig:
         ci=CiConfig(versions=["3.14"], integration_tests=False),
         publish=PublishConfig(release=False, docs=True, consumer_refresh=None),
         container=ContainerConfig(env_prefixes=[]),
+        validation=ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND),
     )
 
 

--- a/vergil.toml
+++ b/vergil.toml
@@ -17,3 +17,12 @@ integration-tests = false
 
 [dependencies]
 vergil = "v2.1"
+
+# This repo dogfoods its own unreleased code: the cached dev image deliberately
+# skips `uv tool install` for the self-repo, so `vrg-validate` is not on PATH —
+# `uv run` activates the project venv instead. Declaring it here (rather than
+# only in CLAUDE.md) lets vrg-container-run resolve the correct command from the
+# target repo, so cross-repo agents validate this repo correctly regardless of
+# where their session started (issue #1433).
+[validation]
+container-command = "uv run vrg-validate"


### PR DESCRIPTION
# Pull Request

## Summary

- Make the per-repo validation invocation self-describing so cross-repo agents
run the correct command at execution time, independent of which CLAUDE.md
their session loaded.

## Issue Linkage

- Ref #1433

## Notes

- Adds an optional [validation] section to vergil.toml with a container-command
key (default "vrg-validate"). vrg-container-run reads the override from the
mounted repo root and rewrites a `vrg-validate` invocation accordingly, so the
fleet-wide `vrg-container-run -- vrg-validate` keeps working everywhere while
repos needing different activation are honored. This repo declares the self-repo
override (`uv run vrg-validate`), which dissolves the CLAUDE.md contradiction.

Scope: this PR delivers BOTH #1433 (the mechanism) and #1430 (the CLAUDE.md
docs contradiction), since #1430's note becomes informational once the
mechanism lands. The body Refs only #1433 because the repo's linkage model
permits a single tracking issue per PR — please close #1430 manually after
merge.

Expected: while the host-installed tooling predates this change, vrg-container-run
prints "unrecognized section [validation]" from its own (older) config parser.
This is a forward-compatibility version-skew artifact — identical to how
[container] and [vm] behaved when introduced — and self-resolves once the host
tool upgrades. The new parser recognizes the section (verified end-to-end).

CI interaction: this repo's CI delegates to vergil-actions reusable workflows
and does not call the host vrg-container-run wrapper, so the mechanism does not
affect CI here; it is forward-compatible if those workflows adopt it later.