### PR TITLE
fix(repo-init): offer "none of the above" for primary-language

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -79,6 +79,41 @@ def prompt_choice(label: str, options: list[str], *, default: str = "") -> str:
         print(f"  Enter a number between 1 and {len(options)}.")
 
 
+def prompt_language(*, default: str = "") -> str:
+    """Prompt for the primary language, with an explicit no-language option.
+
+    "No primary language" is the *absence* of a language, not a sixth language.
+    It is presented as a separate "0. None of the above" choice, set apart from
+    the real languages, and maps to an empty string so the caller omits the
+    ``primary-language`` key entirely (see issue #1579). This is deliberately
+    asymmetric with the other enums (e.g. ``versioning-scheme``), which encode
+    their no-op as a literal ``none`` member.
+    """
+    languages = sorted(_ENUMS["primary-language"])
+    print("\nPrimary language:")
+    for i, lang in enumerate(languages, 1):
+        marker = " (default)" if lang == default else ""
+        print(f"  {i}. {lang}{marker}")
+    print()
+    none_marker = " (default)" if not default else ""
+    print(f"  0. None of the above — this repo has no primary language{none_marker}")
+
+    while True:
+        hint = f" [{default}]" if default else " [none]"
+        raw = input(f"  Choice{hint}: ").strip()
+        if not raw:
+            return default  # may be "" → no primary language
+        if raw == "0":
+            return ""
+        try:
+            idx = int(raw)
+            if 1 <= idx <= len(languages):
+                return languages[idx - 1]
+        except ValueError:
+            pass
+        print(f"  Enter 0–{len(languages)}.")
+
+
 def prompt_yes_no(label: str, *, default: bool | None = None) -> bool:
     """Prompt for a yes/no answer."""
     hint_map = {True: " [Y/n]", False: " [y/N]", None: " [y/n]"}
@@ -625,14 +660,22 @@ def step_generate_config(ctx: RepoInitContext) -> None:
     pub_raw = existing.get("publish", {}) if existing else {}
     deps = existing.get("dependencies", {}) if existing else {}
 
+    ctx.repository_type = prompt_choice(
+        "Repository type",
+        sorted(_ENUMS["repository-type"]),
+        default=project.get("repository-type", ""),
+    )
+
+    # Primary language is prompted on its own — "no language" is the absence of
+    # a language, presented as a separate "none of the above" choice, not a
+    # sixth enum value (issue #1579).
+    ctx.primary_language = prompt_language(default=project.get("primary-language", ""))
+
     enum_fields = [
-        ("repository_type", "repository-type", "Repository type"),
-        ("primary_language", "primary-language", "Primary language"),
         ("branching_model", "branching-model", "Branching model"),
         ("versioning_scheme", "versioning-scheme", "Versioning scheme"),
         ("release_model", "release-model", "Release model"),
     ]
