### PR TITLE
feat(pr-workflow): let report-fixes revise PR metadata mid-workflow

### DIFF
--- a/docs/specs/2026-06-08-pr-workflow-oracle-design.md
+++ b/docs/specs/2026-06-08-pr-workflow-oracle-design.md
@@ -328,7 +328,7 @@ instruction.
 |---|---|---|
 | `next [--no-audit]` | USER, AUDIT | Block (SHA poll). Role resolved from `vrg-whoami` (no `--as` flag). First-ever call as USER: **init/takeover** the file and run the startup handshake (§8.1). Return a Directive or DONE. |
 | `report-ready --title --summary --notes [--linkage]` | USER | Snapshot HEAD, write `pr_metadata`, `owner→audit`. (Initial done signal.) |
-| `report-fixes [--note]` | USER | Verify HEAD moved, snapshot it, `owner→audit`, bump round. |
+| `report-fixes [--note] [--title --summary --notes]` | USER | Verify the round carries something new — HEAD moved **or** a `pr_metadata` revision (`--title`/`--summary`/`--notes`); overwrite the revised fields. Then snapshot HEAD, `owner→audit`, bump round. A metadata-only round (no new commit) makes a `pr-description-fidelity` fail actionable. |
 | `submit-check --payload check.json` | AUDIT | Validate one check vs `check.v1`, record it. Once every registry check has a result for the round, **roll up** → set owner/status, record `last_reviewed_sha`. |
 | `escalate --reason …` | USER, AUDIT | `owner→human`, set `escalation`, status=escalated. |
 | `abort --reason …` | USER, AUDIT | Record a terminal `error` (graceful give-up, §9); the counterpart's `next` detects it and stops. Role resolved from `vrg-whoami`. |
@@ -492,9 +492,12 @@ human is watching the two sessions.
   restart).
 - **Malformed report** — `submit-check`/`report-ready` payloads are validated
   against their schemas; rejection is non-zero so the model retries.
-- **No new commits on `report-fixes`** — the oracle verifies HEAD actually moved
-  since `last_reviewed_sha`; if not, it rejects ("nothing to review") to prevent
-  empty-round loops.
+- **Empty round on `report-fixes`** — a fix round must carry something new to
+  re-review: HEAD moved since `last_reviewed_sha` **or** a `pr_metadata` revision
+  (`--title`/`--summary`/`--notes`). A metadata-only round keeps a
+  `pr-description-fidelity` fail actionable (the summary is fixable without a code
+  commit); a genuinely empty round (no new HEAD and no revision) is rejected to
+  prevent empty-round loops.
 - **Runaway rounds** — a `round` counter with a configurable cap (in `vergil.toml`);
   exceeding it auto-escalates to the human rather than looping forever.
 - **Identity misread** — role comes from `vrg-whoami`; `next` warns on signal

--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -156,6 +156,9 @@ def cmd_report_fixes(args: argparse.Namespace, transport: LocalFileTransport) ->
         head_sha=transport.head_sha(),
         note=args.note,
         now=_now(),
+        title=args.title,
+        summary=args.summary,
+        notes=args.notes,
         max_rounds=settings.max_rounds(transport.worktree_root),
     )
     transport.write(state)
@@ -245,6 +248,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     p_fixes = sub.add_parser("report-fixes", help="USER: report fixes for the last findings")
     p_fixes.add_argument("--note", default=None)
+    p_fixes.add_argument("--title", default=None, help="Revise the PR title (e.g. for fidelity)")
+    p_fixes.add_argument("--summary", default=None, help="Revise the PR summary")
+    p_fixes.add_argument("--notes", default=None, help="Revise the PR notes")
     p_fixes.set_defaults(func=cmd_report_fixes)
 
     p_check = sub.add_parser("submit-check", help="AUDIT: submit one check's result")

