### PR TITLE
fix(vm): size sessions WORKSPACE column to longest path

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -999,12 +999,15 @@ def _list_sessions(config: IdentityConfig, args: argparse.Namespace) -> int:
     rows.sort(key=lambda r: (str(r["identity"]), cast("int", r["slot"]), str(r["path"])))
 
     now = datetime.datetime.now(tz=datetime.UTC).timestamp()
-    print(f"{'IDENTITY':<16} {'SLOT':<6} {'WORKSPACE':<36} {'STATE':<9} {'LAST ACTIVE':<12}")
-    print(f"{'─' * 16} {'─' * 6} {'─' * 36} {'─' * 9} {'─' * 12}")
+    # Size the WORKSPACE column to the longest path present (36 floor), so a
+    # path wider than the historical fixed width keeps STATE/LAST ACTIVE aligned.
+    ws = max([36, *(len(str(r["path"])) for r in rows)])
+    print(f"{'IDENTITY':<16} {'SLOT':<6} {'WORKSPACE':<{ws}} {'STATE':<9} {'LAST ACTIVE':<12}")
+    print(f"{'─' * 16} {'─' * 6} {'─' * ws} {'─' * 9} {'─' * 12}")
     for r in rows:
         slot = f"{cast('int', r['slot']):02d}"
         age = _format_age(cast("float | None", r.get("lastActive")), now)
-        print(f"{r['identity']!s:<16} {slot:<6} {r['path']!s:<36} {r['state']!s:<9} {age:<12}")
+        print(f"{r['identity']!s:<16} {slot:<6} {r['path']!s:<{ws}} {r['state']!s:<9} {age:<12}")
 
     return 0
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -815,6 +815,62 @@ class TestList:
         assert result == 0
         mock_shell.assert_not_called()
 
+    @patch("vergil_tooling.bin.vrg_vm._last_activity", return_value=1700000000.0)
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session")
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_list_sessions_workspace_column_fits_long_paths(
+        self,
+        mock_list: MagicMock,
+        mock_shell: MagicMock,
+        mock_names: MagicMock,
+        _age: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # A workspace longer than the historical 36-char column must render in
+        # full and must not shove STATE / LAST ACTIVE out of alignment.
+        long_path = "logical-minds-foundry/mq-cluster-tooling"  # 40 chars
+        assert len(long_path) > 36
+        mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
+        mock_shell.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {
+                        "identity": "vergil",
+                        "slot": 1,
+                        "path": "vergil-project/vm",
+                        "sessionId": "s1",
+                        "state": "active",
+                        "lastActive": 1748000000.0,
+                    },
+                    {
+                        "identity": "vergil-user",
+                        "slot": 1,
+                        "path": long_path,
+                        "sessionId": "s2",
+                        "state": "idle",
+                        "lastActive": 1748000000.0,
+                    },
+                ]
+            )
+        )
+        mock_names.return_value = {
+            "s1": "vergil:01:vergil-project/vm",
+            "s2": "vergil-user:01:" + long_path,
+        }
+        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        out = capsys.readouterr().out
+        lines = [line for line in out.splitlines() if line.strip()]
+        header = lines[0]
+        state_col = header.index("STATE")
+        # The full long path is rendered, never truncated.
+        assert long_path in out
+        # STATE begins at the same offset on every data row (header + divider
+        # are lines[0] and lines[1]; data rows follow).
+        for row in lines[2:]:
+            assert row[state_col:].startswith(("active", "idle"))
+
 
 class TestUpdate:
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)


### PR DESCRIPTION
# Pull Request

## Summary

- Size the WORKSPACE column in `vrg-vm list --sessions` to the longest workspace path present (keeping the historical 36 as a floor) instead of a hardcoded width, so a path wider than 36 chars no longer overflows its cell and shoves the STATE and LAST ACTIVE columns out of alignment.

## Issue Linkage

- Ref #1541

## Notes

- Adds a regression test that renders a 40-char workspace path and asserts
the STATE column begins at the same offset on every data row; verified red
before the fix and green after, with the full session-list suite passing
and vrg-validate clean.