### PR TITLE
fix(vm): accept --identity/--config in any argument position

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1111,8 +1111,37 @@ def _cmd_session(args: argparse.Namespace) -> int:
 
 
 def _add_identity_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--identity", help="Identity name (default: default_identity)")
-    parser.add_argument("--config", type=Path, help="Path to identities.toml")
+    """Add per-subcommand ``--identity``/``--config`` (placed after the subcommand).
+
+    Their defaults are ``SUPPRESS`` so that omitting them after the subcommand does
+    not overwrite a value supplied *before* it via the matching top-level options
+    (``_add_global_identity_args``). That is the standard argparse parent/subparser
+    default-clobber gotcha: without SUPPRESS, the subparser's own default would
+    silently reset ``args.identity``/``args.config`` whenever the option appeared
+    only before the subcommand. The top-level parser owns the real defaults.
+    """
+    parser.add_argument(
+        "--identity",
+        default=argparse.SUPPRESS,
+        help="Identity name (default: default_identity)",
+    )
+    parser.add_argument(
+        "--config", type=Path, default=argparse.SUPPRESS, help="Path to identities.toml"
+    )
+
+
+def _add_global_identity_args(parser: argparse.ArgumentParser) -> None:
+    """Add ``--identity``/``--config`` on the top-level parser, owning the real defaults.
+
+    Defining them here lets both options appear *before* the subcommand
+    (``vrg-vm --identity X session repo``); the per-subcommand copies let them
+    appear after it too. These defaults guarantee the attributes always exist, so
+    the subcommand copies can safely use SUPPRESS.
+    """
+    parser.add_argument(
+        "--identity", default=None, help="Identity name (default: default_identity)"
+    )
+    parser.add_argument("--config", type=Path, default=None, help="Path to identities.toml")
 
 
 def _add_workspace_arg(parser: argparse.ArgumentParser) -> None:
@@ -1129,6 +1158,7 @@ def main(argv: list[str] | None = None) -> int:
         prog="vrg-vm",
         description="Manage identity VM lifecycle",
     )
+    _add_global_identity_args(parser)
     sub = parser.add_subparsers(dest="command")
 
     p_create = sub.add_parser("create", help="Create and provision a new VM")
@@ -1209,7 +1239,11 @@ def main(argv: list[str] | None = None) -> int:
             "below the repo's declared footprint."
         ),
     )