--- a/src/vergil_tooling/lib/pr_workflow/engine.py
+++ b/src/vergil_tooling/lib/pr_workflow/engine.py
@@ -114,16 +114,32 @@ def apply_report_fixes(
     head_sha: str,
     note: str | None,
     now: str,
+    title: str | None = None,
+    summary: str | None = None,
+    notes: str | None = None,
     max_rounds: int = 10,
 ) -> WorkflowState:
-    """USER reports it addressed findings. Requires a genuinely new HEAD so an
-    empty round cannot loop. When the new round exceeds ``max_rounds`` the
-    workflow auto-escalates to the human instead of looping forever (the
+    """USER reports it addressed findings. A round counts only if it carries
+    something new to re-review: a new HEAD **or** a PR-metadata revision (so a
+    ``pr-description-fidelity`` fail is actionable — the USER can rewrite the
+    summary/notes/title with no code commit). An empty round (neither) is
+    rejected so the loop cannot spin. When the new round exceeds ``max_rounds``
+    the workflow auto-escalates to the human instead of looping forever (the
     runaway-round cap, spec §9). ``max_rounds`` is supplied by the CLI from
     ``settings.max_rounds``; the default keeps the engine usable standalone."""
     _require_owner(state, "user")
-    if head_sha == state.git.get("last_reviewed_sha"):
-        raise WorkflowError("no new commits since the last review; nothing to re-review")
+    revisions = {
+        key: value
+        for key, value in (("title", title), ("summary", summary), ("notes", notes))
+        if value is not None
+    }
+    new_head = head_sha != state.git.get("last_reviewed_sha")
+    if not new_head and not revisions:
+        raise WorkflowError(
+            "no new commits and no metadata revision since the last review; nothing to re-review"
+        )
+    if revisions:
+        state.pr_metadata = {**(state.pr_metadata or {}), **revisions}
     state.git["head_sha"] = head_sha
     state.round += 1
     state.updated_at = now
@@ -136,6 +152,8 @@ def apply_report_fixes(
     }
     if note:
         entry["note"] = note
+    if revisions:
+        entry["revised"] = sorted(revisions)
     state.history.append(entry)
     if state.round > max_rounds:
         state.owner = "human"

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -51,7 +51,20 @@ def _run(monkeypatch: pytest.MonkeyPatch, repo: Path, *args: str, identity: str 
     return cli.main(["--base", "develop", *args])
 
 
-def _seed(repo: Path, *, owner: str, status: str, last_reviewed: str | None = None) -> None:
+def _head_sha(repo: Path) -> str:
+    return subprocess.run(
+        ("git", "rev-parse", "HEAD"), cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _seed(
+    repo: Path,
+    *,
+    owner: str,
+    status: str,
+    last_reviewed: str | None = None,
+    pr_metadata: dict[str, str] | None = None,
+) -> None:
     """Write a workflow state directly, for verbs that need a specific turn."""
     state = engine.init_state(
         issue="1534",
@@ -66,6 +79,7 @@ def _seed(repo: Path, *, owner: str, status: str, last_reviewed: str | None = No
     state.owner = owner
     state.status = status
     state.git["last_reviewed_sha"] = last_reviewed
+    state.pr_metadata = pr_metadata
     LocalFileTransport(repo, base="develop").write(state)
 
 
@@ -185,6 +199,35 @@ def test_report_fixes_hands_back_to_audit(
     _seed(repo, owner="user", status="changes-requested", last_reviewed="oldsha")
     assert _run(monkeypatch, repo, "report-fixes", "--note", "addressed") == 0
     assert json.loads(capsys.readouterr().out)["owner"] == "audit"
+
+
+def test_report_fixes_revises_metadata_without_new_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    repo = _init_repo(tmp_path)
+    # last_reviewed == current HEAD, so there is no new commit: the only thing to
+    # re-review is the revised summary. This is the pr-description-fidelity path.
+    _seed(
+        repo,
+        owner="user",
+        status="changes-requested",
+        last_reviewed=_head_sha(repo),
+        pr_metadata={"title": "t", "summary": "old", "notes": "n", "linkage": "Ref"},
+    )
+    assert _run(monkeypatch, repo, "report-fixes", "--summary", "sharper summary") == 0
+    assert json.loads(capsys.readouterr().out)["owner"] == "audit"
+    state = json.loads((repo / ".vergil" / "pr-workflow.json").read_text())
+    assert state["pr_metadata"]["summary"] == "sharper summary"
+    assert state["round"] == 1
+
+
+def test_report_fixes_rejects_empty_round(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    repo = _init_repo(tmp_path)
+    _seed(repo, owner="user", status="changes-requested", last_reviewed=_head_sha(repo))
+    assert _run(monkeypatch, repo, "report-fixes", "--note", "nothing changed") == 1
+    assert "no new commits and no metadata revision" in capsys.readouterr().err
 
 
 def test_escalate_hands_to_human(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:

--- a/tests/vergil_tooling/pr_workflow/test_engine_reports.py
+++ b/tests/vergil_tooling/pr_workflow/test_engine_reports.py
@@ -227,6 +227,51 @@ def test_report_fixes_bumps_round_and_reopens_all_checks() -> None:
     assert engine.next_pending_check(state) == check_ids()[0]  # all reopen for the new round
 
 
+def test_report_fixes_accepts_metadata_only_round() -> None:
+    state = _paired_owned_by_user()
+    _ready(state)  # pr_metadata {title t, summary s, notes n, linkage Ref}
+    _run_review(state, fail=check_ids()[0])  # owner user, last_reviewed h1
+    # No new commit (head still h1), but the summary is revised: a valid round.
+    engine.apply_report_fixes(
+        state, head_sha="h1", note="reworded summary", now=_NOW, summary="sharper summary"
+    )
+    assert state.round == 1
+    assert state.owner == "audit"
+    assert state.status == "reviewing"
+    assert state.pr_metadata == {
+        "title": "t",
+        "summary": "sharper summary",
+        "notes": "n",
+        "linkage": "Ref",
+    }
+    assert state.history[-1]["revised"] == ["summary"]
+
+
+def test_report_fixes_revises_multiple_metadata_fields() -> None:
+    state = _paired_owned_by_user()
+    _ready(state)
+    _run_review(state, fail=check_ids()[0])
+    engine.apply_report_fixes(
+        state, head_sha="h1", note=None, now=_NOW, title="new title", notes="new notes"
+    )
+    assert state.pr_metadata == {
+        "title": "new title",
+        "summary": "s",
+        "notes": "new notes",
+        "linkage": "Ref",
+    }
+    assert state.history[-1]["revised"] == ["notes", "title"]
+
+
+def test_report_fixes_rejects_empty_round() -> None:
+    state = _paired_owned_by_user()
+    _ready(state)
+    _run_review(state, fail=check_ids()[0])  # owner user, last_reviewed h1
+    # No new commit and no metadata revision: nothing to re-review.
+    with pytest.raises(WorkflowError, match="no new commits and no metadata revision"):
+        engine.apply_report_fixes(state, head_sha="h1", note=None, now=_NOW)
+
+
 def test_report_fixes_escalates_when_round_cap_exceeded() -> None:
     state = _paired_owned_by_user()
     _ready(state)


### PR DESCRIPTION
# Pull Request

## Summary

- Add optional --title/--summary/--notes to report-fixes and relax the no-empty-round guard to accept a metadata revision, so a pr-description-fidelity audit fail is actionable without a code commit.

## Issue Linkage

- Ref #1564

## Notes

- Engine: apply_report_fixes overwrites pr_metadata fields and rejects only a genuinely empty round (no new HEAD and no revision); a metadata-only round still bumps round and hands back to audit. CLI wires the three flags through. Updated the oracle design spec and added engine + CLI e2e tests. Validation green. Prerequisite for #1563.