### PR TITLE
feat(github-repo-config): resolve vergil.toml from main, then develop, then local

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -62,40 +62,90 @@ def _load_local_config(path: str) -> VergilConfig:
     return _parse_raw_config(raw, source=path)
 
 
+# Canonical config branches, in resolution order: the released/stable branch
+# first, then the integration branch as a bootstrap fallback.
+_CONFIG_REFS = ("main", "develop")
+
+
 def _is_not_found(exc: github.GitHubAPIError) -> bool:
     """Return True when a GitHub API error is an HTTP 404 (Not Found)."""
     return "404" in (exc.stderr or "") or "404" in (exc.stdout or "")
 
 
-def _fetch_remote_config(repo: str) -> VergilConfig:
-    """Fetch and parse vergil.toml from a remote repo."""
-    try:
-        content_data = github.read_json(
-            "api",
-            f"repos/{repo}/contents/vergil.toml",
-        )
-    except github.GitHubAPIError as exc:
-        if not _is_not_found(exc):
-            raise
-        msg = (
-            f"vergil.toml could not be fetched from {repo} via the GitHub API "
-            f"(HTTP 404). It is read from the repository's default branch — confirm "
-            f"the file exists there (a repo whose default branch is still 'main' but "
-            f"whose vergil.toml only lives on 'develop' will hit this), that the repo "
-            f"exists, and that your credentials have access. To apply from a local "
-            f"copy instead, pass --config <path/to/vergil.toml>."
-        )
-        raise RuntimeError(msg) from exc
+def _decode_config(
+    repo: str, ref: str, content_data: dict[str, object] | list[object]
+) -> VergilConfig:
+    """Decode a GitHub contents API response into a VergilConfig."""
     if not isinstance(content_data, dict):
-        msg = f"Unexpected response fetching config from {repo}"
+        msg = f"Unexpected response fetching config from {repo}@{ref}"
         raise RuntimeError(msg)
     content = content_data.get("content")
     if not isinstance(content, str):
-        msg = f"No content field in config response from {repo}"
+        msg = f"No content field in config response from {repo}@{ref}"
         raise RuntimeError(msg)
     raw_bytes = base64.b64decode(content)
     raw = tomllib.loads(raw_bytes.decode())
-    return _parse_raw_config(raw, source=f"{repo}:vergil.toml")
+    return _parse_raw_config(raw, source=f"{repo}@{ref}:vergil.toml")
+
+
+def _fetch_config_from_ref(repo: str, ref: str) -> VergilConfig | None:
+    """Fetch and parse vergil.toml from a specific branch of a remote repo.
+
+    Returns ``None`` when the file is absent on that branch (HTTP 404).
+    Non-404 API errors propagate unchanged.
+    """
+    try:
+        content_data = github.read_json(
+            "api",
+            f"repos/{repo}/contents/vergil.toml?ref={ref}",
+        )
+    except github.GitHubAPIError as exc:
+        if _is_not_found(exc):
+            return None
+        raise
+    return _decode_config(repo, ref, content_data)
+
+
+def _load_cwd_config() -> VergilConfig | None:
+    """Load vergil.toml from the current working directory, or None if absent."""
+    path = Path.cwd() / "vergil.toml"
+    if not path.exists():
+        return None
+    return _load_local_config(str(path))
+
+
+def _resolve_config(repo: str) -> VergilConfig:
+    """Resolve the canonical vergil.toml for ``repo``.
+
+    Resolution order: the ``main`` branch, then ``develop``, then the local
+    working-directory copy when the cwd is a checkout of ``repo``. The remote
+    branches are the canonical source; the local fallback makes bootstrapping
+    ergonomic — run ``apply`` from the repo root before the file has landed on
+    any canonical branch — and is safe under the trust model: agents may *write*
+    vergil.toml, but only a human runs ``apply`` and owns that action, so the
+    local copy can never be applied without human oversight. The fallback is
+    gated on the cwd matching the target repo so a ``--repo other/repo`` run can
+    never apply the current directory's unrelated config.
+    """
+    for ref in _CONFIG_REFS:
+        config = _fetch_config_from_ref(repo, ref)
+        if config is not None:
+            return config
+    cwd_is_repo = _cwd_matches_repo(repo)
+    if cwd_is_repo:
+        local = _load_cwd_config()
+        if local is not None:
+            return local
+    locations = "the 'main' and 'develop' branches"
+    if cwd_is_repo:
+        locations += " and the current directory"
+    msg = (
+        f"vergil.toml could not be resolved for {repo}: it is absent from "
+        f"{locations}. Confirm the file exists on a canonical branch or in this "
+        f"checkout, that the repo exists, and that your credentials have access. "
+        f"To apply from a specific file, pass --config <path/to/vergil.toml>."
+    )
+    raise RuntimeError(msg)
 
 
 def _audit_repo(repo: str, config: VergilConfig) -> ConfigDiff:
