### PR TITLE
fix(vrg-vm): defer spec-drift check to post-start so stopped VMs can start

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -202,7 +202,17 @@ def _preflight_target(target: Target) -> int:
             file=sys.stderr,
         )
         return 1
-    if vm_spec_status(target.instance, target.fingerprint) == "needs-rebuild":
+    # The spec fingerprint is stamped inside the guest (/etc/vergil/vm-spec.fingerprint)
+    # and is only readable over `limactl shell` while the VM runs. A stopped VM cannot
+    # be fingerprinted, so the drift gate can only run when already Running — checking it
+    # against a stopped VM always reads needs-rebuild, which made every stopped dedicated
+    # VM un-startable and falsely demanded a rebuild. For start (VM stopped) the check is
+    # deferred to the post-start `spec-check` stage, once the guest is up. Mirrors list's
+    # "drift only while running" contract.
+    if (
+        status == "Running"
+        and vm_spec_status(target.instance, target.fingerprint) == "needs-rebuild"
+    ):
         print(
             f"ERROR: VM '{target.instance}' no longer meets {workspace}'s spec.\n"
             f"Rebuild it: vrg-vm rebuild {workspace} --identity {target.identity_name}",
@@ -286,6 +296,32 @@ def _st_start(state: _LifecycleState) -> None:
     start_vm(state.target.instance, timeout=state.timeout)
 
 
+class SpecDriftError(RuntimeError):
+    """Raised by the post-start spec-check stage when a freshly-started VM's
+    stamped fingerprint no longer matches its composed spec. Carried as a warn:
+    surfaced as a non-fatal ⚠ in the pipeline summary, never aborts the start.
+    """
+
+
+def _st_spec_check(state: _LifecycleState) -> None:
+    # Post-start drift check. The fingerprint lives inside the guest and is only
+    # readable now that it is up — the check _preflight_target cannot perform
+    # against a stopped VM. Warn-mode: a drifted VM is already running and usable,
+    # so we tell the user to rebuild rather than refusing. Base boxes carry no
+    # per-repo spec and are skipped.
+    target = state.target
+    if not target.spec.dedicated:
+        return
+    if vm_spec_status(target.instance, target.fingerprint) != "needs-rebuild":
+        return
+    workspace = f"{target.org}/{target.repo}"
+    msg = (
+        f"VM '{target.instance}' no longer meets {workspace}'s spec — "
+        f"rebuild it: vrg-vm rebuild {workspace} --identity {target.identity_name}"
+    )
+    raise SpecDriftError(msg)
+
+
 def _st_link_config(state: _LifecycleState) -> None:
     link_claude_dirs(state.target.instance, Path.home() / ".claude")
 
@@ -339,6 +375,10 @@ def _create_stages() -> list[Stage]:
 def _start_stages() -> list[Stage]:
     return [
         Stage("start", _st_start, mode="fail_fast"),
+        # Verify the just-booted guest against its composed spec. Non-fatal and
+        # placed immediately after start so a drift warning surfaces before the
+        # credential/config work, without blocking a usable VM from coming up.
+        Stage("spec-check", _st_spec_check, mode="warn"),
         Stage("credentials", _st_credentials, mode="fail_fast"),
         Stage("copy-config", _st_copy_config, mode="fail_fast"),
         Stage("update-tooling", _st_update_tooling, mode="warn"),

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1857,6 +1857,19 @@ class TestPreflight:
     def test_dedicated_drift_aborts(self, _status: MagicMock, _spec: MagicMock) -> None:
         assert _preflight_target(_target(dedicated=True)) == 1
 
+    @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="needs-rebuild")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_dedicated_stopped_defers_spec_check(
+        self, _status: MagicMock, mock_spec: MagicMock
+    ) -> None:
+        # A stopped guest's fingerprint lives at /etc/vergil/vm-spec.fingerprint
+        # and is only readable over `limactl shell` while the VM runs. The drift
+        # gate therefore cannot run pre-start; it must not block start (else every
+        # stopped dedicated VM is un-startable and falsely told to rebuild). The
+        # post-start spec-check stage performs the real check once the VM is up.
+        assert _preflight_target(_target(dedicated=True)) == 0
+        mock_spec.assert_not_called()
+
     @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="ok")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
     def test_dedicated_ok_passes(self, _status: MagicMock, _spec: MagicMock) -> None:
@@ -2177,12 +2190,22 @@ class TestLifecycleStages:
         stages = _start_stages()
         assert [s.name for s in stages] == [
             "start",
+            "spec-check",
             "credentials",
             "copy-config",
             "update-tooling",
         ]
