### PR TITLE
fix(release): write release artifacts into the worktree, not repo_root

### DIFF
--- a/src/vergil_tooling/lib/release/bump.py
+++ b/src/vergil_tooling/lib/release/bump.py
@@ -29,7 +29,7 @@ def back_merge_and_bump(ctx: ReleaseContext) -> None:
     print(f"Creating branch: {branch}")
     git.run("checkout", "-b", branch, "origin/main")
 
-    next_ver = version.bump(ctx.repo_root)
+    next_ver = version.bump(ctx.work_root)
     print(f"Bumped version to {next_ver}")
     git.run("add", "-A")
     git.run("commit", "-m", f"chore(release): bump version to {next_ver}")

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -45,6 +45,20 @@ class ReleaseContext:
 
     promote: bool = True
 
+    @property
+    def work_root(self) -> Path:
+        """Directory release artifacts are written into and git runs in.
+
+        Post-#1600 every release phase runs inside the managed worktree
+        (preflight chdir's into it), so artifact writes — CHANGELOG, release
+        notes, version bump — must target the worktree. ``repo_root`` stays
+        the main checkout, which ``finalize`` chdir's back to so
+        ``vrg-finalize-pr`` (which refuses to run outside the main worktree)
+        works. Falls back to ``repo_root`` when no worktree is set (defensive;
+        preflight always sets ``worktree_path``).
+        """
+        return self.worktree_path or self.repo_root
+
 
 class ReleaseError(Exception):
     """Raised when a release phase fails."""

--- a/src/vergil_tooling/lib/release/prepare.py
+++ b/src/vergil_tooling/lib/release/prepare.py
@@ -34,7 +34,7 @@ def prepare(ctx: ReleaseContext) -> None:
 
     if ctx.version_override is not None:
         print(f"Applying version override: {ctx.version_override}")
-        version.bump(ctx.repo_root, ctx.version_override)
+        version.bump(ctx.work_root, ctx.version_override)
         git.run("add", "-A")
         git.run("commit", "-m", f"chore(release): bump version to {ctx.version}")
 
@@ -49,10 +49,10 @@ def prepare(ctx: ReleaseContext) -> None:
 
 def _generate_changelog(ctx: ReleaseContext) -> None:
     print(f"Generating changelog for v{ctx.version}")
-    changelog.generate_changelog(ctx.repo_root, ctx.version)
+    changelog.generate_changelog(ctx.work_root, ctx.version)
     git.run("add", "CHANGELOG.md")
 
-    notes_path = changelog.generate_release_notes(ctx.repo_root, ctx.version)
+    notes_path = changelog.generate_release_notes(ctx.work_root, ctx.version)
     git.run("add", str(notes_path))
 
     status = git.read_output("status", "--porcelain")

--- a/tests/vergil_tooling/test_release_bump.py
+++ b/tests/vergil_tooling/test_release_bump.py
@@ -15,6 +15,8 @@ def _ctx() -> ReleaseContext:
         version="2.1.0",
         repo_root=Path("/tmp/repo"),  # noqa: S108
         version_override=None,
+        # preflight chdir's into this worktree; the bump must land here.
+        worktree_path=Path("/tmp/repo/.worktrees/release-2.1.0"),  # noqa: S108
     )
     ctx.issue_number = 42
     return ctx
@@ -81,6 +83,25 @@ def test_back_merge_commits_version_bump() -> None:
     commit_calls = [c for c in git_run_calls if c[0] == "commit"]
     assert len(commit_calls) == 1
     assert "bump version to 2.1.1" in commit_calls[0][2]
+
+
+def test_back_merge_bumps_in_worktree() -> None:
+    """The version bump writes into the worktree, not the main checkout (#1626)."""
+    ctx = _ctx()
+    assert ctx.work_root == ctx.worktree_path
+    assert ctx.work_root != ctx.repo_root
+    with (
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".version.bump", return_value="2.1.1") as mock_bump,
+        patch(
+            _MOD + ".github.create_pr",
+            return_value="https://github.com/owner/repo/pull/101",
+        ),
+        patch(_MOD + ".wait_and_merge"),
+    ):
+        back_merge_and_bump(ctx)
+
+    mock_bump.assert_called_once_with(ctx.work_root)
 
 
 def test_back_merge_creates_pr_to_develop() -> None:

--- a/tests/vergil_tooling/test_release_context.py
+++ b/tests/vergil_tooling/test_release_context.py
@@ -77,6 +77,32 @@ def test_context_develop_cd_fields_default_none() -> None:
     assert ctx.develop_cd_run_url is None
 
 