@@ -184,7 +234,7 @@ def main(argv: list[str] | None = None) -> int:
 
     repo = _resolve_repo(args)
     try:
-        config = _load_local_config(args.config) if args.config else _fetch_remote_config(repo)
+        config = _load_local_config(args.config) if args.config else _resolve_config(repo)
     except RuntimeError as exc:
         emit_error(str(exc))
         return 1

--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -24,6 +24,7 @@ from vergil_tooling.lib.github_config import (
     fetch_actual_state,
     format_rules_delta,
 )
+from vergil_tooling.lib.output import emit_error
 from vergil_tooling.lib.repo_config import audit_local_config
 
 
@@ -61,12 +62,30 @@ def _load_local_config(path: str) -> VergilConfig:
     return _parse_raw_config(raw, source=path)
 
 
+def _is_not_found(exc: github.GitHubAPIError) -> bool:
+    """Return True when a GitHub API error is an HTTP 404 (Not Found)."""
+    return "404" in (exc.stderr or "") or "404" in (exc.stdout or "")
+
+
 def _fetch_remote_config(repo: str) -> VergilConfig:
     """Fetch and parse vergil.toml from a remote repo."""
-    content_data = github.read_json(
-        "api",
-        f"repos/{repo}/contents/vergil.toml",
-    )
+    try:
+        content_data = github.read_json(
+            "api",
+            f"repos/{repo}/contents/vergil.toml",
+        )
+    except github.GitHubAPIError as exc:
+        if not _is_not_found(exc):
+            raise
+        msg = (
+            f"vergil.toml could not be fetched from {repo} via the GitHub API "
+            f"(HTTP 404). It is read from the repository's default branch — confirm "
+            f"the file exists there (a repo whose default branch is still 'main' but "
+            f"whose vergil.toml only lives on 'develop' will hit this), that the repo "
+            f"exists, and that your credentials have access. To apply from a local "
+            f"copy instead, pass --config <path/to/vergil.toml>."
+        )
+        raise RuntimeError(msg) from exc
     if not isinstance(content_data, dict):
         msg = f"Unexpected response fetching config from {repo}"
         raise RuntimeError(msg)
@@ -164,7 +183,11 @@ def main(argv: list[str] | None = None) -> int:
         all_compliant = False
 
     repo = _resolve_repo(args)
-    config = _load_local_config(args.config) if args.config else _fetch_remote_config(repo)
+    try:
+        config = _load_local_config(args.config) if args.config else _fetch_remote_config(repo)
+    except RuntimeError as exc:
+        emit_error(str(exc))
+        return 1
 
     github_diff = _audit_repo(repo, config)
     _print_diff(repo, github_diff)

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -238,8 +238,11 @@ def test_main_remote_config_error_exits_one_without_traceback(
     assert result == 1
     mock_audit.assert_not_called()
     err = capsys.readouterr().err
-    assert "ERROR:" in err
+    # The actionable message reaches stderr, emitted cleanly (no traceback).
+    # Assert on substance, not the prefix: emit_error formats differ between
+    # interactive (`ERROR: ...`) and CI (`::error ::...`) environments.
     assert "--config" in err
+    assert "Traceback" not in err
 
 
 def test_apply_returns_one_when_local_issues_remain() -> None:

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -14,8 +14,10 @@ import pytest
 from vergil_tooling.bin.vrg_github_repo_config import (
     _apply_repo,
     _audit_repo,
-    _fetch_remote_config,
+    _fetch_config_from_ref,
+    _load_cwd_config,
     _load_local_config,
+    _resolve_config,
     _resolve_repo,
     main,
     parse_args,
@@ -135,7 +137,7 @@ def test_audit_both_compliant_returns_zero() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         assert main(["audit", "--repo", "o/r"]) == 0
 
@@ -146,7 +148,7 @@ def test_audit_local_noncompliant_returns_one() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_noncompliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         assert main(["audit", "--repo", "o/r"]) == 1
 
@@ -157,7 +159,7 @@ def test_audit_github_noncompliant_returns_one() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         assert main(["audit", "--repo", "o/r"]) == 1
 
@@ -168,7 +170,7 @@ def test_diff_always_returns_zero() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_noncompliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         assert main(["diff", "--repo", "o/r"]) == 0
 
@@ -179,7 +181,7 @@ def test_audit_runs_local_checks_first(capsys: pytest.CaptureFixture[str]) -> No
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_noncompliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "o/r"])
     output = capsys.readouterr().out
