### PR TITLE
feat(release,submit-pr,finalize-pr): --install runs consumer-refresh as the post-release cascade step

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -130,6 +130,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="After a successful finalize, chain straight into vrg-release "
         "(the full submit-finalize-release cascade)",
     )
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="Extend the cascade one step further: implies --release and passes "
+        "--install through, so vrg-release runs the consumer-refresh install "
+        "step (issue #1643)",
+    )
     progress.add_progress_args(parser, ())
     return parser.parse_args(argv)
 
@@ -563,7 +570,7 @@ def build_stages(*, include_pr: bool) -> tuple[Stage, ...]:
     )
 
 
-def _chain_release(root: Path) -> int:
+def _chain_release(root: Path, *, install: bool = False) -> int:
     """Hand off to ``vrg-release`` after a successful finalize (issue #1634).
 
     Runs only when the finalize pipeline succeeded. By the time
@@ -574,22 +581,27 @@ def _chain_release(root: Path) -> int:
     so a caller like ``vrg-submit-pr`` regains control to report the
     cascade outcome.
 
+    With *install*, passes ``--install`` through so ``vrg-release`` also runs
+    the consumer-refresh install step (issue #1643).
+
     A failure here never un-merges the PR — it was already merged and
     cleaned up — so report it clearly and let the human re-run vrg-release
     alone.
     """
+    cmd: tuple[str, ...] = ("vrg-release", "--install") if install else ("vrg-release",)
     print()
-    print("--release: handing off to vrg-release")
+    print(f"--{'install' if install else 'release'}: handing off to {' '.join(cmd)}")
     result = subprocess.run(  # noqa: S603
-        ("vrg-release",),  # noqa: S607
+        cmd,  # noqa: S607
         cwd=root,
         check=False,
     )
     if result.returncode != 0:
+        rerun = "vrg-release --install" if install else "vrg-release"
         print(
             f"vrg-finalize-pr: release failed (exit {result.returncode}); "
             "the PR was already merged and cleaned up and is unaffected.\n"
-            "  Re-run the release alone with: vrg-release",
+            f"  Re-run the release alone with: {rerun}",
             file=sys.stderr,
         )
     return result.returncode
@@ -597,6 +609,11 @@ def _chain_release(root: Path) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    # --install extends the cascade one step past --release; normalize once so
+    # the release-chain logic below sees release on (issue #1643).
+    if args.install:
+        args.release = True
 
     if not git.is_main_worktree():
         main_root = git.main_worktree_root()
@@ -641,9 +658,10 @@ def main(argv: list[str] | None = None) -> int:
     if rc != 0 or not args.release:
         return rc
     if args.dry_run:
-        print("\n[dry-run] would chain into: vrg-release")
+        target = "vrg-release --install" if args.install else "vrg-release"
+        print(f"\n[dry-run] would chain into: {target}")
         return 0
-    return _chain_release(root)
+    return _chain_release(root, install=args.install)
 
 
 if __name__ == "__main__":

--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -7,6 +7,7 @@ import sys
 
 from vergil_tooling.lib import git, github, progress
 from vergil_tooling.lib.release.context import ReleaseError
+from vergil_tooling.lib.release.handoff import run_consumer_refresh
 from vergil_tooling.lib.release.orchestrator import ReleaseState, build_stages
 from vergil_tooling.lib.release.resume import find_resume_target
 
@@ -28,6 +29,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         default=False,
         help="Skip rolling-tag promotion after release.",