-        assert stages[-1].mode == "warn"
-        assert all(s.mode == "fail_fast" for s in stages[:-1])
+        modes = {s.name: s.mode for s in stages}
+        # spec-check verifies the freshly-booted guest's fingerprint; it is
+        # non-fatal (warn) so a drifted-but-running VM stays usable, and it sits
+        # immediately after start so the warning surfaces before later work.
+        assert modes == {
+            "start": "fail_fast",
+            "spec-check": "warn",
+            "credentials": "fail_fast",
+            "copy-config": "fail_fast",
+            "update-tooling": "warn",
+        }
 
     def test_rebuild_stage_order_and_modes(self) -> None:
         from vergil_tooling.bin.vrg_vm import _rebuild_stages
@@ -2233,6 +2256,40 @@ class TestLifecycleStages:
             call.stop_vm("vergil-agent"),
             call.start_vm("vergil-agent", timeout="45m"),
         ]
+
+
+class TestSpecCheckStage:
+    """The post-start drift check: now the guest is up, its stamped fingerprint
+    is finally readable. Warn-mode — it raises to surface a non-fatal ⚠, never
+    aborts the start, and is skipped entirely for non-dedicated (base) targets."""
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="needs-rebuild")
+    def test_warns_on_drift(self, _spec: MagicMock) -> None:
+        from vergil_tooling.bin.vrg_vm import (
+            SpecDriftError,
+            _LifecycleState,
+            _st_spec_check,
+        )
+
+        with pytest.raises(SpecDriftError) as exc:
+            _st_spec_check(_LifecycleState(target=_target(dedicated=True)))
+        # The warning must carry the actionable rebuild command.
+        assert "rebuild" in str(exc.value).lower()
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="ok")
+    def test_silent_when_in_spec(self, _spec: MagicMock) -> None:
+        from vergil_tooling.bin.vrg_vm import _LifecycleState, _st_spec_check
+
+        # In spec -> no raise (stage records "ok").
+        _st_spec_check(_LifecycleState(target=_target(dedicated=True)))
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_spec_status")
+    def test_skips_base_target(self, mock_spec: MagicMock) -> None:
+        from vergil_tooling.bin.vrg_vm import _LifecycleState, _st_spec_check
+
+        # A base (non-dedicated) box carries no per-repo spec to drift from.
+        _st_spec_check(_LifecycleState(target=_target(dedicated=False)))
+        mock_spec.assert_not_called()
 
 
 class TestRunLifecycle:


### PR DESCRIPTION
# Pull Request

## Summary

- `vrg-vm start` could not start any stopped dedicated VM. The spec-drift
preflight reads the fingerprint from inside the guest
(/etc/vergil/vm-spec.fingerprint), which is only possible while the VM runs,
yet it ran as a pre-start gate. Against a stopped VM the read failed and the
check returned needs-rebuild, so start aborted and recommended a destructive
rebuild of a healthy VM — while `vrg-vm list` reported SPEC: ok for the same VM.

This change:
- Gates the `_preflight_target` drift check on `status == "Running"`, matching
  list's "drift only while running" contract. Stopped VMs are no longer
  falsely flagged; `session` (which targets a running VM) is unchanged.
- Adds a post-start `spec-check` warn-stage to `_start_stages()`, immediately
  after `start`. Once the guest is up its fingerprint is readable, so drift is
  verified there and surfaced as a non-fatal warning to rebuild. The VM stays
  up and usable.

## Issue Linkage

- Ref #1535

## Notes

- Why post-start rather than simply skipping the check for stopped VMs: skipping
would also drop the legitimate warning when a VM was stopped while its declared
spec changed (a vergil.toml bump, or a tooling update that alters the composed
spec). Just after boot is the only point where a stopped-then-started VM can
actually be fingerprinted, so that is where the real check belongs.

Testing (TDD red→green via `vrg-container-run -- vrg-validate`):
- `TestPreflight.test_dedicated_stopped_defers_spec_check` — a stopped
  dedicated VM no longer aborts, and `vm_spec_status` is not called pre-start.
- `TestSpecCheckStage` — the new stage raises `SpecDriftError` on drift, is
  silent when in spec, and is skipped for base (non-dedicated) targets.
- `test_start_stage_order_and_modes` updated for the new warn-mode stage.
Full suite: 2594 passed.

Root-cause note: the existing drift tests only ever mocked `vm_status="Running"`,
which is how the stopped-VM path shipped untested.