@@ -197,7 +199,7 @@ def test_apply_all_compliant_does_nothing() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
         patch(f"{_MODULE}._apply_repo") as mock_apply,
     ):
         result = main(["apply", "--repo", "o/r"])
@@ -211,7 +213,7 @@ def test_apply_github_noncompliant_applies() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
         patch(f"{_MODULE}._apply_repo", return_value=[]) as mock_apply,
     ):
         result = main(["apply", "--repo", "o/r"])
@@ -227,7 +229,7 @@ def test_main_remote_config_error_exits_one_without_traceback(
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
         patch(
-            f"{_MODULE}._fetch_remote_config",
+            f"{_MODULE}._resolve_config",
             side_effect=RuntimeError("vergil.toml not found on default branch; pass --config"),
         ),
         patch(f"{_MODULE}._audit_repo") as mock_audit,
@@ -246,7 +248,7 @@ def test_apply_returns_one_when_local_issues_remain() -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_noncompliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         result = main(["apply", "--repo", "o/r"])
     assert result == 1
@@ -258,7 +260,7 @@ def test_apply_reports_legacy_protection_removed(capsys: pytest.CaptureFixture[s
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
         patch(f"{_MODULE}._apply_repo", return_value=["main", "develop"]),
     ):
         main(["apply", "--repo", "o/r"])
@@ -279,7 +281,7 @@ def test_audit_prints_skipped_fields(capsys: pytest.CaptureFixture[str]) -> None
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=diff),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         result = main(["audit", "--repo", "o/r"])
     assert result == 0
@@ -295,7 +297,7 @@ def test_audit_compliant_public_repo_no_skipped(capsys: pytest.CaptureFixture[st
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "o/r"])
     output = capsys.readouterr().out
@@ -311,7 +313,7 @@ def test_audit_non_security_skipped_fields_not_printed(
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=diff),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "o/r"])
     output = capsys.readouterr().out
@@ -345,70 +347,44 @@ def test_config_flag_bypasses_remote_fetch(tmp_path: Path) -> None:
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config") as mock_remote,
+        patch(f"{_MODULE}._resolve_config") as mock_remote,
     ):
         result = main(["audit", "--repo", "o/r", "--config", str(p)])
     assert result == 0
     mock_remote.assert_not_called()
 
 
-# -- _fetch_remote_config ----------------------------------------------------
-
-
-def test_fetch_remote_config_success() -> None:
-    import base64
-
-    encoded = base64.b64encode(_VALID_TOML).decode()
-    with patch(
-        f"{_MODULE}.github.read_json",
-        return_value={"content": encoded},
-    ):
-        cfg = _fetch_remote_config("o/r")
-    assert cfg.project.primary_language == "python"
-
-
-def test_fetch_remote_config_non_dict_response() -> None:
-    with (
-        patch(f"{_MODULE}.github.read_json", return_value=[]),
-        pytest.raises(RuntimeError, match="Unexpected response"),
-    ):
-        _fetch_remote_config("o/r")
-
-
-def test_fetch_remote_config_no_content_field() -> None:
-    with (
-        patch(f"{_MODULE}.github.read_json", return_value={"encoding": "base64"}),
-        pytest.raises(RuntimeError, match="No content field"),
-    ):
-        _fetch_remote_config("o/r")
+# -- _fetch_config_from_ref --------------------------------------------------
 
 
 def _not_found_error() -> GitHubAPIError:
     return GitHubAPIError(
         1,
-        ("gh", "api", "repos/o/r/contents/vergil.toml"),
+        ("gh", "api", "repos/o/r/contents/vergil.toml?ref=main"),
         '{"message":"Not Found","status":"404"}',
         "gh: Not Found (HTTP 404)",
     )
 
 
