### PR TITLE
fix(release): poll confirm-main job conclusions; choose finalize strategy by branch prefix

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -100,9 +100,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--target-branch", default="develop", help="Target branch to switch to")
     parser.add_argument(
         "--strategy",
-        default="squash",
+        default=None,
         choices=["merge", "squash", "rebase"],
-        help="Merge strategy for the PR (feature PRs default to squash)",
+        help=(
+            "Merge strategy for the PR. Default by branch prefix: 'release/*' "
+            "branches merge with a merge commit (preserve develop<->main "
+            "ancestry); all others squash."
+        ),
     )
     parser.add_argument(
         "--allow-provenance-violation",
@@ -303,19 +307,39 @@ def _stage_provenance(ctx: FinalizeContext) -> None:
         )
 
 
+_RELEASE_BRANCH_PREFIX = "release/"
+
+
+def _resolve_strategy(branch: str, override: str | None) -> str:
+    """Merge strategy for *branch*.
+
+    An explicit ``--strategy`` always wins. Otherwise the default is driven by
+    the branch prefix: ``release/*`` branches (release PRs and back-merges)
+    merge with a merge commit to preserve the develop<->main ancestry the
+    release model relies on; squashing them silently breaks that ancestry and
+    makes later release branches conflict (issue #1620). Every other branch
+    squashes, as before.
+    """
+    if override is not None:
+        return override
+    return "merge" if branch.startswith(_RELEASE_BRANCH_PREFIX) else "squash"
+
+
 def _stage_merge(ctx: FinalizeContext) -> None:
     """Merge the PR (or confirm it is already merged) and record its branch."""
     args = ctx.args
+    branch = github.head_ref(args.pr)
+    strategy = _resolve_strategy(branch, args.strategy)
     if github.pr_state(args.pr) == "MERGED":
         print(f"PR {args.pr} already merged.")
     elif args.dry_run:
-        print(f"  [dry-run] wait for green, then merge PR {args.pr} (--{args.strategy})")
+        print(f"  [dry-run] wait for green, then merge PR {args.pr} (--{strategy})")
     else:
         try:
-            pr_merge.wait_and_merge(args.pr, strategy=args.strategy)
+            pr_merge.wait_and_merge(args.pr, strategy=strategy)
         except pr_merge.MergeAbortError as exc:
             raise FinalizeError(str(exc)) from exc
-    ctx.merged_branch = github.head_ref(args.pr)
+    ctx.merged_branch = branch
 
 
 def _stage_cleanup(ctx: FinalizeContext) -> None:

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vergil_tooling.lib import git, github
 from vergil_tooling.lib.release.context import ReleaseError
@@ -17,6 +18,10 @@ _MAIN_EXPECTED_JOBS = ("docs", "release")
 _DEVELOP_EXPECTED_JOBS = ("docs",)
 _CD_POLL_INTERVAL = 10
 _CD_POLL_ATTEMPTS = 30
+# A reusable-workflow leaf job's conclusion can lag the run-level status by a
+# few seconds in the jobs API (issue #1611); poll for it to settle.
+_JOB_SETTLE_INTERVAL = 5
+_JOB_SETTLE_ATTEMPTS = 12
 
 
 def confirm_main(ctx: ReleaseContext) -> None:
@@ -104,6 +109,51 @@ def _poll_for_run(repo: str, branch: str, head_sha: str) -> str:
     )
 
 
