### PR TITLE
feat(vrg-vm): VM-local Claude plugin lifecycle and .claude share-set cleanup

### DIFF
--- a/docs/site/docs/guides/agent-vm-claude-share-set.md
+++ b/docs/site/docs/guides/agent-vm-claude-share-set.md
@@ -52,8 +52,10 @@ on first launch and keeps them current with an in-VM refresh — the same
 model used for vergil-tooling. The host's materialized `~/.claude/plugins`
 checkout is never shared: doing so would cross the macOS/Linux boundary
 (fragile if any plugin ships a binary) and hit the same `EXDEV` write
-problem as the roster. Instead, `update_plugins` runs `claude plugin
-marketplace update` + `claude plugin update` inside the VM, driven by
-`vrg-vm update` and a warn-mode stage on VM start/rebuild.
+problem as the roster. Instead, `update_plugins` refreshes the marketplaces
+(`claude plugin marketplace update`) and then updates each **enabled** plugin to
+its latest version with the plugin's own scope (`claude plugin update <id>
+--scope <user|project>` — there is no bulk-update form), all inside the VM.
+It is driven by `vrg-vm update` and a warn-mode stage on VM start/rebuild.
 
 See also: [Identity Architecture](identity-architecture.md).

--- a/docs/site/docs/guides/agent-vm-claude-share-set.md
+++ b/docs/site/docs/guides/agent-vm-claude-share-set.md
@@ -1,0 +1,59 @@
+# Agent VM `.claude` Share Set
+
+This guide explains which parts of the host's `~/.claude` directory are
+shared into agent VMs, how conversation resume survives a VM rebuild, and
+why plugins and the session roster are deliberately kept VM-local. The
+wiring lives in `src/vergil_tooling/lib/lima.py` (`create_vm`,
+`link_claude_dirs`, `copy_claude_config`); the `vergil-vm` template only
+declares the static `projects` mount.
+
+## The share set
+
+| Subdir | How it is shared | Writable | Why |
+|---|---|---|---|
+| `projects/` | virtiofs mount + symlink | yes | Durable conversation transcripts; must survive rebuilds. |
+| `skills/` | virtiofs mount + symlink | no | Read-only reference. |
+| `sessions/` | **not shared** (VM-local) | n/a | Disposable per-VM roster; sharing breaks atomic writes (EXDEV). |
+| `plugins/` | **not shared** (VM-local) | n/a | Installed/refreshed in-VM from GitHub marketplaces. |
+
+`copy_claude_config` additionally copies `CLAUDE.md` and `settings.json`
+into each VM on create and on every start.
+
+## Why resume survives a rebuild
+
+Conversation transcripts are written as append-only `*.jsonl` files under
+`~/.claude/projects/<slug>/`. That directory is a symlink onto the
+path-preserved host mount, so the transcripts live on the host and are
+untouched when a VM is destroyed and recreated. Resuming a conversation
+reads those transcripts — **not** the `sessions/` roster — so a rebuild
+never loses history.
+
+## Why `sessions/` is VM-local
+
+`~/.claude/sessions/` holds a small roster of `pid -> session` files that
+Claude writes atomically: it writes a temp file in the VM-local tmpdir and
+then `rename()`s it onto the target. Renaming across filesystems (VM-local
+ext4 to the virtiofs host mount) fails with `EXDEV`, so the write would
+silently fail and no roster file would ever appear. The roster is also
+per-machine (pids only mean anything on the owning host), so there is no
+value in sharing it. Session detection reads each VM's local roster
+in-guest over `limactl shell`. See vergil-tooling #1301 and vergil-vm #73.
+
+> A host `~/.claude/sessions` mount used to exist (`mounts[3]`) but the VM
+> never read it once the roster was made VM-local; it was removed as dead
+> weight (#1603).
+
+## Why plugins are VM-local, not shared
+
+Plugins are declared in the host `settings.json` (`enabledPlugins` and
+`extraKnownMarketplaces`), which is copied into each VM. The marketplaces
+are **GitHub repositories**, so each VM installs the enabled plugins itself
+on first launch and keeps them current with an in-VM refresh — the same
+model used for vergil-tooling. The host's materialized `~/.claude/plugins`
+checkout is never shared: doing so would cross the macOS/Linux boundary
+(fragile if any plugin ships a binary) and hit the same `EXDEV` write
+problem as the roster. Instead, `update_plugins` runs `claude plugin
+marketplace update` + `claude plugin update` inside the VM, driven by
+`vrg-vm update` and a warn-mode stage on VM start/rebuild.
+
+See also: [Identity Architecture](identity-architecture.md).

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Credential Management: guides/credential-management.md
       - Permission Model: guides/permission-model.md
       - Account Setup: guides/account-setup.md
+      - Agent VM Claude Share Set: guides/agent-vm-claude-share-set.md
   - Guides:
       - Git Workflow: guides/git-workflow.md
       - Consuming Repo Setup: guides/consuming-repo-setup.md

--- a/docs/specs/2026-06-11-claude-share-set-audit-design.md
+++ b/docs/specs/2026-06-11-claude-share-set-audit-design.md
@@ -1,18 +1,19 @@
-# Audit the `.claude` share set — cleanups + plugins experiment
+# Audit the `.claude` share set — cleanups + VM-local plugin lifecycle
 
 - **Issue:** [#1603](https://github.com/vergil-project/vergil-tooling/issues/1603)
 - **Status:** Design approved
 - **Date:** 2026-06-11
 - **Owner of the affected code:** `src/vergil_tooling/lib/lima.py`
-  (`create_vm`, `link_claude_dirs`, `copy_claude_config`). The
-  `vergil-vm/templates/agent.yaml` template only declares the static
-  `projects` mount; the `.claude` sub-mounts and symlinks are injected
-  dynamically by `lima.py`.
+  (`create_vm`, `link_claude_dirs`, `copy_claude_config`, `update_tooling`)
+  and `src/vergil_tooling/bin/vrg_vm.py` (lifecycle pipeline + `update`
+  command). The `vergil-vm/templates/agent.yaml` template only declares
+  the static `projects` mount; the `.claude` sub-mounts, symlinks, and
+  config copy are injected dynamically by `lima.py`.
 
 ## Background
 
-Agent VMs share a curated subset of the host's `~/.claude` directory. The
-share set is defined entirely in `lima.py`:
+Agent VMs share a curated subset of the host's `~/.claude` directory.
+The share set is defined entirely in `lima.py`:
 
 - **Mounts** (`create_vm`): `mounts[0]` projects_dir · `mounts[1]`
   `.claude/projects` (rw) · `mounts[2]` `.claude/skills` (ro) ·
@@ -21,14 +22,17 @@ share set is defined entirely in `lima.py`:
   "skills")` are symlinked onto the path-preserved host mounts;
   `_CLAUDE_UNLINK_DIRS = ("sessions",)` are kept VM-local (any stale
   symlink from an older build is removed).