-def test_fetch_remote_config_not_found_raises_actionable_error() -> None:
-    with (
-        patch(f"{_MODULE}.github.read_json", side_effect=_not_found_error()),
-        pytest.raises(RuntimeError) as excinfo,
-    ):
-        _fetch_remote_config("o/r")
-    message = str(excinfo.value)
-    # Names the repo, explains the default-branch cause, and points to --config.
-    assert "o/r" in message
-    assert "default branch" in message
-    assert "--config" in message
+def test_fetch_config_from_ref_success() -> None:
+    import base64
+
+    encoded = base64.b64encode(_VALID_TOML).decode()
+    with patch(f"{_MODULE}.github.read_json", return_value={"content": encoded}):
+        cfg = _fetch_config_from_ref("o/r", "main")
+    assert cfg is not None
+    assert cfg.project.primary_language == "python"
 
 
-def test_fetch_remote_config_other_api_error_propagates() -> None:
+def test_fetch_config_from_ref_not_found_returns_none() -> None:
+    with patch(f"{_MODULE}.github.read_json", side_effect=_not_found_error()):
+        assert _fetch_config_from_ref("o/r", "main") is None
+
+
+def test_fetch_config_from_ref_other_api_error_propagates() -> None:
     server_error = GitHubAPIError(
         1,
-        ("gh", "api", "repos/o/r/contents/vergil.toml"),
+        ("gh", "api", "repos/o/r/contents/vergil.toml?ref=main"),
         '{"message":"Server Error","status":"500"}',
         "gh: Server Error (HTTP 500)",
     )
@@ -416,7 +392,118 @@ def test_fetch_remote_config_other_api_error_propagates() -> None:
         patch(f"{_MODULE}.github.read_json", side_effect=server_error),
         pytest.raises(GitHubAPIError),
     ):
-        _fetch_remote_config("o/r")
+        _fetch_config_from_ref("o/r", "main")
+
+
+def test_fetch_config_from_ref_non_dict_response() -> None:
+    with (
+        patch(f"{_MODULE}.github.read_json", return_value=[]),
+        pytest.raises(RuntimeError, match="Unexpected response"),
+    ):
+        _fetch_config_from_ref("o/r", "main")
+
+
+def test_fetch_config_from_ref_no_content_field() -> None:
+    with (
+        patch(f"{_MODULE}.github.read_json", return_value={"encoding": "base64"}),
+        pytest.raises(RuntimeError, match="No content field"),
+    ):
+        _fetch_config_from_ref("o/r", "main")
+
+
+# -- _resolve_config (main -> develop -> local cwd) --------------------------
+
+
+def _by_ref(results: dict[str, object]):
+    """Build a _fetch_config_from_ref side_effect from a ref->result mapping."""
+
+    def _fake(_repo: str, ref: str) -> object:
+        return results[ref]
+
+    return _fake
+
+
+def test_resolve_config_prefers_main() -> None:
+    cfg = _make_config()
+    with patch(
+        f"{_MODULE}._fetch_config_from_ref",
+        side_effect=_by_ref({"main": cfg, "develop": None}),
+    ) as mock_fetch:
+        result = _resolve_config("o/r")
+    assert result is cfg
+    # develop is not consulted once main resolves.
+    assert mock_fetch.call_count == 1
+
+
+def test_resolve_config_falls_back_to_develop() -> None:
+    cfg = _make_config()
+    with patch(
+        f"{_MODULE}._fetch_config_from_ref",
+        side_effect=_by_ref({"main": None, "develop": cfg}),
+    ) as mock_fetch:
+        result = _resolve_config("o/r")
+    assert result is cfg
+    assert mock_fetch.call_count == 2
+
+
+def test_resolve_config_falls_back_to_local_when_cwd_matches() -> None:
+    cfg = _make_config()
+    with (
+        patch(
+            f"{_MODULE}._fetch_config_from_ref",
+            side_effect=_by_ref({"main": None, "develop": None}),
+        ),
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}._load_cwd_config", return_value=cfg) as mock_local,
+    ):
+        result = _resolve_config("o/r")
+    assert result is cfg
+    mock_local.assert_called_once()
+
+
+def test_resolve_config_no_local_fallback_when_cwd_mismatch() -> None:
+    with (
+        patch(
+            f"{_MODULE}._fetch_config_from_ref",
+            side_effect=_by_ref({"main": None, "develop": None}),
+        ),
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=False),
+        patch(f"{_MODULE}._load_cwd_config") as mock_local,
+        pytest.raises(RuntimeError, match="--config"),
+    ):
+        _resolve_config("o/r")
+    mock_local.assert_not_called()
+
+
+def test_load_cwd_config_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "vergil.toml").write_bytes(_VALID_TOML)
+    monkeypatch.chdir(tmp_path)
+    cfg = _load_cwd_config()
+    assert cfg is not None
+    assert cfg.project.primary_language == "python"
+
+
+def test_load_cwd_config_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert _load_cwd_config() is None
+
+
+def test_resolve_config_errors_when_absent_everywhere() -> None:
+    with (
+        patch(
+            f"{_MODULE}._fetch_config_from_ref",
+            side_effect=_by_ref({"main": None, "develop": None}),
+        ),
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}._load_cwd_config", return_value=None),
+        pytest.raises(RuntimeError) as excinfo,
+    ):
+        _resolve_config("o/r")
+    message = str(excinfo.value)
+    assert "o/r" in message
+    assert "main" in message
+    assert "develop" in message
+    assert "--config" in message
 
 
 # -- _load_local_config -------------------------------------------------------
