### PR TITLE
feat(commit): add guarded vrg-reword to fix a branch-local commit message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,11 @@ CLI tools installed as `vrg-*` console scripts:
 
 - **`vrg-commit`** — Construct standards-compliant conventional
   commits with co-author resolution
+- **`vrg-reword`** — Reword a branch-local commit's message via a scripted,
+  non-interactive rebase; the agent-safe path to fix a
+  `commit-message-fidelity` failure. Bounded: refuses shared/merged history
+  and protected branches, refuses a foreign author without
+  `--allow-foreign-author`, and pushes the rewrite with `--force-with-lease`
 - **`vrg-submit-pr`** — Create standards-compliant PRs (manual merge;
   human-run — agents hand off via `.vergil/pr-template.yml`)
 - **`vrg-pr-fix-body`** — Regenerate a PR body from corrected fields via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ vrg-release-validate-inputs = "vergil_tooling.bin.vrg_release_validate_inputs:ma
 vrg-repo-profile = "vergil_tooling.bin.vrg_repo_profile:main"
 vrg-resolve-tooling-version = "vergil_tooling.bin.vrg_resolve_tooling_version:main"
 vrg-resolve-tracking-issue = "vergil_tooling.bin.vrg_resolve_tracking_issue:main"
+vrg-reword = "vergil_tooling.bin.vrg_reword:main"
 vrg-sarif-evaluate = "vergil_tooling.bin.vrg_sarif_evaluate:main"
 vrg-scorecard = "vergil_tooling.bin.vrg_scorecard:main"
 vrg-semgrep-scan = "vergil_tooling.bin.vrg_semgrep_scan:main"

--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -15,18 +15,10 @@ import tempfile
 from pathlib import Path
 
 from vergil_tooling.lib import config, git
-
-ALLOWED_TYPES = (
-    "feat",
-    "fix",
-    "docs",
-    "style",
-    "refactor",
-    "test",
-    "chore",
-    "ci",
-    "build",
-    "revert",
+from vergil_tooling.lib.commit_message import (
+    ALLOWED_TYPES,
+    build_commit_message,
+    contains_autoclose,
 )
 
 _PROTECTED_BRANCHES = {"develop", "release", "main"}
@@ -50,12 +42,6 @@ _ISSUE_REQUIRED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _ISSUE_FORMAT_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9.-]*$")
 _WORKTREE_SCOPED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _WORKTREES_DIRNAME = ".worktrees"
-
-_AUTOCLOSE_RE = re.compile(
-    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
-    r":?\s+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
-    re.IGNORECASE,
-)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -183,7 +169,7 @@ def main(argv: list[str] | None = None) -> int:
     if rc != 0:
         return rc
 
