### PR TITLE
fix(submit-pr): push with --force-with-lease to tolerate a rebased branch

### DIFF
--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -69,6 +69,30 @@ def _target_branch(branch: str, base_override: str | None) -> str:
     return "main" if branch.startswith("release/") else "develop"
 
 
+def _push_branch(branch: str) -> None:
+    """Push *branch* to origin, tolerating a rebased (diverged) remote.
+
+    Submitting a PR routinely follows a rebase onto the current base
+    branch to clear stale drift; that leaves any previously-pushed remote
+    branch diverged, and a plain push is rejected non-fast-forward.
+    ``--force-with-lease`` is the safe overwrite: it updates the remote
+    only while it still matches our remote-tracking ref, so it refuses to
+    clobber commits pushed elsewhere since our last fetch. Bare
+    ``--force`` is never used. (Issue #1557.)
+    """
+    try:
+        git.run("push", "--force-with-lease", "-u", "origin", branch)
+    except subprocess.CalledProcessError as exc:
+        msg = (
+            f"vrg-submit-pr: pushing '{branch}' to origin failed.\n"
+            "  --force-with-lease was refused, which means the remote branch "
+            "moved since your last fetch.\n"
+            "  Run `vrg-git fetch origin` and review the remote commits before "
+            "retrying, so you don't overwrite someone else's work."
+        )
+        raise SystemExit(msg) from exc
+
+
 def _create_pr(*, target_branch: str, title: str, pr_body: str) -> str:
     with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
         f.write(pr_body)
@@ -152,7 +176,7 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
         return 0
 
     print(f"Pushing branch '{branch}' to origin...")
-    git.run("push", "-u", "origin", branch)
+    _push_branch(branch)
 
     print("Creating PR...")
     pr_url = _create_pr(target_branch=target, title=args.title, pr_body=pr_body)
@@ -295,7 +319,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     # succeeds even for branches that touch .github/workflows/ — which the
     # agent's own push would have been rejected for.
     print(f"Ensuring branch '{branch}' is pushed to origin...")
-    git.run("push", "-u", "origin", branch)
+    _push_branch(branch)
 
     print("Creating PR...")
     pr_url = _create_pr(target_branch=target, title=title, pr_body=pr_body)

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
+    _push_branch,
     main,
     parse_args,
 )
@@ -212,8 +214,29 @@ def test_main_submits_pr(tmp_path: Path) -> None:
     ):
         result = main(["--issue", "42", "--summary", "Fix bug", "--title", "fix: bug"])
     assert result == 0
-    mock_git_run.assert_called_once_with("push", "-u", "origin", "feature/x")
+    mock_git_run.assert_called_once_with("push", "--force-with-lease", "-u", "origin", "feature/x")
     mock_create_pr.assert_called_once()
+
+
+def test_push_branch_uses_force_with_lease() -> None:
+    """Issue #1557: submission follows a rebase, so the push must tolerate a
+    diverged remote via --force-with-lease (never bare --force)."""
+    with patch("vergil_tooling.bin.vrg_submit_pr.git.run") as run:
+        _push_branch("feature/x")
+    run.assert_called_once_with("push", "--force-with-lease", "-u", "origin", "feature/x")
+    args = run.call_args[0]
+    assert "--force" not in args  # the bare, unsafe variant is never used
+
+
+def test_push_branch_raises_clear_error_on_rejection() -> None:
+    """A refused force-with-lease (remote moved since fetch) must surface a
+    clear, actionable message — not a raw CalledProcessError traceback."""
+    err = subprocess.CalledProcessError(1, ["git", "push"])
+    with (
+        patch("vergil_tooling.bin.vrg_submit_pr.git.run", side_effect=err),
+        pytest.raises(SystemExit, match="force-with-lease was refused"),
+    ):
+        _push_branch("feature/x")
 
 
 def test_main_submits_pr_with_notes(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Push the feature branch with --force-with-lease (factored into a _push_branch helper used by both push sites) so vrg-submit-pr no longer fails non-fast-forward after the normal rebase-onto-current-base step; a refused lease raises a clear, actionable message instead of a raw traceback.

## Issue Linkage

- Ref #1557

## Notes

- Safe overwrite only — refuses if the remote moved since our last fetch; bare --force is never used. Adds direct tests for both the force-with-lease push and the clear-error path.