### PR TITLE
feat(vm): plumb [vm].port_forwards through to the PORT_FORWARDS template param

### DIFF
--- a/docs/site/docs/reference/vm-spec.md
+++ b/docs/site/docs/reference/vm-spec.md
@@ -30,6 +30,7 @@ memory = "64GiB"
 disk = "300GiB"
 stale_days = 7
 vagrant_plugins = ["vagrant-libvirt"]
+port_forwards = ["3000|10.50.0.2:3000"]   # local VM port | nested target
 nested = true
 ```
 
@@ -45,8 +46,8 @@ Five tiers, later wins:
    below the repo-declared floor are flagged loudly)
 
 Scalars are **last-wins**; list keys (`packages`, `apt_repos`,
-`vagrant_plugins`) **accumulate** across tiers. Declaring any `[vm]`
-key marks the spec customized, which gives the repo a dedicated VM.
+`vagrant_plugins`, `port_forwards`) **accumulate** across tiers. Declaring
+any `[vm]` key marks the spec customized, which gives the repo a dedicated VM.
 
 ## Keys
 
@@ -59,6 +60,7 @@ key marks the spec customized, which gives the repo a dedicated VM.
 | `packages` | list of strings | `[]` | Extra apt packages (accumulates) |
 | `apt_repos` | list of tables | `[]` | Extra apt repositories — `name`, `key_url`, `uri`, `suite`, `components` (accumulates) |
 | `vagrant_plugins` | list of strings | `[]` | Vagrant plugins to install (accumulates) |
+| `port_forwards` | list of strings | `[]` | `"<port>\|<host:port>"` relay records — bind `<port>` in the VM and proxy to `<host:port>` (accumulates; see below) |
 | `nested` | bool | `false` | Nested virtualization (last-wins scalar; see below) |
 
 The vergil-vm template owns *how* declarative installs happen — repos
@@ -84,12 +86,27 @@ Three-layer defense, outermost first:
 3. **In-guest check** — the template verifies `/dev/kvm` exists and
    fails the build rather than degrading silently to TCG emulation.
 
+## Port forwards (`port_forwards`)
+
+Each record is `"<port>|<host:port>"`. The vergil-vm template
+(vergil-project/vergil-vm#170) provisions a `systemd-socket-proxyd`
+relay per record: it binds `0.0.0.0:<port>` inside the VM and proxies
+to `<host:port>` — typically a nested libvirt guest. The `0.0.0.0` bind
+is auto-forwarded by Lima to the Mac's `localhost:<port>` with no extra
+config. The relay is boot-persistent; the build fails loudly if the
+port is already bound.
+
+`vrg-vm` joins the accumulated records with `;` and passes them as
+`--set='.param.PORT_FORWARDS = "<records>"'` — the template splits on
+`;` then `|`. Repos never supply a script; the template owns the relay.
+
 ## Fingerprint and `NEEDS-REBUILD`
 
 The composed spec is fingerprinted (SHA-256 over the declaration) and
 stamped into the VM at create time. `vrg-vm list` compares the stored
 fingerprint against the freshly composed one and shows `NEEDS-REBUILD`
 on any drift. Editing any declarative key — including toggling
-`nested` — flips the fingerprint. `nested` enters the fingerprint
-payload only when true, so profiles that never set it kept their
-fingerprints when the knob was introduced.
+`nested` — flips the fingerprint. `nested` and `port_forwards` enter
+the fingerprint payload only when set (true / non-empty), so profiles
+that never declare them kept their fingerprints when the knobs were
+introduced.

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -439,6 +439,7 @@ def _create_from_target(target: Target, template: Path) -> None:
             packages=list(target.spec.packages),
             apt_repos=list(target.spec.apt_repos),
             vagrant_plugins=list(target.spec.vagrant_plugins),
+            port_forwards=list(target.spec.port_forwards),
             fingerprint=target.fingerprint,
             nested=target.spec.nested,
         )

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -115,6 +115,7 @@ class RoleOverlay:
     stale_days: int | None
     apt_repos: list[dict[str, str]]
     vagrant_plugins: list[str]
+    port_forwards: list[str]
     nested: bool | None = None
 
 
@@ -127,6 +128,7 @@ class VmStanza:
     stale_days: int | None
     apt_repos: list[dict[str, str]]
     vagrant_plugins: list[str]
+    port_forwards: list[str]
     roles: dict[str, RoleOverlay]
     nested: bool | None = None
 
@@ -134,10 +136,22 @@ class VmStanza:
 # Recognized keys in a [vm] / [vm.<role>] table. apt_repos is a list of tables
 # (key + apt source line); vagrant_plugins is a list of plugin names. The
 # vergil-vm template owns *how* these install — repos never supply a script.
-# nested enables Lima nested virtualization for the profile (issue #1447);
-# default off, requires macOS 15+ on M3-or-later Apple silicon at create time.
+# port_forwards is a list of "<port>|<host:port>" records the template relays
+# via systemd-socket-proxyd (vergil-vm #170). nested enables Lima nested
+# virtualization for the profile (issue #1447); default off, requires macOS 15+
+# on M3-or-later Apple silicon at create time.
 _VM_KEYS = frozenset(
-    {"cpus", "memory", "disk", "stale_days", "packages", "apt_repos", "vagrant_plugins", "nested"}
+    {
+        "cpus",
+        "memory",
+        "disk",
+        "stale_days",
+        "packages",
+        "apt_repos",
+        "vagrant_plugins",
+        "port_forwards",
+        "nested",
+    }
 )
 
 
@@ -153,6 +167,7 @@ def _parse_role_overlay(name: str, raw: dict[str, Any], source: str = CONFIG_FIL
         stale_days=raw.get("stale_days"),
         apt_repos=list(raw.get("apt_repos", [])),
         vagrant_plugins=list(raw.get("vagrant_plugins", [])),
+        port_forwards=list(raw.get("port_forwards", [])),
         nested=raw.get("nested"),
     )
 
@@ -179,6 +194,7 @@ def parse_vm_stanza(raw: dict[str, Any], source: str = CONFIG_FILE) -> VmStanza 
         stale_days=fields.get("stale_days"),
         apt_repos=list(fields.get("apt_repos", [])),
         vagrant_plugins=list(fields.get("vagrant_plugins", [])),
+        port_forwards=list(fields.get("port_forwards", [])),
         roles=roles,
         nested=fields.get("nested"),
     )

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -209,6 +209,7 @@ def create_vm(
     packages: list[str] | None = None,
     apt_repos: list[dict[str, str]] | None = None,
     vagrant_plugins: list[str] | None = None,
+    port_forwards: list[str] | None = None,
     fingerprint: str | None = None,
     nested: bool = False,
 ) -> None:
@@ -249,6 +250,10 @@ def create_vm(
         args.append(f'--set=.param.APT_REPOS = "{encoded}"')
     if vagrant_plugins:
         args.append(f'--set=.param.VAGRANT_PLUGINS = "{" ".join(vagrant_plugins)}"')
+    if port_forwards:
+        # Each record "<port>|<host:port>"; records joined by ";" to match the
+        # template's IFS=';' / IFS='|' parser (vergil-vm #170).
+        args.append(f'--set=.param.PORT_FORWARDS = "{";".join(port_forwards)}"')
     if fingerprint:
         args.append(f'--set=.param.SPEC_FINGERPRINT = "{fingerprint}"')
     if nested:

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -30,6 +30,9 @@ class ComposedSpec:
     # plugins. The vergil-vm template owns *how* these install — no repo-supplied code.
     apt_repos: tuple[dict[str, str], ...]
     vagrant_plugins: tuple[str, ...]
+    # "<port>|<host:port>" relay records the vergil-vm template proxies into the
+    # guest (vergil-vm #170). Additive across the [vm]/[vm.<role>] cascade.
+    port_forwards: tuple[str, ...]
     dedicated: bool
     under: tuple[str, ...]
     # Per-profile nested virtualization (issue #1447): default off, last-wins
@@ -48,6 +51,7 @@ class _Acc:
     packages: list[str]
     apt_repos: list[dict[str, str]]
     vagrant_plugins: list[str]
+    port_forwards: list[str]
     customized: bool
     nested: bool
     # Repo-declared footprint (tiers 3+4 only) — the floor an override is measured
@@ -67,6 +71,9 @@ def _apply_overlay(acc: _Acc, overlay: VmStanza | RoleOverlay) -> None:
         acc.customized = True
     if overlay.vagrant_plugins:
         acc.vagrant_plugins.extend(overlay.vagrant_plugins)
+        acc.customized = True
+    if overlay.port_forwards:
+        acc.port_forwards.extend(overlay.port_forwards)
         acc.customized = True
     if overlay.cpus is not None:
         acc.cpus = acc.declared_cpus = overlay.cpus
@@ -104,6 +111,7 @@ def compose_vm_spec(
         packages=[],
         apt_repos=[],
         vagrant_plugins=[],
+        port_forwards=[],
         customized=False,
         nested=False,
         declared_cpus=None,
@@ -145,6 +153,7 @@ def compose_vm_spec(
         packages=tuple(sorted(set(acc.packages))),
         apt_repos=tuple(acc.apt_repos),
         vagrant_plugins=tuple(sorted(set(acc.vagrant_plugins))),
+        port_forwards=tuple(sorted(set(acc.port_forwards))),
         dedicated=acc.customized,
         under=tuple(under),
         nested=acc.nested,
@@ -203,6 +212,12 @@ def spec_fingerprint(spec: ComposedSpec) -> str:
         "apt_repos=" + ",".join(sorted(_repo_key(r) for r in spec.apt_repos)),
         "vagrant_plugins=" + ",".join(sorted(spec.vagrant_plugins)),
     ]
+    # port_forwards enters the payload only when non-empty, for the same reason
+    # as nested below: profiles that never declare forwards keep the fingerprint
+    # they had before the knob existed (no spurious NEEDS-REBUILD on upgrade),
+    # while adding/editing forwards flips the hash.
+    if spec.port_forwards:
+        fields.append("port_forwards=" + ",".join(sorted(spec.port_forwards)))
     # nested enters the payload only when true: profiles that never set it keep
     # the fingerprint they had before the knob existed (no spurious NEEDS-REBUILD
     # on upgrade), while toggling it flips the hash in both directions.

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -677,6 +677,7 @@ class TestParseVmStanza:
         assert stanza.packages == ["qemu-system-x86", "libvirt-clients"]
         assert stanza.apt_repos == []
         assert stanza.vagrant_plugins == []
+        assert stanza.port_forwards == []
         assert stanza.cpus is None
         assert stanza.roles == {}
 
@@ -692,9 +693,11 @@ class TestParseVmStanza:
             "vm": {
                 "apt_repos": [repo],
                 "vagrant_plugins": ["vagrant-libvirt"],
+                "port_forwards": ["3000|10.50.0.2:3000"],
                 "vergil-user": {
                     "apt_repos": [repo],
                     "vagrant_plugins": ["vagrant-libvirt"],
+                    "port_forwards": ["8080|10.50.0.2:8080"],
                     "packages": ["vagrant"],
                 },
             }
@@ -703,9 +706,11 @@ class TestParseVmStanza:
         assert stanza is not None
         assert stanza.apt_repos == [repo]
         assert stanza.vagrant_plugins == ["vagrant-libvirt"]
+        assert stanza.port_forwards == ["3000|10.50.0.2:3000"]
         overlay = stanza.roles["vergil-user"]
         assert overlay.apt_repos == [repo]
         assert overlay.vagrant_plugins == ["vagrant-libvirt"]
+        assert overlay.port_forwards == ["8080|10.50.0.2:8080"]
         assert overlay.packages == ["vagrant"]
 
     def test_role_overlay_parsed(self) -> None:
@@ -739,6 +744,19 @@ class TestParseVmStanza:
 
     def test_nested_not_flagged_unrecognized(self, capsys: pytest.CaptureFixture[str]) -> None:
         parse_vm_stanza({"vm": {"nested": True, "vergil-user": {"nested": True}}})
+        assert "unrecognized" not in capsys.readouterr().err
+
+    def test_port_forwards_not_flagged_unrecognized(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        parse_vm_stanza(
+            {
+                "vm": {
+                    "port_forwards": ["3000|10.50.0.2:3000"],
+                    "vergil-user": {"port_forwards": ["8080|10.50.0.2:8080"]},
+                }
+            }
+        )
         assert "unrecognized" not in capsys.readouterr().err
 
     def test_vm_section_not_flagged_unrecognized(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -1135,6 +1135,7 @@ class TestCreateVmProfileParams:
                 }
             ],
             vagrant_plugins=["vagrant-libvirt"],
+            port_forwards=["3000|10.50.0.2:3000", "8080|10.50.0.2:8080"],
             fingerprint="abc123",
         )
         args = mock_limactl.call_args[0]
@@ -1144,6 +1145,8 @@ class TestCreateVmProfileParams:
             'https://apt.releases.hashicorp.com|noble|main"' in args
         )
         assert '--set=.param.VAGRANT_PLUGINS = "vagrant-libvirt"' in args
+        # records joined by ";" to match the template's IFS=';' parser
+        assert '--set=.param.PORT_FORWARDS = "3000|10.50.0.2:3000;8080|10.50.0.2:8080"' in args
         assert '--set=.param.SPEC_FINGERPRINT = "abc123"' in args
         assert "--set=.cpus = 12" in args
         assert "create" in args
@@ -1161,6 +1164,7 @@ class TestCreateVmProfileParams:
         assert not any("param.EXTRA_PACKAGES" in a for a in args)
         assert not any("param.APT_REPOS" in a for a in args)
         assert not any("param.VAGRANT_PLUGINS" in a for a in args)
+        assert not any("param.PORT_FORWARDS" in a for a in args)
         assert not any("param.SPEC_FINGERPRINT" in a for a in args)
 
 

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -37,6 +37,7 @@ def _mq_stanza() -> VmStanza:
         stale_days=None,
         apt_repos=[_REPO],
         vagrant_plugins=[],
+        port_forwards=["3000|10.50.0.2:3000"],
         roles={
             "vergil-user": RoleOverlay(
                 packages=[],
@@ -46,6 +47,7 @@ def _mq_stanza() -> VmStanza:
                 stale_days=7,
                 apt_repos=[],
                 vagrant_plugins=["vagrant-libvirt"],
+                port_forwards=["8080|10.50.0.2:8080"],
             ),
         },
     )
@@ -73,6 +75,8 @@ class TestComposeVmSpec:
         assert spec.packages == ("libvirt-clients", "qemu-system-x86")
         assert spec.apt_repos == (_REPO,)  # from [vm] tier
         assert spec.vagrant_plugins == ("vagrant-libvirt",)  # from the role tier
+        # base [vm] tier + role tier accumulate, deduped and sorted
+        assert spec.port_forwards == ("3000|10.50.0.2:3000", "8080|10.50.0.2:8080")
         assert spec.under == ()
 
     def test_audit_gets_packages_only_at_base_footprint(self) -> None:
@@ -85,6 +89,7 @@ class TestComposeVmSpec:
         assert spec.packages == ("libvirt-clients", "qemu-system-x86")
         assert spec.apt_repos == (_REPO,)  # all-identity [vm] tier
         assert spec.vagrant_plugins == ()  # role-only, did not apply to audit
+        assert spec.port_forwards == ("3000|10.50.0.2:3000",)  # all-identity [vm] tier only
         assert spec.stale_days == 3
 
     def test_host_override_below_declared_flags_under(self) -> None:
@@ -140,6 +145,7 @@ class TestComposeVmSpec:
             stale_days=None,
             apt_repos=[],
             vagrant_plugins=[],
+            port_forwards=[],
             roles={},
             nested=True,
         )
@@ -156,6 +162,7 @@ class TestComposeVmSpec:
             stale_days=None,
             apt_repos=[],
             vagrant_plugins=[],
+            port_forwards=[],
             nested=True,
             roles={
                 "vergil-user": RoleOverlay(
@@ -166,6 +173,7 @@ class TestComposeVmSpec:
                     stale_days=None,
                     apt_repos=[],
                     vagrant_plugins=[],
+                    port_forwards=[],
                     nested=False,
                 ),
             },
@@ -182,6 +190,7 @@ class TestComposeVmSpec:
             stale_days=None,
             apt_repos=[],
             vagrant_plugins=[],
+            port_forwards=[],
             roles={
                 "vergil-user": RoleOverlay(
                     packages=[],
@@ -191,6 +200,7 @@ class TestComposeVmSpec:
                     stale_days=None,
                     apt_repos=[],
                     vagrant_plugins=[],
+                    port_forwards=[],
                     nested=True,
                 ),
             },
@@ -275,6 +285,7 @@ class TestFingerprint:
             "packages": ("a", "b"),
             "apt_repos": (_REPO,),
             "vagrant_plugins": ("vagrant-libvirt",),
+            "port_forwards": (),
             "dedicated": True,
             "under": (),
         }
@@ -309,6 +320,38 @@ class TestFingerprint:
         assert spec_fingerprint(self._spec(vagrant_plugins=("a",))) != spec_fingerprint(
             self._spec(vagrant_plugins=("a", "b"))
         )
+
+    def test_port_forwards_set_changes_fingerprint(self) -> None:
+        # Going from no forwards to a declared forward flips the hash.
+        assert spec_fingerprint(self._spec(port_forwards=())) != spec_fingerprint(
+            self._spec(port_forwards=("3000|10.50.0.2:3000",))
+        )
+
+    def test_port_forwards_edit_changes_fingerprint(self) -> None:
+        assert spec_fingerprint(self._spec(port_forwards=("3000|10.50.0.2:3000",))) != (
+            spec_fingerprint(self._spec(port_forwards=("8080|10.50.0.2:8080",)))
+        )
+
+    def test_port_forwards_empty_keeps_legacy_fingerprint(self) -> None:
+        """Profiles that never declare forwards must not flip on upgrade.
+
+        Pins the encoding: ``port_forwards`` enters the payload only when
+        non-empty, so every fingerprint stored before the knob existed
+        stays valid.
+        """
+        legacy_payload = "\n".join(
+            (
+                "cpus=12",
+                "memory=64GiB",
+                "disk=300GiB",
+                "stale_days=7",
+                "packages=a,b",
+                "apt_repos=" + "|".join(f"{k}={_REPO[k]}" for k in sorted(_REPO)),
+                "vagrant_plugins=vagrant-libvirt",
+            )
+        )
+        expected = hashlib.sha256(legacy_payload.encode("utf-8")).hexdigest()
+        assert spec_fingerprint(self._spec(port_forwards=())) == expected
 
     def test_nested_toggle_changes_fingerprint(self) -> None:
         assert spec_fingerprint(self._spec(nested=True)) != spec_fingerprint(

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1764,6 +1764,7 @@ cpus = 12
 memory = "64GiB"
 disk = "300GiB"
 vagrant_plugins = ["vagrant-libvirt"]
+port_forwards = ["3000|10.50.0.2:3000"]
 """
 
 
@@ -1805,6 +1806,7 @@ class TestResolveTarget:
         assert target.spec.dedicated is True
         assert target.spec.cpus == 12
         assert target.spec.vagrant_plugins == ("vagrant-libvirt",)
+        assert target.spec.port_forwards == ("3000|10.50.0.2:3000",)
         assert len(target.spec.apt_repos) == 1
         assert target.fingerprint != ""
 
@@ -1816,6 +1818,7 @@ class TestResolveTarget:
         assert target.spec.dedicated is True
         assert target.spec.apt_repos == ()
         assert target.spec.vagrant_plugins == ()
+        assert target.spec.port_forwards == ()
         assert target.fingerprint != ""
 
     def test_one_level_workspace_is_base(self, tmp_path: Path) -> None:
@@ -1869,6 +1872,7 @@ class TestCreateDedicated:
         assert kwargs["fingerprint"] != ""
         assert len(kwargs["apt_repos"]) == 1
         assert kwargs["vagrant_plugins"] == ["vagrant-libvirt"]
+        assert kwargs["port_forwards"] == ["3000|10.50.0.2:3000"]
 
     @patch("vergil_tooling.bin.vrg_vm.stop_vm")
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
@@ -1902,6 +1906,7 @@ class TestCreateDedicated:
         assert kwargs["packages"] == ["qemu-system-x86"]
         assert kwargs["apt_repos"] == []
         assert kwargs["vagrant_plugins"] == []
+        assert kwargs["port_forwards"] == []
 
     @patch("vergil_tooling.bin.vrg_vm.stop_vm")
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
@@ -2090,6 +2095,7 @@ def _target(*, dedicated: bool, under: tuple[str, ...] = (), fingerprint: str = 
         packages=(),
         apt_repos=(),
         vagrant_plugins=(),
+        port_forwards=(),
         dedicated=dedicated,
         under=under,
     )


### PR DESCRIPTION
# Pull Request

## Summary

- Plumb the [vm].port_forwards field through config parse, spec compose/fingerprint, and the create_vm Lima call so a repo's vergil.toml can declare port forwards the vergil-vm #170 template provisions.

## Issue Linkage

- Ref #1645

## Notes

- CLI half of vergil-vm #170. Mirrors the vagrant_plugins path across all four layers (config.py, vm_spec.py, lima.py, vrg_vm.py). Forwards accumulate additively across the [vm]/[vm.<role>] tiers (deduped, sorted) and join with ';' for the PORT_FORWARDS param. The fingerprint appends port_forwards only when non-empty, mirroring the nested guard, so existing profiles keep their fingerprint on upgrade while editing forwards flips it (NEEDS-REBUILD). Tests mirror the vagrant_plugins coverage; vm-spec reference doc updated. 3008 tests pass, vrg-validate green.