### PR TITLE
feat(submit-pr,finalize-pr): add --yes to pre-answer confirmation prompts

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -53,9 +53,10 @@ from vergil_tooling.lib import (
     progress,
     worktrees,
 )
+from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.container_cache import clean_branch_images
 from vergil_tooling.lib.progress import Stage
-from vergil_tooling.lib.repo_init import prompt_choice, prompt_yes_no
+from vergil_tooling.lib.repo_init import prompt_choice
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -130,6 +131,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="After a successful finalize, chain straight into vrg-release "
         "(the full submit-finalize-release cascade)",
     )
+    add_yes_argument(parser)
     progress.add_progress_args(parser, ())
     return parser.parse_args(argv)
 
@@ -191,7 +193,7 @@ def _delete_branch_and_worktree(branch: str, root: Path, *, dry_run: bool) -> bo
     return True
 
 
-def _infer_pr(root: Path, target_branch: str) -> str | None:
+def _infer_pr(root: Path, target_branch: str, *, assume_yes: bool = False) -> str | None:
     """Resolve which PR to finalize when none was given; always confirm.
 
     Returns the PR URL to finalize, or None when the user confirmed
@@ -199,9 +201,12 @@ def _infer_pr(root: Path, target_branch: str) -> str | None:
     a message via require_tty when stdin is not interactive — these
     prompts are the human touch point of the workflow, and the
     explicit-PR argument is the scriptable path.
-    """
-    worktrees.require_tty("vrg-finalize-pr without a PR argument")
 