+def test_work_root_prefers_worktree() -> None:
+    """During a release every phase runs in the worktree, so artifact writes
+    target it — not repo_root, which finalize chdir's back to (#1626)."""
+    worktree = Path("/tmp/repo/.worktrees/release-2.1.0")  # noqa: S108
+    ctx = ReleaseContext(
+        repo="owner/repo",
+        version="2.1.0",
+        repo_root=Path("/tmp/repo"),  # noqa: S108
+        version_override=None,
+        worktree_path=worktree,
+    )
+    assert ctx.work_root == worktree
+    assert ctx.work_root != ctx.repo_root
+
+
+def test_work_root_falls_back_to_repo_root() -> None:
+    """With no worktree set, work_root is repo_root (defensive fallback)."""
+    ctx = ReleaseContext(
+        repo="owner/repo",
+        version="2.1.0",
+        repo_root=Path("/tmp/repo"),  # noqa: S108
+        version_override=None,
+    )
+    assert ctx.work_root == ctx.repo_root
+
+
 def test_release_error_carries_diagnostics() -> None:
     err = ReleaseError(
         phase="merge-release",

--- a/tests/vergil_tooling/test_release_prepare.py
+++ b/tests/vergil_tooling/test_release_prepare.py
@@ -17,8 +17,10 @@ def _ctx(*, version_override: str | None = None) -> ReleaseContext:
         version="2.1.0",
         repo_root=Path("/tmp/repo"),  # noqa: S108
         version_override=version_override,
-        # preflight creates the worktree and sets the release branch.
+        # preflight creates the worktree (distinct from repo_root) and sets
+        # the release branch, then chdir's into the worktree.
         release_branch="release/2.1.0",
+        worktree_path=Path("/tmp/repo/.worktrees/release-2.1.0"),  # noqa: S108
     )
     ctx.issue_number = 42
     ctx.issue_url = "https://github.com/owner/repo/issues/42"
@@ -118,23 +120,36 @@ def test_prepare_without_version_override_skips_bump() -> None:
     mock_bump.assert_not_called()
 
 
-def test_generate_changelog_uses_lib() -> None:
+def test_generate_changelog_targets_worktree() -> None:
+    """Artifacts are written into the managed worktree, not the main checkout.
+
+    Regression test for #1626: preflight chdir's into the worktree, so every
+    ``git add`` runs there. Writing CHANGELOG/notes to ``repo_root`` (the main
+    checkout) instead left ``git add <abs-notes-path>`` pointing outside the
+    worktree ("fatal: ... is outside repository") and broke every release.
+    """
     from vergil_tooling.lib.release.prepare import _generate_changelog
 
     ctx = _ctx()
-    notes_path = Path("/tmp/repo/releases/v2.1.0.md")  # noqa: S108
+    assert ctx.work_root == ctx.worktree_path
+    assert ctx.work_root != ctx.repo_root
+    notes_path = ctx.work_root / "releases" / "v2.1.0.md"
     with (
         patch(_MOD + ".changelog.generate_changelog") as mock_cl,
         patch(
             _MOD + ".changelog.generate_release_notes",
             return_value=notes_path,
         ) as mock_rn,
-        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.run") as mock_git,
         patch(_MOD + ".git.read_output", return_value="M CHANGELOG.md"),
     ):
         _generate_changelog(ctx)
-    mock_cl.assert_called_once_with(ctx.repo_root, ctx.version)
-    mock_rn.assert_called_once_with(ctx.repo_root, ctx.version)
+    mock_cl.assert_called_once_with(ctx.work_root, ctx.version)
+    mock_rn.assert_called_once_with(ctx.work_root, ctx.version)
+    # The notes path git adds must live under the worktree, never repo_root.
+    add_calls = [c.args for c in mock_git.call_args_list if c.args and c.args[0] == "add"]
+    assert ("add", str(notes_path)) in add_calls
+    assert str(ctx.worktree_path) in str(notes_path)
 
 
 def test_generate_changelog_fails_on_no_changes() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-release's #1600 worktree refactor left CHANGELOG/notes/version writes pointing at ctx.repo_root (the main checkout) while git add ran in the worktree, so 'git add <notes>' failed 'outside repository' and broke every release; route those writes through a new ctx.work_root (worktree_path or repo_root).

## Issue Linkage

- Ref #1626

## Notes

- repo_root intentionally stays the main checkout for finalize's chdir-back to vrg-finalize-pr. Added work_root unit tests plus prepare/bump regression tests that set a distinct worktree_path and assert artifacts target the worktree. Full vrg-validate green (2930 passed). Rollout: host tool carries the bug and can't ship the fix via a normal release, so reinstall from the merged ref with 'uv tool install --reinstall'.