+def _fetch_run_jobs(ctx: ReleaseContext, run_id: str) -> list[dict[str, Any]]:
+    """Return the ``jobs`` array for *run_id* from the GitHub API."""
+    out = github.read_output("run", "view", "--repo", ctx.repo, run_id, "--json", "jobs")
+    data = json.loads(out) if out.strip() else {}
+    jobs: list[dict[str, Any]] = data.get("jobs", [])
+    return jobs
+
+
+def _find_job(jobs: list[dict[str, Any]], job_name: str) -> dict[str, Any] | None:
+    """First job whose name *contains* ``job_name``.
+
+    Reusable-workflow leaf jobs are surfaced as ``<caller> / <job>`` (e.g.
+    ``docs / docs``), so we substring-match rather than compare exactly.
+    """
+    for job in jobs:
+        if job_name in job.get("name", ""):
+            return job
+    return None
+
+
+def _settled_run_jobs(
+    ctx: ReleaseContext, run_id: str, expected: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    """Poll until every *expected* job is present and ``completed``.
+
+    ``gh run watch`` returns when the run-level status is terminal, but a
+    reusable-workflow leaf job's ``conclusion`` can still be ``null`` in the
+    jobs API for a few seconds (issue #1611). Reading once raced that window
+    and aborted an already-succeeded release. Polling for ``completed`` closes
+    the race; a genuinely absent job never settles and the final snapshot lets
+    the caller report it as not found.
+    """
+    jobs: list[dict[str, Any]] = []
+    for attempt in range(_JOB_SETTLE_ATTEMPTS):
+        jobs = _fetch_run_jobs(ctx, run_id)
+        if all(
+            (job := _find_job(jobs, name)) is not None and job.get("status") == "completed"
+            for name in expected
+        ):
+            return jobs
+        if attempt < _JOB_SETTLE_ATTEMPTS - 1:
+            time.sleep(_JOB_SETTLE_INTERVAL)
+    return jobs
+
+
 def _verify_jobs(
     ctx: ReleaseContext,
     run_id: str,
@@ -111,24 +161,16 @@ def _verify_jobs(
     *,
     phase: str,
 ) -> None:
+    jobs = _settled_run_jobs(ctx, run_id, expected)
     for job_name in expected:
-        conclusion = github.read_output(
-            "run",
-            "view",
-            "--repo",
-            ctx.repo,
-            run_id,
-            "--json",
-            "jobs",
-            "--jq",
-            f'.jobs[] | select(.name | contains("{job_name}")) | .conclusion',
-        )
-        if not conclusion:
+        job = _find_job(jobs, job_name)
+        if job is None:
             raise ReleaseError(
                 phase=phase,
                 command=f"verify job '{job_name}'",
                 message=(f"Expected job '{job_name}' not found in workflow run {run_id}."),
             )
+        conclusion = job.get("conclusion")
         if conclusion != "success":
             raise ReleaseError(
                 phase=phase,

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -18,6 +18,17 @@ _MOD = "vergil_tooling.lib.release.confirm"
 _SHA = "abc123def456"
 
 
+def _job(
+    name: str, status: str = "completed", conclusion: str | None = "success"
+) -> dict[str, str | None]:
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+# Reusable-workflow leaf jobs are surfaced as "<caller> / <job>".
+_MAIN_JOBS_OK = [_job("docs / docs"), _job("release / release")]
+_DEVELOP_JOBS_OK = [_job("docs / docs")]
+
+
 def _ctx() -> ReleaseContext:
     ctx = ReleaseContext(
         repo="owner/repo",
@@ -67,11 +78,10 @@ def test_confirm_main_success() -> None:
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "success",
-                "success",
                 "https://github.com/o/r/releases/tag/v2.1.0",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_MAIN_JOBS_OK),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -96,11 +106,10 @@ def test_confirm_main_polls_until_run_appears() -> None:
                 "",
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "success",
-                "success",
                 "https://github.com/o/r/releases/tag/v2.1.0",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_MAIN_JOBS_OK),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -132,9 +141,11 @@ def test_confirm_main_fails_job_not_found() -> None:
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "",
             ],
         ),
+        # 'docs' never appears — poll exhausts and it is reported missing.
+        patch(_MOD + "._fetch_run_jobs", return_value=[_job("release / release")]),
+        patch(_MOD + ".time.sleep"),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -151,8 +162,11 @@ def test_confirm_main_fails_job_not_success() -> None:
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "failure",
             ],
+        ),
+        patch(
+            _MOD + "._fetch_run_jobs",
+            return_value=[_job("docs / docs", conclusion="failure"), _job("release / release")],
         ),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
