### PR TITLE
feat(submit-pr,finalize-pr): --release cascades submit, finalize, and release

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -25,6 +25,14 @@ After cleanup succeeds, validation runs in the dev container, then the
 most recent CD workflow run on the target branch is checked and the
 command fails if it did not succeed (issue #303 — docs publish is async
 and used to fail silently).
+
+``--release`` chains straight into ``vrg-release`` after the finalize
+pipeline completes **successfully** (issue #1634) — the fast-turnaround
+cascade that merges, cleans up, and cuts a release in one command. The
+chain runs only on success, and only after ``run_pipeline`` has torn down
+its live display, so the two renderers never nest (cf. issue #1470). It
+runs as a subprocess, not ``exec``, so the caller (e.g. ``vrg-submit-pr``)
+regains control to report how far the cascade got.
 """
 
 from __future__ import annotations
@@ -115,6 +123,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Show what would be done without making changes"
+    )
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="After a successful finalize, chain straight into vrg-release "
+        "(the full submit-finalize-release cascade)",
     )
     progress.add_progress_args(parser, ())
     return parser.parse_args(argv)
@@ -549,6 +563,38 @@ def build_stages(*, include_pr: bool) -> tuple[Stage, ...]:
     )
 
 
+def _chain_release(root: Path) -> int:
+    """Hand off to ``vrg-release`` after a successful finalize (issue #1634).
+
+    Runs only when the finalize pipeline succeeded. By the time
+    ``run_pipeline`` returns it has closed its live display (its ``finally``
+    block calls ``renderer.close()``), so ``vrg-release`` starts a fresh
+    renderer with no nesting — the two live displays never overlap
+    (cf. issue #1470). Run as a subprocess inheriting the TTY, not ``exec``,
+    so a caller like ``vrg-submit-pr`` regains control to report the
+    cascade outcome.
+
+    A failure here never un-merges the PR — it was already merged and
+    cleaned up — so report it clearly and let the human re-run vrg-release
+    alone.
+    """
+    print()
+    print("--release: handing off to vrg-release")
+    result = subprocess.run(  # noqa: S603
+        ("vrg-release",),  # noqa: S607
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            f"vrg-finalize-pr: release failed (exit {result.returncode}); "
+            "the PR was already merged and cleaned up and is unaffected.\n"
+            "  Re-run the release alone with: vrg-release",
+            file=sys.stderr,
+        )
+    return result.returncode
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -579,7 +625,7 @@ def main(argv: list[str] | None = None) -> int:
     # below runs under the progress pipeline, which owns stdout/stderr
     # (issue #1479).
     ctx = FinalizeContext(args=args, root=root)
-    return progress.run_pipeline(
+    rc = progress.run_pipeline(
         ctx,
         build_stages(include_pr=args.pr is not None),
         command="vrg-finalize-pr",
@@ -587,6 +633,17 @@ def main(argv: list[str] | None = None) -> int:
         args=args,
         repo_root=root,
     )
+
+    # --release cascade (issue #1634): chain into vrg-release only after a
+    # clean finalize. A non-zero pipeline must not trigger a release, and the
+    # hand-off happens here — after run_pipeline has closed its live display —
+    # so the two renderers never nest (cf. issue #1470).
+    if rc != 0 or not args.release:
+        return rc
+    if args.dry_run:
+        print("\n[dry-run] would chain into: vrg-release")
+        return 0
+    return _chain_release(root)
 
 
 if __name__ == "__main__":

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -22,6 +22,14 @@ where the human has already decided to merge on green. The chain runs
 only after the PR exists, so a submit failure leaves no half-finalized
 state, and a finalize failure reports the created PR so the human can
 re-run ``vrg-finalize-pr`` alone.
+
+``--release`` extends that one step further (issue #1634): it implies
+``--finalize`` and passes ``--release`` through, so a clean finalize
+cascades into ``vrg-release`` — the whole submit -> finalize -> release
+sequence from one command. Each hop runs as a subprocess (not ``exec``)
+so control returns here for the final summary, which states how far the
+cascade got: submitted, submitted and finalized, or submitted, finalized,
+and released.
 """
 
 from __future__ import annotations
@@ -59,6 +67,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="After creating the PR, chain straight into vrg-finalize-pr "
         "(wait for checks, merge, post-merge cleanup)",
+    )
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="After creating the PR, run the full cascade: finalize (implies "
+        "--finalize) and then vrg-release",
     )
     return parser.parse_args(argv)
 
@@ -118,37 +132,59 @@ def _create_pr(*, target_branch: str, title: str, pr_body: str) -> str:
     return pr_url
 
 
-def _chain_finalize(pr_url: str) -> int:
+def _chain_finalize(pr_url: str, *, release: bool = False) -> int:
     """Hand off to ``vrg-finalize-pr`` right after PR creation (issue #1491).
 
     Equivalent to running ``vrg-finalize-pr <pr-url>`` by hand: same
-    merge-strategy default, same post-merge cleanup. Runs as a subprocess
-    from the main worktree root because vrg-finalize-pr refuses to run
-    from a secondary worktree (it removes worktrees during cleanup) and
-    template mode chdir'd into one. The child inherits the TTY so its
-    live progress display and prompts behave exactly as a manual run.
+    merge-strategy default, same post-merge cleanup. With *release*, passes
+    ``--release`` through so a clean finalize cascades into ``vrg-release``
+    (issue #1634). Runs as a subprocess from the main worktree root because
+    vrg-finalize-pr refuses to run from a secondary worktree (it removes
+    worktrees during cleanup) and template mode chdir'd into one. The child
+    inherits the TTY so its live progress display and prompts behave exactly
+    as a manual run.
 
     A failure here never un-creates the PR — report the PR clearly so
-    the human can re-run vrg-finalize-pr alone.
+    the human can re-run the finalize (or the cascade) alone.
     """
     main_root = git.main_worktree_root()
+    cmd: tuple[str, ...] = ("vrg-finalize-pr", pr_url)
+    if release:
+        cmd = (*cmd, "--release")
     print()
-    print(f"--finalize: handing off to vrg-finalize-pr {pr_url}")
-    result = subprocess.run(  # noqa: S603
-        ("vrg-finalize-pr", pr_url),  # noqa: S607
-        cwd=main_root,
-        check=False,
-    )
+    print(f"--{'release' if release else 'finalize'}: handing off to {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=main_root, check=False)  # noqa: S603
     if result.returncode != 0:
+        rerun = f"vrg-finalize-pr {pr_url}{' --release' if release else ''}"
         print(
-            f"vrg-submit-pr: finalize failed (exit {result.returncode}); "
+            f"vrg-submit-pr: cascade failed (exit {result.returncode}); "
             "the PR was created and is unaffected:\n"
             f"  {pr_url}\n"
-            f"  Re-run finalization alone with: vrg-finalize-pr {pr_url}",
+            f"  Re-run the rest of the cascade alone with: {rerun}",
             file=sys.stderr,
         )
         return result.returncode
     return 0
+
+
+def _print_cascade_summary(pr_url: str, *, released: bool) -> None:
+    """Final summary owned by vrg-submit-pr stating how far the cascade got.
+
+    Reached only after a successful chain, so it always reports completed
+    work (issue #1634). The submitted-only outcome is reported separately by
+    the pr-watch one-liner.
+    """
+    print()
+    if released:
+        print(f"Done: PR submitted, finalized, and released.\n  {pr_url}")
+    else:
+        print(f"Done: PR submitted and finalized.\n  {pr_url}")
+
+
+def _dry_run_chain_note(*, release: bool) -> str:
+    """The ``[dry-run]`` line naming the chain command that would run."""
+    cmd = "vrg-finalize-pr --release <pr-url>" if release else "vrg-finalize-pr <pr-url>"
+    return f"\n[dry-run] would chain into: {cmd}"
 
 
 def _print_pr_watch(pr_url: str) -> None:
@@ -186,7 +222,7 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
         print(f"=== Target Branch ===\n{target}\n")
         print(f"=== PR Body ===\n{pr_body}")
         if args.finalize:
-            print("\n[dry-run] would chain into: vrg-finalize-pr <pr-url>")
+            print(_dry_run_chain_note(release=args.release))
         return 0
 
     print(f"Pushing branch '{branch}' to origin...")
@@ -195,9 +231,13 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
     print("Creating PR...")
     pr_url = _create_pr(target_branch=target, title=args.title, pr_body=pr_body)
     print(f"PR created: {pr_url}")
-    print(f"Done. PR URL: {pr_url}")
     if args.finalize:
-        return _chain_finalize(pr_url)
+        rc = _chain_finalize(pr_url, release=args.release)
+        if rc != 0:
+            return rc
+        _print_cascade_summary(pr_url, released=args.release)
+        return 0
+    print(f"Done. PR URL: {pr_url}")
     _print_pr_watch(pr_url)
     return 0
 
@@ -315,7 +355,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
 
     if args.dry_run:
         if args.finalize:
-            print("\n[dry-run] would chain into: vrg-finalize-pr <pr-url>")
+            print(_dry_run_chain_note(release=args.release))
         return 0
 
     try:
@@ -339,15 +379,25 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     pr_url = _create_pr(target_branch=target, title=title, pr_body=pr_body)
     submission.delete_submission(root)
     print(f"PR created: {pr_url}")
-    print(f"Done. PR URL: {pr_url}")
     if args.finalize:
-        return _chain_finalize(pr_url)
+        rc = _chain_finalize(pr_url, release=args.release)
+        if rc != 0:
+            return rc
+        _print_cascade_summary(pr_url, released=args.release)
+        return 0
+    print(f"Done. PR URL: {pr_url}")
     _print_pr_watch(pr_url)
     return 0
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    # --release is the full cascade and implies --finalize; normalize once so
+    # every downstream branch (dry-run notes, chain, summary) sees finalize on
+    # (issue #1634).
+    if args.release:
+        args.finalize = True
 
     if identity_mode.is_agent():
         print(

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -1567,3 +1567,109 @@ def test_sweep_skips_eternal_branch_worktree(tmp_path: Path) -> None:
     assert result == 0
     gather.assert_not_called()
     deleter.assert_not_called()
+
+
+# -- --release: chain into vrg-release after a clean finalize (issue #1634) ----
+
+
+def test_parse_args_release_defaults_false() -> None:
+    assert parse_args([]).release is False
+
+
+def test_parse_args_release_flag() -> None:
+    assert parse_args(["--release"]).release is True
+
+
+def test_release_chains_into_vrg_release_on_success(tmp_path: Path) -> None:
+    """A clean finalize hands off to vrg-release from the repo root."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.returncode = 0
+        result = main(["--release"])
+    assert result == 0
+    mock_run.assert_called_once()
+    call = mock_run.call_args
+    assert call.args[0] == ("vrg-release",)
+    assert call.kwargs["cwd"] == tmp_path
+
+
+def test_release_skipped_when_finalize_fails(tmp_path: Path) -> None:
+    """A non-zero pipeline must never trigger the release."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(
+            _MOD + ".progress.run",
+            side_effect=subprocess.CalledProcessError(1, ("vrg-container-run",)),
+        ),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        result = main(["--release"])
+    assert result == 1
+    mock_run.assert_not_called()
+
+
+def test_release_dry_run_notes_without_running(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        result = main(["--release", "--dry-run"])
+    assert result == 0
+    mock_run.assert_not_called()
+    assert "vrg-release" in capsys.readouterr().out
+
+
+def test_release_failure_reports_pr_unaffected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A release failure propagates its exit code and points the human at a
+    re-run; the merge already happened and is unaffected."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.returncode = 2
+        result = main(["--release"])
+    assert result == 2
+    err = capsys.readouterr().err
+    assert "release failed" in err
+    assert "vrg-release" in err
+
+
+def test_no_release_flag_does_not_invoke_release(tmp_path: Path) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        result = main([])
+    assert result == 0
+    mock_run.assert_not_called()

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -948,3 +948,186 @@ class TestFinalizeFlag:
         assert result != 0
         mock_run.assert_not_called()
         assert "human maintainer" in capsys.readouterr().err.lower()
+
+
+# -- --release: cascade submit -> finalize -> release (issue #1634) ------------
+
+
+class TestReleaseFlag:
+    """--release implies --finalize and passes --release through to the chain."""
+
+    @pytest.fixture(autouse=True)
+    def _human_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+
+    def test_parse_args_release_defaults_false(self) -> None:
+        args = parse_args(["--issue", "42", "--summary", "Fix", "--title", "fix: bug"])
+        assert args.release is False
+
+    def test_parse_args_release_flag(self) -> None:
+        args = parse_args(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--release"])
+        assert args.release is True
+
+    def test_cli_mode_chains_into_finalize_with_release(self, tmp_path: Path) -> None:
+        """--release implies --finalize and appends --release to the chain."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--release"])
+        assert result == 0
+        mock_run.assert_called_once()
+        call = mock_run.call_args
+        assert call.args[0] == ("vrg-finalize-pr", "https://github.com/pr/1", "--release")
+        assert call.kwargs["cwd"] == tmp_path
+
+    def test_cli_mode_release_prints_three_way_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """On success the final summary reports the full cascade."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--release"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "submitted, finalized, and released" in out
+        assert "pr-watch" not in out
+
+    def test_finalize_only_prints_two_way_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--finalize without --release stops the summary at 'finalized'."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = main(
+                ["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--finalize"]
+            )
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "submitted and finalized" in out
+        assert "released" not in out
+
+    def test_release_failure_reports_created_pr_with_release_rerun(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A cascade failure must not obscure the created PR; the re-run hint
+        carries --release so the human can resume the whole cascade."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 1
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--release"])
+        assert result != 0
+        err = capsys.readouterr().err
+        assert "https://github.com/pr/1" in err
+        assert "vrg-finalize-pr https://github.com/pr/1 --release" in err
+
+    def test_dry_run_notes_release_chain_without_running(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            result = main(
+                [
+                    "--issue",
+                    "42",
+                    "--summary",
+                    "Fix",
+                    "--title",
+                    "fix: bug",
+                    "--release",
+                    "--dry-run",
+                ]
+            )
+        assert result == 0
+        mock_run.assert_not_called()
+        assert "vrg-finalize-pr --release" in capsys.readouterr().out
+
+    def test_template_mode_chains_into_finalize_with_release(self, tmp_path: Path) -> None:
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text(
+            "issue: 42\ntitle: fix\nsummary: Fix\nnotes: Verified locally\n"
+        )
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/7"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+            patch("builtins.input", return_value="y"),
+        ):
+            mock_run.return_value.returncode = 0
+            result = main(["--release"])
+        assert result == 0
+        mock_run.assert_called_once()
+        assert mock_run.call_args.args[0] == (
+            "vrg-finalize-pr",
+            "https://github.com/pr/7",
+            "--release",
+        )
+
+    def test_template_mode_chain_failure_propagates_and_skips_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A failed cascade from template mode returns the child's code and
+        never prints a success summary — the failure helper reported the PR."""
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text(
+            "issue: 42\ntitle: fix\nsummary: Fix\nnotes: Verified locally\n"
+        )
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/7"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+            patch("builtins.input", return_value="y"),
+        ):
+            mock_run.return_value.returncode = 3
+            result = main(["--release"])
+        assert result == 3
+        out = capsys.readouterr().out
+        assert "submitted, finalized, and released" not in out
+
+    def test_agent_identity_still_blocked_with_release(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--release must not weaken the identity-mode gate."""
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
+        with patch(_MOD + ".subprocess.run") as mock_run:
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--release"])
+        assert result != 0
+        mock_run.assert_not_called()
+        assert "human maintainer" in capsys.readouterr().err.lower()


### PR DESCRIPTION
# Pull Request

## Summary

- Add a --release flag to vrg-submit-pr and vrg-finalize-pr that chains submit -> finalize -> release in one command, handing off via subprocesses so each tool's rich renderer runs without nesting and vrg-submit-pr reports how far the cascade got.

## Issue Linkage

- Ref #1634

## Notes

- Subprocess (not exec) per the design decision on #1634: exec would have lost vrg-submit-pr's final summary and complicated its worktree CWD handling. The nested-renderer requirement is met by chaining only after run_pipeline tears down its live display. --release implies --finalize; failures short-circuit (no release on a failed finalize) and report the created/merged PR with a re-run hint. vrg-finalize-pr stays at 100% coverage; vrg-submit-pr's template-mode failure path is covered by a new test.