### PR TITLE
feat(vrg-git): allow read-only git subcommands and read-only reflog

### DIFF
--- a/docs/site/docs/guides/permission-model.md
+++ b/docs/site/docs/guides/permission-model.md
@@ -45,6 +45,30 @@ shell expansion, no pipes, no redirection.
 | `branch` | `--force`; `-D` conditional | `-d` allowed; `-D` allowed when upstream is `[gone]` |
 | `ls-remote` | — | Read-only |
 | `rev-parse` | — | Read-only |
+| `annotate` | — | Read-only — line-level authorship |
+| `blame` | — | Read-only — line-level authorship |
+| `cat-file` | — | Read-only — object type/size/content |
+| `cherry` | — | Read-only — commits not yet upstream |
+| `count-objects` | — | Read-only — repo object stats |
+| `describe` | — | Read-only — nearest reachable tag |
+| `diff-files` | — | Read-only — plumbing diff |
+| `diff-index` | — | Read-only — plumbing diff |
+| `diff-tree` | — | Read-only — plumbing diff |
+| `for-each-ref` | — | Read-only — enumerate refs |
+| `grep` | — | Read-only — search tracked content |
+| `ls-files` | — | Read-only — list tracked files |
+| `ls-tree` | — | Read-only — list a tree's contents |
+| `merge-base` | — | Read-only — common-ancestor lookup |
+| `name-rev` | — | Read-only — symbolic names for commits |
+| `reflog` | `expire`, `delete` | Read-only show/exists allowed; mutating sub-ops denied |
+| `rev-list` | — | Read-only — list commits |
+| `shortlog` | — | Read-only — summarized log |
+| `show-branch` | — | Read-only — compare branches |
+| `show-ref` | — | Read-only — list refs |
+| `var` | — | Read-only — logical git variables |
+| `verify-commit` | — | Read-only — signature verification |
+| `verify-tag` | — | Read-only — signature verification |
+| `whatchanged` | — | Read-only — log with file changes |
 | `worktree add` | — | Parallel agent work |
 | `worktree list` | — | Read-only |
 | `worktree remove` | — | Cleanup after merge |

