### PR TITLE
fix(vm): distinguish unreachable VM from spec drift in preflight

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -210,16 +210,27 @@ def _preflight_target(target: Target) -> int:
     # VM un-startable and falsely demanded a rebuild. For start (VM stopped) the check is
     # deferred to the post-start `spec-check` stage, once the guest is up. Mirrors list's
     # "drift only while running" contract.
-    if (
-        status == "Running"
-        and vm_spec_status(target.instance, target.fingerprint) == "needs-rebuild"
-    ):
-        print(
-            f"ERROR: VM '{target.instance}' no longer meets {workspace}'s spec.\n"
-            f"Rebuild it: vrg-vm rebuild {workspace} --identity {target.identity_name}",
-            file=sys.stderr,
-        )
-        return 1
+    if status == "Running":
+        spec_status = vm_spec_status(target.instance, target.fingerprint)
+        # 'unreachable' is not drift: Lima reports the box Running but the shell
+        # transport (SSH) refused, so the spec was never read. Telling the user to
+        # rebuild would be wrong — the VM may be mid-boot or wedged. Surface the
+        # reachability problem with a restart remediation instead.
+        if spec_status == "unreachable":
+            print(
+                f"ERROR: VM '{target.instance}' is reported Running but is not reachable "
+                f"over SSH — it may be mid-boot or wedged.\nTry: vrg-vm restart {workspace} "
+                f"--identity {target.identity_name} (or inspect with `limactl list`).",
+                file=sys.stderr,
+            )
+            return 1
+        if spec_status == "needs-rebuild":
+            print(
+                f"ERROR: VM '{target.instance}' no longer meets {workspace}'s spec.\n"
+                f"Rebuild it: vrg-vm rebuild {workspace} --identity {target.identity_name}",
+                file=sys.stderr,
+            )
+            return 1
     _warn_under(target)
     return 0
 
@@ -304,6 +315,14 @@ class SpecDriftError(RuntimeError):
     """
 
 
+class SpecCheckUnreachableError(RuntimeError):
+    """Raised by the post-start spec-check stage when a freshly-started VM cannot
+    be reached over SSH to read its fingerprint. Surfaced as a non-fatal ⚠ like
+    SpecDriftError, but explicitly *not* drift: the spec was never read, so the
+    warning must never tell the user to rebuild.
+    """
+
+
 def _st_spec_check(state: _LifecycleState) -> None:
     # Post-start drift check. The fingerprint lives inside the guest and is only
     # readable now that it is up — the check _preflight_target cannot perform
@@ -313,9 +332,18 @@ def _st_spec_check(state: _LifecycleState) -> None:
     target = state.target
     if not target.spec.dedicated:
         return
-    if vm_spec_status(target.instance, target.fingerprint) != "needs-rebuild":
+    spec_status = vm_spec_status(target.instance, target.fingerprint)
+    if spec_status == "ok":
         return
     workspace = f"{target.org}/{target.repo}"
+    # 'unreachable' is not drift: the VM was just started but the shell transport
+    # could not read the fingerprint. Warn about reachability — never rebuild.
+    if spec_status == "unreachable":
+        msg = (
+            f"VM '{target.instance}' was started but could not be reached over SSH to "
+            f"verify its spec — it may still be settling. Re-run if the session fails to connect."
+        )
+        raise SpecCheckUnreachableError(msg)
     msg = (
         f"VM '{target.instance}' no longer meets {workspace}'s spec — "
         f"rebuild it: vrg-vm rebuild {workspace} --identity {target.identity_name}"

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -824,9 +824,7 @@ def read_fingerprint(instance: str) -> str | None:
     VM is not a drifted VM.
     """
     try:
