### PR TITLE
fix(vm): re-assert -n on session resume so Claude restores the prompt-box title

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -340,8 +340,16 @@ def _execute(path: str, action: PlanAction, extra: list[str], names: dict[str, s
         _note(f"Creating session {action.name}")
         return _exec_claude(["-n", action.name, *extra])
     if isinstance(action, Resume):
-        _note(f"Resuming session {names.get(action.session_id, action.session_id)}")
-        return _exec_claude(["--resume", action.session_id, *extra])
+        name = names.get(action.session_id)
+        _note(f"Resuming session {name or action.session_id}")
+        # Re-assert -n on every resume so Claude restores the prompt-box
+        # title. Claude derives the displayed title from the last naming
+        # event in the transcript; sessions last named by a transitional
+        # Claude version end on a legacy ``agent-name`` event that current
+        # Claude no longer recognizes, leaving the label blank. Passing -n
+        # sets the live title directly, independent of transcript history.
+        rename = ["-n", name] if name else []
+        return _exec_claude(["--resume", action.session_id, *rename, *extra])
     if isinstance(action, Fork):
         _note(f"Forking session {names.get(action.session_id, action.session_id)} -> {action.name}")
         return _exec_claude(
@@ -357,7 +365,8 @@ def _execute(path: str, action: PlanAction, extra: list[str], names: dict[str, s
         _note(f"Creating session {prompt.name}")
         return _exec_claude(["-n", prompt.name, *extra])
     _note(f"Resuming session {prompt.name}")
-    return _exec_claude(["--resume", prompt.session_id, *extra])
+    # Re-assert -n on resume (see the Resume branch above).
+    return _exec_claude(["--resume", prompt.session_id, "-n", prompt.name, *extra])
 
 
 def resolve(

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -370,7 +370,8 @@ def test_resolve_resume(
 ) -> None:
     monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, set(), {}))
     assert _resolve("id", "p") == 0
-    assert capture_exec == [["claude", "--resume", "s1"]]
+    # -n is re-asserted on resume so Claude restores the prompt-box title.
+    assert capture_exec == [["claude", "--resume", "s1", "-n", "id:01:p"]]
     assert "Resuming session id:01:p" in capsys.readouterr().err
 
 
@@ -426,7 +427,7 @@ def test_resolve_warn_prompt_resume(
     monkeypatch.setattr(r, "_now", lambda: now)
     monkeypatch.setattr(r, "_prompt_stale", lambda *_a: "r")
     assert _resolve("vergil", "p") == 0
-    assert capture_exec == [["claude", "--resume", "s1"]]
+    assert capture_exec == [["claude", "--resume", "s1", "-n", "vergil:01:p"]]
     assert "Resuming session vergil:01:p" in capsys.readouterr().err
 
 
@@ -692,7 +693,8 @@ def test_resolve_resumes_session_under_current_slug(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
 ) -> None:
     # Regression guard: a session whose transcript lives under the current cwd's
-    # slug is still resumable after scoping.
+    # slug is still resumable after scoping. Its name lives in a legacy
+    # ``agent-name`` event, so resume must re-assert -n to restore the title.
     claude = tmp_path / ".claude"
     projects = claude / "projects"
     (projects / "-work-tool").mkdir(parents=True)
@@ -703,4 +705,4 @@ def test_resolve_resumes_session_under_current_slug(
     monkeypatch.setattr(r, "_claude_dir", lambda: claude)
     monkeypatch.setattr(os, "getcwd", lambda: "/work/tool")
     assert _resolve("id", "tool") == 0
-    assert capture_exec == [["claude", "--resume", "good"]]
+    assert capture_exec == [["claude", "--resume", "good", "-n", "id:01:tool"]]


### PR DESCRIPTION
# Pull Request

## Summary

- The vrg-vm session resolver now passes `-n <name>` on the resume and stale-prompt-resume paths so Claude Code restores the prompt-box session title on every reconnect; long-lived sessions whose transcripts end on a legacy agent-name naming event no longer come back with a blank label.

## Issue Linkage

- Ref #1547

## Notes

- Root cause: Claude derives the displayed title from the last naming
event in the transcript and no longer recognizes legacy agent-name
events, while vergil's own roster and pane label read either event
type — which masked the regression. Mirrors what the Fork path
already did. Verified manually that `claude --resume <id> -n <name>`
(without --fork-session) restores the label. Three tests that encoded
the old no-`-n` resume behavior were updated; vrg-validate is green
(2601 passed).