+    With *assume_yes* (``--yes``) the single-PR finalize confirm and the
+    cleanup-only confirm are pre-answered "yes". The multiple-PR choice is
+    a disambiguation, not a yes/no, so it is still presented even under
+    ``--yes`` — there is no single obvious answer to skip to.
+    """
     pairs: list[tuple[worktrees.Worktree, dict[str, str]]] = []
     for wt in worktrees.list_worktrees(root):
         pr = github.pr_for_branch(wt.branch)
@@ -211,10 +216,18 @@ def _infer_pr(root: Path, target_branch: str) -> str | None:
             continue
         pairs.append((wt, pr))
 
+    # A prompt is unavoidable only when more than one PR forces a choice;
+    # every other interaction here is a single yes/no that --yes pre-answers.
+    # Demand a TTY only when an interactive prompt will actually be shown.
+    must_disambiguate = len(pairs) > 1
+    if must_disambiguate or not assume_yes:
+        worktrees.require_tty("vrg-finalize-pr without a PR argument")
+
     if not pairs:
-        confirmed = prompt_yes_no(
+        confirmed = confirm(
             f"No open PRs found in worktrees. Run cleanup only (switch to "
             f"{target_branch}, sync, prune branches/worktrees)?",
+            assume_yes=assume_yes,
             default=False,
         )
         if not confirmed:
@@ -229,7 +242,11 @@ def _infer_pr(root: Path, target_branch: str) -> str | None:
         chosen = prompt_choice("Multiple PRs ready to finalize", labels)
         wt, pr = pairs[labels.index(chosen)]
 
-    if not prompt_yes_no(f"Finalize PR #{pr['number']} ({pr['title']})?", default=False):
+    if not confirm(
+        f"Finalize PR #{pr['number']} ({pr['title']})?",
+        assume_yes=assume_yes,
+        default=False,
+    ):
         print("Aborted.")
         raise SystemExit(0)
     return pr["url"]
@@ -615,7 +632,7 @@ def main(argv: list[str] | None = None) -> int:
     # cleanup/validation/cd-check stages run (issue #1448).
     if args.pr is None and not args.cleanup_only:
         try:
-            args.pr = _infer_pr(root, args.target_branch)
+            args.pr = _infer_pr(root, args.target_branch, assume_yes=args.yes)
         except SystemExit as exc:
             if exc.code == 0:
                 return 0

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -42,6 +42,7 @@ import tempfile
 from pathlib import Path
 
 from vergil_tooling.lib import git, github, identity_mode, pr_template, worktrees
+from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.linkage import ALLOWED_LINKAGES
 from vergil_tooling.lib.pr_body import build_pr_body, resolve_issue_ref
 from vergil_tooling.lib.pr_workflow import submission
@@ -74,6 +75,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="After creating the PR, run the full cascade: finalize (implies "
         "--finalize) and then vrg-release",
     )
+    add_yes_argument(parser)
     return parser.parse_args(argv)
 
 
@@ -358,13 +360,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
             print(_dry_run_chain_note(release=args.release))
         return 0
 
-    try:
-        answer = input("\nSubmit this PR? [y/N] ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        print("\nAborted.")
-        return 1
-
-    if answer != "y":
+    if not confirm("\nSubmit this PR?", assume_yes=args.yes):
         print("Aborted.")
         return 1
 

--- a/src/vergil_tooling/lib/confirm.py
+++ b/src/vergil_tooling/lib/confirm.py
@@ -1,0 +1,67 @@
+"""Shared ``--yes`` confirmation helper (issue #1644).
+
+A single, consistent definition of the ``--yes`` flag and the yes/no
+gate it pre-answers, so every tool that asks "are you sure?" behaves
+the same way.
+
+``--yes`` is deliberately narrow:
+
+- It auto-answers a *single, unambiguous* yes/no confirmation.
+- It does **not** pick between multiple choices — disambiguation
+  prompts (e.g. "which of these PRs?") are still shown.
+- It does **not** override a safety gate. Tools keep their own
+  ``--force`` / ``--allow-*`` flags for pushing past code-level
+  guardrails; ``--yes`` only skips the courtesy "are you sure?".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+YES_FLAG_HELP = (
+    "Auto-answer the confirmation prompt with 'yes'. Only bypasses a "
+    "single, unambiguous yes/no confirmation; prompts that disambiguate "
+    "between multiple choices are still shown, and safety gates are not "
+    "overridden (use the relevant --force/--allow-* flag for those)."
+)
+
+
+def add_yes_argument(parser: argparse.ArgumentParser) -> None:
+    """Register the standard ``--yes`` / ``-y`` flag on *parser*."""
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help=YES_FLAG_HELP,
+    )
+
+
+def confirm(prompt: str, *, assume_yes: bool, default: bool = False) -> bool:
+    """Ask *prompt* as a yes/no question; return ``True`` to proceed.
+
+    With *assume_yes* (``--yes``), return ``True`` without reading stdin,
+    echoing the auto-answer so the transcript still records the decision.
+    Empty input returns *default*. EOF / interrupt is treated as a
+    decline (returns ``False``), leaving the caller to print its own
+    "Aborted." message.
+    """
+    hint = "[Y/n]" if default else "[y/N]"
+    if assume_yes:
+        print(f"{prompt} {hint} y  (--yes)")
+        return True
+    while True:
+        try:
+            raw = input(f"{prompt} {hint} ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return False
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+        print("  Enter y or n.")

--- a/tests/vergil_tooling/test_confirm.py
+++ b/tests/vergil_tooling/test_confirm.py
@@ -1,0 +1,88 @@
+"""Tests for vergil_tooling.lib.confirm (issue #1644)."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from vergil_tooling.lib.confirm import add_yes_argument, confirm
+
+_MOD = "vergil_tooling.lib.confirm"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    add_yes_argument(parser)
+    return parser
+
+
+def test_add_yes_argument_defaults_false() -> None:
+    assert _parser().parse_args([]).yes is False
+
+
+def test_add_yes_argument_long_flag() -> None:
+    assert _parser().parse_args(["--yes"]).yes is True
+
+
+def test_add_yes_argument_short_flag() -> None:
+    assert _parser().parse_args(["-y"]).yes is True
+
+
+def test_assume_yes_returns_true_without_reading_stdin(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--yes pre-answers without touching stdin, but still echoes the
+    decision so the transcript records it."""
+    with patch(_MOD + ".input", side_effect=AssertionError("stdin read")) as inp:
+        assert confirm("Proceed?", assume_yes=True) is True
+    inp.assert_not_called()
+    assert "(--yes)" in capsys.readouterr().out
+
+
+def test_assume_yes_echo_reflects_default_hint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    confirm("Proceed?", assume_yes=True, default=True)
+    assert "[Y/n]" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("answer", ["y", "yes", "Y", "YES"])
+def test_interactive_yes(answer: str) -> None:
+    with patch(_MOD + ".input", return_value=answer):
+        assert confirm("Proceed?", assume_yes=False) is True
+
+
+@pytest.mark.parametrize("answer", ["n", "no", "N", "NO"])
+def test_interactive_no(answer: str) -> None:
+    with patch(_MOD + ".input", return_value=answer):
+        assert confirm("Proceed?", assume_yes=False) is False
+
+
+def test_empty_input_uses_default_false() -> None:
+    with patch(_MOD + ".input", return_value=""):
+        assert confirm("Proceed?", assume_yes=False, default=False) is False
+
+
+def test_empty_input_uses_default_true() -> None:
+    with patch(_MOD + ".input", return_value=""):
+        assert confirm("Proceed?", assume_yes=False, default=True) is True
+
+
+def test_garbage_input_reprompts_until_valid(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch(_MOD + ".input", side_effect=["maybe", "y"]):
+        assert confirm("Proceed?", assume_yes=False) is True
+    assert "Enter y or n." in capsys.readouterr().out
+
+
+def test_eof_is_treated_as_decline() -> None:
+    with patch(_MOD + ".input", side_effect=EOFError):
+        assert confirm("Proceed?", assume_yes=False) is False
+
+
+def test_keyboard_interrupt_is_treated_as_decline() -> None:
+    with patch(_MOD + ".input", side_effect=KeyboardInterrupt):
+        assert confirm("Proceed?", assume_yes=False) is False

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -57,7 +57,7 @@ def _interactive_defaults() -> Iterator[None]:
     with (
         patch(_MOD + ".worktrees.require_tty"),
         patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
-        patch(_MOD + ".prompt_yes_no", return_value=True),
+        patch(_MOD + ".confirm", return_value=True),
     ):
         yield
 
@@ -859,7 +859,7 @@ def test_no_arg_single_candidate_confirms_and_finalizes(tmp_path: Path) -> None:
         _cleanup_path_mocks(tmp_path),
         patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7]),
         patch(_MOD + ".github.pr_for_branch", return_value=_PR7),