--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -14,6 +14,9 @@ from vergil_tooling.lib import github, identity_mode
 from vergil_tooling.lib.git import _git_auth_env
 
 _ALLOWED_SIMPLE: set[str] = {
+    # Read-only inspection commands. These only read history, objects, or
+    # refs and have no mode that mutates the repository, so they are allowed
+    # unconditionally for triage and debugging (#1602).
     "status",
     "log",
     "diff",
@@ -21,6 +24,30 @@ _ALLOWED_SIMPLE: set[str] = {
     "branch",
     "ls-remote",
     "rev-parse",
+    "annotate",
+    "blame",
+    "cat-file",
+    "cherry",
+    "count-objects",
+    "describe",
+    "diff-files",
+    "diff-index",
+    "diff-tree",
+    "for-each-ref",
+    "grep",
+    "ls-files",
+    "ls-tree",
+    "merge-base",
+    "name-rev",
+    "rev-list",
+    "shortlog",
+    "show-branch",
+    "show-ref",
+    "var",
+    "verify-commit",
+    "verify-tag",
+    "whatchanged",
+    # Mutating commands, gated further by _FLAG_DENY and worktree checks.
     "add",
     "mv",
     "rm",
@@ -39,13 +66,23 @@ _ALLOWED_COMPOUND: dict[str, set[str]] = {
     "worktree": {"add", "list", "remove"},
 }
 
+# Commands whose default/listing form is read-only but which also expose
+# mutating sub-operations. The read-only forms (bare invocation plus any
+# sub-operation not listed here) are allowed; the listed sub-operations are
+# denied. Used for high-value debugging commands like reflog (#1602).
+_READONLY_WITH_DENIED_SUBS: dict[str, set[str]] = {
+    "reflog": {"expire", "delete"},
+}
+
 _DENIED: dict[str, str] = {
     "commit": "Use vrg-commit instead of git commit.",
     "reset": "git reset is denied by vrg-git.",
     "clean": "git clean is denied by vrg-git.",
+    # config has a broad mutating-flag surface (--add/--unset/--replace-all/
+    # --rename-section/--remove-section/-e/bare set); its read-only forms
+    # (--get/--list) need a careful flag allowlist and are deferred (#1602).
     "config": "git config is denied by vrg-git.",
     "remote": "git remote is denied by vrg-git.",
-    "reflog": "git reflog is denied by vrg-git.",
     "gc": "git gc is denied by vrg-git.",
     "prune": "git prune is denied by vrg-git.",
     "filter-branch": "git filter-branch is denied by vrg-git.",
@@ -260,6 +297,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"vrg-git: {subcmd} is denied. {msg}", file=sys.stderr)
         return 1
 
+    if subcmd in _READONLY_WITH_DENIED_SUBS:
+        denied_subs = _READONLY_WITH_DENIED_SUBS[subcmd]
+        # The mutating sub-operation, if any, is the first positional token.
+        sub = argv[1] if len(argv) >= 2 else None
+        if sub in denied_subs:
+            print(f"vrg-git: {subcmd} {sub} is denied by vrg-git.", file=sys.stderr)
+            return 1
+        result = subprocess.run(["git", *argv], check=False)  # noqa: S603, S607
+        return result.returncode
+
     if subcmd in _ALLOWED_COMPOUND:
         allowed_subs = _ALLOWED_COMPOUND[subcmd]
         if len(argv) < 2 or argv[1] not in allowed_subs:
@@ -280,9 +327,9 @@ def main(argv: list[str] | None = None) -> int:
         return result.returncode
 
     if subcmd not in _ALLOWED_SIMPLE:
+        allowed = _ALLOWED_SIMPLE | set(_ALLOWED_COMPOUND) | set(_READONLY_WITH_DENIED_SUBS)
         print(
-            f"vrg-git: {subcmd} is not recognized. "
-            f"Allowed: {', '.join(sorted(_ALLOWED_SIMPLE | set(_ALLOWED_COMPOUND)))}",
+            f"vrg-git: {subcmd} is not recognized. Allowed: {', '.join(sorted(allowed))}",
             file=sys.stderr,
         )
         return 1

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -41,6 +41,29 @@ _ALLOWED_SIMPLE = [
     "branch",
     "ls-remote",
     "rev-parse",
+    "annotate",
+    "blame",
+    "cat-file",
+    "cherry",
+    "count-objects",
+    "describe",
+    "diff-files",
+    "diff-index",
+    "diff-tree",
+    "for-each-ref",
+    "grep",
+    "ls-files",
+    "ls-tree",
+    "merge-base",
+    "name-rev",
+    "rev-list",
+    "shortlog",
+    "show-branch",
+    "show-ref",
+    "var",
+    "verify-commit",
+    "verify-tag",
+    "whatchanged",
     "add",
     "mv",
     "rm",
@@ -117,7 +140,6 @@ _DENIED = [
     "clean",
     "config",
     "remote",
-    "reflog",
     "gc",
     "prune",
     "filter-branch",
@@ -150,6 +172,44 @@ def test_config_denied(capsys: pytest.CaptureFixture[str]) -> None:
 def test_config_with_args_denied(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["config", "user.email", "x@example.com"]) != 0
     assert "denied" in capsys.readouterr().err.lower()
+
+
+# -- reflog: read-only forms allowed, mutating sub-ops denied -----------------
+
+
+def test_reflog_bare_allowed() -> None:
+    with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        rc = main(["reflog"])
+    assert rc == 0
+    args = mock_run.call_args[0][0]
+    assert args == ["git", "reflog"]
+
+
+@pytest.mark.parametrize("sub", ["show", "exists"])
+def test_reflog_readonly_subcommand_allowed(sub: str) -> None:
+    with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        rc = main(["reflog", sub, "HEAD"])
+    assert rc == 0
+    args = mock_run.call_args[0][0]
+    assert args[:3] == ["git", "reflog", sub]
+
+
+@pytest.mark.parametrize("sub", ["expire", "delete"])
+def test_reflog_mutating_subcommand_denied(sub: str, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["reflog", sub, "--all"]) != 0
+    err = capsys.readouterr().err
+    assert sub in err
+    assert "denied" in err.lower()
+
+
+def test_reflog_flag_before_subcommand_allowed() -> None:
+    """A flag in the first position is read-only (e.g. `git reflog --all`)."""
+    with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        rc = main(["reflog", "--all"])
+    assert rc == 0
 
 
 # -- helper: _is_protected_branch --------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Add all purely read-only git subcommands (blame, grep, ls-files, cat-file, rev-list, merge-base, and more) to the vrg-git allowlist and gate reflog to its read-only forms, so agents have maximum read-only access for triage and debugging.

## Issue Linkage

- Ref #1602

## Notes

- Dual-mode commands config/tag/notes are deliberately left denied: config has a broad mutating-flag surface whose read-only --get/--list forms need a careful flag allowlist, and tag/notes share the bare-default-writes ambiguity. These are deferred to a follow-up rather than risk loosening a write path. reflog is gated by denying only expire/delete. permission-model.md allowlist table updated to match. 138 tests pass; vrg-validate green.