-
     for attr, toml_key, label in enum_fields:
         options = sorted(_ENUMS[toml_key])
         default = project.get(toml_key, "")

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -20,6 +20,7 @@ from vergil_tooling.lib.repo_init import (
     detect_completed_steps,
     prompt_choice,
     prompt_free_text,
+    prompt_language,
     prompt_yes_no,
     render_cd_workflow,
     render_ci_workflow,
@@ -59,6 +60,29 @@ class TestPromptChoice:
         with patch("builtins.input", side_effect=["0", "abc", "1"]):
             result = prompt_choice("Pick one", options)
         assert result == "alpha"
+
+
+class TestPromptLanguage:
+    # Languages are listed sorted: go, java, python, ruby, rust (so index 3 is python).
+    def test_selects_language(self) -> None:
+        with patch("builtins.input", return_value="3"):
+            assert prompt_language() == "python"
+
+    def test_none_of_the_above_returns_empty(self) -> None:
+        with patch("builtins.input", return_value="0"):
+            assert prompt_language() == ""
+
+    def test_empty_with_no_default_means_no_language(self) -> None:
+        with patch("builtins.input", return_value=""):
+            assert prompt_language() == ""
+
+    def test_empty_with_language_default_keeps_default(self) -> None:
+        with patch("builtins.input", return_value=""):
+            assert prompt_language(default="python") == "python"
+
+    def test_invalid_then_none(self) -> None:
+        with patch("builtins.input", side_effect=["9", "abc", "0"]):
+            assert prompt_language() == ""
 
 
 class TestPromptYesNo:
@@ -634,6 +658,76 @@ class TestStepGenerateConfig:
         assert 'primary-language = "python"' in content
 
         assert any("commit" in c for c in calls)
+
+    def test_none_of_the_above_omits_primary_language(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="dot-github")
+        ctx.work_dir = tmp_path
+
+        inputs = iter(
+            [
+                "2",  # repository-type: documentation
+                "0",  # primary-language: none of the above
+                "3",  # branching-model: docs-single-branch
+                "2",  # versioning-scheme: none
+                "3",  # release-model: none
+                "latest",  # ci versions
+                "n",  # integration tests
+                "n",  # publish releases
+                "y",  # publish docs
+                "",  # vergil version
+                "1",  # license: GPL-3.0
+                "",  # initial version
+            ]
+        )
+
+        with (
+            patch("builtins.input", side_effect=lambda _="": next(inputs)),
+            patch("vergil_tooling.lib.repo_init.git.run"),
+        ):
+            step_generate_config(ctx)
+
+        assert ctx.primary_language == ""
+        content = (tmp_path / "vergil.toml").read_text()
+        assert "primary-language" not in content
+        # Round-trips through config validation as a language-less repo.
+        assert _parse_raw_config(tomllib.loads(content)).project.primary_language is None
+
+    def test_adopt_language_less_toml_round_trips(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="dot-github", adopt=True)
+        ctx.work_dir = tmp_path
+
+        existing = (
+            "[project]\n"
+            'repository-type = "documentation"\n'
+            'versioning-scheme = "none"\n'
+            'branching-model = "docs-single-branch"\n'
+            'release-model = "none"\n'
+            "\n"
+            "[ci]\n"
+            'versions = ["latest"]\n'
+            "integration-tests = false\n"
+            "\n"
+            "[publish]\n"
+            "release = false\n"
+            "docs = true\n"
+            "\n"
+            "[dependencies]\n"
+            'vergil = "v2.1"\n'
+        )
+        (tmp_path / "vergil.toml").write_text(existing)
+
+        # All defaults accepted (empty input); the language default is "no language".
+        inputs = iter([""] * 12)
+
+        with (
+            patch("builtins.input", side_effect=lambda _="": next(inputs)),
+            patch("vergil_tooling.lib.repo_init.git.run"),
+        ):
+            step_generate_config(ctx)
+
+        assert ctx.primary_language == ""
+        content = (tmp_path / "vergil.toml").read_text()
+        assert "primary-language" not in content
 
     def test_prefills_from_existing_toml_in_adopt_mode(
         self,


### PR DESCRIPTION
# Pull Request

## Summary

- The init wizard now offers a distinct "none of the above" option for primary-language so language-less repos (e.g. .github) can be adopted instead of dead-ending on a forced language choice.

## Issue Linkage

- Ref #1579

## Notes

- Wizard-only change. primary-language moves out of the generic required-enum loop into its own prompt with a separate "0. None of the above" choice that maps to empty, so render_vergil_toml omits the key — a state the config parser and vrg-validate already treat as valid (primary_language=None, common-checks-only). No change to the five-language enum, the omission-on-disk model, or defaults. Step-3 re-runnability is unchanged: the checkpoint commits atomically at step end, so a mid-step abort (the original failure) leaves no checkpoint and re-runs cleanly. New tests: TestPromptLanguage plus no-language selection and language-less adopt round-trip in TestStepGenerateConfig.