### PR TITLE
fix(vm): self-heal poisoned uv cache in the in-VM tooling install

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -534,16 +534,40 @@ def get_tooling_version(instance: str) -> str | None:
     return None
 
 
+def _uv_tool_install(instance: str, install_spec: str, *, reinstall: bool) -> None:
+    """Run ``uv tool install`` inside the VM, self-healing a poisoned uv cache.
+
+    A corrupt cache entry — e.g. a zero-byte wheel ``METADATA`` left behind by
+    an unclean VM stop — makes ``uv tool install`` fail with "wheel is invalid".
+    On the reinstall path uv removes the existing tool *before* it fails, so a
+    poisoned cache leaves the VM with no tooling at all and bricks every future
+    ``vrg-vm session`` until the cache is cleared by hand. So on failure, clear
+    the VM's uv cache and retry the install once.
+    """
+    flag = "--reinstall " if reinstall else ""
+    install_cmd = f'export PATH="$HOME/.local/bin:$PATH" && uv tool install {flag}"{install_spec}"'
+    try:
+        shell_run(instance, "bash", "-c", install_cmd)
+        return
+    except subprocess.CalledProcessError:
+        print(
+            "  uv tool install failed — clearing the VM uv cache and retrying once...",
+            file=sys.stderr,
+        )
+        shell_run(
+            instance,
+            "bash",
+            "-c",
+            'export PATH="$HOME/.local/bin:$PATH" && uv cache clean',
+        )
+        shell_run(instance, "bash", "-c", install_cmd)
+
+
 def install_tooling(instance: str, tag: str) -> None:
     """Install vergil-tooling inside the VM and record the tag."""
     install_spec = _TOOLING_INSTALL.format(tag=tag)
     print(f"  Installing vergil-tooling ({tag})...")
-    shell_run(
-        instance,
-        "bash",
-        "-c",
-        f'export PATH="$HOME/.local/bin:$PATH" && uv tool install "{install_spec}"',
-    )
+    _uv_tool_install(instance, install_spec, reinstall=False)
     shell_run(instance, "bash", "-c", f"mkdir -p $(dirname {_TOOLING_TAG_FILE})")
     shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