-        patch(_MOD + ".prompt_yes_no", return_value=True) as confirm,
+        patch(_MOD + ".confirm", return_value=True) as confirm,
         patch(_MOD + "._stage_provenance") as prov,
         patch(_MOD + "._stage_merge"),
     ):
@@ -869,11 +869,49 @@ def test_no_arg_single_candidate_confirms_and_finalizes(tmp_path: Path) -> None:
     assert prov.call_args[0][0].args.pr == "https://github.com/o/r/pull/7"
 
 
+def test_yes_single_candidate_skips_tty_guard_and_finalizes(tmp_path: Path) -> None:
+    """--yes pre-answers the single-PR confirm, so no interactive prompt is
+    shown and the TTY guard is not required (issue #1644)."""
+    with (
+        _cleanup_path_mocks(tmp_path),
+        patch(_MOD + ".worktrees.require_tty") as guard,
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7]),
+        patch(_MOD + ".github.pr_for_branch", return_value=_PR7),
+        patch(_MOD + "._stage_provenance") as prov,
+        patch(_MOD + "._stage_merge"),
+    ):
+        rc = main(["--yes", "--dry-run"])
+    assert rc == 0
+    guard.assert_not_called()
+    assert prov.call_args[0][0].args.pr == "https://github.com/o/r/pull/7"
+
+
+def test_yes_multiple_candidates_still_disambiguates(tmp_path: Path) -> None:
+    """--yes never auto-picks among PRs: the disambiguation menu is still
+    shown, and only the post-choice confirm is pre-answered (issue #1644)."""
+
+    def _pr_for(branch: str) -> dict[str, str]:
+        return _PR7 if branch == "feature/7-foo" else _PR8
+
+    with (
+        _cleanup_path_mocks(tmp_path),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7, _WT8]),
+        patch(_MOD + ".github.pr_for_branch", side_effect=_pr_for),
+        patch(_MOD + ".prompt_choice", return_value="PR #8 (feature/8-bar): Bar") as menu,
+        patch(_MOD + "._stage_provenance") as prov,
+        patch(_MOD + "._stage_merge"),
+    ):
+        rc = main(["--yes", "--dry-run"])
+    assert rc == 0
+    menu.assert_called_once()
+    assert prov.call_args[0][0].args.pr == "https://github.com/o/r/pull/8"
+
+
 def test_no_arg_single_candidate_decline_exits_zero_without_action() -> None:
     with (
         patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7]),
         patch(_MOD + ".github.pr_for_branch", return_value=_PR7),
-        patch(_MOD + ".prompt_yes_no", return_value=False),
+        patch(_MOD + ".confirm", return_value=False),
         patch(_MOD + "._stage_provenance") as fin,
         patch(_MOD + ".git.current_branch") as branch,
     ):
@@ -892,7 +930,7 @@ def test_no_arg_multiple_candidates_menu_then_confirm(tmp_path: Path) -> None:
         patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7, _WT8]),
         patch(_MOD + ".github.pr_for_branch", side_effect=_pr_for),
         patch(_MOD + ".prompt_choice", return_value="PR #8 (feature/8-bar): Bar") as menu,
-        patch(_MOD + ".prompt_yes_no", return_value=True),
+        patch(_MOD + ".confirm", return_value=True),
         patch(_MOD + "._stage_provenance") as prov,
         patch(_MOD + "._stage_merge"),
     ):
@@ -906,7 +944,7 @@ def test_no_arg_no_candidates_confirms_cleanup_only() -> None:
     with (
         patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7]),
         patch(_MOD + ".github.pr_for_branch", return_value=None),
-        patch(_MOD + ".prompt_yes_no", return_value=False) as confirm,
+        patch(_MOD + ".confirm", return_value=False) as confirm,
     ):
         rc = main([])
     assert rc == 0