@@ -170,10 +184,9 @@ def test_confirm_main_fails_tag_missing() -> None:
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "success",
-                "success",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_MAIN_JOBS_OK),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -192,11 +205,10 @@ def test_confirm_main_fails_develop_tag_missing() -> None:
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "success",
-                "success",
                 "https://github.com/o/r/releases/tag/v2.1.0",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_MAIN_JOBS_OK),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -214,9 +226,9 @@ def test_confirm_develop_success() -> None:
             side_effect=[
                 "67890",
                 "https://github.com/o/r/actions/runs/67890",
-                "success",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_DEVELOP_JOBS_OK),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -247,8 +259,11 @@ def test_confirm_develop_fails_job_not_success() -> None:
             side_effect=[
                 "67890",
                 "https://github.com/o/r/actions/runs/67890",
-                "failure",
             ],
+        ),
+        patch(
+            _MOD + "._fetch_run_jobs",
+            return_value=[_job("docs / docs", conclusion="failure")],
         ),
         patch(_MOD + ".watch_workflow"),
         patch(_MOD + ".git.run"),
@@ -256,6 +271,54 @@ def test_confirm_develop_fails_job_not_success() -> None:
         pytest.raises(ReleaseError, match="did not succeed"),
     ):
         confirm_develop(ctx)
+
+
+def test_fetch_run_jobs_parses_jobs_array() -> None:
+    from vergil_tooling.lib.release.confirm import _fetch_run_jobs
+
+    ctx = _ctx()
+    payload = '{"jobs": [{"name": "docs / docs", "status": "completed", "conclusion": "success"}]}'
+    with patch(_MOD + ".github.read_output", return_value=payload):
+        jobs = _fetch_run_jobs(ctx, "12345")
+    assert jobs == [{"name": "docs / docs", "status": "completed", "conclusion": "success"}]
+
+
+def test_fetch_run_jobs_empty_output_returns_empty() -> None:
+    from vergil_tooling.lib.release.confirm import _fetch_run_jobs
+
+    ctx = _ctx()
+    with patch(_MOD + ".github.read_output", return_value=""):
+        assert _fetch_run_jobs(ctx, "12345") == []
+
+
+def test_find_job_substring_matches_reusable_leaf() -> None:
+    from vergil_tooling.lib.release.confirm import _find_job
+
+    jobs = [_job("docs / docs"), _job("release / release")]
+    matched = _find_job(jobs, "docs")
+    assert matched is not None
+    assert matched["name"] == "docs / docs"
+    assert _find_job(jobs, "missing") is None
+
+
+def test_settled_run_jobs_polls_until_leaf_conclusion_settles() -> None:
+    """Regression #1611: a reusable-workflow leaf whose conclusion lags the
+    run-level status is polled until it settles, not read once."""
+    from vergil_tooling.lib.release.confirm import _settled_run_jobs
+
+    ctx = _ctx()
+    lagging = [
+        _job("docs / docs", status="in_progress", conclusion=None),
+        _job("release / release"),
+    ]
+    settled = [_job("docs / docs"), _job("release / release")]
+    with (
+        patch(_MOD + "._fetch_run_jobs", side_effect=[lagging, settled]),
+        patch(_MOD + ".time.sleep") as sleep,
+    ):
+        jobs = _settled_run_jobs(ctx, "12345", _MAIN_EXPECTED_JOBS)
+    assert jobs == settled
+    sleep.assert_called_once()
 
 
 def test_poll_attempts_constant() -> None:
@@ -277,11 +340,10 @@ def test_confirm_main_prints_run_url_before_watching(
             side_effect=[
                 "12345",
                 "https://github.com/o/r/actions/runs/12345",
-                "success",
-                "success",
                 "https://github.com/o/r/releases/tag/v2.1.0",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_MAIN_JOBS_OK),
         patch(_MOD + ".watch_workflow", side_effect=fake_watch),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
@@ -307,9 +369,9 @@ def test_confirm_develop_prints_run_url_before_watching(
             side_effect=[
                 "67890",
                 "https://github.com/o/r/actions/runs/67890",
-                "success",
             ],
         ),
+        patch(_MOD + "._fetch_run_jobs", return_value=_DEVELOP_JOBS_OK),
         patch(_MOD + ".watch_workflow", side_effect=fake_watch),
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -16,6 +16,7 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     FinalizeContext,
     FinalizeError,
     _check_cd_workflow_status,
+    _resolve_strategy,
     _stage_cd_check,
     _stage_merge,
     _stage_provenance,
@@ -88,6 +89,7 @@ def test_parse_args_defaults() -> None:
     args = parse_args([])
     assert args.target_branch == "develop"
     assert args.dry_run is False
+    assert args.strategy is None
 
 
 def test_parse_args_custom() -> None:
@@ -785,6 +787,7 @@ def test_merge_abort_returns_one_from_main(
     with (
         patch(f"{_MOD}.pr_provenance.check_pr", return_value=_clean()),
         patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
+        patch(f"{_MOD}.github.head_ref", return_value="feature/42-x"),
         patch(f"{_MOD}.pr_merge.wait_and_merge", side_effect=MergeAbortError("is a draft")),
         patch(f"{_MOD}.git.repo_root", return_value=tmp_path),
         patch(f"{_MOD}.git.current_branch") as branch,
@@ -1313,10 +1316,50 @@ def test_stage_merge_abort_raises() -> None:
     ctx = _stage_ctx(["123"])
     with (
         patch(_MOD + ".github.pr_state", return_value="OPEN"),
+        patch(_MOD + ".github.head_ref", return_value="feature/42-x"),
         patch(_MOD + ".pr_merge.wait_and_merge", side_effect=MergeAbortError("is a draft")),
         pytest.raises(FinalizeError, match="is a draft"),
     ):
         _stage_merge(ctx)
+
+
+def test_resolve_strategy_release_branch_merges() -> None:
+    assert _resolve_strategy("release/2.1.30", None) == "merge"
+    assert _resolve_strategy("release/post-2.1.30", None) == "merge"
+
+
+def test_resolve_strategy_feature_branch_squashes() -> None:
+    assert _resolve_strategy("feature/42-x", None) == "squash"
+    assert _resolve_strategy("develop", None) == "squash"
+
+
+def test_resolve_strategy_explicit_override_wins() -> None:
+    assert _resolve_strategy("release/2.1.30", "squash") == "squash"
+    assert _resolve_strategy("feature/42-x", "merge") == "merge"
+
+
+def test_stage_merge_release_branch_uses_merge_commit() -> None:
+    """A release/* branch with no explicit --strategy merges with a merge
+    commit, preserving develop<->main ancestry (issue #1620)."""
+    ctx = _stage_ctx(["123"])
+    with (
+        patch(_MOD + ".github.pr_state", return_value="OPEN"),
+        patch(_MOD + ".pr_merge.wait_and_merge") as engine,
+        patch(_MOD + ".github.head_ref", return_value="release/post-2.1.30"),
+    ):
+        _stage_merge(ctx)
+    engine.assert_called_once_with("123", strategy="merge")
+
+
+def test_stage_merge_explicit_strategy_overrides_prefix() -> None:
+    ctx = _stage_ctx(["123", "--strategy", "squash"])
+    with (
+        patch(_MOD + ".github.pr_state", return_value="OPEN"),
+        patch(_MOD + ".pr_merge.wait_and_merge") as engine,
+        patch(_MOD + ".github.head_ref", return_value="release/2.1.30"),
+    ):
+        _stage_merge(ctx)
+    engine.assert_called_once_with("123", strategy="squash")
 
 
 def test_stage_merge_already_merged_skips_engine() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Fix two release-flow robustness bugs found during the 2.1.27-2.1.30 recovery: confirm-main now polls for reusable-workflow leaf job conclusions instead of racing them (no more false 'job not found' aborts), and vrg-finalize-pr picks its merge strategy by branch prefix (release/* -> merge commit, else squash) so squashing can no longer silently break develop<->main ancestry.

## Issue Linkage

- Ref #1620

## Notes

- Two commits, two issues. #1611: _verify_jobs polls until each expected job is completed (distinguishes settling from absent); new regression + unit tests; 100% coverage. #1620: _resolve_strategy(branch, override) drives the --strategy default by prefix, explicit override wins; unit + _stage_merge tests. vrg-validate green. Ref #1611, #1620.