@@ -489,7 +576,7 @@ def test_audit_skips_local_checks_on_repo_mismatch(
         patch(f"{_MODULE}.github.current_repo", return_value="local/repo"),
         patch(f"{_MODULE}.audit_local_config") as mock_local,
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         result = main(["audit", "--repo", "other/repo"])
     mock_local.assert_not_called()
@@ -503,7 +590,7 @@ def test_audit_repo_mismatch_prints_warning_to_stderr(
         patch(f"{_MODULE}.github.current_repo", return_value="local/repo"),
         patch(f"{_MODULE}.audit_local_config"),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "other/repo"])
     captured = capsys.readouterr()
@@ -518,7 +605,7 @@ def test_audit_repo_mismatch_reports_local_skipped(
         patch(f"{_MODULE}.github.current_repo", return_value="local/repo"),
         patch(f"{_MODULE}.audit_local_config"),
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "other/repo"])
     output = capsys.readouterr().out
@@ -530,7 +617,7 @@ def test_apply_skips_local_on_repo_mismatch() -> None:
         patch(f"{_MODULE}.github.current_repo", return_value="local/repo"),
         patch(f"{_MODULE}.audit_local_config") as mock_local,
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
         patch(f"{_MODULE}._apply_repo", return_value=[]) as mock_apply,
     ):
         result = main(["apply", "--repo", "other/repo"])
@@ -544,7 +631,7 @@ def test_audit_runs_local_when_repo_matches_cwd() -> None:
         patch(f"{_MODULE}.github.current_repo", return_value="o/r"),
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()) as mock_local,
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         result = main(["audit", "--repo", "o/r"])
     mock_local.assert_called_once()
@@ -594,7 +681,7 @@ def test_print_diff_shows_delta_for_rules_mismatch(
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=diff),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "o/r"])
     output = capsys.readouterr().out
@@ -669,7 +756,7 @@ def test_print_diff_falls_back_for_rules_without_status_checks(
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=diff),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "o/r"])
     output = capsys.readouterr().out
@@ -688,7 +775,7 @@ def test_print_diff_falls_back_for_non_rules_field(
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=diff),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         main(["audit", "--repo", "o/r"])
     output = capsys.readouterr().out