@@ -567,12 +591,7 @@ def update_tooling(instance: str, tag: str | None = None, *, fallback_tag: str =
         raise SystemExit(1)
     install_spec = _TOOLING_INSTALL.format(tag=tag)
     print(f"  Updating vergil-tooling ({tag})...")
-    shell_run(
-        instance,
-        "bash",
-        "-c",
-        f'export PATH="$HOME/.local/bin:$PATH" && uv tool install --reinstall "{install_spec}"',
-    )
+    _uv_tool_install(instance, install_spec, reinstall=True)
     if not explicit:
         shell_run(instance, "bash", "-c", f"mkdir -p $(dirname {_TOOLING_TAG_FILE})")
         shell_pipe(instance, f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
@@ -752,11 +771,27 @@ def try_update_tooling(
     *,
     fallback_tag: str = "",
 ) -> bool:
-    """Update vergil-tooling, returning False on failure instead of aborting."""
+    """Update vergil-tooling, returning False on failure instead of aborting.
+
+    A soft failure is only safe when a working install remains: continuing into
+    a session with *no* tooling installed would leave the user with no ``vrg-*``
+    commands. So when the update fails, check what is actually installed — warn
+    and continue only if a version is still present, otherwise abort loudly.
+    """
     try:
         update_tooling(instance, tag, fallback_tag=fallback_tag)
         return True
     except (subprocess.CalledProcessError, SystemExit):
+        if get_tooling_version(instance) is None:
+            print(
+                "ERROR: vergil-tooling update failed and no working tooling "
+                "remains in the VM (the uv cache is likely corrupt).\n"
+                "Recover by rebuilding the VM, or clear the cache manually:\n"
+                "  limactl shell <instance> -- bash -c "
+                "'export PATH=\"$HOME/.local/bin:$PATH\" && uv cache clean'",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from None
         print(
             "WARNING: vergil-tooling update failed — continuing with installed version",
             file=sys.stderr,

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -1082,9 +1082,13 @@ class TestTryUpdateTooling:
         assert result is True
         mock_update.assert_called_once_with("vergil-agent", None, fallback_tag="v2.0")
 
+    @patch("vergil_tooling.lib.lima.get_tooling_version", return_value="v2.0.63")
     @patch("vergil_tooling.lib.lima.update_tooling")
     def test_returns_false_on_subprocess_error(
-        self, mock_update: MagicMock, capsys: pytest.CaptureFixture[str]
+        self,
+        mock_update: MagicMock,
+        _mock_version: MagicMock,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         mock_update.side_effect = subprocess.CalledProcessError(1, "uv")
         result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
@@ -1092,9 +1096,13 @@ class TestTryUpdateTooling:
         captured = capsys.readouterr()
         assert "WARNING" in captured.err
 
+    @patch("vergil_tooling.lib.lima.get_tooling_version", return_value="v2.0.63")
     @patch("vergil_tooling.lib.lima.update_tooling")
     def test_returns_false_on_system_exit(
-        self, mock_update: MagicMock, capsys: pytest.CaptureFixture[str]
+        self,
+        mock_update: MagicMock,
+        _mock_version: MagicMock,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         mock_update.side_effect = SystemExit(1)
         result = try_update_tooling("vergil-agent", fallback_tag="v2.0")
@@ -1102,10 +1110,71 @@ class TestTryUpdateTooling:
         captured = capsys.readouterr()
         assert "WARNING" in captured.err
 
+    @patch("vergil_tooling.lib.lima.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.lib.lima.update_tooling")
+    def test_raises_when_no_tooling_remains_after_failure(
+        self,
+        mock_update: MagicMock,
+        _mock_version: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mock_update.side_effect = subprocess.CalledProcessError(1, "uv")
+        with pytest.raises(SystemExit):
+            try_update_tooling("vergil-agent", fallback_tag="v2.0")
+        captured = capsys.readouterr()
+        assert "no working tooling" in captured.err.lower()
+
     @patch("vergil_tooling.lib.lima.update_tooling")
     def test_passes_explicit_tag(self, mock_update: MagicMock) -> None:
         try_update_tooling("vergil-agent", tag="v2.1", fallback_tag="v2.0")
         mock_update.assert_called_once_with("vergil-agent", "v2.1", fallback_tag="v2.0")
+
+
+class TestToolingInstallSelfHeal:
+    """A corrupt uv cache must not permanently brick the install: on failure
+    the VM's uv cache is cleared and the install is retried once."""
+
+    @staticmethod
+    def _cmds(mock_run: MagicMock) -> list[str]:
+        return [" ".join(str(a) for a in call[0]) for call in mock_run.call_args_list]
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_update_clears_cache_and_retries_on_failure(
+        self, mock_run: MagicMock, _mock_pipe: MagicMock
+    ) -> None:
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        mock_run.side_effect = [subprocess.CalledProcessError(1, "uv"), ok, ok]
+        update_tooling("vergil-agent", "v2.0")
+        cmds = self._cmds(mock_run)
+        assert any("uv cache clean" in c for c in cmds)
+        assert sum("uv tool install" in c for c in cmds) == 2
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_update_propagates_when_retry_also_fails(
+        self, mock_run: MagicMock, _mock_pipe: MagicMock
+    ) -> None:
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "uv"),
+            ok,
+            subprocess.CalledProcessError(1, "uv"),
+        ]
+        with pytest.raises(subprocess.CalledProcessError):
+            update_tooling("vergil-agent", "v2.0")
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_install_clears_cache_and_retries_on_failure(
+        self, mock_run: MagicMock, _mock_pipe: MagicMock
+    ) -> None:
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        mock_run.side_effect = [subprocess.CalledProcessError(1, "uv"), ok, ok, ok]
+        install_tooling("vergil-agent", "v2.0")
+        cmds = self._cmds(mock_run)
+        assert any("uv cache clean" in c for c in cmds)
+        assert sum("uv tool install" in c for c in cmds) == 2
 
 
 class TestCreateVmProfileParams:


### PR DESCRIPTION
# Pull Request

## Summary

- On uv-install failure the in-VM tooling install now clears the VM uv cache and retries once, so a corrupt cache entry (e.g. a zero-byte wheel METADATA from an unclean stop) can no longer permanently brick vrg-vm session.

## Issue Linkage

- Ref #1656

## Notes

- lib/lima.py: new _uv_tool_install helper wraps both install_tooling and update_tooling with cache-clean-and-retry; try_update_tooling now hard-fails (instead of soft-warning) when no tooling remains after a failed update. TDD: 4 new tests + 2 existing try_update tests updated for the new conditional behavior. vrg-validate green (lint, types, 3056 tests, audit).