-        result = shell_run(
-            instance, "bash", "-c", f"cat {_FINGERPRINT_PATH} 2>/dev/null || true"
-        )
+        result = shell_run(instance, "bash", "-c", f"cat {_FINGERPRINT_PATH} 2>/dev/null || true")
     except subprocess.CalledProcessError as exc:
         raise VmUnreachableError(instance) from exc
     value = result.stdout.strip()

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -802,12 +802,33 @@ def try_update_tooling(
 _FINGERPRINT_PATH = "/etc/vergil/vm-spec.fingerprint"
 
 
+class VmUnreachableError(RuntimeError):
+    """Raised when the Lima shell transport to a VM fails (e.g. SSH connection
+    refused) — the VM could not be contacted at all.
+
+    Distinct from an absent spec marker: an unreachable VM says nothing about
+    whether its spec drifted, so callers must not collapse this into the
+    "needs-rebuild" signal. Doing so misreports a reachability failure as spec
+    drift and tells the user to rebuild a VM that may just be mid-boot or wedged.
+    """
+
+
 def read_fingerprint(instance: str) -> str | None:
-    """Return the spec fingerprint stamped into the VM, or None if absent/unreadable."""
+    """Return the spec fingerprint stamped into the VM, or None if the marker is absent.
+
+    The in-guest read is masked (``cat ... 2>/dev/null || true``) so a missing
+    marker yields empty stdout from a zero exit rather than a non-zero exit. Any
+    remaining failure of the shell round-trip is therefore unambiguously a
+    transport failure (the VM is unreachable), which is raised as
+    ``VmUnreachableError`` instead of being collapsed into None — an unreachable
+    VM is not a drifted VM.
+    """
     try:
-        result = shell_run(instance, "cat", _FINGERPRINT_PATH)
-    except subprocess.CalledProcessError:
-        return None
+        result = shell_run(
+            instance, "bash", "-c", f"cat {_FINGERPRINT_PATH} 2>/dev/null || true"
+        )
+    except subprocess.CalledProcessError as exc:
+        raise VmUnreachableError(instance) from exc
     value = result.stdout.strip()
     return value or None
 
@@ -816,9 +837,14 @@ def vm_spec_status(instance: str, expected_fingerprint: str) -> str:
     """Compare the VM's stamped fingerprint to the freshly composed one.
 
     Returns 'ok' on match, 'needs-rebuild' on drift (including a missing marker on a
-    box that should carry one).
+    box that should carry one), and 'unreachable' when the VM cannot be contacted
+    over the Lima shell transport. 'unreachable' is deliberately *not* drift: the
+    spec was never read, so the caller must remediate reachability, not rebuild.
     """
-    actual = read_fingerprint(instance)
+    try:
+        actual = read_fingerprint(instance)
+    except VmUnreachableError:
+        return "unreachable"
     return "ok" if actual == expected_fingerprint else "needs-rebuild"
 
 

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -10,6 +10,7 @@ import pytest
 
 from vergil_tooling.lib.identity import Identity
 from vergil_tooling.lib.lima import (
+    VmUnreachableError,
     _inject_host_git_identity,
     _limactl,
     _nested_virt_unsupported_reason,
@@ -1245,13 +1246,27 @@ class TestFingerprintHelpers:
 
     @patch("vergil_tooling.lib.lima.shell_run")
     def test_read_fingerprint_missing_marker_is_none(self, mock_shell: MagicMock) -> None:
-        mock_shell.side_effect = subprocess.CalledProcessError(1, "cat")
+        # The in-guest read is masked (`cat ... 2>/dev/null || true`), so an absent
+        # marker is empty stdout from a zero exit — never a non-zero exit. That is
+        # what distinguishes "marker gone" (drift) from "VM unreachable" (transport).
+        mock_shell.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         assert read_fingerprint("vergil-user") is None
 
     @patch("vergil_tooling.lib.lima.shell_run")
     def test_read_fingerprint_empty_marker_is_none(self, mock_shell: MagicMock) -> None:
         mock_shell.return_value = subprocess.CompletedProcess([], 0, stdout="\n", stderr="")
         assert read_fingerprint("vergil-user") is None
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    def test_read_fingerprint_transport_failure_raises_unreachable(
+        self, mock_shell: MagicMock
+    ) -> None:
+        # The shell round-trip itself failing (SSH refused) is a transport failure,
+        # NOT an absent marker — it must surface as VmUnreachableError rather than
+        # collapse into None (which would be misread as drift).
+        mock_shell.side_effect = subprocess.CalledProcessError(255, "limactl")
+        with pytest.raises(VmUnreachableError):
+            read_fingerprint("vergil-user")
 
     @patch("vergil_tooling.lib.lima.read_fingerprint")
     def test_vm_spec_status_ok_on_match(self, mock_read: MagicMock) -> None:
@@ -1262,6 +1277,19 @@ class TestFingerprintHelpers:
     def test_vm_spec_status_needs_rebuild_on_drift(self, mock_read: MagicMock) -> None:
         mock_read.return_value = "old"
         assert vm_spec_status("inst", "new") == "needs-rebuild"
+
+    @patch("vergil_tooling.lib.lima.read_fingerprint")
+    def test_vm_spec_status_needs_rebuild_on_missing_marker(self, mock_read: MagicMock) -> None:
+        # A reachable VM whose marker is genuinely absent is still drift.
+        mock_read.return_value = None
+        assert vm_spec_status("inst", "abc123") == "needs-rebuild"
+
+    @patch("vergil_tooling.lib.lima.read_fingerprint")
+    def test_vm_spec_status_unreachable_on_transport_failure(self, mock_read: MagicMock) -> None:
+        # An unreachable VM is not a drifted VM: the third state keeps callers from
+        # telling the user to rebuild when the real problem is reachability.
+        mock_read.side_effect = VmUnreachableError("inst")
+        assert vm_spec_status("inst", "abc123") == "unreachable"
 
 
 class TestOccupancy:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2120,6 +2120,18 @@ class TestPreflight:
     def test_dedicated_drift_aborts(self, _status: MagicMock, _spec: MagicMock) -> None:
         assert _preflight_target(_target(dedicated=True)) == 1
 
+    @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="unreachable")
+    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
+    def test_dedicated_unreachable_aborts_without_rebuild(
+        self, _status: MagicMock, _spec: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A Running-but-unreachable VM says nothing about its spec. The gate must
+        # abort with a reachability message and must NOT tell the user to rebuild.
+        assert _preflight_target(_target(dedicated=True)) == 1
+        err = capsys.readouterr().err
+        assert "reach" in err.lower()
+        assert "rebuild" not in err.lower()
+
     @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="needs-rebuild")
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
     def test_dedicated_stopped_defers_spec_check(
@@ -2547,6 +2559,21 @@ class TestSpecCheckStage:
             _st_spec_check(_LifecycleState(target=_target(dedicated=True)))
         # The warning must carry the actionable rebuild command.
         assert "rebuild" in str(exc.value).lower()
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="unreachable")
+    def test_warns_unreachable_not_drift(self, _spec: MagicMock) -> None:
+        from vergil_tooling.bin.vrg_vm import (
+            SpecCheckUnreachableError,
+            _LifecycleState,
+            _st_spec_check,
+        )
+
+        # Post-start, a VM we cannot reach must warn about reachability — never
+        # raise drift or suggest a rebuild (the spec was never read).
+        with pytest.raises(SpecCheckUnreachableError) as exc:
+            _st_spec_check(_LifecycleState(target=_target(dedicated=True)))
+        assert "reach" in str(exc.value).lower()
+        assert "rebuild" not in str(exc.value).lower()
 
     @patch("vergil_tooling.bin.vrg_vm.vm_spec_status", return_value="ok")
     def test_silent_when_in_spec(self, _spec: MagicMock) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm preflight now reports a Running-but-unreachable VM (SSH refused) as a reachability problem with a restart remediation, instead of swallowing the transport failure into a false 'no longer meets spec' / rebuild verdict.

## Issue Linkage

- Ref #1665

## Notes

- Root cause: read_fingerprint caught all CalledProcessError and returned None, which vm_spec_status read as drift. Fix masks the in-guest read (cat ... 2>/dev/null || true) so an absent marker is empty stdout, leaving any shell round-trip failure as an unambiguous transport failure that raises VmUnreachableError; vm_spec_status gains a third 'unreachable' state handled by _preflight_target and _st_spec_check. The same latent conflation on the list path (vm_probe) is documented in the issue as out of scope for this PR. Tests added in test_lima.py and test_vrg_vm.py; full vrg-validate green.