### PR TITLE
fix(progress): stop wrapped lines from overflowing the live viewport

### DIFF
--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -229,6 +229,20 @@ _STATUS_STYLES: dict[str, str] = {
 }
 
 
+def _tail_line(line: str) -> Text:
+    """One rolling-window line, forced to a single physical row.
+
+    The auto-window budgets *logical* lines (``_visible_window``), but Rich's
+    LiveRender measures *physical* rows. A streamed line wider than the console
+    (e.g. a CI-check row ending in a ~95-char job URL) would wrap to two rows,
+    pushing the live block past the viewport; Rich then ellipsis-crops it to the
+    full viewport height, and a full-viewport block scrolls on every repaint,
+    leaving duplicated top rows behind. ``no_wrap`` + ellipsis keeps one logical
+    line to one physical row so the budget holds and the block never overflows.
+    """
+    return Text.from_ansi(f"   {line}", style="dim", no_wrap=True, overflow="ellipsis")
+
+
 class RichRenderer:
     """Live TTY display: completed stages collapse to one line, the active stage
     shows a spinner plus a rolling window of its last N output lines.
@@ -271,12 +285,14 @@ class RichRenderer:
     def _renderable(self) -> Group:
         parts: list[Text | Spinner] = list(self._completed)
         if self._active is not None:
-            parts.append(Spinner("dots", text=Text(f" {self._active}")))
+            parts.append(
+                Spinner("dots", text=Text(f" {self._active}", no_wrap=True, overflow="ellipsis"))
+            )
             if self._window is None:
                 visible = list(self._tail)[-self._visible_window() :]
-                parts.extend(Text.from_ansi(f"   {line}", style="dim") for line in visible)
+                parts.extend(_tail_line(line) for line in visible)
             elif self._window > 0:
-                parts.extend(Text.from_ansi(f"   {line}", style="dim") for line in self._tail)
+                parts.extend(_tail_line(line) for line in self._tail)
         return Group(*parts)
 
     def start_stage(self, name: str) -> None:
@@ -292,7 +308,14 @@ class RichRenderer:
         self._live.update(self._renderable())
 
     def end_stage(self, result: StageResult) -> None:
-        self._completed.append(Text(_status_line(result), style=_STATUS_STYLES[result.status]))
+        self._completed.append(
+            Text(
+                _status_line(result),
+                style=_STATUS_STYLES[result.status],
+                no_wrap=True,
+                overflow="ellipsis",
+            )
+        )
         self._active = None
         self._tail.clear()
         self._live.update(self._renderable())

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -275,6 +275,53 @@ def test_rich_renderer_auto_buffers_only_up_to_cap() -> None:
     r.close()
 
 
+def _physical_height(r: progress.RichRenderer) -> int:
+    """Rows the current renderable actually occupies, after wrapping."""
+    lines = r._console.render_lines(r._renderable(), r._console.options, pad=False)
+    return len(lines)
+
+
+def test_rich_renderer_long_lines_do_not_overflow_viewport() -> None:
+    """Regression (#1517): streamed lines longer than the console width — e.g.
+    CI-check rows ending in ~95-char job URLs — must not wrap to multiple
+    physical rows.
+
+    The auto-window budgets *logical* lines, but Rich's LiveRender measures
+    *physical* rows. Wrapped lines push the live block past the viewport, Rich
+    ellipsis-crops it to the full viewport height, and a full-viewport block
+    scrolls the terminal on every repaint — leaking duplicated top rows (the
+    repeated ``✓ audit`` lines seen in vrg-release)."""
+    height = 30
+    out = io.StringIO()
+    r = progress.RichRenderer(out, window=None, force_terminal=True, width=100, height=height)
+    for name in ("audit", "preflight", "prepare", "merge-release", "confirm-main"):
+        r.end_stage(StageResult(name, "ok", 3.3))
+    r.start_stage("back-merge-bump")
+    long = (
+        "quality / typecheck / 3.14\tpass\t25s\t"
+        "https://github.com/vergil-project/vergil-tooling/actions/runs/27133407446/job/80079745066"
+    )
+    for _ in range(200):  # saturate the tail with would-be-wrapping lines
+        r.stage_line(long)
+    # Each line occupies exactly one row, so the block stays within the viewport
+    # and Rich never has to crop/scroll it.
+    expected_rows = len(r._completed) + 1 + min(r._visible_window(), len(r._tail))
+    assert _physical_height(r) == expected_rows
+    assert _physical_height(r) <= height
+    r.close()
+
+
+def test_rich_renderer_completed_status_line_does_not_wrap() -> None:
+    """A completed-stage line with a long error must occupy one physical row,
+    not wrap and inflate the block height (#1517)."""
+    out = io.StringIO()
+    r = progress.RichRenderer(out, window=None, force_terminal=True, width=60, height=24)
+    r.end_stage(StageResult("build-images", "failed", 4.0, "x" * 200))
+    r.start_stage("next")
+    assert _physical_height(r) == len(r._completed) + 1  # completed row + spinner
+    r.close()
+
+
 class _FakeRenderer:
     def __init__(self) -> None:
         self.lines: list[str] = []


### PR DESCRIPTION
# Pull Request

## Summary

- ## Problem

The `RichRenderer` live display intermittently leaves duplicated rows on
screen — most visibly the topmost completed-stage line (`✓ audit  3.3s`)
repeated two or three times during a long stage like `back-merge-bump` while
CI checks stream below it. #1462 reduced this but did not eliminate it.

## Root cause

`RichRenderer._visible_window()` budgets the rolling window in **logical
lines** (`height − completed − 1 − MARGIN`), but Rich's `LiveRender` measures
**physical rows**. `gh pr checks --watch` rows end in ~95-char job URLs that,
with the tail prefix, exceed the terminal width and wrap to two rows each — and
the watch re-emits the whole table on every refresh, saturating the tail. The
block reaches 50–72 physical rows against a 30-row viewport; Rich
ellipsis-crops it to exactly the full viewport height, and a full-viewport live
block scrolls the terminal on every repaint. `position_cursor()` can then only
move up `viewport − 1` rows and never reaches the rows that scrolled off the
top, so each repaint leaks one row.

## Fix

Render completed-stage lines, the spinner text, and tail lines with
`no_wrap=True, overflow="ellipsis"`, so one logical line maps to exactly one
physical row. The existing `height − MARGIN` budget then holds in physical
rows, the block stays inside the viewport, and Rich never crops or scrolls it.
Long URLs truncate with `…` rather than wrapping.

## Verification

- New regression tests assert the rendered physical height stays within the
  viewport (and equals the logical part count) when long lines stream, and that
  a long completed-stage error line stays on one row.
- Measured against the live Rich version, the reproduced scenario drops from 50
  physical rows (overflow) to 28 (no overflow).
- `vrg-container-run -- vrg-validate` passes.

## Issue Linkage

- Ref #1517

## Notes

- -