### PR TITLE
fix(github-config): require forking on org repos; clear error on org fork denial

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -253,7 +253,11 @@ def main(argv: list[str] | None = None) -> int:
         print("GitHub config compliant, nothing to apply.")
     else:
         print(f"  Applying to {repo}...")
-        removed = _apply_repo(repo, config)
+        try:
+            removed = _apply_repo(repo, config)
+        except RuntimeError as exc:
+            emit_error(str(exc))
+            return 1
         if removed:
             print(f"  {repo}: applied (legacy protection removed: {', '.join(removed)})")
         else:

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -104,7 +104,7 @@ _LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {
 }
 
 
-def desired_repo_settings(*, visibility: str, is_org: bool) -> DesiredRepoSettings:
+def desired_repo_settings(*, is_org: bool) -> DesiredRepoSettings:
     return DesiredRepoSettings(
         default_branch="develop",
         allow_auto_merge=False,
@@ -115,7 +115,12 @@ def desired_repo_settings(*, visibility: str, is_org: bool) -> DesiredRepoSettin
         has_issues=True,
         has_projects=True,
         has_wiki=True,
-        allow_forking=False if (is_org and visibility == "private") else None,
+        # The tooling requires repos to be forkable, so org repos (public and
+        # private) declare forking enabled. Private repos additionally depend on
+        # the org-level ``members_can_fork_private_repositories`` flag, which the
+        # tool cannot yet manage (vergil-tooling#1268). User-owned repos are left
+        # unmanaged (vergil-tooling#666).
+        allow_forking=True if is_org else None,
         allow_update_branch=True,
         has_downloads=False,
         merge_commit_title="MERGE_MESSAGE",
@@ -343,7 +348,7 @@ def compute_desired_state(
     )
 
     return DesiredState(
-        repo_settings=desired_repo_settings(visibility=visibility, is_org=is_org),
+        repo_settings=desired_repo_settings(is_org=is_org),
         security=desired_security_settings(ghas=ghas),
         actions_permissions=desired_actions_permissions(config.project.primary_language),
         rulesets=rulesets,
@@ -767,6 +772,28 @@ def compute_diff(*, desired: DesiredState, actual: DesiredState) -> ConfigDiff:
 # ---------------------------------------------------------------------------
 
 
+_PRIVATE_FORKING_DENIED = "does not allow private repository forking"
+
+_PRIVATE_FORKING_HELP = (
+    "{repo}: cannot apply repository settings because the organization disallows "
+    "forking private repositories. The tooling requires repos to be forkable. "
+    "Enable the org-level setting 'members_can_fork_private_repositories' "
+    "(Settings > Member privileges > Repository forking), then re-run. Org-level "
+    "enforcement is tracked in vergil-tooling#1268."
+)
+
+
+def _is_private_forking_error(exc: github.GitHubAPIError) -> bool:
+    """True when a settings PATCH was rejected for the org-level fork policy.
+
+    GitHub returns 422 with this message when ``allow_forking`` is included in a
+    private repo's settings PATCH while the org disallows private forking — even
+    when the value is ``False``.
+    """
+    blob = f"{exc.stderr or ''}\n{exc.stdout or ''}"
+    return _PRIVATE_FORKING_DENIED in blob
+
+
 def _apply_repo_settings(repo: str, settings: DesiredRepoSettings) -> None:
     body: dict[str, object] = {
         "default_branch": settings.default_branch,
@@ -788,7 +815,12 @@ def _apply_repo_settings(repo: str, settings: DesiredRepoSettings) -> None:
     }
     if settings.allow_forking is not None:
         body["allow_forking"] = settings.allow_forking
-    github.write_json("PATCH", f"repos/{repo}", body)
+    try:
+        github.write_json("PATCH", f"repos/{repo}", body)
+    except github.GitHubAPIError as exc:
+        if "allow_forking" in body and _is_private_forking_error(exc):
+            raise RuntimeError(_PRIVATE_FORKING_HELP.format(repo=repo)) from exc
+        raise
 
 
 def _apply_security_settings(repo: str, security: DesiredSecuritySettings) -> None:

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -6,6 +6,8 @@ import subprocess
 from typing import cast
 from unittest.mock import patch
 
+import pytest
+
 from vergil_tooling.lib.config import (
     DEFAULT_VALIDATION_COMMAND,
     CiConfig,
@@ -16,6 +18,7 @@ from vergil_tooling.lib.config import (
     ValidationConfig,
     VergilConfig,
 )
+from vergil_tooling.lib.github import GitHubAPIError
 from vergil_tooling.lib.github_config import (
     DesiredRuleset,
     FetchResult,
@@ -45,7 +48,7 @@ from vergil_tooling.lib.github_config import (
 
 
 def test_desired_repo_settings_are_fixed() -> None:
-    s = desired_repo_settings(visibility="public", is_org=True)
+    s = desired_repo_settings(is_org=True)
     assert s.default_branch == "develop"
     assert s.allow_auto_merge is False
     assert s.delete_branch_on_merge is True
@@ -57,18 +60,15 @@ def test_desired_repo_settings_are_fixed() -> None:
     assert s.has_wiki is True
 
 
-def test_desired_repo_settings_public_org_omits_forking() -> None:
-    s = desired_repo_settings(visibility="public", is_org=True)
-    assert s.allow_forking is None
-
-
-def test_desired_repo_settings_private_disallows_forking() -> None:
-    s = desired_repo_settings(visibility="private", is_org=True)
-    assert s.allow_forking is False
+def test_desired_repo_settings_org_repo_allows_forking() -> None:
+    # The tooling requires forkable repos, so org repos declare forking enabled
+    # regardless of visibility (public or private).
+    s = desired_repo_settings(is_org=True)
+    assert s.allow_forking is True
 
 
 def test_desired_repo_settings_new_hardcoded_values() -> None:
-    s = desired_repo_settings(visibility="public", is_org=True)
+    s = desired_repo_settings(is_org=True)
     assert s.allow_update_branch is True
     assert s.has_downloads is False
     assert s.merge_commit_title == "MERGE_MESSAGE"
@@ -1090,7 +1090,7 @@ def test_canonicalize_rules_preserves_non_dict_entries() -> None:
 
 
 def test_apply_repo_settings_calls_write_json() -> None:
-    settings = desired_repo_settings(visibility="public", is_org=True)
+    settings = desired_repo_settings(is_org=True)
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     mock_write.assert_called_once()
@@ -1103,11 +1103,11 @@ def test_apply_repo_settings_calls_write_json() -> None:
 
 
 def test_apply_repo_settings_includes_new_fields() -> None:
-    settings = desired_repo_settings(visibility="public", is_org=True)
+    settings = desired_repo_settings(is_org=True)
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
-    assert "allow_forking" not in body
+    assert body["allow_forking"] is True
     assert body["allow_update_branch"] is True
     assert body["has_downloads"] is False
     assert body["merge_commit_title"] == "MERGE_MESSAGE"
@@ -1473,19 +1473,12 @@ def test_compute_desired_state_publish_release_true() -> None:
 
 
 def test_desired_repo_settings_user_repo_allow_forking_is_none() -> None:
-    s = desired_repo_settings(visibility="public", is_org=False)
+    s = desired_repo_settings(is_org=False)
     assert s.allow_forking is None
-
-
-def test_desired_repo_settings_org_repo_allow_forking_set() -> None:
-    s = desired_repo_settings(visibility="public", is_org=True)
-    assert s.allow_forking is None
-    s2 = desired_repo_settings(visibility="private", is_org=True)
-    assert s2.allow_forking is False
 
 
 def test_apply_repo_settings_omits_allow_forking_when_none() -> None:
-    settings = desired_repo_settings(visibility="public", is_org=False)
+    settings = desired_repo_settings(is_org=False)
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
@@ -1493,11 +1486,50 @@ def test_apply_repo_settings_omits_allow_forking_when_none() -> None:
 
 
 def test_apply_repo_settings_includes_allow_forking_for_private_org() -> None:
-    settings = desired_repo_settings(visibility="private", is_org=True)
+    settings = desired_repo_settings(is_org=True)
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
-    assert body["allow_forking"] is False
+    assert body["allow_forking"] is True
+
+
+def _private_forking_error() -> GitHubAPIError:
+    return GitHubAPIError(
+        1,
+        ("gh", "api", "repos/o/r", "-X", "PATCH", "--input", "-"),
+        '{"message":"This organization does not allow private repository forking","status":"422"}',
+        "gh: This organization does not allow private repository forking (HTTP 422)",
+    )
+
+
+def test_apply_repo_settings_raises_actionable_error_on_private_forking_422() -> None:
+    settings = desired_repo_settings(is_org=True)
+    with (
+        patch(
+            "vergil_tooling.lib.github_config.github.write_json",
+            side_effect=_private_forking_error(),
+        ),
+        pytest.raises(RuntimeError, match="members_can_fork_private_repositories"),
+    ):
+        _apply_repo_settings("o/r", settings)
+
+
+def test_apply_repo_settings_propagates_unrelated_api_error() -> None:
+    settings = desired_repo_settings(is_org=True)
+    unrelated = GitHubAPIError(
+        1,
+        ("gh", "api", "repos/o/r"),
+        '{"message":"Server Error","status":"500"}',
+        "gh: Server Error (HTTP 500)",
+    )
+    with (
+        patch(
+            "vergil_tooling.lib.github_config.github.write_json",
+            side_effect=unrelated,
+        ),
+        pytest.raises(GitHubAPIError),
+    ):
+        _apply_repo_settings("o/r", settings)
 
 
 def test_diff_skips_allow_forking_when_desired_is_none() -> None:

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -245,6 +245,31 @@ def test_main_remote_config_error_exits_one_without_traceback(
     assert "Traceback" not in err
 
 
+def test_apply_surfaces_actionable_forking_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
+        patch(f"{_MODULE}._audit_repo", return_value=_mock_github_noncompliant()),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(f"{_MODULE}._resolve_config"),
+        patch(
+            f"{_MODULE}._apply_repo",
+            side_effect=RuntimeError(
+                "o/r: cannot set 'allow_forking' because the organization disallows "
+                "forking private repositories. Enable the org-level setting "
+                "'members_can_fork_private_repositories'."
+            ),
+        ),
+    ):
+        result = main(["apply", "--repo", "o/r"])
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "members_can_fork_private_repositories" in err
+    assert "Traceback" not in err
+
+
 def test_apply_returns_one_when_local_issues_remain() -> None:
     with (
         patch(f"{_MODULE}._cwd_matches_repo", return_value=True),


### PR DESCRIPTION
# Pull Request

## Summary

- Changes the managed GitHub repo-config posture so forking is ENABLED on
organization repositories (both public and private), reversing the prior
default that set `allow_forking=False` on private org repos.

Why: the Vergil tooling requires repositories to be forkable. The old posture
both contradicted that requirement and was unappliable on private repos —
GitHub rejects an `allow_forking` field in a private repo's settings PATCH with
`422 This organization does not allow private repository forking` unless the
org-level `members_can_fork_private_repositories` flag is enabled, even when the
value being set is `False`. That redundant, unsettable field aborted the entire
`vrg-github-repo-config apply` before any real drift (default branch, rulesets,
Actions allowlist, …) was corrected.

Changes:
- `desired_repo_settings` returns `allow_forking=True` for org repos and `None`
  (unmanaged) for user-owned repos, preserving the #666 decision. The now-unused
  `visibility` parameter is dropped.
- `_apply_repo_settings` catches the org-level fork-denial 422 and raises an
  actionable error naming the `members_can_fork_private_repositories`
  prerequisite; `main()` prints it cleanly instead of an uncaught traceback,
  mirroring the existing config-load error handling.

## Issue Linkage

- Ref #1519

## Notes

- Runtime dependency: on a private repo the new `allow_forking=True` still
requires the org-level `members_can_fork_private_repositories` flag to be
enabled first. The tool cannot manage that org-level setting yet — it is set
manually for now, and org-level management is tracked in #1268. Until the flag
is on, `apply` fails with the new actionable message rather than crashing.

Testing: TDD red → green. Flipped the posture expectations, consolidated the
now-redundant public/private duplicate tests, and added coverage for the
actionable-error path and unrelated-error passthrough. Full `vrg-validate`
passes: lint, typecheck, tests at 100% branch coverage, audit.

Lineage: sibling private-repo edge case to #1516, which was closed as a
strategy change (free-tier private repos are out of scope; paid plans are
required where rulesets are needed).