-- **Copy** (`copy_claude_config`): only `CLAUDE.md` + `settings.json`.
+- **Copy** (`copy_claude_config`): `_CLAUDE_CONFIG_FILES = ("CLAUDE.md",
+  "settings.json")`.
 
 An audit (#1603) surfaced three findings of differing certainty:
 
-1. **Plugins version skew (open question).** `~/.claude/plugins` is never
-   shared — not mounted, symlinked, or copied. It is VM-local, installed
-   at build time, so it drifts from the host between rebuilds. History
-   confirms this was never implemented (not a regression).
+1. **Plugins version skew.** `~/.claude/plugins` is never shared — not
+   mounted, symlinked, or copied. It is installed VM-locally on first
+   launch and then drifts from the host between rebuilds (observed: a VM
+   pinned to vergil **2.1.4** while the host had **2.1.8**). History
+   confirms this was never a regression; plugins were never in the share
+   set.
 2. **Sessions persistence is correct (decided).** Resume-after-rebuild
    works because it reads the **shared `projects/` transcript**, not the
    VM-local `sessions/` roster. The #1301 "keep the roster VM-local"
@@ -36,15 +40,64 @@ An audit (#1603) surfaced three findings of differing certainty:
 3. **Vestigial sessions mount (decided).** `mounts[3]` mounts the host
    `~/.claude/sessions`, but the VM keeps `sessions/` VM-local
    (`_CLAUDE_UNLINK_DIRS`) and never reads the mount. It is dead weight.
+   (History: `32bc0484d` added the mount "for session persistence";
+   #1301 later made the directory VM-local without removing the mount,
+   orphaning it.)
+
+## How the VM gets its plugins today
+
+There is no `claude plugin` or marketplace command anywhere in the
+agent-VM template, `lima.py`, or `vrg_vm.py`. The plugins arrive
+indirectly:
+
+- The host `settings.json` declares `enabledPlugins` (the on/off set —
+  currently `paad`, `vergil`, `superpowers`, `diogenes` enabled) and
+  `extraKnownMarketplaces` (their **GitHub source repos**).
+- `copy_claude_config` copies `settings.json` into the VM on create and
+  on every start (the `copy-config` lifecycle stage).
+- On first launch in the VM, Claude reads `settings.json` and installs
+  the enabled plugins **VM-locally** from their GitHub marketplaces into
+  `~/.claude/plugins`.
+
+Two consequences follow, and they decide the design:
+
+1. The plugins are sourced from **GitHub repos**, not from the host's
+   materialized `~/.claude/plugins` checkout. The "what to install" is
+   already declared (`settings.json`) and already seeded into the VM.
+2. Once installed at first launch, the VM never refreshes; the host
+   advances and the VM stays pinned. That is the skew.
 
 ## Scope
 
-This issue ships the two **decided** cleanups (findings 2 and 3) and a
-**documented, reproducible** EXDEV experiment procedure for finding 1.
+This issue delivers all three findings:
 
-**Out of scope:** any permanent plugins mount/symlink wiring. That is a
-follow-up issue, decided by the experiment's outcome (see Component 3).
-Nothing irreversible happens to plugins in this issue.
+- **Findings 2 and 3** — the decided cleanups (remove the vestigial
+  mount; document the persistence model).
+- **Finding 1** — a VM-local plugin lifecycle that mirrors how
+  vergil-tooling is kept current in VMs. We **do not** share plugins
+  across the host/VM boundary.
+
+### Rejected approach: sharing plugins via a mount
+
+An earlier direction was to mount + symlink `~/.claude/plugins` like
+`projects`/`skills`, gated on an EXDEV experiment (atomic `rename()`
+across the virtiofs boundary fails with `EXDEV`, the #1301 failure mode).
+That approach is rejected:
+
+- **It fights two problems, not one.** Beyond EXDEV, the host's
+  `~/.claude/plugins` is a materialized checkout on macOS; symlinking it
+  into a Linux VM is fragile and would break outright if any plugin ever
+  shipped a compiled/binary component. Sharing the materialized directory
+  is the wrong boundary to cross.
+- **It is unnecessary.** The marketplaces are GitHub repos, so each VM
+  can install and refresh plugins itself, platform-independently — the
+  same model already used for vergil-tooling. No shared mount, no
+  virtiofs writes, no EXDEV.
+
+This is a deliberate retreat from making host/VM plugin state transparent.
+Transparent cross-boundary sharing is an unusual code path; the
+tooling-style "push the update into each VM" model is simpler and
+robust.
 
 ## Component 1 — Remove the vestigial sessions mount
 
@@ -54,10 +107,11 @@ In `create_vm` (`lima.py`):
   the last slot, so the remaining mounts do not re-index.
 - Remove the now-dead `claude_sessions_path` / `claude_sessions` locals
   and the host `claude_sessions_path.mkdir(...)`. Nothing mounts or reads
-  that host directory anymore — VM session detection reads each VM's
-  *local* roster over `limactl shell`, and the host's own Claude creates
-  `~/.claude/sessions` for itself when it needs it. `create_vm` only ever
-  created it to back the (now-removed) mount.
+  that host directory: VM session detection reads each VM's *local*
+  roster in-guest (`vrg_vm_resolve.read_roster` over `Path.home()/
+  ".claude"/"sessions"`, invoked via `limactl shell`), and the host's own
+  Claude creates `~/.claude/sessions` for itself when it needs it.
+  `create_vm` only ever created it to back the now-removed mount.
 
 **Keep unchanged:** `_CLAUDE_UNLINK_DIRS = ("sessions",)` and the
 symlink-removal loop in `link_claude_dirs`. An existing VM carrying a
@@ -65,16 +119,17 @@ stale `sessions` symlink (from an older build) must still be cleaned up
 on re-link. The mount removal and the symlink guard are independent
 concerns; only the mount is vestigial.
 
+Existing VMs created with the old `mounts[3]` keep the (unused) mount
+until their next rebuild — harmless, since nothing reads it.
+
 ## Component 2 — Document the persistence model
 
-The point of finding 2 is that the projects-vs-sessions persistence model
-should be written down in one place so it is not re-litigated. Two
-pieces:
+Two pieces:
 
 ### Code comment
 
 Expand the comment block at `_CLAUDE_LINK_DIRS` (and a short note at the
-mounts in `create_vm`) to state the full model:
+mounts in `create_vm`) to state the full model in one place:
 
 - `projects/` → durable, **host-shared** transcript store. Resume reads
   these; survives VM rebuilds because the data lives on the host.
@@ -91,51 +146,59 @@ The comment links to the guide below.
 
 New `docs/site/docs/guides/agent-vm-claude-share-set.md` narrating:
 
-- the `.claude` share set (projects rw / skills ro / sessions VM-local),
+- the `.claude` share set (projects rw / skills ro / sessions VM-local);
 - the resume-after-rebuild mechanism (reads the shared `projects/`
-  transcript, not the local roster), and
-- why `sessions/` must stay VM-local (the #1301 `EXDEV` story).
+  transcript, not the local roster);
+- why `sessions/` must stay VM-local (the #1301 `EXDEV` story); and
+- how plugins are kept current (VM-local install + refresh, Component 3),
+  and why they are deliberately *not* shared.
 
-This is the durable "so it isn't re-litigated" record. Cross-reference
-adjacent guides (e.g. `identity-architecture.md`) and the worktree
-convention where relevant.
+Cross-reference adjacent guides (e.g. `identity-architecture.md`) where
+relevant.
 
-## Component 3 — Plugins EXDEV experiment procedure
+## Component 3 — VM-local plugin lifecycle (mirrors vergil-tooling)
 
-This issue **documents and hands off** the experiment; it does not wire
-plugins and does not flip any code on.
+Plugins stay unmounted and unshared. Each VM owns its own plugin
+directory and is refreshed from the GitHub marketplaces — exactly the
+model already used for vergil-tooling, where `update_tooling` runs both
+on demand (`vrg-vm update`) and as a warn-mode start stage.
 
-**Ownership.** The human runs the experiment on a macOS host. It needs a
-live Lima VM and the real virtiofs boundary, which an agent session
-(itself inside a VM/container) cannot faithfully reproduce. The agent
-produces the procedure; the human runs it; the result seeds the
-follow-up.
+### Refresh primitive
 
-**Why an experiment is required.** `sessions/` was made VM-local
-precisely because Claude's atomic temp-file + `rename()` writes hit
-`EXDEV` across the virtiofs boundary (#1301). Plugin installs and
-marketplace updates likely use the same temp+rename pattern. Wiring a
-plugins mount without testing risks trading a stale-version bug for a
-silent-write-failure bug.
+Add `update_plugins(instance: str)` to `lima.py`, mirroring
+`update_tooling`. It runs, inside the VM:
 
-**Procedure:**
+- `claude plugin marketplace update` — refresh marketplace metadata; then
+- `claude plugin update` — update installed plugins to latest.
 
-1. Scratch/uncommitted change: add a `.claude/plugins` mount in
-   `create_vm` and `"plugins"` to `_CLAUDE_LINK_DIRS`, mirroring
-   `projects`.
-2. Rebuild/start an agent VM; confirm `~/.claude/plugins` is a symlink
-   onto the virtiofs mount.
-3. In the VM, run `claude plugin marketplace update` and
-   `claude plugin update`.
-4. Observe: success (writes land on the host mount) vs. `EXDEV` /
-   silent-failure on the atomic temp+rename.
+The "what" needs no new configuration: `settings.json` (already copied by
+the `copy-config` stage on every start) is the source of truth for
+enabled plugins and marketplaces, so newly enabled/disabled host plugins
+propagate on the next start, and `update_plugins` only advances versions.
 
-**Decision the result feeds (follow-up issue, not this one):**
+### Drive it two ways (mirroring tooling)
 
-- **Success** → wire the mount + symlink permanently, so plugins track
-  the host live.
-- **`EXDEV`** → fallback: host→VM copy at provision, or a VM-side
-  `claude plugin update` on session start.
+1. **Fold into `vrg-vm update`.** `vrg-vm update` and `vrg-vm update
+   --all` refresh **both** tooling and plugins in one pass. Concretely,
+   `_update_instance` calls `update_plugins` alongside `update_tooling`.
+   "Update my VM(s)" brings everything current — the same gesture used
+   after re-releasing tooling now also picks up re-released plugins.
+2. **Warn-mode start/rebuild stage.** Add `Stage("update-plugins",
+   _st_update_plugins, mode="warn")` beside the existing `update-tooling`
+   stage in the start and rebuild pipelines, so a started or rebuilt VM
+   converges to latest plugins. Warn mode: a failed refresh surfaces as
+   ⚠ in the lifecycle summary, never aborts the session.
+
+### First-launch install on create
+
+The create pipeline relies on Claude's first-launch auto-install from
+`settings.json`. **Implementation must verify this happens reliably in
+the headless/agent launch path.** If first-launch auto-install is not
+dependable without an interactive TUI, add an explicit plugin-install
+step to the create pipeline (install the enabled plugins from
+`settings.json`) so a freshly created VM is never plugin-less. Resolve
+this during implementation; the refresh primitive above is install-safe
+to re-run regardless.
 
 ## Testing
 
@@ -144,6 +207,14 @@ silent-write-failure bug.
     `mounts[3]` / sessions args, and `mounts[0..2]` are unchanged.
   - Update `test_creates_host_claude_dirs`: drop the `sessions` directory
     assertion (projects/ and skills/ still created).
+  - Add coverage for `update_plugins`: asserts the in-VM command is
+    `claude plugin marketplace update` followed by `claude plugin
+    update`, dispatched through the shell wrapper.
+- `tests/vergil_tooling/test_vrg_vm.py`:
+  - `vrg-vm update` / `--all` invokes the plugin refresh as well as the
+    tooling update.
+  - The start (and rebuild) pipeline includes the `update-plugins`
+    warn-mode stage.
 - `link_claude_dirs` behavior is unchanged; existing coverage stands.
 - markdownlint on the new guide.
 - Full gate: `vrg-container-run -- vrg-validate`.
@@ -152,5 +223,9 @@ silent-write-failure bug.
 
 - #1301 — sessions roster kept VM-local (`EXDEV` rationale).
 - vergil-vm #73 — same `EXDEV` thread.
+- `32bc0484d` — added the sessions mount "for persistence" (now
+  vestigial).
 - #1602 — `vrg-git blame` allowlist gap surfaced during the audit
   (separate).
+- Prior art: `update_tooling` (`lima.py`) + `vrg-vm update` — the pattern
+  Component 3 mirrors.

--- a/docs/specs/2026-06-11-claude-share-set-audit-design.md
+++ b/docs/specs/2026-06-11-claude-share-set-audit-design.md
@@ -1,0 +1,156 @@
+# Audit the `.claude` share set — cleanups + plugins experiment
+
+- **Issue:** [#1603](https://github.com/vergil-project/vergil-tooling/issues/1603)
+- **Status:** Design approved
+- **Date:** 2026-06-11
+- **Owner of the affected code:** `src/vergil_tooling/lib/lima.py`
+  (`create_vm`, `link_claude_dirs`, `copy_claude_config`). The
+  `vergil-vm/templates/agent.yaml` template only declares the static
+  `projects` mount; the `.claude` sub-mounts and symlinks are injected
+  dynamically by `lima.py`.
+
+## Background
+
+Agent VMs share a curated subset of the host's `~/.claude` directory. The
+share set is defined entirely in `lima.py`:
+
+- **Mounts** (`create_vm`): `mounts[0]` projects_dir · `mounts[1]`
+  `.claude/projects` (rw) · `mounts[2]` `.claude/skills` (ro) ·
+  `mounts[3]` `.claude/sessions` (rw).
+- **Symlinks** (`link_claude_dirs`): `_CLAUDE_LINK_DIRS = ("projects",
+  "skills")` are symlinked onto the path-preserved host mounts;
+  `_CLAUDE_UNLINK_DIRS = ("sessions",)` are kept VM-local (any stale
+  symlink from an older build is removed).
+- **Copy** (`copy_claude_config`): only `CLAUDE.md` + `settings.json`.
+
+An audit (#1603) surfaced three findings of differing certainty:
+
+1. **Plugins version skew (open question).** `~/.claude/plugins` is never
+   shared — not mounted, symlinked, or copied. It is VM-local, installed
+   at build time, so it drifts from the host between rebuilds. History
+   confirms this was never implemented (not a regression).
+2. **Sessions persistence is correct (decided).** Resume-after-rebuild
+   works because it reads the **shared `projects/` transcript**, not the
+   VM-local `sessions/` roster. The #1301 "keep the roster VM-local"
+   change did not break resume.
+3. **Vestigial sessions mount (decided).** `mounts[3]` mounts the host
+   `~/.claude/sessions`, but the VM keeps `sessions/` VM-local
+   (`_CLAUDE_UNLINK_DIRS`) and never reads the mount. It is dead weight.
+
+## Scope
+
+This issue ships the two **decided** cleanups (findings 2 and 3) and a
+**documented, reproducible** EXDEV experiment procedure for finding 1.
+
+**Out of scope:** any permanent plugins mount/symlink wiring. That is a
+follow-up issue, decided by the experiment's outcome (see Component 3).
+Nothing irreversible happens to plugins in this issue.
+
+## Component 1 — Remove the vestigial sessions mount
+
+In `create_vm` (`lima.py`):
+
+- Delete the three `--set=.mounts[3]...` (sessions) args. `mounts[3]` is
+  the last slot, so the remaining mounts do not re-index.
+- Remove the now-dead `claude_sessions_path` / `claude_sessions` locals
+  and the host `claude_sessions_path.mkdir(...)`. Nothing mounts or reads
+  that host directory anymore — VM session detection reads each VM's
+  *local* roster over `limactl shell`, and the host's own Claude creates
+  `~/.claude/sessions` for itself when it needs it. `create_vm` only ever
+  created it to back the (now-removed) mount.
+
+**Keep unchanged:** `_CLAUDE_UNLINK_DIRS = ("sessions",)` and the
+symlink-removal loop in `link_claude_dirs`. An existing VM carrying a
+stale `sessions` symlink (from an older build) must still be cleaned up
+on re-link. The mount removal and the symlink guard are independent
+concerns; only the mount is vestigial.
+
+## Component 2 — Document the persistence model
+
+The point of finding 2 is that the projects-vs-sessions persistence model
+should be written down in one place so it is not re-litigated. Two
+pieces:
+
+### Code comment
+
+Expand the comment block at `_CLAUDE_LINK_DIRS` (and a short note at the
+mounts in `create_vm`) to state the full model:
+
+- `projects/` → durable, **host-shared** transcript store. Resume reads
+  these; survives VM rebuilds because the data lives on the host.
+  Append-only writes, so virtiofs is fine.
+- `skills/` → read-only reference mount.
+- `sessions/` → disposable **VM-local** roster (pid→session); regenerated
+  each run; never shared (atomic `rename()` across the virtiofs boundary
+  fails with `EXDEV`, and pids are meaningless cross-machine). **Resume
+  does not depend on it.**
+
+The comment links to the guide below.
+
+### Docs guide
+
+New `docs/site/docs/guides/agent-vm-claude-share-set.md` narrating:
+
+- the `.claude` share set (projects rw / skills ro / sessions VM-local),
+- the resume-after-rebuild mechanism (reads the shared `projects/`
+  transcript, not the local roster), and
+- why `sessions/` must stay VM-local (the #1301 `EXDEV` story).
+
+This is the durable "so it isn't re-litigated" record. Cross-reference
+adjacent guides (e.g. `identity-architecture.md`) and the worktree
+convention where relevant.
+
+## Component 3 — Plugins EXDEV experiment procedure
+
+This issue **documents and hands off** the experiment; it does not wire
+plugins and does not flip any code on.
+
+**Ownership.** The human runs the experiment on a macOS host. It needs a
+live Lima VM and the real virtiofs boundary, which an agent session
+(itself inside a VM/container) cannot faithfully reproduce. The agent
+produces the procedure; the human runs it; the result seeds the
+follow-up.
+
+**Why an experiment is required.** `sessions/` was made VM-local
+precisely because Claude's atomic temp-file + `rename()` writes hit
+`EXDEV` across the virtiofs boundary (#1301). Plugin installs and
+marketplace updates likely use the same temp+rename pattern. Wiring a
+plugins mount without testing risks trading a stale-version bug for a
+silent-write-failure bug.
+
+**Procedure:**
+
+1. Scratch/uncommitted change: add a `.claude/plugins` mount in
+   `create_vm` and `"plugins"` to `_CLAUDE_LINK_DIRS`, mirroring
+   `projects`.
+2. Rebuild/start an agent VM; confirm `~/.claude/plugins` is a symlink
+   onto the virtiofs mount.
+3. In the VM, run `claude plugin marketplace update` and
+   `claude plugin update`.
+4. Observe: success (writes land on the host mount) vs. `EXDEV` /
+   silent-failure on the atomic temp+rename.
+
+**Decision the result feeds (follow-up issue, not this one):**
+
+- **Success** → wire the mount + symlink permanently, so plugins track
+  the host live.
+- **`EXDEV`** → fallback: host→VM copy at provision, or a VM-side
+  `claude plugin update` on session start.
+
+## Testing
+
+- `tests/vergil_tooling/test_lima.py`:
+  - Update `test_adds_claude_submounts`: assert there are **no**
+    `mounts[3]` / sessions args, and `mounts[0..2]` are unchanged.
+  - Update `test_creates_host_claude_dirs`: drop the `sessions` directory
+    assertion (projects/ and skills/ still created).
+- `link_claude_dirs` behavior is unchanged; existing coverage stands.
+- markdownlint on the new guide.
+- Full gate: `vrg-container-run -- vrg-validate`.
+
+## Related
+
+- #1301 — sessions roster kept VM-local (`EXDEV` rationale).
+- vergil-vm #73 — same `EXDEV` thread.
+- #1602 — `vrg-git blame` allowlist gap surfaced during the audit
+  (separate).

--- a/docs/specs/2026-06-11-claude-share-set-audit-design.md
+++ b/docs/specs/2026-06-11-claude-share-set-audit-design.md
@@ -168,8 +168,15 @@ on demand (`vrg-vm update`) and as a warn-mode start stage.
 Add `update_plugins(instance: str)` to `lima.py`, mirroring
 `update_tooling`. It runs, inside the VM:
 
-- `claude plugin marketplace update` — refresh marketplace metadata; then
-- `claude plugin update` — update installed plugins to latest.
+- `claude plugin marketplace update` — refresh all marketplace metadata; then
+- for each **enabled** plugin from `claude plugin list --json`,
+  `claude plugin update <id> --scope <user|project>`.
+
+`claude plugin update` has no bulk form and honours each plugin's scope
+(the `vergil` plugin is `project`-scoped, others `user`), so the refresh
+enumerates the installed list and updates each enabled plugin with its own
+scope. It is best-effort across the set — one plugin failing does not block
+the rest, and failures are surfaced by raising afterwards.
 
 The "what" needs no new configuration: `settings.json` (already copied by
 the `copy-config` stage on every start) is the source of truth for

--- a/docs/specs/2026-06-11-claude-share-set-audit-plan.md
+++ b/docs/specs/2026-06-11-claude-share-set-audit-plan.md
@@ -1,0 +1,710 @@
+# `.claude` Share-Set Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the vestigial `~/.claude/sessions` VM mount, document the projects-vs-sessions persistence model, and keep agent-VM Claude plugins current with a VM-local refresh that mirrors the existing vergil-tooling update path — without ever sharing plugins across the host/VM boundary.
+
+**Architecture:** All agent-VM `.claude` wiring lives in `src/vergil_tooling/lib/lima.py` (mounts, symlinks, config copy, in-VM update primitives) and is driven by the lifecycle pipeline + `update` command in `src/vergil_tooling/bin/vrg_vm.py`. We add an `update_plugins(instance)` primitive next to `update_tooling`, fold it into `vrg-vm update`, and add a warn-mode `update-plugins` stage to the start and rebuild pipelines. Plugins are installed VM-locally from their GitHub marketplaces (declared in the copied `settings.json`); the refresh just advances them to latest.
+
+**Tech Stack:** Python 3.12+, pytest + `unittest.mock`, Lima (`limactl`), MkDocs docs site. Git via `vrg-git`/`vrg-commit` (raw `git` is blocked in this repo).
+
+**Spec:** `docs/specs/2026-06-11-claude-share-set-audit-design.md` (issue #1603).
+
+---
+
+## Working context (read before starting)
+
+- **Worktree:** all work happens in `/Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1603-claude-share-set/` on branch `feature/1603-claude-share-set`. Use absolute paths or `cd` into the worktree first.
+- **Git:** use `vrg-git` (never raw `git`) and `vrg-commit` (never `git commit`). `vrg-commit` signature:
+  `vrg-commit --type <type> --scope <scope> --message "<desc>" --body "<body>"`.
+- **Run a single test:** from inside the worktree,
+  `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest <path>::<test> -v`.
+  (The dev-tree override venv; see CLAUDE.md "Environment Setup".)
+- **Full validation (final gate only):** `vrg-container-run -- vrg-validate` (transparently expands to `uv run vrg-validate` here).
+- **Do not run `vrg-submit-pr`.** PR submission is the human's job.
+
+## File structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `src/vergil_tooling/lib/lima.py` | `create_vm` mounts; `update_plugins` primitive; persistence-model comment | 1, 2, 3 |
+| `src/vergil_tooling/bin/vrg_vm.py` | fold plugins into `vrg-vm update`; warn-mode start/rebuild stage | 4, 5 |
+| `docs/site/docs/guides/agent-vm-claude-share-set.md` | new durable guide (persistence + plugin model) | 2 |
+| `docs/site/mkdocs.yml` | register the new guide in nav | 2 |
+| `tests/vergil_tooling/test_lima.py` | mount-removal + `update_plugins` coverage | 1, 3 |
+| `tests/vergil_tooling/test_vrg_vm.py` | update-command + start/rebuild-stage coverage | 4, 5 |
+
+---
+
+## Task 1: Remove the vestigial `~/.claude/sessions` mount
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py` (`create_vm`, ~lines 215-240)
+- Test: `tests/vergil_tooling/test_lima.py` (`test_adds_claude_submounts` ~280, `test_creates_host_claude_dirs` ~300)
+
+Rationale: `mounts[3]` mounts the host `~/.claude/sessions`, but the VM keeps `sessions/` VM-local (`_CLAUDE_UNLINK_DIRS`) and never reads the mount. Nothing host-side reads that dir either — `vrg_vm_resolve.read_roster` reads the VM's *local* roster in-guest. Keep `_CLAUDE_UNLINK_DIRS` and the symlink-removal loop untouched (they still clean up stale symlinks on old VMs).
+
+- [ ] **Step 1: Update the two tests to assert the sessions mount and host dir are gone**
+
+In `tests/vergil_tooling/test_lima.py`, replace the body of `test_adds_claude_submounts` (drop the `claude_sessions` local and the three `mounts[3]` asserts; add an assert that no `mounts[3]` arg exists):
+
+```python
+    @patch("vergil_tooling.lib.lima.Path.home")
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_adds_claude_submounts(
+        self, mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects")
+        args = mock.call_args[0]
+        claude_projects = str(tmp_path / ".claude" / "projects")
+        claude_skills = str(tmp_path / ".claude" / "skills")
+        assert f'--set=.mounts[1].location = "{claude_projects}"' in args
+        assert f'--set=.mounts[1].mountPoint = "{claude_projects}"' in args
+        assert "--set=.mounts[1].writable = true" in args
+        assert f'--set=.mounts[2].location = "{claude_skills}"' in args
+        assert f'--set=.mounts[2].mountPoint = "{claude_skills}"' in args
+        assert "--set=.mounts[2].writable = false" in args
+        # The vestigial sessions mount (mounts[3]) is removed; sessions stays VM-local.
+        assert not any(".mounts[3]" in a for a in args)
+```
+
+And replace the body of `test_creates_host_claude_dirs` (drop the `sessions` dir assertion; assert it is NOT created):
+
+```python
+    @patch("vergil_tooling.lib.lima.Path.home")
+    @patch("vergil_tooling.lib.lima._limactl")
+    def test_creates_host_claude_dirs(
+        self, _mock: MagicMock, mock_home: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_home.return_value = tmp_path
+        tpl = Path("/tmp/template.yaml")  # noqa: S108
+        create_vm("vergil-agent", tpl, "/home/user/projects")
+        assert (tmp_path / ".claude" / "projects").is_dir()
+        assert (tmp_path / ".claude" / "skills").is_dir()
+        # create_vm no longer backs a sessions mount, so it must not create the dir.
+        assert not (tmp_path / ".claude" / "sessions").is_dir()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_lima.py::TestCreateVm::test_adds_claude_submounts tests/vergil_tooling/test_lima.py::TestCreateVm::test_creates_host_claude_dirs -v`
+Expected: FAIL — `test_adds_claude_submounts` fails on the new `mounts[3]` assertion; `test_creates_host_claude_dirs` fails because the sessions dir is still created.
+
+- [ ] **Step 3: Remove the sessions mount from `create_vm`**
+
+In `src/vergil_tooling/lib/lima.py`, change the head of `create_vm`. Replace:
+
+```python
+    claude_projects_path = Path.home() / ".claude" / "projects"
+    claude_skills_path = Path.home() / ".claude" / "skills"
+    claude_sessions_path = Path.home() / ".claude" / "sessions"
+    claude_projects_path.mkdir(parents=True, exist_ok=True)
+    claude_skills_path.mkdir(parents=True, exist_ok=True)
+    claude_sessions_path.mkdir(parents=True, exist_ok=True)
+    claude_projects = str(claude_projects_path)
+    claude_skills = str(claude_skills_path)
+    claude_sessions = str(claude_sessions_path)
+```
+
+with:
+
+```python
+    claude_projects_path = Path.home() / ".claude" / "projects"
+    claude_skills_path = Path.home() / ".claude" / "skills"
+    claude_projects_path.mkdir(parents=True, exist_ok=True)
+    claude_skills_path.mkdir(parents=True, exist_ok=True)
+    claude_projects = str(claude_projects_path)
+    claude_skills = str(claude_skills_path)
+```
+
+And in the `args` list, delete these three lines:
+
+```python
+        f'--set=.mounts[3].location = "{claude_sessions}"',
+        f'--set=.mounts[3].mountPoint = "{claude_sessions}"',
+        "--set=.mounts[3].writable = true",
+```
+
+Leave `_CLAUDE_LINK_DIRS`, `_CLAUDE_UNLINK_DIRS`, and `link_claude_dirs` unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_lima.py::TestCreateVm -v`
+Expected: PASS (all `TestCreateVm` tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1603-claude-share-set
+vrg-git add src/vergil_tooling/lib/lima.py tests/vergil_tooling/test_lima.py
+vrg-commit --type fix --scope lima \
+  --message "remove vestigial .claude/sessions VM mount (#1603)" \
+  --body "mounts[3] mounted the host ~/.claude/sessions, but the VM keeps sessions/ VM-local (_CLAUDE_UNLINK_DIRS) and never reads the mount; nothing host-side reads it either. Remove the mount and its host mkdir. The _CLAUDE_UNLINK_DIRS guard stays so old VMs with a stale sessions symlink are still cleaned up on re-link.
+
+Ref #1603"
+```
+
+---
+
+## Task 2: Document the projects-vs-sessions persistence model
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py` (comment block at `_CLAUDE_LINK_DIRS`, ~lines 622-636)
+- Create: `docs/site/docs/guides/agent-vm-claude-share-set.md`
+- Modify: `docs/site/mkdocs.yml` (nav, ~line 128-132)
+
+Documentation-only task (no unit tests). Validation is markdownlint via the final `vrg-validate` gate (Task 6).
+
+- [ ] **Step 1: Expand the code comment to state the full model**
+
+In `src/vergil_tooling/lib/lima.py`, replace the comment immediately above `_CLAUDE_LINK_DIRS`:
+
+```python
+# Subdirs symlinked to the path-preserved host mounts so they are shared with
+# the host and survive VM rebuilds. projects/ holds the conversation
+# transcripts (append writes, which work fine through the virtiofs mount);
+# skills/ is a read-only reference mount.
+_CLAUDE_LINK_DIRS = ("projects", "skills")
+```
+
+with:
+
+```python
+# The agent-VM ~/.claude share set. See
+# docs/site/docs/guides/agent-vm-claude-share-set.md for the full model.
+#
+# projects/ -> durable, host-shared transcript store. Resume-after-rebuild
+#   reads these, so a conversation survives a VM rebuild (the data lives on
+#   the host). Append-only writes, which work fine through the virtiofs mount.
+# skills/   -> read-only reference mount.
+# sessions/ -> NOT shared; see _CLAUDE_UNLINK_DIRS below. It is a disposable
+#   VM-local roster (pid->session), regenerated each run. Resume does NOT
+#   depend on it, so keeping it VM-local does not break resume.
+# plugins/  -> NOT shared; kept current VM-locally via update_plugins (each VM
+#   installs/refreshes from the GitHub marketplaces declared in the copied
+#   settings.json). Sharing the host's materialized checkout across the
+#   macOS/Linux boundary would be fragile and is unnecessary.
+_CLAUDE_LINK_DIRS = ("projects", "skills")
+```
+
+- [ ] **Step 2: Create the durable guide**
+
+Create `docs/site/docs/guides/agent-vm-claude-share-set.md` with exactly this content:
+
+```markdown
+# Agent VM `.claude` Share Set
+
+This guide explains which parts of the host's `~/.claude` directory are
+shared into agent VMs, how conversation resume survives a VM rebuild, and
+why plugins and the session roster are deliberately kept VM-local. The
+wiring lives in `src/vergil_tooling/lib/lima.py` (`create_vm`,
+`link_claude_dirs`, `copy_claude_config`); the `vergil-vm` template only
+declares the static `projects` mount.
+
+## The share set
+
+| Subdir | How it is shared | Writable | Why |
+|---|---|---|---|
+| `projects/` | virtiofs mount + symlink | yes | Durable conversation transcripts; must survive rebuilds. |
+| `skills/` | virtiofs mount + symlink | no | Read-only reference. |
+| `sessions/` | **not shared** (VM-local) | n/a | Disposable per-VM roster; sharing breaks atomic writes (EXDEV). |
+| `plugins/` | **not shared** (VM-local) | n/a | Installed/refreshed in-VM from GitHub marketplaces. |
+
+`copy_claude_config` additionally copies `CLAUDE.md` and `settings.json`
+into each VM on create and on every start.
+
+## Why resume survives a rebuild
+
+Conversation transcripts are written as append-only `*.jsonl` files under
+`~/.claude/projects/<slug>/`. That directory is a symlink onto the
+path-preserved host mount, so the transcripts live on the host and are
+untouched when a VM is destroyed and recreated. Resuming a conversation
+reads those transcripts — **not** the `sessions/` roster — so a rebuild
+never loses history.
+
+## Why `sessions/` is VM-local
+
+`~/.claude/sessions/` holds a small roster of `pid -> session` files that
+Claude writes atomically: it writes a temp file in the VM-local tmpdir and
+then `rename()`s it onto the target. Renaming across filesystems (VM-local
+ext4 to the virtiofs host mount) fails with `EXDEV`, so the write would
+silently fail and no roster file would ever appear. The roster is also
+per-machine (pids only mean anything on the owning host), so there is no
+value in sharing it. Session detection reads each VM's local roster
+in-guest over `limactl shell`. See vergil-tooling #1301 and vergil-vm #73.
+
+> A host `~/.claude/sessions` mount used to exist (`mounts[3]`) but the VM
+> never read it once the roster was made VM-local; it was removed as dead
+> weight (#1603).
+
+## Why plugins are VM-local, not shared
+
+Plugins are declared in the host `settings.json` (`enabledPlugins` and
+`extraKnownMarketplaces`), which is copied into each VM. The marketplaces
+are **GitHub repositories**, so each VM installs the enabled plugins itself
+on first launch and keeps them current with an in-VM refresh — the same
+model used for vergil-tooling. The host's materialized `~/.claude/plugins`
+checkout is never shared: doing so would cross the macOS/Linux boundary
+(fragile if any plugin ships a binary) and hit the same `EXDEV` write
+problem as the roster. Instead, `update_plugins` runs `claude plugin
+marketplace update` + `claude plugin update` inside the VM, driven by
+`vrg-vm update` and a warn-mode stage on VM start/rebuild.
+
+See also: [Identity Architecture](identity-architecture.md).
+```
+
+- [ ] **Step 3: Register the guide in the docs nav**
+
+In `docs/site/mkdocs.yml`, under the `Identity & Permissions:` nav section, add the new guide after `Account Setup`. Change:
+
+```yaml
+  - Identity & Permissions:
+      - Identity Architecture: guides/identity-architecture.md
+      - Credential Management: guides/credential-management.md
+      - Permission Model: guides/permission-model.md
+      - Account Setup: guides/account-setup.md
+```
+
+to:
+
+```yaml
+  - Identity & Permissions:
+      - Identity Architecture: guides/identity-architecture.md
+      - Credential Management: guides/credential-management.md
+      - Permission Model: guides/permission-model.md
+      - Account Setup: guides/account-setup.md
+      - Agent VM Claude Share Set: guides/agent-vm-claude-share-set.md
+```
+
+- [ ] **Step 4: Sanity-check the new doc renders as valid markdown**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run python -c "import pathlib; print(pathlib.Path('docs/site/docs/guides/agent-vm-claude-share-set.md').read_text().count('#'), 'headings')"`
+Expected: prints a heading count > 0 (a cheap existence/readability check; full markdownlint runs in Task 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1603-claude-share-set
+vrg-git add src/vergil_tooling/lib/lima.py docs/site/docs/guides/agent-vm-claude-share-set.md docs/site/mkdocs.yml
+vrg-commit --type docs --scope lima \
+  --message "document the agent-VM .claude persistence model (#1603)" \
+  --body "Expand the _CLAUDE_LINK_DIRS comment to state the full share-set model and add a durable guide: projects/ is the host-shared transcript store that makes resume survive rebuilds; sessions/ and plugins/ are deliberately VM-local. Register the guide in the docs nav.
+
+Ref #1603"
+```
+
+---
+
+## Task 3: Add the `update_plugins` VM-local refresh primitive
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py` (add `update_plugins` after `update_tooling`, ~line 580)
+- Test: `tests/vergil_tooling/test_lima.py` (new `TestUpdatePlugins` class)
+
+`update_plugins` mirrors `update_tooling`: run two `claude plugin` commands inside the VM via `shell_run`. It is invoked through a **login shell** (`bash -lc`) so the VM's interactive environment resolves `claude` on `PATH` — `claude` is a global npm install, not a `uv` tool, so the `~/.local/bin` export used by `update_tooling` does not apply. (Task 6 verifies this resolves on a real VM.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_lima.py`. First ensure `update_plugins` is in the imports from `vergil_tooling.lib.lima` (add it next to `update_tooling` in the existing import block at the top of the file). Then add:
+
+```python
+class TestUpdatePlugins:
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_runs_marketplace_then_plugin_update(self, mock_run: MagicMock) -> None:
+        update_plugins("vergil-agent")
+        # Two in-VM commands, marketplace refresh before plugin update.
+        assert mock_run.call_count == 2
+        first_cmd = mock_run.call_args_list[0][0][-1]
+        second_cmd = mock_run.call_args_list[1][0][-1]
+        assert "claude plugin marketplace update" in first_cmd
+        assert "claude plugin update" in second_cmd
+        # Invoked via a login shell so claude resolves on PATH.
+        assert mock_run.call_args_list[0][0][:3] == ("vergil-agent", "bash", "-lc")
+        assert mock_run.call_args_list[1][0][:3] == ("vergil-agent", "bash", "-lc")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_lima.py::TestUpdatePlugins -v`
+Expected: FAIL — `ImportError`/`cannot import name 'update_plugins'` (or `NameError` at collection).
+
+- [ ] **Step 3: Implement `update_plugins`**
+
+In `src/vergil_tooling/lib/lima.py`, add directly after the `update_tooling` function (after its final line, ~580):
+
+```python
+def update_plugins(instance: str) -> None:
+    """Refresh Claude Code plugins inside the VM.
+
+    Plugins are installed VM-locally from their GitHub marketplaces (declared
+    in the copied settings.json); they are deliberately not shared from the
+    host (see docs/site/docs/guides/agent-vm-claude-share-set.md). This
+    advances them to the latest published versions, mirroring how
+    update_tooling advances vergil-tooling.
+
+    Uses a login shell (bash -lc) so claude resolves on PATH: claude is a
+    global npm install, not a uv tool, so the ~/.local/bin export that the
+    tooling install uses does not apply here.
+    """
+    print("  Refreshing Claude plugins...")
+    shell_run(instance, "bash", "-lc", "claude plugin marketplace update")
+    shell_run(instance, "bash", "-lc", "claude plugin update")
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_lima.py::TestUpdatePlugins -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1603-claude-share-set
+vrg-git add src/vergil_tooling/lib/lima.py tests/vergil_tooling/test_lima.py
+vrg-commit --type feat --scope lima \
+  --message "add update_plugins VM-local plugin refresh (#1603)" \
+  --body "update_plugins runs 'claude plugin marketplace update' then 'claude plugin update' inside the VM over a login shell, mirroring update_tooling. Plugins stay VM-local (installed from the GitHub marketplaces declared in settings.json); this only advances them to latest.
+
+Ref #1603"
+```
+
+---
+
+## Task 4: Fold the plugin refresh into `vrg-vm update`
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (import `update_plugins`; call it in `_update_instance`, ~line 533)
+- Test: `tests/vergil_tooling/test_vrg_vm.py` (`TestUpdate` class, ~line 907; existing tests need a new patch)
+
+`vrg-vm update` and `vrg-vm update --all` both go through `_update_instance`. Adding `update_plugins` there makes a single "update my VM(s)" refresh both tooling and plugins. **Because the existing `TestUpdate` tests drive `_update_instance` with the real functions patched, they will call the real `update_plugins` (hitting `limactl`) unless you add a patch.**
+
+- [ ] **Step 1: Add a failing assertion and patch the existing update tests**
+
+In `tests/vergil_tooling/test_vrg_vm.py`:
+
+(a) Add a new test to `TestUpdate` that asserts plugins are refreshed:
+
+```python
+    @patch("vergil_tooling.bin.vrg_vm.update_plugins")
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_update_refreshes_plugins(
+        self,
+        _status: MagicMock,
+        _update: MagicMock,
+        _ver: MagicMock,
+        mock_plugins: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["update", "--config", str(config_file)])
+        assert result == 0
+        mock_plugins.assert_called_once_with("vergil-agent")
+```
+
+(b) Every existing test in `TestUpdate` that patches `update_tooling` and reaches `_update_instance` must also patch `update_plugins`, or it will invoke the real one. Find them:
+
+Run: `grep -n 'vrg_vm.update_tooling' tests/vergil_tooling/test_vrg_vm.py`
+
+For each such test inside `TestUpdate` (`test_update_default_tag`, `test_update_explicit_tag`, `test_shows_version_change`, `test_shows_already_up_to_date`, `test_shows_version_when_before_unknown`, and the `update --all` tests in `TestUpdateAll`), add the decorator as the **innermost** `@patch` and a matching first positional param after `self`. Example — change:
+
+```python
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_update_default_tag(
+        self, _status: MagicMock, mock_update: MagicMock, _ver: MagicMock, config_file: Path
+    ) -> None:
+```
+
+to:
+
+```python
+    @patch("vergil_tooling.bin.vrg_vm.update_plugins")
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_update_default_tag(
+        self,
+        _status: MagicMock,
+        mock_update: MagicMock,
+        _ver: MagicMock,
+        _plugins: MagicMock,
+        config_file: Path,
+    ) -> None:
+```
+
+(Decorators apply bottom-up, so the bottom-most `@patch` maps to the first param after `self`. The newly added top decorator maps to the **last** mock param before the fixtures — here `_plugins`.)
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestUpdate::test_update_refreshes_plugins -v`
+Expected: FAIL — `AssertionError: Expected 'update_plugins' to be called once. Called 0 times.`
+
+- [ ] **Step 3: Wire `update_plugins` into `_update_instance`**
+
+In `src/vergil_tooling/bin/vrg_vm.py`:
+
+(a) Add `update_plugins` to the import from `vergil_tooling.lib.lima` (the block that already imports `update_tooling`, ~lines 42-56).
+
+(b) In `_update_instance` (~line 533), refresh plugins after tooling:
+
+```python
+def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -> None:
+    """Update vergil-tooling and Claude plugins in one running VM, printing the version transition."""
+    print(f"Updating vergil-tooling in VM '{instance}' (identity: {name})...")
+
+    before = get_tooling_version(instance)
+    update_tooling(instance, tag, fallback_tag=fallback)
+    after = get_tooling_version(instance)
+
+    if before and after:
+        if before == after:
+            print(f"  vergil-tooling: {after} (already up to date)")
+        else:
+            print(f"  vergil-tooling: {before} → {after}")
+    elif after:
+        print(f"  vergil-tooling: {after}")
+
+    update_plugins(instance)
+```
+
+- [ ] **Step 4: Run the update tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestUpdate tests/vergil_tooling/test_vrg_vm.py::TestUpdateAll -v`
+Expected: PASS (new test green; existing tests still green because `update_plugins` is now patched in each).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1603-claude-share-set
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vrg-vm \
+  --message "refresh Claude plugins in vrg-vm update (#1603)" \
+  --body "vrg-vm update and update --all now refresh Claude plugins alongside vergil-tooling via _update_instance, so one 'update my VM' gesture brings everything current. Mirrors the established tooling-update path.
+
+Ref #1603"
+```
+
+---
+
+## Task 5: Refresh plugins on VM start and rebuild (warn-mode stage)
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_st_update_plugins` after `_st_update_tooling` ~line 349; add to `_start_stages` ~375 and `_rebuild_stages` ~388)
+- Test: `tests/vergil_tooling/test_vrg_vm.py` (new stage-presence test; existing `TestStart`/`TestStartStaleness`/`TestRebuild` tests need a new patch)
+
+Warn-mode means a failed plugin refresh surfaces as ⚠ in the lifecycle summary and never aborts the session — identical to `update-tooling`. **Adding the stage means every test that drives `main(["start"...])` or `main(["rebuild"...])` through the pipeline will call the real `update_plugins` unless patched.**
+
+- [ ] **Step 1: Confirm the `Stage` field names, then write the failing stage-presence test**
+
+First inspect how `Stage` is defined so the asserts match reality:
+
+Run: `grep -rn "class Stage\|Stage = \|namedtuple\|@dataclass" src/vergil_tooling/lib/progress.py`
+(Follow the `Stage` import in `vrg_vm.py` if it lives elsewhere.) Confirm the name attribute is `.name` and the mode attribute is `.mode`; if not, adjust the asserts below to the real field names.
+
+In `tests/vergil_tooling/test_vrg_vm.py`, add (near the other lifecycle tests; the pipeline factories are module-level in `vergil_tooling.bin.vrg_vm`):
+
+```python
+class TestPluginStage:
+    def test_start_pipeline_includes_update_plugins(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _start_stages
+
+        names = [s.name for s in _start_stages()]
+        assert "update-plugins" in names
+        # Runs after tooling, in warn mode.
+        assert names.index("update-plugins") > names.index("update-tooling")
+        stage = next(s for s in _start_stages() if s.name == "update-plugins")
+        assert stage.mode == "warn"
+
+    def test_rebuild_pipeline_includes_update_plugins(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _rebuild_stages
+
+        names = [s.name for s in _rebuild_stages()]
+        assert "update-plugins" in names
+        stage = next(s for s in _rebuild_stages() if s.name == "update-plugins")
+        assert stage.mode == "warn"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestPluginStage -v`
+Expected: FAIL — `"update-plugins" in names` is False; the stage does not exist yet.
+
+- [ ] **Step 3: Add the stage function and wire both pipelines**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, add after `_st_update_tooling` (~line 349):
+
+```python
+def _st_update_plugins(state: _LifecycleState) -> None:
+    # Warn-mode stage: a failed plugin refresh surfaces as ⚠ and the lifecycle
+    # continues, the same warn-and-continue contract as update-tooling. Plugins
+    # are VM-local; this advances them to the latest published versions.
+    update_plugins(state.target.instance)
+```
+
+In `_start_stages`, add the stage after `update-tooling`:
+
+```python
+def _start_stages() -> list[Stage]:
+    return [
+        Stage("start", _st_start, mode="fail_fast"),
+        Stage("spec-check", _st_spec_check, mode="warn"),
+        Stage("credentials", _st_credentials, mode="fail_fast"),
+        Stage("copy-config", _st_copy_config, mode="fail_fast"),
+        Stage("update-tooling", _st_update_tooling, mode="warn"),
+        Stage("update-plugins", _st_update_plugins, mode="warn"),
+    ]
+```
+
+In `_rebuild_stages`, add the stage after `copy-config` (rebuild has no `update-tooling`; it installs fresh, then this converges plugins to latest):
+
+```python
+def _rebuild_stages() -> list[Stage]:
+    return [
+        Stage("destroy", _st_destroy, mode="fail_fast"),
+        Stage("fetch-template", _st_fetch_template, mode="fail_fast"),
+        Stage("create", _st_create, mode="fail_fast"),
+        Stage("start", _st_start, mode="fail_fast"),
+        Stage("credentials", _st_credentials, mode="fail_fast"),
+        Stage("tooling", _st_install_tooling, mode="fail_fast"),
+        Stage("copy-config", _st_copy_config, mode="fail_fast"),
+        Stage("update-plugins", _st_update_plugins, mode="warn"),
+        Stage("cycle-ssh", _st_cycle_ssh, mode="fail_fast"),
+    ]
+```
+
+(`update_plugins` is already imported from Task 4.)
+
+- [ ] **Step 4: Run the stage test to verify it passes, then find the now-broken pipeline tests**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestPluginStage -v`
+Expected: PASS.
+
+Now the existing pipeline tests call the real `update_plugins`. Surface them:
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestStart tests/vergil_tooling/test_vrg_vm.py::TestStartStaleness tests/vergil_tooling/test_vrg_vm.py::TestRebuild -v`
+Expected: FAIL/ERROR — real `update_plugins` calls `shell_run`/`limactl` (no VM). This tells you which tests to patch.
+
+Patch them: every test that drives `main(["start"...])` or `main(["rebuild"...])` to completion needs `@patch("vergil_tooling.bin.vrg_vm.update_plugins")` as the **innermost** decorator plus a matching first param after `self`. Find them:
+
+Run: `grep -n 'main(\["start"\|main(\["rebuild"' tests/vergil_tooling/test_vrg_vm.py`
+
+Apply to each pipeline-completing test (the `*_fails_if_not_created` early-return tests do not reach the stage and need no patch). Example — change:
+
+```python
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_and_inject(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        mock_inject: MagicMock,
+        mock_update: MagicMock,
+        mock_copy: MagicMock,
+        config_file: Path,
+    ) -> None:
+```
+
+to (add the plugins patch at the top, param at the end before fixtures):
+
+```python
+    @patch("vergil_tooling.bin.vrg_vm.update_plugins")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    def test_start_and_inject(
+        self,
+        _status: MagicMock,
+        _age: MagicMock,
+        mock_start: MagicMock,
+        mock_inject: MagicMock,
+        mock_update: MagicMock,
+        mock_copy: MagicMock,
+        _plugins: MagicMock,
+        config_file: Path,
+    ) -> None:
+```
+
+For `TestRebuild` tests, do the same: add `@patch("vergil_tooling.bin.vrg_vm.update_plugins")` as the innermost (top) decorator and a trailing `_plugins: MagicMock` param before the fixtures.
+
+- [ ] **Step 5: Run the full vrg_vm suite to verify it passes**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_vm.py -v`
+Expected: PASS (all green — stage present, all pipeline tests patched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1603-claude-share-set
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vrg-vm \
+  --message "refresh Claude plugins on VM start and rebuild (#1603)" \
+  --body "Add a warn-mode update-plugins lifecycle stage to the start and rebuild pipelines, beside update-tooling, so a started or rebuilt VM converges to the latest plugin versions. A failed refresh surfaces as a warning and never aborts the session.
+
+Ref #1603"
+```
+
+---
+
+## Task 6: Full validation and live-VM verification of the open item
+
+**Files:** none (verification only).
+
+This task closes the spec's one open item (first-launch install reliability) with real evidence, and runs the full gate. The unit suite mocks `limactl`, so the in-VM behavior must be confirmed on a real VM by a human (the agent cannot spin up host Lima VMs).
+
+- [ ] **Step 1: Run the full validation gate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS — lint, typecheck, pytest, markdownlint (covers the new guide), and common checks all green. Fix anything that fails before proceeding.
+
+- [ ] **Step 2: (Human, on a macOS host) Verify the plugin refresh on a live VM**
+
+This step must be run by the human; the agent should hand off with these exact commands. From a host with a running agent VM `<vm>`:
+
+```bash
+# 1. Confirm claude resolves over a login shell (the invocation update_plugins uses):
+limactl shell <vm> -- bash -lc 'command -v claude && claude --version'
+
+# 2. Record current plugin state, run the refresh, record again:
+limactl shell <vm> -- bash -lc 'claude plugin list'
+vrg-vm update --identity <identity>     # or: vrg-vm update --all
+limactl shell <vm> -- bash -lc 'claude plugin list'
+```
+
+Pass conditions:
+- `command -v claude` resolves (Step 1 of this verification). **If it does not**, `update_plugins` must switch from `bash -lc` to an explicit absolute path or the npm global bin — fix `update_plugins` in `lima.py`, update the `TestUpdatePlugins` assertions accordingly, and re-run Task 3's tests.
+- `vrg-vm update` advances at least one plugin's version (or reports already-current), with no error from the `update-plugins` stage.
+
+- [ ] **Step 3: (Human) Verify a rebuilt VM ends up with plugins installed**
+
+```bash
+vrg-vm rebuild --identity <identity>
+limactl shell <vm> -- bash -lc 'claude plugin list'
+```
+
+Pass condition: the enabled plugins from `settings.json` are present after rebuild (whether via first-launch auto-install or the `update-plugins` stage).
+
+- **If plugins are NOT installed after a fresh rebuild** (first-launch auto-install is not dependable headlessly): this is a follow-up — `update_plugins` updates already-installed plugins but does not install from scratch. File a follow-up issue to add an explicit install step (read `enabledPlugins`/`extraKnownMarketplaces` from `settings.json`, run `claude plugin marketplace add` + `claude plugin install <plugin>@<marketplace>` per enabled plugin) to the create/rebuild pipeline. Do **not** block this PR on it: the observed behavior to date is that auto-install works, and the version-skew bug (#1603's actual finding) is fixed by the refresh shipped here.
+
+- [ ] **Step 4: Hand off for PR**
+
+The agent writes `.vergil/pr-template.yml` (`issue: 1603`, `title`, `summary`, `notes`; `linkage` omitted/`Ref`). The human runs `vrg-submit-pr`. Do not run `vrg-submit-pr` as the agent.
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** Finding 3 → Task 1. Finding 2 → Task 2. Finding 1 (refresh primitive → Task 3; folded into `vrg-vm update` → Task 4; start/rebuild stage → Task 5). Open item (first-launch install) → Task 6 verification with a concrete fallback. Rejected share-via-mount approach → no task, by design.
+- **Test fragility:** Tasks 4 and 5 add calls into already-tested code paths. The plan calls this out explicitly and gives a `grep` to find every affected test, because a missed patch turns a unit test into a real `limactl` call. Do not skip the grep.
+- **Type/name consistency:** `update_plugins(instance: str) -> None` is defined in Task 3 and used unchanged in Tasks 4 and 5. The stage is named `update-plugins` everywhere. Confirm the `Stage` field names in Task 5 Step 2 before asserting on them.

--- a/docs/specs/2026-06-11-claude-share-set-audit-plan.md
+++ b/docs/specs/2026-06-11-claude-share-set-audit-plan.md
@@ -673,17 +673,21 @@ Expected: PASS — lint, typecheck, pytest, markdownlint (covers the new guide),
 This step must be run by the human; the agent should hand off with these exact commands. From a host with a running agent VM `<vm>`:
 
 ```bash
-# 1. Confirm claude resolves over a login shell (the invocation update_plugins uses):
-limactl shell <vm> -- bash -lc 'command -v claude && claude --version'
+# update_plugins uses: bash -c with an explicit PATH (NOT a login shell), because
+# the VM's login shell is zsh and PATH comes from /etc/environment, not bash rc.
+PE='export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
+
+# 1. Confirm claude resolves under the exact invocation update_plugins uses:
+limactl shell <vm> -- bash -c "$PE && command -v claude && claude --version"
 
 # 2. Record current plugin state, run the refresh, record again:
-limactl shell <vm> -- bash -lc 'claude plugin list'
+limactl shell <vm> -- bash -c "$PE && claude plugin list"
 vrg-vm update --identity <identity>     # or: vrg-vm update --all
-limactl shell <vm> -- bash -lc 'claude plugin list'
+limactl shell <vm> -- bash -c "$PE && claude plugin list"
 ```
 
 Pass conditions:
-- `command -v claude` resolves (Step 1 of this verification). **If it does not**, `update_plugins` must switch from `bash -lc` to an explicit absolute path or the npm global bin — fix `update_plugins` in `lima.py`, update the `TestUpdatePlugins` assertions accordingly, and re-run Task 3's tests.
+- `command -v claude` resolves (Step 1 of this verification). **If it does not**, the explicit PATH in `update_plugins` is wrong for this VM — note where `command -v claude` actually points, update the PATH (or use the absolute path) in `lima.py`, update the `TestUpdatePlugins` assertions, and re-run Task 3's tests.
 - `vrg-vm update` advances at least one plugin's version (or reports already-current), with no error from the `update-plugins` stage.
 
 - [ ] **Step 3: (Human) Verify a rebuilt VM ends up with plugins installed**

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -349,6 +349,13 @@ def _st_update_tooling(state: _LifecycleState) -> None:
     update_tooling(state.target.instance, fallback_tag=fallback)
 
 
+def _st_update_plugins(state: _LifecycleState) -> None:
+    # Warn-mode stage: a failed plugin refresh surfaces as ⚠ and the lifecycle
+    # continues, the same warn-and-continue contract as update-tooling. Plugins
+    # are VM-local; this advances them to the latest published versions.
+    update_plugins(state.target.instance)
+
+
 def _st_cycle_ssh(state: _LifecycleState) -> None:
     # Lima establishes its multiplexed SSH ControlMaster as soon as the
     # guest's sshd answers — before cloud-init group provisioning
@@ -383,6 +390,7 @@ def _start_stages() -> list[Stage]:
         Stage("credentials", _st_credentials, mode="fail_fast"),
         Stage("copy-config", _st_copy_config, mode="fail_fast"),
         Stage("update-tooling", _st_update_tooling, mode="warn"),
+        Stage("update-plugins", _st_update_plugins, mode="warn"),
     ]
 
 
@@ -395,6 +403,7 @@ def _rebuild_stages() -> list[Stage]:
         Stage("credentials", _st_credentials, mode="fail_fast"),
         Stage("tooling", _st_install_tooling, mode="fail_fast"),
         Stage("copy-config", _st_copy_config, mode="fail_fast"),
+        Stage("update-plugins", _st_update_plugins, mode="warn"),
         Stage("cycle-ssh", _st_cycle_ssh, mode="fail_fast"),
     ]
 
@@ -532,7 +541,7 @@ def _cmd_restart(args: argparse.Namespace) -> int:
 
 
 def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -> None:
-    """Update vergil-tooling and Claude plugins in one running VM, printing the version transition."""
+    """Update tooling and plugins in one running VM, printing the version transition."""
     print(f"Updating vergil-tooling in VM '{instance}' (identity: {name})...")
 
     before = get_tooling_version(instance)

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -53,6 +53,7 @@ from vergil_tooling.lib.lima import (
     start_vm,
     stop_vm,
     try_update_tooling,
+    update_plugins,
     update_tooling,
     vm_age_days,
     vm_probe,
@@ -531,7 +532,7 @@ def _cmd_restart(args: argparse.Namespace) -> int:
 
 
 def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -> None:
-    """Update vergil-tooling in one running VM, printing the version transition."""
+    """Update vergil-tooling and Claude plugins in one running VM, printing the version transition."""
     print(f"Updating vergil-tooling in VM '{instance}' (identity: {name})...")
 
     before = get_tooling_version(instance)
@@ -545,6 +546,8 @@ def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -
             print(f"  vergil-tooling: {before} → {after}")
     elif after:
         print(f"  vergil-tooling: {after}")
+
+    update_plugins(instance)
 
 
 def _cmd_update(args: argparse.Namespace) -> int:

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -582,13 +582,18 @@ def update_plugins(instance: str) -> None:
     advances them to the latest published versions, mirroring how
     update_tooling advances vergil-tooling.
 
-    Uses a login shell (bash -lc) so claude resolves on PATH: claude is a
-    global npm install, not a uv tool, so the ~/.local/bin export that the
-    tooling install uses does not apply here.
+    Sets PATH explicitly rather than relying on a login shell, exactly as
+    update_tooling does. The VM's login shell is zsh (vergil-vm `chsh -s
+    /bin/zsh`), configured via ~/.zshenv / /etc/environment — a bash login
+    shell would source none of that. claude is a global npm install
+    (apt node + `npm install -g`) under /usr/local/bin; add it and
+    ~/.local/bin to PATH so resolution does not depend on the interactive
+    environment at all.
     """
+    plugin_env = 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
     print("  Refreshing Claude plugins...")
-    shell_run(instance, "bash", "-lc", "claude plugin marketplace update")
-    shell_run(instance, "bash", "-lc", "claude plugin update")
+    shell_run(instance, "bash", "-c", f"{plugin_env} && claude plugin marketplace update")
+    shell_run(instance, "bash", "-c", f"{plugin_env} && claude plugin update")
 
 
 def vm_age_days(instance: str) -> float | None:

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -214,13 +214,10 @@ def create_vm(
 ) -> None:
     claude_projects_path = Path.home() / ".claude" / "projects"
     claude_skills_path = Path.home() / ".claude" / "skills"
-    claude_sessions_path = Path.home() / ".claude" / "sessions"
     claude_projects_path.mkdir(parents=True, exist_ok=True)
     claude_skills_path.mkdir(parents=True, exist_ok=True)
-    claude_sessions_path.mkdir(parents=True, exist_ok=True)
     claude_projects = str(claude_projects_path)
     claude_skills = str(claude_skills_path)
-    claude_sessions = str(claude_sessions_path)
 
     args = [
         "create",
@@ -234,9 +231,6 @@ def create_vm(
         f'--set=.mounts[2].location = "{claude_skills}"',
         f'--set=.mounts[2].mountPoint = "{claude_skills}"',
         "--set=.mounts[2].writable = false",
-        f'--set=.mounts[3].location = "{claude_sessions}"',
-        f'--set=.mounts[3].mountPoint = "{claude_sessions}"',
-        "--set=.mounts[3].writable = true",
     ]
     if cpus is not None:
         args.append(f"--set=.cpus = {cpus}")

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -573,6 +573,24 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
         shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
 
+def update_plugins(instance: str) -> None:
+    """Refresh Claude Code plugins inside the VM.
+
+    Plugins are installed VM-locally from their GitHub marketplaces (declared
+    in the copied settings.json); they are deliberately not shared from the
+    host (see docs/site/docs/guides/agent-vm-claude-share-set.md). This
+    advances them to the latest published versions, mirroring how
+    update_tooling advances vergil-tooling.
+
+    Uses a login shell (bash -lc) so claude resolves on PATH: claude is a
+    global npm install, not a uv tool, so the ~/.local/bin export that the
+    tooling install uses does not apply here.
+    """
+    print("  Refreshing Claude plugins...")
+    shell_run(instance, "bash", "-lc", "claude plugin marketplace update")
+    shell_run(instance, "bash", "-lc", "claude plugin update")
+
+
 def vm_age_days(instance: str) -> float | None:
     """Return VM age in fractional days, or None if not found."""
     try:

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -573,27 +573,70 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
         shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
 
+# Prepended to every in-VM `claude` invocation. claude itself is on the base
+# PATH (/usr/bin/claude, from apt node + `npm install -g`), but exporting PATH
+# explicitly — exactly as update_tooling does — keeps resolution independent of
+# the interactive environment. The VM's login shell is zsh (vergil-vm `chsh -s
+# /bin/zsh`), configured via ~/.zshenv / /etc/environment, so a bash login shell
+# would source none of its config; a non-login `bash -c` with an explicit PATH
+# avoids depending on any of that.
+_PLUGIN_PATH_EXPORT = 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
+
+
 def update_plugins(instance: str) -> None:
-    """Refresh Claude Code plugins inside the VM.
+    """Refresh enabled Claude Code plugins inside the VM.
 
     Plugins are installed VM-locally from their GitHub marketplaces (declared
     in the copied settings.json); they are deliberately not shared from the
     host (see docs/site/docs/guides/agent-vm-claude-share-set.md). This
-    advances them to the latest published versions, mirroring how
-    update_tooling advances vergil-tooling.
+    refreshes marketplace metadata and then advances each enabled plugin to its
+    latest version, mirroring how update_tooling advances vergil-tooling.
 
-    Sets PATH explicitly rather than relying on a login shell, exactly as
-    update_tooling does. The VM's login shell is zsh (vergil-vm `chsh -s
-    /bin/zsh`), configured via ~/.zshenv / /etc/environment — a bash login
-    shell would source none of that. claude is a global npm install
-    (apt node + `npm install -g`) under /usr/local/bin; add it and
-    ~/.local/bin to PATH so resolution does not depend on the interactive
-    environment at all.
+    `claude plugin update` has no bulk form: it requires a specific plugin id
+    and honours the plugin's scope (user vs project), which differ across the
+    set. So enumerate the installed plugins with `claude plugin list --json`
+    and update each enabled one with its own scope. Updates apply on the next
+    Claude restart, which every new session triggers.
+
+    Best-effort across the set: one plugin failing does not block the others;
+    failures are collected and surfaced by raising afterwards (never swallowed).
     """
-    plugin_env = 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
     print("  Refreshing Claude plugins...")
-    shell_run(instance, "bash", "-c", f"{plugin_env} && claude plugin marketplace update")
-    shell_run(instance, "bash", "-c", f"{plugin_env} && claude plugin update")
+    shell_run(
+        instance,
+        "bash",
+        "-c",
+        f"{_PLUGIN_PATH_EXPORT} && claude plugin marketplace update",
+    )
+    listing = shell_run(
+        instance,
+        "bash",
+        "-c",
+        f"{_PLUGIN_PATH_EXPORT} && claude plugin list --json",
+    )
+    plugins = json.loads(listing.stdout)
+
+    failures: list[str] = []
+    for plugin in plugins:
+        if not plugin.get("enabled"):
+            continue
+        pid = plugin["id"]
+        scope = plugin.get("scope", "user")
+        print(f"    updating {pid} ({scope})...")
+        cmd = (
+            f"{_PLUGIN_PATH_EXPORT} && claude plugin update "
+            f"{shlex.quote(pid)} --scope {shlex.quote(scope)}"
+        )
+        try:
+            shell_run(instance, "bash", "-c", cmd)
+        except subprocess.CalledProcessError:
+            failures.append(pid)
+
+    if failures:
+        joined = ", ".join(failures)
+        msg = f"failed to update plugin(s): {joined}"
+        print(f"ERROR: {msg}", file=sys.stderr)
+        raise RuntimeError(msg)
 
 
 def vm_age_days(instance: str) -> float | None:

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -613,10 +613,20 @@ def copy_claude_config(instance: str, claude_dir: Path) -> None:
             )
 
 
-# Subdirs symlinked to the path-preserved host mounts so they are shared with
-# the host and survive VM rebuilds. projects/ holds the conversation
-# transcripts (append writes, which work fine through the virtiofs mount);
-# skills/ is a read-only reference mount.
+# The agent-VM ~/.claude share set. See
+# docs/site/docs/guides/agent-vm-claude-share-set.md for the full model.
+#
+# projects/ -> durable, host-shared transcript store. Resume-after-rebuild
+#   reads these, so a conversation survives a VM rebuild (the data lives on
+#   the host). Append-only writes, which work fine through the virtiofs mount.
+# skills/   -> read-only reference mount.
+# sessions/ -> NOT shared; see _CLAUDE_UNLINK_DIRS below. It is a disposable
+#   VM-local roster (pid->session), regenerated each run. Resume does NOT
+#   depend on it, so keeping it VM-local does not break resume.
+# plugins/  -> NOT shared; kept current VM-locally via update_plugins (each VM
+#   installs/refreshes from the GitHub marketplaces declared in the copied
+#   settings.json). Sharing the host's materialized checkout across the
+#   macOS/Linux boundary would be fragile and is unnecessary.
 _CLAUDE_LINK_DIRS = ("projects", "skills")
 
 # Subdirs that must NOT be symlinked onto the host mount and must stay

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -1432,6 +1432,9 @@ class TestUpdatePlugins:
         second_cmd = mock_run.call_args_list[1][0][-1]
         assert "claude plugin marketplace update" in first_cmd
         assert "claude plugin update" in second_cmd
-        # Invoked via a login shell so claude resolves on PATH.
-        assert mock_run.call_args_list[0][0][:3] == ("vergil-agent", "bash", "-lc")
-        assert mock_run.call_args_list[1][0][:3] == ("vergil-agent", "bash", "-lc")
+        # PATH is set explicitly (not via a login shell) so claude resolves
+        # regardless of the VM's zsh-configured interactive environment.
+        assert mock_run.call_args_list[0][0][:3] == ("vergil-agent", "bash", "-c")
+        assert mock_run.call_args_list[1][0][:3] == ("vergil-agent", "bash", "-c")
+        assert "/usr/local/bin" in first_cmd
+        assert "/usr/local/bin" in second_cmd

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -1423,18 +1423,56 @@ class TestProvisionMonitor:
 
 
 class TestUpdatePlugins:
+    _LISTING = json.dumps(
+        [
+            {"id": "paad@paad", "scope": "user", "enabled": True},
+            {"id": "frontend-design@official", "scope": "user", "enabled": False},
+            {"id": "vergil@vergil-marketplace", "scope": "project", "enabled": True},
+        ]
+    )
+
+    def _fake_shell(self) -> MagicMock:
+        def side_effect(_instance: str, *args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            out = self._LISTING if "plugin list --json" in cmd else ""
+            return MagicMock(stdout=out, returncode=0)
+
+        mock = MagicMock(side_effect=side_effect)
+        return mock
+
     @patch("vergil_tooling.lib.lima.shell_run")
-    def test_runs_marketplace_then_plugin_update(self, mock_run: MagicMock) -> None:
+    def test_refreshes_marketplaces_then_updates_enabled_plugins(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = self._fake_shell().side_effect
         update_plugins("vergil-agent")
-        # Two in-VM commands, marketplace refresh before plugin update.
-        assert mock_run.call_count == 2
-        first_cmd = mock_run.call_args_list[0][0][-1]
-        second_cmd = mock_run.call_args_list[1][0][-1]
-        assert "claude plugin marketplace update" in first_cmd
-        assert "claude plugin update" in second_cmd
-        # PATH is set explicitly (not via a login shell) so claude resolves
-        # regardless of the VM's zsh-configured interactive environment.
-        assert mock_run.call_args_list[0][0][:3] == ("vergil-agent", "bash", "-c")
-        assert mock_run.call_args_list[1][0][:3] == ("vergil-agent", "bash", "-c")
-        assert "/usr/local/bin" in first_cmd
-        assert "/usr/local/bin" in second_cmd
+        cmds = [c.args[-1] for c in mock_run.call_args_list]
+        # Marketplace metadata refreshed first, then the installed list is read.
+        assert any("claude plugin marketplace update" in c for c in cmds)
+        assert any("claude plugin list --json" in c for c in cmds)
+        # Each ENABLED plugin updated with its own scope; no bulk update exists.
+        assert any("claude plugin update paad@paad --scope user" in c for c in cmds)
+        assert any(
+            "claude plugin update vergil@vergil-marketplace --scope project" in c for c in cmds
+        )
+        # Disabled plugins are left alone.
+        assert not any("frontend-design" in c for c in cmds)
+        # Every call is a non-login bash -c with an explicit PATH export, so claude
+        # resolves regardless of the VM's zsh-configured interactive environment.
+        for c in mock_run.call_args_list:
+            assert c.args[:3] == ("vergil-agent", "bash", "-c")
+            assert "export PATH=" in c.args[-1]
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_raises_after_attempting_all_when_a_plugin_fails(self, mock_run: MagicMock) -> None:
+        def side_effect(_instance: str, *args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "claude plugin update paad@paad" in cmd:
+                raise subprocess.CalledProcessError(1, "claude plugin update")
+            out = self._LISTING if "plugin list --json" in cmd else ""
+            return MagicMock(stdout=out, returncode=0)
+
+        mock_run.side_effect = side_effect
+        with pytest.raises(RuntimeError, match="paad@paad"):
+            update_plugins("vergil-agent")
+        # Best-effort: the other enabled plugin is still attempted before raising.
+        cmds = [c.args[-1] for c in mock_run.call_args_list]
+        assert any("claude plugin update vergil@vergil-marketplace" in c for c in cmds)

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -30,6 +30,7 @@ from vergil_tooling.lib.lima import (
     start_vm,
     stop_vm,
     try_update_tooling,
+    update_plugins,
     update_tooling,
     vm_age_days,
     vm_occupancy,
@@ -1419,3 +1420,18 @@ class TestProvisionMonitor:
         with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
             _provision_monitor(tmp_path, "30m", stop, poll_secs=0.01, heartbeat_secs=0.03)
         assert [c.args[0] for c in m_emit.call_args_list] == ["[guest] final line"]
+
+
+class TestUpdatePlugins:
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_runs_marketplace_then_plugin_update(self, mock_run: MagicMock) -> None:
+        update_plugins("vergil-agent")
+        # Two in-VM commands, marketplace refresh before plugin update.
+        assert mock_run.call_count == 2
+        first_cmd = mock_run.call_args_list[0][0][-1]
+        second_cmd = mock_run.call_args_list[1][0][-1]
+        assert "claude plugin marketplace update" in first_cmd
+        assert "claude plugin update" in second_cmd
+        # Invoked via a login shell so claude resolves on PATH.
+        assert mock_run.call_args_list[0][0][:3] == ("vergil-agent", "bash", "-lc")
+        assert mock_run.call_args_list[1][0][:3] == ("vergil-agent", "bash", "-lc")

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -286,16 +286,14 @@ class TestCreateVm:
         args = mock.call_args[0]
         claude_projects = str(tmp_path / ".claude" / "projects")
         claude_skills = str(tmp_path / ".claude" / "skills")
-        claude_sessions = str(tmp_path / ".claude" / "sessions")
         assert f'--set=.mounts[1].location = "{claude_projects}"' in args
         assert f'--set=.mounts[1].mountPoint = "{claude_projects}"' in args
         assert "--set=.mounts[1].writable = true" in args
         assert f'--set=.mounts[2].location = "{claude_skills}"' in args
         assert f'--set=.mounts[2].mountPoint = "{claude_skills}"' in args
         assert "--set=.mounts[2].writable = false" in args
-        assert f'--set=.mounts[3].location = "{claude_sessions}"' in args
-        assert f'--set=.mounts[3].mountPoint = "{claude_sessions}"' in args
-        assert "--set=.mounts[3].writable = true" in args
+        # The vestigial sessions mount (mounts[3]) is removed; sessions stays VM-local.
+        assert not any(".mounts[3]" in a for a in args)
 
     @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")
@@ -307,7 +305,8 @@ class TestCreateVm:
         create_vm("vergil-agent", tpl, "/home/user/projects")
         assert (tmp_path / ".claude" / "projects").is_dir()
         assert (tmp_path / ".claude" / "skills").is_dir()
-        assert (tmp_path / ".claude" / "sessions").is_dir()
+        # create_vm no longer backs a sessions mount, so it must not create the dir.
+        assert not (tmp_path / ".claude" / "sessions").is_dir()
 
     @patch("vergil_tooling.lib.lima.Path.home")
     @patch("vergil_tooling.lib.lima._limactl")

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -905,6 +905,13 @@ class TestList:
 
 
 class TestUpdate:
+    # vrg-vm update refreshes plugins too (via _update_instance); mock it so the
+    # command tests don't reach the real claude/limactl call.
+    @pytest.fixture(autouse=True)
+    def _mock_update_plugins(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm.update_plugins") as m:
+            yield m
+
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
@@ -914,6 +921,21 @@ class TestUpdate:
         result = main(["update", "--config", str(config_file)])
         assert result == 0
         mock_update.assert_called_once_with("vergil-agent", None, fallback_tag="v2.0")
+
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_update_refreshes_plugins(
+        self,
+        _status: MagicMock,
+        _update: MagicMock,
+        _ver: MagicMock,
+        _mock_update_plugins: MagicMock,
+        config_file: Path,
+    ) -> None:
+        result = main(["update", "--config", str(config_file)])
+        assert result == 0
+        _mock_update_plugins.assert_called_once_with("vergil-agent")
 
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
@@ -1004,6 +1026,12 @@ def config_file_multi(tmp_path: Path) -> Path:
 
 
 class TestUpdateAll:
+    # vrg-vm update --all refreshes plugins per VM (via _update_instance); mock it.
+    @pytest.fixture(autouse=True)
+    def _mock_update_plugins(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm.update_plugins") as m:
+            yield m
+
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.list_vms")

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -338,6 +338,13 @@ class TestCreate:
 
 
 class TestStart:
+    # The start pipeline includes a warn-mode update-plugins stage; mock it so
+    # the pipeline tests don't reach the real claude/limactl call.
+    @pytest.fixture(autouse=True)
+    def _mock_update_plugins(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm.update_plugins") as m:
+            yield m
+
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
@@ -388,6 +395,11 @@ class TestStart:
 
 
 class TestStartStaleness:
+    @pytest.fixture(autouse=True)
+    def _mock_update_plugins(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm.update_plugins") as m:
+            yield m
+
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
@@ -542,6 +554,12 @@ class TestDestroy:
 
 
 class TestRebuild:
+    # The rebuild pipeline includes a warn-mode update-plugins stage; mock it.
+    @pytest.fixture(autouse=True)
+    def _mock_update_plugins(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm.update_plugins") as m:
+            yield m
+
     @patch("vergil_tooling.bin.vrg_vm.stop_vm")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
@@ -2404,17 +2422,21 @@ class TestLifecycleStages:
             "credentials",
             "copy-config",
             "update-tooling",
+            "update-plugins",
         ]
         modes = {s.name: s.mode for s in stages}
         # spec-check verifies the freshly-booted guest's fingerprint; it is
         # non-fatal (warn) so a drifted-but-running VM stays usable, and it sits
         # immediately after start so the warning surfaces before later work.
+        # update-plugins is warn for the same reason as update-tooling: a failed
+        # plugin refresh must not abort a usable session.
         assert modes == {
             "start": "fail_fast",
             "spec-check": "warn",
             "credentials": "fail_fast",
             "copy-config": "fail_fast",
             "update-tooling": "warn",
+            "update-plugins": "warn",
         }
 
     def test_rebuild_stage_order_and_modes(self) -> None:
@@ -2429,9 +2451,14 @@ class TestLifecycleStages:
             "credentials",
             "tooling",
             "copy-config",
+            "update-plugins",
             "cycle-ssh",
         ]
-        assert all(s.mode == "fail_fast" for s in stages)
+        # All fail_fast except update-plugins, which is warn so a failed plugin
+        # refresh does not abort the rebuild.
+        modes = {s.name: s.mode for s in stages}
+        assert modes["update-plugins"] == "warn"
+        assert all(s.mode == "fail_fast" for s in stages if s.name != "update-plugins")
 
     def test_st_create_requires_template(self, tmp_path: Path) -> None:
         from vergil_tooling.bin.vrg_vm import _LifecycleState, _st_create
@@ -2537,6 +2564,7 @@ class TestRunLifecycle:
         assert rc == 1
         assert not template.exists()
 
+    @patch("vergil_tooling.bin.vrg_vm.update_plugins")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch(
         "vergil_tooling.bin.vrg_vm.update_tooling",
@@ -2554,6 +2582,7 @@ class TestRunLifecycle:
         _inject: MagicMock,
         _update: MagicMock,
         _copy: MagicMock,
+        _plugins: MagicMock,
         config_file: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -2575,3 +2604,23 @@ class TestLogRoot:
         completed = MagicMock(returncode=128, stdout="")
         with patch("vergil_tooling.bin.vrg_vm.subprocess.run", return_value=completed):
             assert _REAL_LOG_ROOT() == Path.home()
+
+
+class TestPluginStage:
+    def test_start_pipeline_includes_update_plugins(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _start_stages
+
+        names = [s.name for s in _start_stages()]
+        assert "update-plugins" in names
+        # Runs after tooling, in warn mode.
+        assert names.index("update-plugins") > names.index("update-tooling")
+        stage = next(s for s in _start_stages() if s.name == "update-plugins")
+        assert stage.mode == "warn"
+
+    def test_rebuild_pipeline_includes_update_plugins(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _rebuild_stages
+
+        names = [s.name for s in _rebuild_stages()]
+        assert "update-plugins" in names
+        stage = next(s for s in _rebuild_stages() if s.name == "update-plugins")
+        assert stage.mode == "warn"


### PR DESCRIPTION
# Pull Request

## Summary

- Agent-VM Claude plugins were installed once at build and never refreshed (the 2.1.4-vs-2.1.8 skew); this adds a VM-local plugin refresh mirroring the vergil-tooling update path, wired into vrg-vm update and the start/rebuild pipelines, removes the vestigial ~/.claude/sessions mount, and documents the projects-vs-sessions persistence model.

## Issue Linkage

- Ref #1603

## Notes

- Resolves the audit in #1603 (three findings). Plugins are kept current VM-locally rather than shared across the host/VM boundary: the share-via-mount approach was rejected because atomic plugin writes would hit EXDEV over virtiofs (same as #1301's sessions roster) and the host's materialized checkout would be fragile across the macOS/Linux boundary. settings.json (already copied into each VM) remains the source of truth for which plugins/marketplaces. Commits are split per finding. One open item needs a live-VM check before merge (unit tests mock limactl): confirm 'claude' resolves over 'bash -lc' in the VM and that a freshly rebuilt VM ends up with plugins installed — see Task 6 in docs/specs/2026-06-11-claude-share-set-audit-plan.md for the exact commands and the documented fallback if first-launch auto-install proves unreliable. Design + plan: docs/specs/2026-06-11-claude-share-set-audit-{design,plan}.md.