-    if args.body and _AUTOCLOSE_RE.search(args.body):
+    if args.body and contains_autoclose(args.body):
         return _reject(
             "ERROR: commit body contains a GitHub auto-close keyword "
             "(close/fix/resolve). Use 'Ref #N' instead.",
@@ -199,14 +185,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    subject = f"{args.commit_type}({args.scope}): {args.message}"
+    message = build_commit_message(
+        commit_type=args.commit_type,
+        scope=args.scope,
+        message=args.message,
+        body=args.body,
+        co_author=co_author,
+    )
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-        f.write(f"{subject}\n")
-        if args.body:
-            f.write(f"\n{args.body}\n")
-        if co_author:
-            f.write(f"\nCo-Authored-By: {co_author}\n")
+        f.write(message)
         tmp_path = f.name
 
     try:

--- a/src/vergil_tooling/bin/vrg_reword.py
+++ b/src/vergil_tooling/bin/vrg_reword.py
@@ -1,0 +1,422 @@
+"""Reword a branch-local commit's message through the standards path.
+
+The agent tool surface otherwise cannot fix a commit message:
+``vrg-git commit`` is denied, ``vrg-commit`` only creates new commits,
+and interactive rebase is unavailable. Yet ``commit-message-fidelity``
+is a judgment gate, so a USER agent needs a way to act on it. This tool
+rewords *any of the current branch's own commits* via a scripted,
+non-interactive rebase, re-stamping the new message through the same
+standards/identity path ``vrg-commit`` uses.
+
+It is a deliberate relaxation of a tight restriction, so it is bounded:
+
+- **Branch-local only** — refuses to touch any commit reachable from the
+  base branch (never rewrites shared/merged history) or any commit on a
+  protected branch.
+- **Own-identity only** — refuses when the target commit's author email
+  differs from the current git identity, unless ``--allow-foreign-author``
+  is passed.
+- **Force-with-lease** — when the branch is already on the remote, the
+  rewrite is pushed with ``--force-with-lease`` (never bare ``--force``);
+  safe on an unmerged feature branch (the #1557 pattern).
+
+Rewording a *mid-chain* commit re-applies the commits after it, which
+changes their **committer** (the author is preserved). In an
+identity-aware system that should be a deliberate decision, so the tool
+prints a warning naming the affected commits before it runs.
+
+The rebase drives two scripted editors, both re-entrant invocations of
+this same module (``--seq-edit`` / ``--msg-edit``): the sequence editor
+flips the target line from ``pick`` to ``reword``, and the commit-message
+editor writes the re-stamped message. Neither prompts interactively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from vergil_tooling.lib import git
+from vergil_tooling.lib.commit_message import (
+    ALLOWED_TYPES,
+    build_commit_message,
+    contains_autoclose,
+)
+
+_PROTECTED_BRANCHES = {"develop", "main"}
+_PROTECTED_PREFIXES = ("release/",)
+
+# Env channel from the parent invocation to its scripted-editor children.
+_ENV_TARGET = "VRG_REWORD_TARGET"
+_ENV_MSG_FILE = "VRG_REWORD_MSG_FILE"
+
+_SEQ_EDIT_FLAG = "--seq-edit"
+_MSG_EDIT_FLAG = "--msg-edit"
+
+
+def _is_protected_branch(branch: str) -> bool:
+    if branch in _PROTECTED_BRANCHES:
+        return True
+    return any(branch.startswith(p) for p in _PROTECTED_PREFIXES)
+
+
+def _base_branch(branch: str) -> str:
+    """Return the integration branch this feature branch targets."""
+    return "main" if branch.startswith("release/") else "develop"
+
+
+def _reject(reason: str, *hints: str) -> int:
+    """Print rejection reason and hints to stderr; return 1."""
+    print(f"vrg-reword: {reason}", file=sys.stderr)
+    for hint in hints:
+        print(f"  {hint}", file=sys.stderr)
+    return 1
+
+
+# --------------------------------------------------------------------------
+# Scripted-editor children (re-entrant invocations of this module)
+# --------------------------------------------------------------------------
+
+
+def _seq_edit(todo_path: Path, target_sha: str) -> int:
+    """Flip the target commit's ``pick`` line to ``reword`` in the todo list.
+
+    Invoked by git as ``GIT_SEQUENCE_EDITOR`` with the rebase todo file.
+    The target SHA arrives via the environment so this stays a fixed,
+    quote-safe command string.
+    """
+    lines = todo_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == "pick" and target_sha.startswith(parts[1]):
+            lines[i] = line.replace("pick", "reword", 1)
+            todo_path.write_text("".join(lines), encoding="utf-8")
+            return 0
+    print(
+        f"vrg-reword: could not find commit {target_sha[:12]} in the rebase plan.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _msg_edit(msg_path: Path, source_path: Path) -> int:
+    """Overwrite the commit-message file with the re-stamped message.
+
+    Invoked by git as ``GIT_EDITOR`` for the single reworded commit. The
+    source path (a temp file holding the new message) arrives via the
+    environment.
+    """
+    msg_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return 0
+
+
+def _dispatch_editor(argv: list[str]) -> int | None:
+    """Run an editor child if *argv* names one; else return None.
+
+    git invokes the configured editor as ``<command> <file>``, so the
+    file path is the trailing argument.
+    """
+    if not argv:
+        return None
+    if argv[0] == _SEQ_EDIT_FLAG:
+        target = os.environ.get(_ENV_TARGET, "")
+        if not target:
+            print(f"vrg-reword: {_ENV_TARGET} not set for sequence editor.", file=sys.stderr)
+            return 1
+        return _seq_edit(Path(argv[-1]), target)
+    if argv[0] == _MSG_EDIT_FLAG:
+        source = os.environ.get(_ENV_MSG_FILE, "")
+        if not source:
+            print(f"vrg-reword: {_ENV_MSG_FILE} not set for message editor.", file=sys.stderr)
+            return 1
+        return _msg_edit(Path(argv[-1]), Path(source))
+    return None
+
+
+# --------------------------------------------------------------------------
+# Guards
+# --------------------------------------------------------------------------
+
+
+def _rev_parse(ref: str) -> str | None:
+    result = subprocess.run(  # noqa: S603
+        ("git", "rev-parse", "--verify", "--quiet", ref),  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _is_ancestor(commit: str, ancestor_of: str) -> bool:
+    result = subprocess.run(  # noqa: S603
+        ("git", "merge-base", "--is-ancestor", commit, ancestor_of),  # noqa: S607
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _author_email(sha: str) -> str:
+    return git.read_output("show", "-s", "--format=%ae", sha)
+
+
+def _current_identity_email() -> str:
+    result = subprocess.run(  # noqa: S603
+        ("git", "config", "user.email"),  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+def _later_commits(target_sha: str) -> list[str]:
+    """Return short SHAs of commits applied after *target_sha* on HEAD."""
+    out = git.read_output("rev-list", "--reverse", "--abbrev-commit", f"{target_sha}..HEAD")
+    return out.splitlines() if out else []
+
+
+def _validate(args: argparse.Namespace) -> tuple[int, str, str]:
+    """Run every guard. Return ``(rc, target_sha, branch)``.
+
+    ``rc`` is 0 when all guards pass, and the SHA and branch are then
+    meaningful. On any failure ``rc`` is 1 and the two strings are empty
+    placeholders the caller must not use.
+    """
+    branch = git.current_branch()
+
+    if _is_protected_branch(branch):
+        return (
+            _reject(
+                f"refusing to reword on protected branch '{branch}'.",
+                "Reword only your own feature branch's commits.",
+            ),
+            "",
+            "",
+        )
+
+    target_sha = _rev_parse(args.sha)
+    if target_sha is None:
+        return _reject(f"'{args.sha}' is not a valid commit."), "", ""
+
+    if not _is_ancestor(target_sha, "HEAD"):
+        return _reject(f"commit {args.sha} is not reachable from HEAD ({branch})."), "", ""
+
+    base = _base_branch(branch)
+    base_ref = f"origin/{base}" if _rev_parse(f"origin/{base}") else base
+    if _rev_parse(base_ref) is None:
+        return (
+            _reject(
+                f"cannot resolve base branch '{base}' to verify history is unshared.",
+                f"Fetch '{base}' before rewording.",
+            ),
+            "",
+            "",
+        )
+    if _is_ancestor(target_sha, base_ref):
+        return (
+            _reject(
+                f"commit {args.sha} is already part of '{base_ref}' — "
+                "refusing to rewrite shared history.",
+                "Reword only commits unique to this branch.",
+            ),
+            "",
+            "",
+        )
+
+    if not args.allow_foreign_author:
+        author = _author_email(target_sha)
+        current = _current_identity_email()
+        if not current:
+            return (
+                _reject(
+                    "cannot determine the current git identity (user.email is unset).",
+                    "Configure git user.email, or pass --allow-foreign-author to skip the check.",
+                ),
+                "",
+                "",
+            )
+        if author.lower() != current.lower():
+            return (
+                _reject(
+                    f"commit {args.sha} was authored by {author}, not the current "
+                    f"identity {current}.",
+                    "Rewording re-stamps the message under the current identity.",
+                    "Pass --allow-foreign-author to override this provenance guard.",
+                ),
+                "",
+                "",
+            )
+
+    if git.working_tree_status():
+        return (
+            _reject(
+                "the working tree is not clean; the rebase reword needs a clean tree.",
+                "Commit or stash your changes first.",
+            ),
+            "",
+            "",
+        )
+
+    return 0, target_sha, branch
+
+
+# --------------------------------------------------------------------------
+# Rebase
+# --------------------------------------------------------------------------
+
+
+def _editor_command(flag: str) -> str:
+    """Build a quote-safe ``python -m`` editor command for git to invoke."""
+    return f"{shlex.quote(sys.executable)} -m vergil_tooling.bin.vrg_reword {flag}"
+
+
+def _run_reword_rebase(target_sha: str, message: str) -> int:
+    """Drive the scripted non-interactive rebase that rewords *target_sha*."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".msg", delete=False, encoding="utf-8") as f:
+        f.write(message)
+        msg_file = f.name
+
+    env = {
+        **os.environ,
+        _ENV_TARGET: target_sha,
+        _ENV_MSG_FILE: msg_file,
+        "GIT_SEQUENCE_EDITOR": _editor_command(_SEQ_EDIT_FLAG),
+        "GIT_EDITOR": _editor_command(_MSG_EDIT_FLAG),
+    }
+    try:
+        result = subprocess.run(  # noqa: S603
+            ("git", "rebase", "-i", f"{target_sha}^"),  # noqa: S607
+            env=env,
+            check=False,
+        )
+    finally:
+        Path(msg_file).unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        print(
+            "vrg-reword: the rebase did not complete. The repository may be "
+            "mid-rebase;\n  run `git rebase --abort` to restore the branch.",
+            file=sys.stderr,
+        )
+    return result.returncode
+
+
+def _maybe_push(branch: str, *, no_push: bool) -> int:
+    """Push the rewritten branch with --force-with-lease when it has a remote.
+
+    Skips silently when the branch was never pushed (nothing to update)
+    or when ``--no-push`` is given. ``--force-with-lease`` refuses to
+    clobber commits pushed elsewhere since the last fetch.
+    """
+    if no_push:
+        print(
+            "Skipping push (--no-push). Update the remote with:\n"
+            f"  vrg-git push --force-with-lease origin {branch}"
+        )
+        return 0
+    if _rev_parse(f"refs/remotes/origin/{branch}") is None:
+        print(f"Branch '{branch}' is not on origin yet; nothing to push.")
+        return 0
+    print(f"Updating origin/{branch} with --force-with-lease...")
+    try:
+        git.run("push", "--force-with-lease", "origin", branch)
+    except subprocess.CalledProcessError:
+        print(
+            "vrg-reword: the reword succeeded locally but the push was refused — "
+            "the remote moved since your last fetch.\n"
+            f"  Run `vrg-git fetch origin` and review origin/{branch} before retrying.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Reword a branch-local commit's message via a scripted rebase."
+    )
+    parser.add_argument("sha", help="The commit to reword (any branch-local revision)")
+    parser.add_argument(
+        "--type",
+        required=True,
+        choices=ALLOWED_TYPES,
+        dest="commit_type",
+        help="Conventional commit type",
+    )
+    parser.add_argument("--scope", required=True, help="Conventional commit scope")
+    parser.add_argument("--message", required=True, help="Commit description")
+    parser.add_argument("--body", default="", help="Detailed commit body")
+    parser.add_argument(
+        "--allow-foreign-author",
+        action="store_true",
+        default=False,
+        help="Reword even when the commit's author differs from the current identity",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        default=False,
+        help="Do not push the rewritten branch to origin afterward",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Re-entrant scripted-editor modes must short-circuit before argparse,
+    # which would reject the bare editor flags.
+    editor_rc = _dispatch_editor(argv)
+    if editor_rc is not None:
+        return editor_rc
+
+    args = parse_args(argv)
+
+    if args.body and contains_autoclose(args.body):
+        return _reject(
+            "commit body contains a GitHub auto-close keyword (close/fix/resolve).",
+            "Use 'Ref #N' instead. Issues stay open until post-merge workflows succeed.",
+        )
+
+    rc, target_sha, branch = _validate(args)
+    if rc != 0:
+        return rc
+
+    later = _later_commits(target_sha)
+    if later:
+        print(
+            f"Note: rewording {args.sha} re-applies {len(later)} later commit(s) "
+            f"({', '.join(later)}),\n"
+            "  which changes their committer (the author is preserved).",
+            file=sys.stderr,
+        )
+
+    co_author = os.environ.get("VRG_CO_AUTHOR")
+    message = build_commit_message(
+        commit_type=args.commit_type,
+        scope=args.scope,
+        message=args.message,
+        body=args.body,
+        co_author=co_author,
+    )
+
+    rebase_rc = _run_reword_rebase(target_sha, message)
+    if rebase_rc != 0:
+        return rebase_rc
+
+    print(f"Reworded {args.sha}: {args.commit_type}({args.scope}): {args.message}")
+    return _maybe_push(branch, no_push=args.no_push)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vergil_tooling/lib/commit_message.py
+++ b/src/vergil_tooling/lib/commit_message.py
@@ -1,0 +1,62 @@
+"""Shared construction of standards-compliant commit messages.
+
+Both ``vrg-commit`` (new commits) and ``vrg-reword`` (rewriting an
+existing branch-local commit's message) build the same conventional
+subject, optional body, and co-author trailer through these helpers, so
+a reworded message is stamped exactly like a freshly authored one.
+"""
+
+from __future__ import annotations
+
+import re
+
+ALLOWED_TYPES = (
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "test",
+    "chore",
+    "ci",
+    "build",
+    "revert",
+)
+
+# Matches a GitHub auto-close keyword anywhere in a commit body. Broader
+# than ``linkage.AUTOCLOSE_RE`` (which anchors to a line start for PR
+# bodies) — a commit body must not smuggle an auto-close even mid-line.
+AUTOCLOSE_RE = re.compile(
+    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+    r":?\s+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
+    re.IGNORECASE,
+)
+
+
+def contains_autoclose(body: str) -> bool:
+    """Return True if *body* contains a GitHub auto-close keyword."""
+    return bool(AUTOCLOSE_RE.search(body))
+
+
+def build_commit_message(
+    *,
+    commit_type: str,
+    scope: str,
+    message: str,
+    body: str = "",
+    co_author: str | None = None,
+) -> str:
+    """Return the full commit message text (subject, body, co-author trailer).
+
+    The layout matches what ``vrg-commit`` writes to its commit-message
+    file byte-for-byte: a ``type(scope): message`` subject line, then an
+    optional blank-line-separated body, then an optional
+    ``Co-Authored-By`` trailer.
+    """
+    subject = f"{commit_type}({scope}): {message}"
+    parts = [f"{subject}\n"]
+    if body:
+        parts.append(f"\n{body}\n")
+    if co_author:
+        parts.append(f"\nCo-Authored-By: {co_author}\n")
+    return "".join(parts)

--- a/tests/vergil_tooling/test_commit_message.py
+++ b/tests/vergil_tooling/test_commit_message.py
@@ -1,0 +1,79 @@
+"""Tests for vergil_tooling.lib.commit_message."""
+
+from __future__ import annotations
+
+import pytest
+
+from vergil_tooling.lib.commit_message import (
+    ALLOWED_TYPES,
+    build_commit_message,
+    contains_autoclose,
+)
+
+
+def test_allowed_types_includes_conventional_set() -> None:
+    assert "feat" in ALLOWED_TYPES
+    assert "revert" in ALLOWED_TYPES
+
+
+def test_build_subject_only() -> None:
+    msg = build_commit_message(commit_type="feat", scope="core", message="add thing")
+    assert msg == "feat(core): add thing\n"
+
+
+def test_build_with_body() -> None:
+    msg = build_commit_message(
+        commit_type="fix", scope="lint", message="correct regex", body="Edge case."
+    )
+    assert msg == "fix(lint): correct regex\n\nEdge case.\n"
+
+
+def test_build_with_co_author() -> None:
+    msg = build_commit_message(
+        commit_type="feat",
+        scope="core",
+        message="add thing",
+        co_author="Claude <noreply@anthropic.com>",
+    )
+    assert msg == "feat(core): add thing\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n"
+
+
+def test_build_with_body_and_co_author_ordering() -> None:
+    msg = build_commit_message(
+        commit_type="feat",
+        scope="core",
+        message="add thing",
+        body="Why it changed.",
+        co_author="Claude <noreply@anthropic.com>",
+    )
+    assert msg == (
+        "feat(core): add thing\n\nWhy it changed.\n"
+        "\nCo-Authored-By: Claude <noreply@anthropic.com>\n"
+    )
+
+
+def test_empty_co_author_omits_trailer() -> None:
+    msg = build_commit_message(commit_type="feat", scope="core", message="x", co_author="")
+    assert "Co-Authored-By" not in msg
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #42",
+        "fixes #42",
+        "Resolved owner/repo#42",
+        "Some context.\n\nCloses #99",
+        "inline resolve #7 here",
+    ],
+)
+def test_contains_autoclose_detects_keywords(body: str) -> None:
+    assert contains_autoclose(body) is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    ["Ref #42", "This closes the loop.", "Fixed the edge case for input.", ""],
+)
+def test_contains_autoclose_allows_safe_bodies(body: str) -> None:
+    assert contains_autoclose(body) is False