@@ -927,7 +965,7 @@ def test_no_arg_excluded_worktree_prints_reason(
         _cleanup_path_mocks(tmp_path),
         patch(_MOD + ".worktrees.list_worktrees", return_value=[_WT7, _WT8]),
         patch(_MOD + ".github.pr_for_branch", side_effect=_pr_for),
-        patch(_MOD + ".prompt_yes_no", return_value=True),
+        patch(_MOD + ".confirm", return_value=True),
         patch(_MOD + "._stage_provenance"),
         patch(_MOD + "._stage_merge"),
     ):
@@ -945,7 +983,7 @@ def test_no_arg_non_tty_fails_fast_before_prompting() -> None:
             _MOD + ".worktrees.require_tty",
             side_effect=SystemExit("requires an interactive terminal"),
         ),
-        patch(_MOD + ".prompt_yes_no") as confirm,
+        patch(_MOD + ".confirm") as confirm,
         patch(_MOD + "._stage_provenance") as fin,
         pytest.raises(SystemExit, match="interactive terminal"),
     ):
@@ -960,7 +998,7 @@ def test_explicit_pr_skips_inference_and_prompts(tmp_path: Path) -> None:
     # assertions prove inference was skipped. Empty list → worktree arm no-op.
     with (
         patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
-        patch(_MOD + ".prompt_yes_no") as confirm,
+        patch(_MOD + ".confirm") as confirm,
         patch(_MOD + "._stage_provenance") as fin,
         patch(_MOD + ".github.pr_state", return_value="MERGED"),
         patch(_MOD + ".github.head_ref", return_value="feature/7-foo"),
@@ -1006,7 +1044,7 @@ def test_cleanup_only_skips_inference_and_prompts(tmp_path: Path) -> None:
     with (
         patch(_MOD + ".worktrees.require_tty") as guard,
         patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
-        patch(_MOD + ".prompt_yes_no") as confirm,
+        patch(_MOD + ".confirm") as confirm,
         patch(_MOD + "._stage_provenance") as fin,
         patch(_MOD + ".config.read_config", side_effect=FileNotFoundError),
         patch(_MOD + ".git.repo_root", return_value=tmp_path),
@@ -1034,7 +1072,7 @@ def test_explicit_target_cleanup_deletes_merged_pr_branch(tmp_path: Path) -> Non
         git_run_calls.append(args)
 
     with (
-        patch(_MOD + ".prompt_yes_no") as confirm,
+        patch(_MOD + ".confirm") as confirm,
         patch(_MOD + ".pr_provenance.check_pr", return_value=_CLEAN_PROVENANCE),
         patch(_MOD + ".github.pr_state", return_value="MERGED"),
         patch(_MOD + ".git.repo_root", return_value=tmp_path),

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -483,6 +483,32 @@ class TestTemplateMode:
         mock_pr.assert_called_once()
         assert not (vergil / "pr-template.yml").exists()
 
+    def test_template_yes_flag_submits_without_prompting(self, tmp_path: Path) -> None:
+        """--yes pre-answers the submit confirmation, so the PR is created
+        without reading stdin (issue #1644)."""
+        vergil = tmp_path / ".vergil"
+        vergil.mkdir()
+        (vergil / "pr-template.yml").write_text(
+            "issue: 42\ntitle: 'fix: bug'\nsummary: Fix the bug\nnotes: Verified locally\n"
+        )
+        with (
+            patch("vergil_tooling.bin.vrg_submit_pr.git.repo_root", return_value=tmp_path),
+            patch(
+                "vergil_tooling.bin.vrg_submit_pr.git.current_branch",
+                return_value="feature/x",
+            ),
+            patch("vergil_tooling.bin.vrg_submit_pr.git.run"),
+            patch(
+                "vergil_tooling.bin.vrg_submit_pr.github.create_pr",
+                return_value="https://github.com/pr/1",
+            ) as mock_pr,
+            patch("builtins.input", side_effect=AssertionError("stdin read")) as mock_input,
+        ):
+            result = main(["--yes"])
+        assert result == 0
+        mock_pr.assert_called_once()
+        mock_input.assert_not_called()
+
     def test_template_prints_pr_watch_oneliner(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a shared --yes/-y flag and confirm() helper that pre-answers a single unambiguous yes/no confirmation in vrg-submit-pr and vrg-finalize-pr, while still showing disambiguation menus and never overriding safety gates.

## Issue Linkage

- Ref #1644

## Notes

- New lib/confirm.py centralizes the flag and gate. vrg-finalize-pr's multiple-PR menu still prompts under --yes; its TTY guard is now required only when an interactive prompt will actually appear. Deliberately out of scope: the vrg-github-repo-init wizard (multi-way data collection, not a single yes/no) and vrg-vm-resolve's 3-way resume/fresh/cancel prompt (a disambiguation, not a confirmation). Coverage 100%, vrg-validate green in container.