-    p_list.add_argument("--config", type=Path, help="Path to identities.toml")
+    # SUPPRESS so a global `--config` (before the subcommand) is not clobbered;
+    # `list` carries no `--identity` (identity does not scope a list of all VMs).
+    p_list.add_argument(
+        "--config", type=Path, default=argparse.SUPPRESS, help="Path to identities.toml"
+    )
     p_list.add_argument(
         "--sessions",
         action="store_true",
@@ -1252,8 +1286,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_session.add_argument(
         "cmd",
-        nargs=argparse.REMAINDER,
-        help="Optional command override after '--' (e.g. -- bash)",
+        nargs="*",
+        help=(
+            "Optional command override. A bare 'claude' (or nothing) goes through the "
+            "session resolver; anything else runs raw. Pass flags after '--' so they are "
+            "not parsed as session options (e.g. '-- bash', '-- claude --model X')."
+        ),
     )
 
     args = parser.parse_args(argv)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -80,6 +80,27 @@ def config_file_model(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
+def config_file_two(tmp_path: Path) -> Path:
+    """Two identities so identity-selection tests can assert a non-default choice."""
+    p = tmp_path / "identities-two.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        default_identity = "vergil"
+        vergil = "v2.0"
+
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        projects_dir = "/home/user/projects"
+
+        [identities.audit]
+        vm_instance = "audit-agent"
+        projects_dir = "/home/user/projects"
+    """)
+    )
+    return p
+
+
+@pytest.fixture()
 def config_file_top_model(tmp_path: Path) -> Path:
     p = tmp_path / "identities-top-model.toml"
     p.write_text(
@@ -475,6 +496,17 @@ class TestStop:
         result = main(["stop", "--config", str(config_file)])
         assert result == 0
         mock_stop.assert_called_once_with("vergil-agent")
+
+    @patch("vergil_tooling.bin.vrg_vm.stop_vm")
+    def test_global_identity_and_config_before_subcommand(
+        self, mock_stop: MagicMock, config_file_two: Path
+    ) -> None:
+        # --identity/--config are accepted globally (before the subcommand) for
+        # every verb, not just session — and the global value is honored, not
+        # clobbered by the subparser's default.
+        result = main(["--identity", "audit", "--config", str(config_file_two), "stop"])
+        assert result == 0
+        mock_stop.assert_called_once_with("audit-agent")
 
 
 class TestRestart:
@@ -1334,6 +1366,100 @@ class TestSession:
         inner = self._inner(mock_exec)
         assert "exec bash" in inner
         assert "vrg-vm-resolve-session" not in inner
+
+    def test_session_identity_after_workspace(
+        self,
+        _age: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        _link: MagicMock,
+        mock_exec: MagicMock,
+        config_file_two: Path,
+    ) -> None:
+        # Regression: --identity placed AFTER the workspace positional used to be
+        # swallowed by the REMAINDER `cmd` and handed to the guest shell as a raw
+        # `exec --identity ...`. It must now parse as the option.
+        main(["session", "--config", str(config_file_two), "vergil-tooling", "--identity", "audit"])
+        cmd = mock_exec.call_args[0][1]
+        assert "audit-agent" in cmd
+        inner = self._inner(mock_exec)
+        assert "vrg-vm-resolve-session --identity audit" in inner
+        assert "exec --identity" not in inner
+
+    def test_session_identity_before_subcommand(
+        self,
+        _age: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        _link: MagicMock,
+        mock_exec: MagicMock,
+        config_file_two: Path,
+    ) -> None:
+        # --identity placed BEFORE the subcommand (global) is honored.
+        main(["--identity", "audit", "session", "--config", str(config_file_two), "vergil-tooling"])
+        assert "audit-agent" in mock_exec.call_args[0][1]
+
+    def test_session_identity_between_subcommand_and_workspace(
+        self,
+        _age: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        _link: MagicMock,
+        mock_exec: MagicMock,
+        config_file_two: Path,
+    ) -> None:
+        # The historically-only-accepted slot must keep working.
+        main(["session", "--identity", "audit", "--config", str(config_file_two), "vergil-tooling"])
+        assert "audit-agent" in mock_exec.call_args[0][1]
+
+    def test_session_passthrough_unknown_flag_after_dashdash(
+        self,
+        _age: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        _link: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        # Arbitrary claude flags pass through when placed after '--', regardless
+        # of leading dashes (nargs="*" captures everything past the separator).
+        main(
+            [
+                "session",
+                "--config",
+                str(config_file),
+                "vergil-tooling",
+                "--",
+                "claude",
+                "--dangerously-skip-permissions",
+            ]
+        )
+        inner = self._inner(mock_exec)
+        assert "vrg-vm-resolve-session" in inner
+        assert "-- --dangerously-skip-permissions" in inner
+
+    def test_session_unknown_flag_without_dashdash_errors(
+        self,
+        _age: MagicMock,
+        _update: MagicMock,
+        _copy: MagicMock,
+        _link: MagicMock,
+        _exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        # Without '--', an unknown flag is a clear argparse error rather than being
+        # silently swallowed and mis-executed (the old REMAINDER failure mode).
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    "session",
+                    "--config",
+                    str(config_file),
+                    "vergil-tooling",
+                    "claude",
+                    "--dangerously-skip-permissions",
+                ]
+            )
 
     def test_session_slot_passed_to_resolver(
         self,


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm now accepts --identity/--config before the subcommand, between the subcommand and the workspace, or after the workspace — instead of only the middle slot — eliminating the two confusing failures (a cryptic guest-shell "exec: --: invalid option" when placed after the workspace, and an "invalid choice" misparse when placed before the subcommand).

## Issue Linkage

- Ref #1545

## Notes

- Two root causes in vrg_vm.py. (1) session's cmd used nargs=REMAINDER,
which greedily swallowed trailing options (e.g. --identity) and ran them
as a raw guest-shell command; switched to nargs="*" so trailing options
parse correctly while a literal "--" still passes arbitrary flags through
to the inner command. (2) --identity/--config were defined only per
subcommand; they are now also defined on the top-level parser (owning the
real None defaults), with the per-subcommand copies using SUPPRESS so a
value supplied before the subcommand is not clobbered by the subparser
default (the standard argparse parent/subparser gotcha). Behavior change:
passing arbitrary inner-command flags without a leading "--" (e.g.
"session repo claude --foo") now raises a clear argparse error instead of
being silently swallowed — use "-- claude --foo". Verified across all
orderings; 2601 tests pass at 100% coverage.