### PR TITLE
fix(repo-init): omit allow_forking for public org repos

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -104,7 +104,7 @@ _LANGUAGE_ACTION_PATTERNS: dict[str, list[str]] = {
 }
 
 
-def desired_repo_settings(*, is_org: bool) -> DesiredRepoSettings:
+def desired_repo_settings(*, is_org: bool, visibility: str) -> DesiredRepoSettings:
     return DesiredRepoSettings(
         default_branch="develop",
         allow_auto_merge=False,
@@ -115,12 +115,15 @@ def desired_repo_settings(*, is_org: bool) -> DesiredRepoSettings:
         has_issues=True,
         has_projects=True,
         has_wiki=True,
-        # The tooling requires repos to be forkable, so org repos (public and
-        # private) declare forking enabled. Private repos additionally depend on
-        # the org-level ``members_can_fork_private_repositories`` flag, which the
-        # tool cannot yet manage (vergil-tooling#1268). User-owned repos are left
-        # unmanaged (vergil-tooling#666).
-        allow_forking=True if is_org else None,
+        # GitHub only accepts the ``allow_forking`` field on org-owned *private*
+        # repos; PATCHing it on a public repo returns 422 (vergil-tooling#1584),
+        # and it is moot there since public repos are forkable per org policy.
+        # Private org repos additionally depend on the org-level
+        # ``members_can_fork_private_repositories`` flag, which the tool cannot
+        # yet manage (vergil-tooling#1268). User-owned repos are left unmanaged
+        # (vergil-tooling#666). Anything other than a private org repo is left
+        # unmanaged (``None`` → omitted from the PATCH body).
+        allow_forking=True if (is_org and visibility == "private") else None,
         allow_update_branch=True,
         has_downloads=False,
         merge_commit_title="MERGE_MESSAGE",
@@ -348,7 +351,7 @@ def compute_desired_state(
     )
 
     return DesiredState(
-        repo_settings=desired_repo_settings(is_org=is_org),
+        repo_settings=desired_repo_settings(is_org=is_org, visibility=visibility),
         security=desired_security_settings(ghas=ghas),
         actions_permissions=desired_actions_permissions(config.project.primary_language),
         rulesets=rulesets,

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -48,7 +48,7 @@ from vergil_tooling.lib.github_config import (
 
 
 def test_desired_repo_settings_are_fixed() -> None:
-    s = desired_repo_settings(is_org=True)
+    s = desired_repo_settings(is_org=True, visibility="private")
     assert s.default_branch == "develop"
     assert s.allow_auto_merge is False
     assert s.delete_branch_on_merge is True
@@ -60,15 +60,15 @@ def test_desired_repo_settings_are_fixed() -> None:
     assert s.has_wiki is True
 
 
-def test_desired_repo_settings_org_repo_allows_forking() -> None:
-    # The tooling requires forkable repos, so org repos declare forking enabled
-    # regardless of visibility (public or private).
-    s = desired_repo_settings(is_org=True)
+def test_desired_repo_settings_private_org_repo_allows_forking() -> None:
+    # GitHub only accepts allow_forking on org-owned *private* repos, so the
+    # tooling declares forking enabled for private org repos (issue #1584).
+    s = desired_repo_settings(is_org=True, visibility="private")
     assert s.allow_forking is True
 
 
 def test_desired_repo_settings_new_hardcoded_values() -> None:
-    s = desired_repo_settings(is_org=True)
+    s = desired_repo_settings(is_org=True, visibility="private")
     assert s.allow_update_branch is True
     assert s.has_downloads is False
     assert s.merge_commit_title == "MERGE_MESSAGE"
@@ -1090,7 +1090,7 @@ def test_canonicalize_rules_preserves_non_dict_entries() -> None:
 
 
 def test_apply_repo_settings_calls_write_json() -> None:
-    settings = desired_repo_settings(is_org=True)
+    settings = desired_repo_settings(is_org=True, visibility="private")
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     mock_write.assert_called_once()
@@ -1103,7 +1103,7 @@ def test_apply_repo_settings_calls_write_json() -> None:
 
 
 def test_apply_repo_settings_includes_new_fields() -> None:
-    settings = desired_repo_settings(is_org=True)
+    settings = desired_repo_settings(is_org=True, visibility="private")
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
@@ -1473,12 +1473,12 @@ def test_compute_desired_state_publish_release_true() -> None:
 
 
 def test_desired_repo_settings_user_repo_allow_forking_is_none() -> None:
-    s = desired_repo_settings(is_org=False)
+    s = desired_repo_settings(is_org=False, visibility="public")
     assert s.allow_forking is None
 
 
 def test_apply_repo_settings_omits_allow_forking_when_none() -> None:
-    settings = desired_repo_settings(is_org=False)
+    settings = desired_repo_settings(is_org=False, visibility="public")
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
@@ -1486,11 +1486,35 @@ def test_apply_repo_settings_omits_allow_forking_when_none() -> None:
 
 
 def test_apply_repo_settings_includes_allow_forking_for_private_org() -> None:
-    settings = desired_repo_settings(is_org=True)
+    settings = desired_repo_settings(is_org=True, visibility="private")
     with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
         _apply_repo_settings("o/r", settings)
     body = mock_write.call_args[0][2]
     assert body["allow_forking"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #1584: GitHub only accepts allow_forking on org-owned *private* repos;
+# PATCHing it on a public repo returns 422. Public org repos must omit it.
+# ---------------------------------------------------------------------------
+
+
+def test_public_org_repo_omits_allow_forking() -> None:
+    state = compute_desired_state(_vergil_config(), visibility="public", is_org=True)
+    assert state.repo_settings.allow_forking is None
+
+
+def test_private_org_repo_sets_allow_forking() -> None:
+    state = compute_desired_state(_vergil_config(), visibility="private", is_org=True)
+    assert state.repo_settings.allow_forking is True
+
+
+def test_apply_repo_settings_omits_allow_forking_for_public_org() -> None:
+    settings = desired_repo_settings(is_org=True, visibility="public")
+    with patch("vergil_tooling.lib.github_config.github.write_json") as mock_write:
+        _apply_repo_settings("o/r", settings)
+    body = mock_write.call_args[0][2]
+    assert "allow_forking" not in body
 
 
 def _private_forking_error() -> GitHubAPIError:
@@ -1503,7 +1527,7 @@ def _private_forking_error() -> GitHubAPIError:
 
 
 def test_apply_repo_settings_raises_actionable_error_on_private_forking_422() -> None:
-    settings = desired_repo_settings(is_org=True)
+    settings = desired_repo_settings(is_org=True, visibility="private")
     with (
         patch(
             "vergil_tooling.lib.github_config.github.write_json",
@@ -1515,7 +1539,7 @@ def test_apply_repo_settings_raises_actionable_error_on_private_forking_422() ->
 
 
 def test_apply_repo_settings_propagates_unrelated_api_error() -> None:
-    settings = desired_repo_settings(is_org=True)
+    settings = desired_repo_settings(is_org=True, visibility="private")
     unrelated = GitHubAPIError(
         1,
         ("gh", "api", "repos/o/r"),


### PR DESCRIPTION
# Pull Request

## Summary

- Gate the allow_forking repo setting on visibility so it is only sent for private org repos, fixing the 422 that broke the GitHub-config step when adopting public repos like an org .github repo.

## Issue Linkage

- Ref #1584

## Notes

- Root cause: GitHub only accepts allow_forking on org-owned private repos; the tooling sent it for every org repo. Fix threads visibility (already in compute_desired_state scope) into desired_repo_settings: allow_forking=True only when is_org and visibility=="private", else None. The existing plumbing already handles None — _diff_dataclass treats it as unmanaged and _apply_repo_settings omits it from the PATCH body — so public repos simply stop sending the field. Private-org behavior and the members_can_fork_private_repositories 422 handler (#1268) are untouched. Tests: added public-org-omits / private-org-sets / apply-omits-for-public cases at both desired_repo_settings and compute_desired_state levels; updated existing call sites for the now-required visibility kwarg and corrected a stale "regardless of visibility" comment. Resulting matrix: org+private=True, org+public=None, user=None.