--- a/tests/vergil_tooling/test_vrg_reword.py
+++ b/tests/vergil_tooling/test_vrg_reword.py
@@ -1,0 +1,512 @@
+"""Tests for vergil_tooling.bin.vrg_reword."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from vergil_tooling.bin import vrg_reword
+from vergil_tooling.bin.vrg_reword import (
+    _dispatch_editor,
+    _is_protected_branch,
+    _msg_edit,
+    _seq_edit,
+    main,
+    parse_args,
+)
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Iterator
+    from pathlib import Path
+
+_MOD = "vergil_tooling.bin.vrg_reword"
+
+
+# --------------------------------------------------------------------------
+# parse_args
+# --------------------------------------------------------------------------
+
+
+def test_parse_args_required() -> None:
+    args = parse_args(["abc123", "--type", "feat", "--scope", "core", "--message", "do thing"])
+    assert args.sha == "abc123"
+    assert args.commit_type == "feat"
+    assert args.scope == "core"
+    assert args.message == "do thing"
+    assert args.allow_foreign_author is False
+    assert args.no_push is False
+
+
+def test_parse_args_missing_sha() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--type", "feat", "--scope", "core", "--message", "x"])
+
+
+def test_parse_args_invalid_type() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["abc", "--type", "bogus", "--scope", "core", "--message", "x"])
+
+
+# --------------------------------------------------------------------------
+# protected-branch helper
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("branch", ["develop", "main", "release/1.2.3"])
+def test_is_protected_branch_true(branch: str) -> None:
+    assert _is_protected_branch(branch) is True
+
+
+@pytest.mark.parametrize("branch", ["feature/1-x", "bugfix/9-y", "chore/3-z"])
+def test_is_protected_branch_false(branch: str) -> None:
+    assert _is_protected_branch(branch) is False
+
+
+# --------------------------------------------------------------------------
+# scripted editors
+# --------------------------------------------------------------------------
+
+
+def test_seq_edit_flips_target_pick_to_reword(tmp_path: Path) -> None:
+    todo = tmp_path / "todo"
+    todo.write_text("pick aaaaaaa first\npick bbbbbbb second\npick ccccccc third\n")
+    assert _seq_edit(todo, "bbbbbbbdeadbeef") == 0
+    lines = todo.read_text().splitlines()
+    assert lines == ["pick aaaaaaa first", "reword bbbbbbb second", "pick ccccccc third"]
+
+
+def test_seq_edit_missing_target_fails(tmp_path: Path) -> None:
+    todo = tmp_path / "todo"
+    todo.write_text("pick aaaaaaa first\n")
+    assert _seq_edit(todo, "ffffffffff") == 1
+
+
+def test_msg_edit_overwrites_commit_message(tmp_path: Path) -> None:
+    source = tmp_path / "new.msg"
+    source.write_text("feat(core): reworded\n")
+    target = tmp_path / "COMMIT_EDITMSG"
+    target.write_text("old message\n")
+    assert _msg_edit(target, source) == 0
+    assert target.read_text() == "feat(core): reworded\n"
+
+
+def test_dispatch_editor_routes_seq(tmp_path: Path) -> None:
+    todo = tmp_path / "todo"
+    todo.write_text("pick aaaaaaa first\n")
+    with patch.dict("os.environ", {"VRG_REWORD_TARGET": "aaaaaaadead"}, clear=False):
+        rc = _dispatch_editor(["--seq-edit", str(todo)])
+    assert rc == 0
+    assert todo.read_text().startswith("reword ")
+
+
+def test_dispatch_editor_routes_msg(tmp_path: Path) -> None:
+    source = tmp_path / "new.msg"
+    source.write_text("feat(core): x\n")
+    target = tmp_path / "COMMIT_EDITMSG"
+    target.write_text("old\n")
+    with patch.dict("os.environ", {"VRG_REWORD_MSG_FILE": str(source)}, clear=False):
+        rc = _dispatch_editor(["--msg-edit", str(target)])
+    assert rc == 0
+    assert target.read_text() == "feat(core): x\n"
+
+
+def test_dispatch_editor_returns_none_for_normal_args() -> None:
+    assert _dispatch_editor(["abc", "--type", "feat"]) is None
+    assert _dispatch_editor([]) is None
+
+
+def test_dispatch_editor_seq_without_env_target_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("VRG_REWORD_TARGET", raising=False)
+    assert _dispatch_editor(["--seq-edit", str(tmp_path / "todo")]) == 1
+
+
+def test_dispatch_editor_msg_without_env_source_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("VRG_REWORD_MSG_FILE", raising=False)
+    assert _dispatch_editor(["--msg-edit", str(tmp_path / "msg")]) == 1
+
+
+def test_main_dispatches_editor_before_argparse(tmp_path: Path) -> None:
+    """The bare editor flags must not reach argparse (which would reject them)."""
+    todo = tmp_path / "todo"
+    todo.write_text("pick aaaaaaa first\n")
+    with patch.dict("os.environ", {"VRG_REWORD_TARGET": "aaaaaaadead"}, clear=False):
+        assert main(["--seq-edit", str(todo)]) == 0
+
+
+def test_main_reads_sys_argv_when_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """main(None) falls back to sys.argv."""
+    todo = tmp_path / "todo"
+    todo.write_text("pick aaaaaaa first\n")
+    monkeypatch.setenv("VRG_REWORD_TARGET", "aaaaaaadead")
+    monkeypatch.setattr("sys.argv", ["vrg-reword", "--seq-edit", str(todo)])
+    assert main() == 0
+
+
+# --------------------------------------------------------------------------
+# guard validation (mocked)
+# --------------------------------------------------------------------------
+
+
+def _args(
+    *,
+    sha: str = "deadbeef",
+    body: str = "",
+    allow_foreign_author: bool = False,
+    no_push: bool = False,
+) -> argparse.Namespace:
+    argv = [sha, "--type", "feat", "--scope", "core", "--message", "do thing"]
+    if body:
+        argv += ["--body", body]
+    if allow_foreign_author:
+        argv.append("--allow-foreign-author")
+    if no_push:
+        argv.append("--no-push")
+    return parse_args(argv)
+
+
+def test_validate_rejects_protected_branch() -> None:
+    with patch(f"{_MOD}.git.current_branch", return_value="develop"):
+        rc, sha, branch = vrg_reword._validate(_args())
+    assert rc == 1
+    assert sha == ""
+
+
+def test_validate_rejects_unknown_sha() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", return_value=None),
+    ):
+        rc, sha, _ = vrg_reword._validate(_args())
+    assert rc == 1
+
+
+def test_validate_rejects_commit_not_on_branch() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", return_value="fullsha"),
+        patch(f"{_MOD}._is_ancestor", return_value=False),
+    ):
+        rc, _, _ = vrg_reword._validate(_args())
+    assert rc == 1
+
+
+def test_validate_rejects_ancestor_of_base() -> None:
+    # reachable from HEAD, and also an ancestor of base → shared history.
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=lambda ref: "fullsha"),
+        patch(f"{_MOD}._is_ancestor", side_effect=[True, True]),
+    ):
+        rc, _, _ = vrg_reword._validate(_args())
+    assert rc == 1
+
+
+def test_validate_rejects_unresolvable_base() -> None:
+    # target resolves, but neither origin/develop nor develop exists.
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=["fullsha", None, None]),
+        patch(f"{_MOD}._is_ancestor", return_value=True),
+    ):
+        rc, sha, _ = vrg_reword._validate(_args())
+    assert rc == 1
+    assert sha == ""
+
+
+def test_validate_rejects_foreign_author_without_override() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=lambda ref: "fullsha"),
+        patch(f"{_MOD}._is_ancestor", side_effect=[True, False]),
+        patch(f"{_MOD}._author_email", return_value="someone@else.com"),
+        patch(f"{_MOD}._current_identity_email", return_value="me@here.com"),
+    ):
+        rc, _, _ = vrg_reword._validate(_args())
+    assert rc == 1
+
+
+def test_validate_allows_foreign_author_with_override() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=lambda ref: "fullsha"),
+        patch(f"{_MOD}._is_ancestor", side_effect=[True, False]),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+    ):
+        rc, sha, branch = vrg_reword._validate(_args(allow_foreign_author=True))
+    assert rc == 0
+    assert sha == "fullsha"
+    assert branch == "feature/1-x"
+
+
+def test_validate_rejects_missing_identity() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=lambda ref: "fullsha"),
+        patch(f"{_MOD}._is_ancestor", side_effect=[True, False]),
+        patch(f"{_MOD}._author_email", return_value="me@here.com"),
+        patch(f"{_MOD}._current_identity_email", return_value=""),
+    ):
+        rc, _, _ = vrg_reword._validate(_args())
+    assert rc == 1
+
+
+def test_validate_rejects_dirty_tree() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=lambda ref: "fullsha"),
+        patch(f"{_MOD}._is_ancestor", side_effect=[True, False]),
+        patch(f"{_MOD}._author_email", return_value="me@here.com"),
+        patch(f"{_MOD}._current_identity_email", return_value="me@here.com"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=" M file.py"),
+    ):
+        rc, _, _ = vrg_reword._validate(_args())
+    assert rc == 1
+
+
+def test_validate_passes_all_guards() -> None:
+    with (
+        patch(f"{_MOD}.git.current_branch", return_value="feature/1-x"),
+        patch(f"{_MOD}._rev_parse", side_effect=lambda ref: "fullsha"),
+        patch(f"{_MOD}._is_ancestor", side_effect=[True, False]),
+        patch(f"{_MOD}._author_email", return_value="me@here.com"),
+        patch(f"{_MOD}._current_identity_email", return_value="ME@here.com"),
+        patch(f"{_MOD}.git.working_tree_status", return_value=""),
+    ):
+        rc, sha, branch = vrg_reword._validate(_args())
+    assert rc == 0
+    assert sha == "fullsha"
+
+
+# --------------------------------------------------------------------------
+# body auto-close guard in main()
+# --------------------------------------------------------------------------
+
+
+def test_main_rejects_autoclose_body() -> None:
+    rc = main(["abc", "--type", "feat", "--scope", "core", "--message", "x", "--body", "Closes #5"])
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------
+# push behavior
+# --------------------------------------------------------------------------
+
+
+def test_maybe_push_skips_when_no_push() -> None:
+    assert vrg_reword._maybe_push("feature/1-x", no_push=True) == 0
+
+
+def test_maybe_push_skips_when_no_remote_branch() -> None:
+    with patch(f"{_MOD}._rev_parse", return_value=None):
+        assert vrg_reword._maybe_push("feature/1-x", no_push=False) == 0
+
+
+def test_maybe_push_runs_force_with_lease() -> None:
+    with (
+        patch(f"{_MOD}._rev_parse", return_value="remotesha"),
+        patch(f"{_MOD}.git.run") as run,
+    ):
+        rc = vrg_reword._maybe_push("feature/1-x", no_push=False)
+    assert rc == 0
+    run.assert_called_once_with("push", "--force-with-lease", "origin", "feature/1-x")
+
+
+def test_maybe_push_reports_rejected_push() -> None:
+    err = subprocess.CalledProcessError(1, ("git", "push"))
+    with (
+        patch(f"{_MOD}._rev_parse", return_value="remotesha"),
+        patch(f"{_MOD}.git.run", side_effect=err),
+    ):
+        rc = vrg_reword._maybe_push("feature/1-x", no_push=False)
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------
+# rebase failure paths
+# --------------------------------------------------------------------------
+
+
+def test_run_reword_rebase_reports_failure() -> None:
+    failed = subprocess.CompletedProcess(args=[], returncode=1)
+    with patch(f"{_MOD}.subprocess.run", return_value=failed) as run:
+        rc = vrg_reword._run_reword_rebase("deadbeef", "feat(core): x\n")
+    assert rc == 1
+    # The rebase is driven with the scripted editors via env.
+    _, kwargs = run.call_args
+    assert kwargs["env"]["GIT_SEQUENCE_EDITOR"].endswith("--seq-edit")
+    assert kwargs["env"]["GIT_EDITOR"].endswith("--msg-edit")
+
+
+def test_main_returns_rebase_failure_before_push() -> None:
+    with (
+        patch(f"{_MOD}._validate", return_value=(0, "fullsha", "feature/1-x")),
+        patch(f"{_MOD}._later_commits", return_value=[]),
+        patch(f"{_MOD}._run_reword_rebase", return_value=1),
+        patch(f"{_MOD}._maybe_push") as push,
+    ):
+        rc = main(["fullsha", "--type", "feat", "--scope", "core", "--message", "x"])
+    assert rc == 1
+    push.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# end-to-end: a real git repo exercising the scripted rebase
+# --------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def reword_repo(tmp_path: Path) -> Iterator[tuple[Path, str]]:
+    """A repo with a `develop` base and a feature branch of three commits.
+
+    The target (B) is authored by the current identity (so the own-identity
+    guard passes). The *later* commit (C) carries a distinct author and a
+    distinct committer, so the test can prove rewording B preserves C's
+    author while re-stamping its committer. Returns (repo, sha_of_B).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "develop")
+    _git(repo, "config", "user.name", "Me")
+    _git(repo, "config", "user.email", "me@here.com")
+
+    (repo / "base.txt").write_text("base\n")
+    _git(repo, "add", "base.txt")
+    _git(repo, "commit", "-q", "-m", "chore(core): base on develop")
+
+    _git(repo, "switch", "-q", "-c", "feature/1-x")
+
+    (repo / "a.txt").write_text("a\n")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-q", "-m", "feat(core): commit A")
+
+    (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "b.txt")
+    _git(repo, "commit", "-q", "-m", "feat(core): bad B message")
+    sha_b = _git(repo, "rev-parse", "HEAD")
+
+    # Commit C: distinct author and committer, both different from "me".
+    c_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Other",
+        "GIT_AUTHOR_EMAIL": "other@x.com",
+        "GIT_COMMITTER_NAME": "Orig Committer",
+        "GIT_COMMITTER_EMAIL": "orig-committer@x.com",
+    }
+    (repo / "c.txt").write_text("c\n")
+    _git(repo, "add", "c.txt")
+    _git(repo, "commit", "-q", "-m", "feat(core): commit C", env=c_env)
+
+    yield repo, sha_b
+
+
+def test_reword_midchain_commit_end_to_end(
+    reword_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, sha_b = reword_repo
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("VRG_CO_AUTHOR", "Claude <noreply@anthropic.com>")
+
+    rc = main(
+        [
+            sha_b,
+            "--type",
+            "feat",
+            "--scope",
+            "core",
+            "--message",
+            "good B message",
+            "--no-push",
+        ]
+    )
+    assert rc == 0
+
+    subjects = _git(repo, "log", "--format=%s", "develop..HEAD").splitlines()
+    # Newest first: C, reworded B, A.
+    assert subjects == [
+        "feat(core): commit C",
+        "feat(core): good B message",
+        "feat(core): commit A",
+    ]
+
+    # The reworded commit carries the co-author trailer (standards path).
+    b_body = _git(repo, "log", "--format=%B", "-1", "HEAD~1")
+    assert "Co-Authored-By: Claude <noreply@anthropic.com>" in b_body
+
+    # Commit C (applied after B) keeps its author but gets a new committer —
+    # the design note made observable.
+    c_author = _git(repo, "log", "--format=%ae", "-1", "HEAD")
+    c_committer = _git(repo, "log", "--format=%ce", "-1", "HEAD")
+    assert c_author == "other@x.com"
+    assert c_committer == "me@here.com"
+
+    # The original B sha is gone; history was rewritten.
+    assert sha_b not in _git(repo, "rev-parse", "HEAD~1")
+
+
+def test_reword_head_commit_end_to_end(
+    reword_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reword HEAD (no later commits) — exercises the no-note and override paths.
+
+    HEAD here (commit C) is authored by a foreign identity, so the run also
+    needs ``--allow-foreign-author`` end-to-end.
+    """
+    repo, _ = reword_repo
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv("VRG_CO_AUTHOR", raising=False)
+    head = _git(repo, "rev-parse", "HEAD")
+
+    rc = main(
+        [
+            head,
+            "--type",
+            "feat",
+            "--scope",
+            "core",
+            "--message",
+            "renamed C",
+            "--allow-foreign-author",
+            "--no-push",
+        ]
+    )
+    assert rc == 0
+
+    assert _git(repo, "log", "--format=%s", "-1", "HEAD") == "feat(core): renamed C"
+    # No co-author was configured, so no trailer is stamped.
+    assert "Co-Authored-By" not in _git(repo, "log", "--format=%B", "-1", "HEAD")
+
+
+def test_reword_refuses_shared_history_end_to_end(
+    reword_repo: tuple[Path, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = reword_repo
+    monkeypatch.chdir(repo)
+    base_sha = _git(repo, "rev-parse", "develop")
+
+    rc = main(
+        [base_sha, "--type", "chore", "--scope", "core", "--message", "rewrite base", "--no-push"]
+    )
+    assert rc == 1
+    # develop's tip is untouched.
+    assert _git(repo, "rev-parse", "develop") == base_sha


### PR DESCRIPTION
# Pull Request

## Summary

- Add vrg-reword, a guarded scripted-rebase tool that lets the USER agent reword any of its own branch-local commits so it can act on a commit-message-fidelity failure.

## Issue Linkage

- Ref #1566

## Notes

- Guards: refuses shared/merged history and protected branches; refuses a foreign-author target without --allow-foreign-author; requires a clean tree; force-with-lease push only when the branch already has a remote. The conventional-message builder and auto-close body guard were extracted from vrg-commit into lib/commit_message.py (vrg-commit output unchanged) so both tools re-stamp through one path. Mid-chain rewords change later commits' committer (author preserved) and the tool warns first. A real-git integration test exercises the full rebase, the foreign-author override, and the shared-history refusal.