+    )
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        default=False,
+        help=(
+            "After a successful release, execute the [publish].consumer-refresh "
+            "commands (the install/refresh step of the cascade) instead of only "
+            "printing them."
+        ),
     )
     parser.add_argument(
         "--resume",
@@ -93,6 +104,21 @@ def main(argv: list[str] | None = None) -> int:
     if state.ctx is not None and state.ctx.consumer_refresh_message:
         print()
         print(state.ctx.consumer_refresh_message)
+
+    # --install: run the consumer-refresh commands rather than leaving them
+    # for the human to copy/paste (issue #1643). Only on a clean release —
+    # a failed pipeline must not trigger an install — and only after the
+    # message above has been printed, so the human sees what is about to run.
+    if args.install and rc == 0:
+        commands = state.ctx.consumer_refresh_commands if state.ctx is not None else None
+        if not commands:
+            print(
+                "vrg-release: --install was given but no [publish].consumer-refresh "
+                "is configured; nothing to run.",
+                file=sys.stderr,
+            )
+            return 1
+        return run_consumer_refresh(commands)
     return rc
 
 

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -26,10 +26,13 @@ re-run ``vrg-finalize-pr`` alone.
 ``--release`` extends that one step further (issue #1634): it implies
 ``--finalize`` and passes ``--release`` through, so a clean finalize
 cascades into ``vrg-release`` — the whole submit -> finalize -> release
-sequence from one command. Each hop runs as a subprocess (not ``exec``)
-so control returns here for the final summary, which states how far the
-cascade got: submitted, submitted and finalized, or submitted, finalized,
-and released.
+sequence from one command. ``--install`` extends it one link further still
+(issue #1643): it implies ``--release`` and passes ``--install`` through, so
+``vrg-release`` runs the consumer-refresh install commands rather than only
+printing them — submit -> finalize -> release -> install. Each hop runs as a
+subprocess (not ``exec``) so control returns here for the final summary,
+which states how far the cascade got: submitted, submitted and finalized,
+submitted/finalized/released, or submitted/finalized/released/installed.
 """
 
 from __future__ import annotations
@@ -73,6 +76,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="After creating the PR, run the full cascade: finalize (implies "
         "--finalize) and then vrg-release",
+    )
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="Run the full cascade through the install step: implies --release "
+        "(hence --finalize) and passes --install through so vrg-release runs the "
+        "consumer-refresh install commands (issue #1643)",
     )
     return parser.parse_args(argv)
 
@@ -132,17 +142,18 @@ def _create_pr(*, target_branch: str, title: str, pr_body: str) -> str:
     return pr_url
 
 
-def _chain_finalize(pr_url: str, *, release: bool = False) -> int:
+def _chain_finalize(pr_url: str, *, release: bool = False, install: bool = False) -> int:
     """Hand off to ``vrg-finalize-pr`` right after PR creation (issue #1491).
 
     Equivalent to running ``vrg-finalize-pr <pr-url>`` by hand: same
     merge-strategy default, same post-merge cleanup. With *release*, passes
     ``--release`` through so a clean finalize cascades into ``vrg-release``
-    (issue #1634). Runs as a subprocess from the main worktree root because
-    vrg-finalize-pr refuses to run from a secondary worktree (it removes
-    worktrees during cleanup) and template mode chdir'd into one. The child
-    inherits the TTY so its live progress display and prompts behave exactly
-    as a manual run.
+    (issue #1634); with *install*, also passes ``--install`` so the cascade
+    runs vrg-release's consumer-refresh install step (issue #1643). Runs as a
+    subprocess from the main worktree root because vrg-finalize-pr refuses to
+    run from a secondary worktree (it removes worktrees during cleanup) and
+    template mode chdir'd into one. The child inherits the TTY so its live
+    progress display and prompts behave exactly as a manual run.
 
     A failure here never un-creates the PR — report the PR clearly so
     the human can re-run the finalize (or the cascade) alone.
@@ -151,11 +162,15 @@ def _chain_finalize(pr_url: str, *, release: bool = False) -> int:
     cmd: tuple[str, ...] = ("vrg-finalize-pr", pr_url)
     if release:
         cmd = (*cmd, "--release")
+    if install:
+        cmd = (*cmd, "--install")
+    stage = "install" if install else "release" if release else "finalize"
     print()
-    print(f"--{'release' if release else 'finalize'}: handing off to {' '.join(cmd)}")
+    print(f"--{stage}: handing off to {' '.join(cmd)}")
     result = subprocess.run(cmd, cwd=main_root, check=False)  # noqa: S603
     if result.returncode != 0:
-        rerun = f"vrg-finalize-pr {pr_url}{' --release' if release else ''}"
+        flags = f"{' --release' if release else ''}{' --install' if install else ''}"
+        rerun = f"vrg-finalize-pr {pr_url}{flags}"
         print(
             f"vrg-submit-pr: cascade failed (exit {result.returncode}); "
             "the PR was created and is unaffected:\n"
@@ -167,23 +182,26 @@ def _chain_finalize(pr_url: str, *, release: bool = False) -> int:
     return 0
 
 
-def _print_cascade_summary(pr_url: str, *, released: bool) -> None:
+def _print_cascade_summary(pr_url: str, *, released: bool, installed: bool) -> None:
     """Final summary owned by vrg-submit-pr stating how far the cascade got.
 
     Reached only after a successful chain, so it always reports completed
-    work (issue #1634). The submitted-only outcome is reported separately by
-    the pr-watch one-liner.
+    work (issue #1634, extended for --install in issue #1643). The
+    submitted-only outcome is reported separately by the pr-watch one-liner.
     """
     print()
-    if released:
+    if installed:
+        print(f"Done: PR submitted, finalized, released, and installed.\n  {pr_url}")
+    elif released:
         print(f"Done: PR submitted, finalized, and released.\n  {pr_url}")
     else:
         print(f"Done: PR submitted and finalized.\n  {pr_url}")
 
 
-def _dry_run_chain_note(*, release: bool) -> str:
+def _dry_run_chain_note(*, release: bool, install: bool) -> str:
     """The ``[dry-run]`` line naming the chain command that would run."""
-    cmd = "vrg-finalize-pr --release <pr-url>" if release else "vrg-finalize-pr <pr-url>"
+    flags = f"{' --release' if release else ''}{' --install' if install else ''}"
+    cmd = f"vrg-finalize-pr{flags} <pr-url>"
     return f"\n[dry-run] would chain into: {cmd}"
 
 
@@ -222,7 +240,7 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
         print(f"=== Target Branch ===\n{target}\n")
         print(f"=== PR Body ===\n{pr_body}")
         if args.finalize:
-            print(_dry_run_chain_note(release=args.release))
+            print(_dry_run_chain_note(release=args.release, install=args.install))
         return 0
 
     print(f"Pushing branch '{branch}' to origin...")
@@ -232,10 +250,10 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
     pr_url = _create_pr(target_branch=target, title=args.title, pr_body=pr_body)
     print(f"PR created: {pr_url}")
     if args.finalize:
-        rc = _chain_finalize(pr_url, release=args.release)
+        rc = _chain_finalize(pr_url, release=args.release, install=args.install)
         if rc != 0:
             return rc
-        _print_cascade_summary(pr_url, released=args.release)
+        _print_cascade_summary(pr_url, released=args.release, installed=args.install)
         return 0
     print(f"Done. PR URL: {pr_url}")
     _print_pr_watch(pr_url)
@@ -355,7 +373,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
 
     if args.dry_run:
         if args.finalize:
-            print(_dry_run_chain_note(release=args.release))
+            print(_dry_run_chain_note(release=args.release, install=args.install))
         return 0
 
     try:
@@ -380,10 +398,10 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     submission.delete_submission(root)
     print(f"PR created: {pr_url}")
     if args.finalize:
-        rc = _chain_finalize(pr_url, release=args.release)
+        rc = _chain_finalize(pr_url, release=args.release, install=args.install)
         if rc != 0:
             return rc
-        _print_cascade_summary(pr_url, released=args.release)
+        _print_cascade_summary(pr_url, released=args.release, installed=args.install)
         return 0
     print(f"Done. PR URL: {pr_url}")
     _print_pr_watch(pr_url)
@@ -393,9 +411,12 @@ def _run_template_mode(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
-    # --release is the full cascade and implies --finalize; normalize once so
-    # every downstream branch (dry-run notes, chain, summary) sees finalize on
-    # (issue #1634).
+    # --install extends the cascade one link past --release, which itself
+    # implies --finalize; normalize once (install ⇒ release ⇒ finalize) so
+    # every downstream branch (dry-run notes, chain, summary) sees the right
+    # flags (issues #1634, #1643).
+    if args.install:
+        args.release = True
     if args.release:
         args.finalize = True
 

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -43,6 +43,11 @@ class ReleaseContext:
 
     consumer_refresh_message: str | None = None
 
+    # The version-expanded consumer-refresh command block, without the
+    # display wrapper, so ``vrg-release --install`` can execute exactly what
+    # the message shows (issue #1643). None when no template is configured.
+    consumer_refresh_commands: str | None = None
+
     # Names of fail-defer stages that errored. close-finalize leaves the
     # tracking issue open (and skips cleanup) when any are pending, so the
     # release stays resumable (#1612).

--- a/src/vergil_tooling/lib/release/handoff.py
+++ b/src/vergil_tooling/lib/release/handoff.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import config
@@ -15,7 +17,10 @@ def consumer_refresh(ctx: ReleaseContext) -> None:
 
     The message is also stored on ``ctx.consumer_refresh_message`` so
     ``vrg-release`` can re-print it after the progress renderer collapses
-    this stage's output (the commands are for the human to act on).
+    this stage's output (the commands are for the human to act on). The
+    version-expanded command block is stored separately on
+    ``ctx.consumer_refresh_commands`` so ``vrg-release --install`` can
+    execute exactly what the message shows (issue #1643).
     """
     cfg = config.read_config(ctx.repo_root)
     template = cfg.publish.consumer_refresh
@@ -25,10 +30,47 @@ def consumer_refresh(ctx: ReleaseContext) -> None:
             f"No consumer-refresh sequence is configured for {ctx.repo}. "
             f"Add [publish].consumer-refresh to vergil.toml."
         )
+        ctx.consumer_refresh_commands = None
     else:
         commands = template.replace("<VERSION>", ctx.version)
         message = f"Consumer refresh commands:\n\n{commands}"
+        ctx.consumer_refresh_commands = commands
 
     ctx.consumer_refresh_message = message
     print()
     print(message)
+
+
+def run_consumer_refresh(commands: str) -> int:
+    """Execute the version-expanded consumer-refresh *commands*, fail-fast.
+
+    Drives the ``--install`` step of the release cascade (issue #1643): the
+    same command block the human would otherwise copy/paste is run through a
+    single ``bash`` invocation under ``set -e`` so the first failing command
+    stops the block and surfaces a non-zero exit. The block runs *after* the
+    release has already completed, so a failed install never un-does the
+    release — it only reports that the local refresh did not finish.
+
+    Output is inherited (not captured) so ``uv tool install`` / ``vrg-vm
+    update`` progress streams live; by this point the release progress
+    renderer has already torn down, so there is no nesting (cf. issue #1470).
+    """
+    print()
+    print("--install: running consumer-refresh commands:")
+    print()
+    print(commands)
+    print()
+    # `set -e` (fail-fast) plus pipefail so a failure anywhere in the block
+    # stops it; `-u` is deliberately omitted so a command referencing an
+    # unset shell variable is not turned into a spurious failure.
+    script = "set -eo pipefail\n" + commands
+    result = subprocess.run(("bash", "-c", script), check=False)  # noqa: S603, S607
+    if result.returncode != 0:
+        print(
+            f"vrg-release: consumer-refresh install commands failed "
+            f"(exit {result.returncode}); the release itself completed and is "
+            "unaffected. Re-run the commands above by hand to finish the "
+            "local refresh.",
+            file=sys.stderr,
+        )
+    return result.returncode

--- a/tests/vergil_tooling/test_release_handoff.py
+++ b/tests/vergil_tooling/test_release_handoff.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.lib.release.context import ReleaseContext
-from vergil_tooling.lib.release.handoff import consumer_refresh
+from vergil_tooling.lib.release.handoff import consumer_refresh, run_consumer_refresh
 
 if TYPE_CHECKING:
     import pytest
@@ -57,3 +57,55 @@ def test_consumer_refresh_none_stores_notice_on_ctx() -> None:
         consumer_refresh(ctx)
     assert ctx.consumer_refresh_message is not None
     assert "no consumer-refresh" in ctx.consumer_refresh_message.lower()
+
+
+# -- consumer_refresh stores the raw command block for --install (issue #1643) --
+
+
+def test_consumer_refresh_stores_expanded_commands_on_ctx() -> None:
+    ctx = _ctx()
+    template = "uv tool install pkg@v<VERSION>\nvrg-vm update --all"
+    with patch(_MOD + ".config.read_config") as mock_config:
+        mock_config.return_value.publish.consumer_refresh = template
+        consumer_refresh(ctx)
+    # The version macro is expanded and the display wrapper is stripped, so
+    # --install runs exactly the command lines.
+    assert ctx.consumer_refresh_commands == "uv tool install pkg@v2.1.0\nvrg-vm update --all"
+
+
+def test_consumer_refresh_none_stores_no_commands() -> None:
+    ctx = _ctx()
+    with patch(_MOD + ".config.read_config") as mock_config:
+        mock_config.return_value.publish.consumer_refresh = None
+        consumer_refresh(ctx)
+    assert ctx.consumer_refresh_commands is None
+
+
+# -- run_consumer_refresh: execute the command block fail-fast (issue #1643) ----
+
+
+def test_run_consumer_refresh_executes_via_bash_failfast() -> None:
+    with patch(_MOD + ".subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        rc = run_consumer_refresh("uv tool install pkg\nvrg-vm update --all")
+    assert rc == 0
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "bash"
+    assert cmd[1] == "-c"
+    # fail-fast wrapper, then the verbatim command block.
+    assert cmd[2].startswith("set -eo pipefail\n")
+    assert "uv tool install pkg" in cmd[2]
+    assert "vrg-vm update --all" in cmd[2]
+
+
+def test_run_consumer_refresh_returns_failure_code(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch(_MOD + ".subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 3
+        rc = run_consumer_refresh("false")
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "install commands failed" in err
+    # The release itself is not implicated by a failed local refresh.
+    assert "release itself completed" in err

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -1673,3 +1673,70 @@ def test_no_release_flag_does_not_invoke_release(tmp_path: Path) -> None:
         result = main([])
     assert result == 0
     mock_run.assert_not_called()
+
+
+# -- --install: extend the cascade through vrg-release --install (issue #1643) --
+
+
+def test_parse_args_install_defaults_false() -> None:
+    assert parse_args([]).install is False
+
+
+def test_parse_args_install_flag() -> None:
+    assert parse_args(["--install"]).install is True
+
+
+def test_install_chains_into_vrg_release_install_on_success(tmp_path: Path) -> None:
+    """--install implies --release and hands off to `vrg-release --install`."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.returncode = 0
+        result = main(["--install"])
+    assert result == 0
+    mock_run.assert_called_once()
+    call = mock_run.call_args
+    assert call.args[0] == ("vrg-release", "--install")
+    assert call.kwargs["cwd"] == tmp_path
+
+
+def test_install_dry_run_notes_release_install_without_running(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        result = main(["--install", "--dry-run"])
+    assert result == 0
+    mock_run.assert_not_called()
+    assert "vrg-release --install" in capsys.readouterr().out
+
+
+def test_install_failure_points_at_release_install_rerun(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".subprocess.run") as mock_run,
+    ):
+        mock_run.return_value.returncode = 2
+        result = main(["--install"])
+    assert result == 2
+    assert "vrg-release --install" in capsys.readouterr().err

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -8,6 +8,8 @@ from vergil_tooling.bin.vrg_release import main, parse_args
 from vergil_tooling.lib.release.context import ReleaseContext
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import pytest
 
     from vergil_tooling.lib.release.orchestrator import ReleaseState
@@ -160,3 +162,92 @@ def test_main_passes_version_override() -> None:
     kwargs = m_pipeline.call_args.kwargs
     assert kwargs["command"] == "vrg-release"
     assert kwargs["label"] == "vrg-release"
+
+
+# -- --install: run the consumer-refresh commands after release (issue #1643) --
+
+
+def test_parse_args_install_defaults_false() -> None:
+    assert parse_args([]).install is False
+
+
+def test_parse_args_install_flag() -> None:
+    assert parse_args(["--install"]).install is True
+
+
+def _pipeline_with_commands(commands: str | None, rc: int) -> Callable[..., int]:
+    """A fake run_pipeline that hydrates ctx with consumer-refresh state."""
+
+    def fake_pipeline(state: ReleaseState, *args: object, **kwargs: object) -> int:
+        state.ctx = ReleaseContext(
+            repo="owner/repo",
+            version="2.1.0",
+            repo_root=Path("/tmp/repo"),  # noqa: S108
+            version_override=None,
+            consumer_refresh_message="Consumer refresh commands:\n\n<cmds>",
+            consumer_refresh_commands=commands,
+        )
+        return rc
+
+    return fake_pipeline
+
+
+def test_main_install_runs_consumer_refresh_on_success() -> None:
+    with (
+        patch(_MOD + ".git"),
+        patch(
+            _MOD + ".progress.run_pipeline",
+            side_effect=_pipeline_with_commands("uv tool install pkg\nvrg-vm update --all", 0),
+        ),
+        patch(_MOD + ".run_consumer_refresh", return_value=0) as m_run,
+    ):
+        assert main(["--install"]) == 0
+    m_run.assert_called_once_with("uv tool install pkg\nvrg-vm update --all")
+
+
+def test_main_install_returns_consumer_refresh_exit_code() -> None:
+    """A failed install propagates its exit code (the release already
+    succeeded; only the local refresh failed)."""
+    with (
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", side_effect=_pipeline_with_commands("cmd", 0)),
+        patch(_MOD + ".run_consumer_refresh", return_value=5) as m_run,
+    ):
+        assert main(["--install"]) == 5
+    m_run.assert_called_once()
+
+
+def test_main_install_skipped_when_release_fails() -> None:
+    """A non-zero pipeline must never trigger the install step."""
+    with (
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", side_effect=_pipeline_with_commands("cmd", 1)),
+        patch(_MOD + ".run_consumer_refresh") as m_run,
+    ):
+        assert main(["--install"]) == 1
+    m_run.assert_not_called()
+
+
+def test_main_install_without_configured_commands_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--install with no [publish].consumer-refresh is a clear error, not a
+    silent no-op."""
+    with (
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", side_effect=_pipeline_with_commands(None, 0)),
+        patch(_MOD + ".run_consumer_refresh") as m_run,
+    ):
+        assert main(["--install"]) == 1
+    m_run.assert_not_called()
+    assert "--install" in capsys.readouterr().err
+
+
+def test_main_without_install_never_runs_consumer_refresh() -> None:
+    with (
+        patch(_MOD + ".git"),
+        patch(_MOD + ".progress.run_pipeline", side_effect=_pipeline_with_commands("cmd", 0)),
+        patch(_MOD + ".run_consumer_refresh") as m_run,
+    ):
+        assert main([]) == 0
+    m_run.assert_not_called()

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -1131,3 +1131,120 @@ class TestReleaseFlag:
         assert result != 0
         mock_run.assert_not_called()
         assert "human maintainer" in capsys.readouterr().err.lower()
+
+
+# -- --install: cascade submit -> finalize -> release -> install (issue #1643) -
+
+
+class TestInstallFlag:
+    """--install implies --release (hence --finalize) and passes --install
+    through, so the chain runs vrg-release's consumer-refresh install step."""
+
+    @pytest.fixture(autouse=True)
+    def _human_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+
+    def test_parse_args_install_defaults_false(self) -> None:
+        args = parse_args(["--issue", "42", "--summary", "Fix", "--title", "fix: bug"])
+        assert args.install is False
+
+    def test_parse_args_install_flag(self) -> None:
+        args = parse_args(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--install"])
+        assert args.install is True
+
+    def test_cli_mode_chains_finalize_with_release_and_install(self, tmp_path: Path) -> None:
+        """--install implies --release and appends both flags to the chain."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--install"])
+        assert result == 0
+        mock_run.assert_called_once()
+        call = mock_run.call_args
+        assert call.args[0] == (
+            "vrg-finalize-pr",
+            "https://github.com/pr/1",
+            "--release",
+            "--install",
+        )
+        assert call.kwargs["cwd"] == tmp_path
+
+    def test_cli_mode_install_prints_four_way_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """On success the final summary reports the full submit→install cascade."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--install"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "submitted, finalized, released, and installed" in out
+
+    def test_install_failure_reports_created_pr_with_install_rerun(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A cascade failure must not obscure the created PR; the re-run hint
+        carries --release --install so the human can resume the whole cascade."""
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".git.run"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1"),
+            patch(_MOD + ".git.main_worktree_root", return_value=tmp_path),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 1
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--install"])
+        assert result != 0
+        err = capsys.readouterr().err
+        assert "https://github.com/pr/1" in err
+        assert "vrg-finalize-pr https://github.com/pr/1 --release --install" in err
+
+    def test_dry_run_notes_install_chain_without_running(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch(_MOD + ".git.repo_root", return_value=tmp_path),
+            patch(_MOD + ".git.current_branch", return_value="feature/x"),
+            patch(_MOD + ".subprocess.run") as mock_run,
+        ):
+            result = main(
+                [
+                    "--issue",
+                    "42",
+                    "--summary",
+                    "Fix",
+                    "--title",
+                    "fix: bug",
+                    "--install",
+                    "--dry-run",
+                ]
+            )
+        assert result == 0
+        mock_run.assert_not_called()
+        assert "vrg-finalize-pr --release --install" in capsys.readouterr().out
+
+    def test_agent_identity_still_blocked_with_install(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--install must not weaken the identity-mode gate."""
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
+        with patch(_MOD + ".subprocess.run") as mock_run:
+            result = main(["--issue", "42", "--summary", "Fix", "--title", "fix: bug", "--install"])
+        assert result != 0
+        mock_run.assert_not_called()
+        assert "human maintainer" in capsys.readouterr().err.lower()

--- a/vergil.toml
+++ b/vergil.toml
@@ -8,7 +8,10 @@ primary-language = "python"
 release = true
 docs = true
 consumer-refresh = """\
+# Reinstall the host tools at the just-released version
 uv tool install --python 3.14 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v<VERSION>'
+# Refresh all dev VMs
+vrg-vm update --all
 """
 
 [ci]


### PR DESCRIPTION
# Pull Request

## Summary

- Add an --install flag that extends the submit -> finalize -> release cascade so vrg-release executes the [publish].consumer-refresh commands (fail-fast) instead of only printing them, and expand this repo's consumer-refresh to reinstall the host tools and run vrg-vm update --all.

## Issue Linkage

- Ref #1643

## Notes

- Implements #1643. --install implies --release (hence --finalize) on vrg-submit-pr and vrg-finalize-pr and is passed through to 'vrg-release --install'; the new executor lives in lib/release/handoff.py:run_consumer_refresh and runs the version-expanded block via 'bash -c' under 'set -eo pipefail'. A failed install propagates its exit code but never implicates the already-completed release; --install with no consumer-refresh configured errors rather than silently no-op'ing. No dry-run was added to vrg-release itself: the cascade entry points (submit-pr/finalize-pr) short-circuit before release under --dry-run, and their dry-run notes now name --install. Coupled sibling sub-task tracked in vergil-claude-plugin#494 (convert that repo's consumer-refresh from slash commands to CLI). Two commits; vrg-validate green.