### PR TITLE
feat(vm): rebuild creates the VM when it doesn't exist instead of aborting

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -690,11 +690,13 @@ def _cmd_rebuild(args: argparse.Namespace) -> int:
 
     status = vm_status(target.instance)
     if not status:
-        print(
-            f"ERROR: VM '{target.instance}' does not exist — run 'vrg-vm create' first",
-            file=sys.stderr,
-        )
-        return 1
+        # Rebuild is idempotent: with nothing to rebuild, create the VM rather
+        # than abort. An absent VM has nothing to destroy, so the create
+        # lifecycle — not a destroy-skipped rebuild — is the right pipeline.
+        # Delegate to _cmd_create, which re-confirms absence and runs the
+        # create stages (and accurately labels the run as a create).
+        print(f"VM '{target.instance}' does not exist yet — creating it (nothing to rebuild).")
+        return _cmd_create(args)
 
     if not identity.projects_dir:
         print(

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -634,10 +634,39 @@ class TestRebuild:
             call("vergil-agent", timeout="45m"),
         ]
 
+    @patch("vergil_tooling.bin.vrg_vm.stop_vm")
+    @patch("vergil_tooling.bin.vrg_vm.install_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
+    @patch("vergil_tooling.bin.vrg_vm.start_vm")
+    @patch("vergil_tooling.bin.vrg_vm.create_vm")
+    @patch("vergil_tooling.bin.vrg_vm.fetch_template")
+    @patch("vergil_tooling.bin.vrg_vm.delete_vm")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
-    def test_rebuild_fails_if_not_created(self, _status: MagicMock, config_file: Path) -> None:
+    def test_rebuild_creates_if_not_created(
+        self,
+        _status: MagicMock,
+        mock_delete: MagicMock,
+        mock_fetch: MagicMock,
+        mock_create: MagicMock,
+        _start: MagicMock,
+        mock_inject: MagicMock,
+        mock_install: MagicMock,
+        _stop: MagicMock,
+        config_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Rebuild is idempotent: with no VM present it creates one instead of
+        aborting, and never runs the destroy stage (#1631)."""
+        template = tmp_path / "template.yaml"
+        template.write_text("cpus: 4")
+        mock_fetch.return_value = template
+
         result = main(["rebuild", "--config", str(config_file)])
-        assert result == 1
+        assert result == 0
+        mock_create.assert_called_once()
+        mock_delete.assert_not_called()
+        mock_inject.assert_called_once()
+        mock_install.assert_called_once()
 
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
     def test_rebuild_fails_without_projects_dir(self, _status: MagicMock, tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm rebuild aborted with 'VM does not exist — run vrg-vm create first' when the target VM was absent; it now prints a note and delegates to _cmd_create so rebuild is idempotent, while an existing VM still runs the destroy-first rebuild pipeline.

## Issue Linkage

- Ref #1631

## Notes

- An absent VM has nothing to destroy, so delegation uses the create lifecycle (not a destroy-skipped rebuild); _cmd_create re-confirms absence and runs the create stages. Replaced test_rebuild_fails_if_not_created with test_rebuild_creates_if_not_created (create_vm runs, delete_vm does not); existing-VM destroy path still covered. Full vrg-validate green (2930 passed). Host-tool change — reinstall after merge.