@@ -708,7 +795,7 @@ def test_audit_skips_local_when_cwd_origin_unavailable() -> None:
         ),
         patch(f"{_MODULE}.audit_local_config") as mock_local,
         patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         result = main(["audit", "--repo", "other/repo"])
     mock_local.assert_not_called()
@@ -732,7 +819,7 @@ def test_audit_prints_skipped_bypass_actors(capsys: pytest.CaptureFixture[str]) 
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
         patch(f"{_MODULE}._audit_repo", return_value=diff),
         patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
-        patch(f"{_MODULE}._fetch_remote_config"),
+        patch(f"{_MODULE}._resolve_config"),
     ):
         result = main(["audit", "--repo", "o/r"])
     assert result == 0

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -30,6 +30,7 @@ from vergil_tooling.lib.config import (
     ValidationConfig,
     VergilConfig,
 )
+from vergil_tooling.lib.github import GitHubAPIError
 from vergil_tooling.lib.github_config import ConfigDiff, DiffItem
 
 # -- Argument parsing ---------------------------------------------------------
@@ -218,6 +219,27 @@ def test_apply_github_noncompliant_applies() -> None:
     mock_apply.assert_called_once()
 
 
+def test_main_remote_config_error_exits_one_without_traceback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(
+            f"{_MODULE}._fetch_remote_config",
+            side_effect=RuntimeError("vergil.toml not found on default branch; pass --config"),
+        ),
+        patch(f"{_MODULE}._audit_repo") as mock_audit,
+    ):
+        result = main(["apply", "--repo", "o/r"])
+    assert result == 1
+    mock_audit.assert_not_called()
+    err = capsys.readouterr().err
+    assert "ERROR:" in err
+    assert "--config" in err
+
+
 def test_apply_returns_one_when_local_issues_remain() -> None:
     with (
         patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
@@ -357,6 +379,42 @@ def test_fetch_remote_config_no_content_field() -> None:
     with (
         patch(f"{_MODULE}.github.read_json", return_value={"encoding": "base64"}),
         pytest.raises(RuntimeError, match="No content field"),
+    ):
+        _fetch_remote_config("o/r")
+
+
+def _not_found_error() -> GitHubAPIError:
+    return GitHubAPIError(
+        1,
+        ("gh", "api", "repos/o/r/contents/vergil.toml"),
+        '{"message":"Not Found","status":"404"}',
+        "gh: Not Found (HTTP 404)",
+    )
+
+
+def test_fetch_remote_config_not_found_raises_actionable_error() -> None:
+    with (
+        patch(f"{_MODULE}.github.read_json", side_effect=_not_found_error()),
+        pytest.raises(RuntimeError) as excinfo,
+    ):
+        _fetch_remote_config("o/r")
+    message = str(excinfo.value)
+    # Names the repo, explains the default-branch cause, and points to --config.
+    assert "o/r" in message
+    assert "default branch" in message
+    assert "--config" in message
+
+
+def test_fetch_remote_config_other_api_error_propagates() -> None:
+    server_error = GitHubAPIError(
+        1,
+        ("gh", "api", "repos/o/r/contents/vergil.toml"),
+        '{"message":"Server Error","status":"500"}',
+        "gh: Server Error (HTTP 500)",
+    )
+    with (
+        patch(f"{_MODULE}.github.read_json", side_effect=server_error),
+        pytest.raises(GitHubAPIError),
     ):
         _fetch_remote_config("o/r")
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the single default-branch fetch (which 404'd and crashed with a raw traceback during bootstrap) with a resolution chain: the 'main' branch, then 'develop', then the working-directory copy when the cwd is a checkout of the target repo; when the file is absent everywhere, exit with an actionable error instead of a traceback.

## Issue Linkage

- Ref #1511

## Notes

- The local fallback makes bootstrapping ergonomic (edit vergil.toml and run apply from the repo root before it has landed on a canonical branch) and is safe under the trust model: agents may write vergil.toml but only a human runs apply and owns that action, and the fallback is gated on the cwd matching the target repo so a --repo override never applies an unrelated local config. Non-404 API errors still propagate unchanged. TDD throughout; full vrg-validate green (100% coverage). Separately filed vergil-claude-plugin#458 about the pr-template.yml format being under-documented and its parser silently mangling unsupported YAML.