### PR TITLE
fix(submit-pr): report in-flight worktrees instead of 'not ready' after submission

### DIFF
--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -49,7 +49,7 @@ from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.linkage import ALLOWED_LINKAGES
 from vergil_tooling.lib.pr_body import build_pr_body, resolve_issue_ref
 from vergil_tooling.lib.pr_workflow import submission
-from vergil_tooling.lib.pr_workflow.errors import WorkflowError
+from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -280,25 +280,34 @@ def _choose_submit_worktree(root: Path) -> Path:
     worktrees.require_tty("vrg-submit-pr from the repo root")
 
     ready: list[tuple[worktrees.Worktree, dict[str, str]]] = []
-    skipped: list[str] = []
+    in_flight: list[str] = []
+    not_ready: list[str] = []
     for wt in worktrees.list_worktrees(root):
         try:
             fields = submission.read_pr_fields(wt.path)
+        except AlreadySubmittedError as exc:
+            ref = f"PR #{exc.pr_number}" if exc.pr_number is not None else "open PR"
+            in_flight.append(f"{wt.path.name}: {ref} ({exc.pr_url})")
+            continue
         except FileNotFoundError:
-            skipped.append(
-                f"{wt.path.name}: no .vergil/pr-workflow.json or pr-template.yml — not ready"
-            )
+            not_ready.append(f"{wt.path.name}: no .vergil/pr-workflow.json or pr-template.yml")
             continue
         except (pr_template.TemplateError, WorkflowError) as exc:
-            skipped.append(f"{wt.path.name}: {exc}")
+            not_ready.append(f"{wt.path.name}: {exc}")
             continue
         ready.append((wt, fields))
 
     if not ready:
         lines = ["vrg-submit-pr: no submittable worktrees found."]
-        if skipped:
-            lines.extend(f"  {reason}" for reason in skipped)
-        else:
+        if in_flight:
+            lines.append("")
+            lines.append("  In flight (open PR — nothing to do):")
+            lines.extend(f"    {entry}" for entry in in_flight)
+        if not_ready:
+            lines.append("")
+            lines.append("  Not ready (no submission metadata yet):")
+            lines.extend(f"    {entry}" for entry in not_ready)
+        if not in_flight and not not_ready:
             lines.append("  (no .worktrees/ entries exist)")
         raise SystemExit("\n".join(lines))
 
@@ -329,6 +338,12 @@ def _run_template_mode(args: argparse.Namespace) -> int:
 
     try:
         fields = submission.read_pr_fields(root)
+    except AlreadySubmittedError as exc:
+        print(
+            f"vrg-submit-pr: this worktree's PR is already submitted — {exc}.\n"
+            "  Nothing to do; the PR is in flight. Use vrg-finalize-pr to merge it.",
+        )
+        return 0
     except FileNotFoundError:
         print(
             "vrg-submit-pr: No .vergil/pr-workflow.json or .vergil/pr-template.yml found,\n"
@@ -391,7 +406,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
 
     print("Creating PR...")
     pr_url = _create_pr(target_branch=target, title=title, pr_body=pr_body)
-    submission.delete_submission(root)
+    submission.record_submission(root, pr_url=pr_url)
     print(f"PR created: {pr_url}")
     if args.finalize:
         rc = _chain_finalize(pr_url, release=args.release, install=args.install)

--- a/src/vergil_tooling/lib/pr_workflow/engine.py
+++ b/src/vergil_tooling/lib/pr_workflow/engine.py
@@ -172,6 +172,30 @@ def apply_report_fixes(
     return state
 
 
+def apply_submitted(
+    state: WorkflowState, *, pr_url: str, pr_number: int | None, now: str
+) -> WorkflowState:
+    """Mark the workflow submitted after ``vrg-submit-pr`` opens the PR.
+
+    The state file is retained (not deleted) so the worktree scanner can report
+    the worktree as in-flight rather than re-submitting it. This is a terminal
+    annotation written by the human's submit step, not an agent turn, so it does
+    not require ownership and leaves ``status``/``owner`` untouched."""
+    state.submitted = {"pr_url": pr_url, "pr_number": pr_number, "at": now}
+    state.updated_at = now
+    state.history.append(
+        {
+            "round": state.round,
+            "at": now,
+            "actor": "human",
+            "action": "submitted",
+            "pr_url": pr_url,
+            "pr_number": pr_number,
+        }
+    )
+    return state
+
+
 def apply_error(state: WorkflowState, *, by: str, reason: str, now: str) -> WorkflowState:
     """Record a terminal error (a graceful give-up). The counterpart's wait
     detects ``state.error`` and stops with a complementary exception (spec §9)."""

--- a/src/vergil_tooling/lib/pr_workflow/errors.py
+++ b/src/vergil_tooling/lib/pr_workflow/errors.py
@@ -5,3 +5,21 @@ from __future__ import annotations
 
 class WorkflowError(Exception):
     """Raised when workflow state is malformed or a verb is invalid for the state."""
+
+
+class AlreadySubmittedError(WorkflowError):
+    """Raised when a worktree's PR has already been submitted.
+
+    The state file is retained (marked submitted) after a successful
+    ``vrg-submit-pr`` so the worktree scanner can report it as in-flight
+    rather than re-submitting it. Callers catch this to distinguish an
+    in-flight worktree from one that is genuinely not ready. Subclasses
+    ``WorkflowError`` so code that only knows the base type still treats it
+    as a benign domain error, but it should be caught explicitly first.
+    """
+
+    def __init__(self, *, pr_url: str, pr_number: int | None = None) -> None:
+        self.pr_url = pr_url
+        self.pr_number = pr_number
+        ref = f"PR #{pr_number}" if pr_number is not None else "a PR"
+        super().__init__(f"already submitted as {ref} ({pr_url})")

--- a/src/vergil_tooling/lib/pr_workflow/state.py
+++ b/src/vergil_tooling/lib/pr_workflow/state.py
@@ -59,6 +59,7 @@ class WorkflowState:
     participants: dict[str, Any]
     git: dict[str, Any]
     pr_metadata: dict[str, str] | None = None
+    submitted: dict[str, Any] | None = None
     escalation: dict[str, Any] | None = None
     error: dict[str, Any] | None = None
     checks: list[dict[str, Any]] = field(default_factory=list)
@@ -83,6 +84,7 @@ class WorkflowState:
             "participants": self.participants,
             "pr_metadata": self.pr_metadata,
             "git": self.git,
+            "submitted": self.submitted,
             "checks": self.checks,
             "escalation": self.escalation,
             "error": self.error,
@@ -115,6 +117,7 @@ class WorkflowState:
             participants=data["participants"],
             git=data["git"],
             pr_metadata=data.get("pr_metadata"),
+            submitted=data.get("submitted"),
             escalation=data.get("escalation"),
             error=data.get("error"),
             checks=data.get("checks", []),

--- a/src/vergil_tooling/lib/pr_workflow/submission.py
+++ b/src/vergil_tooling/lib/pr_workflow/submission.py
@@ -3,15 +3,26 @@
 The oracle's state file (``.vergil/pr-workflow.json``) subsumes the legacy
 ``.vergil/pr-template.yml``. ``read_pr_fields`` returns the submission fields from
 the state file when it exists, falling back to the legacy template so both flows
-work during the transition; ``delete_submission`` removes whichever was used.
+work during the transition.
+
+After a successful submission the state file is *retained* and marked submitted
+(``record_submission``), not deleted, so the worktree scanner can report the
+worktree as in-flight rather than as "not ready". The file lives inside the
+worktree (``.vergil/`` is git-ignored), so it is cleaned up for free when
+``vrg-finalize-pr`` removes the worktree once the branch lands. The legacy
+template carries no state to mark, so for that path ``record_submission`` deletes
+it (no in-flight tracking).
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import pr_template
-from vergil_tooling.lib.pr_workflow.errors import WorkflowError
+from vergil_tooling.lib.pr_workflow import engine
+from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
+from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
 from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
 if TYPE_CHECKING:
@@ -25,6 +36,16 @@ def _state_path(worktree_root: Path) -> Path:
     return worktree_root / _DIR / _STATE_FILE
 
 
+def _now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _pr_number_from_url(pr_url: str) -> int | None:
+    """Parse the trailing PR number from a GitHub PR URL (``.../pull/312``)."""
+    tail = pr_url.rstrip("/").rsplit("/", 1)[-1]
+    return int(tail) if tail.isdigit() else None
+
+
 def read_pr_fields(worktree_root: Path) -> dict[str, str]:
     """Return the PR submission fields (``issue``/``title``/``summary``/``notes``/
     ``linkage``/``base``) from the workflow state file if present, else the
@@ -35,13 +56,19 @@ def read_pr_fields(worktree_root: Path) -> dict[str, str]:
     intended rather than re-inferring it from the branch name. The legacy
     template path omits ``base`` (it never recorded one).
 
-    Raises ``FileNotFoundError`` if neither exists, and ``WorkflowError`` if the
-    state file carries no PR metadata yet (the USER agent must ``report-ready``
-    first).
+    Raises ``FileNotFoundError`` if neither exists, ``AlreadySubmittedError`` if
+    the state file is marked submitted (its PR is in flight), and
+    ``WorkflowError`` if the state file carries no PR metadata yet (the USER
+    agent must ``report-ready`` first).
     """
     path = _state_path(worktree_root)
     if path.is_file():
         state = WorkflowState.from_json(path.read_text())
+        if state.submitted is not None:
+            raise AlreadySubmittedError(
+                pr_url=state.submitted.get("pr_url", ""),
+                pr_number=state.submitted.get("pr_number"),
+            )
         meta = state.pr_metadata
         if meta is None:
             raise WorkflowError(
@@ -59,10 +86,22 @@ def read_pr_fields(worktree_root: Path) -> dict[str, str]:
     return pr_template.read_template(worktree_root)
 
 
-def delete_submission(worktree_root: Path) -> None:
-    """Delete the workflow state file if present, else the legacy template."""
+def record_submission(worktree_root: Path, *, pr_url: str) -> None:
+    """Record that the worktree's PR was submitted.
+
+    For the workflow state file: mark it submitted (retain it) so the scanner
+    can report the worktree as in-flight. For the legacy template: delete it
+    (no in-flight tracking is possible without the state file).
+    """
     path = _state_path(worktree_root)
     if path.is_file():
-        path.unlink()
+        state = WorkflowState.from_json(path.read_text())
+        engine.apply_submitted(
+            state,
+            pr_url=pr_url,
+            pr_number=_pr_number_from_url(pr_url),
+            now=_now(),
+        )
+        LocalFileTransport(worktree_root, base=state.base).write(state)
         return
     pr_template.delete_template(worktree_root)

--- a/tests/vergil_tooling/pr_workflow/test_engine_reports.py
+++ b/tests/vergil_tooling/pr_workflow/test_engine_reports.py
@@ -80,6 +80,24 @@ def _run_review(
             )
 
 
+def test_apply_submitted_records_the_pr_marker() -> None:
+    state = _paired_owned_by_user()
+    _ready(state)
+    engine.apply_submitted(
+        state,
+        pr_url="https://github.com/o/r/pull/312",
+        pr_number=312,
+        now="2026-06-08T01:00:00Z",
+    )
+    assert state.submitted == {
+        "pr_url": "https://github.com/o/r/pull/312",
+        "pr_number": 312,
+        "at": "2026-06-08T01:00:00Z",
+    }
+    assert state.updated_at == "2026-06-08T01:00:00Z"
+    assert state.history[-1]["action"] == "submitted"
+
+
 def test_report_ready_paired_hands_to_audit() -> None:
     state = _paired_owned_by_user()
     _ready(state)

--- a/tests/vergil_tooling/pr_workflow/test_state.py
+++ b/tests/vergil_tooling/pr_workflow/test_state.py
@@ -54,7 +54,19 @@ def test_to_dict_has_stable_top_level_keys() -> None:
         "escalation",
         "error",
         "history",
+        "submitted",
     }
+
+
+def test_roundtrip_preserves_submitted_marker() -> None:
+    state = _minimal()
+    state.submitted = {
+        "pr_url": "https://github.com/o/r/pull/312",
+        "pr_number": 312,
+        "at": "2026-06-08T15:01:00Z",
+    }
+    restored = WorkflowState.from_json(state.to_json())
+    assert restored.submitted == state.submitted
 
 
 def test_from_json_rejects_non_json() -> None:

--- a/tests/vergil_tooling/pr_workflow/test_submission.py
+++ b/tests/vergil_tooling/pr_workflow/test_submission.py
@@ -8,7 +8,7 @@ import pytest
 
 from vergil_tooling.lib import pr_template
 from vergil_tooling.lib.pr_workflow import engine, submission
-from vergil_tooling.lib.pr_workflow.errors import WorkflowError
+from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
 from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
 
 if TYPE_CHECKING:
@@ -78,13 +78,32 @@ def test_read_pr_fields_raises_when_neither_exists(tmp_path: Path) -> None:
         submission.read_pr_fields(tmp_path)
 
 
-def test_delete_submission_removes_the_state_file(tmp_path: Path) -> None:
+def test_record_submission_retains_and_marks_the_state_file(tmp_path: Path) -> None:
     _write_state(tmp_path, with_metadata=True)
-    submission.delete_submission(tmp_path)
-    assert not (tmp_path / ".vergil" / "pr-workflow.json").exists()
+    submission.record_submission(tmp_path, pr_url="https://github.com/o/r/pull/312")
+    # The file is kept (not deleted) so the scanner can report it as in-flight.
+    state_path = tmp_path / ".vergil" / "pr-workflow.json"
+    assert state_path.is_file()
+    from vergil_tooling.lib.pr_workflow.state import WorkflowState
+
+    state = WorkflowState.from_json(state_path.read_text())
+    assert state.submitted is not None
+    assert state.submitted["pr_url"] == "https://github.com/o/r/pull/312"
+    assert state.submitted["pr_number"] == 312
 
 
-def test_delete_submission_removes_the_template_when_no_state(tmp_path: Path) -> None:
+def test_record_submission_makes_read_pr_fields_raise_already_submitted(tmp_path: Path) -> None:
+    _write_state(tmp_path, with_metadata=True)
+    submission.record_submission(tmp_path, pr_url="https://github.com/o/r/pull/312")
+    with pytest.raises(AlreadySubmittedError) as exc:
+        submission.read_pr_fields(tmp_path)
+    assert exc.value.pr_number == 312
+    assert exc.value.pr_url == "https://github.com/o/r/pull/312"
+
+
+def test_record_submission_deletes_the_legacy_template(tmp_path: Path) -> None:
+    # The legacy template carries no state to mark, so it is deleted (no
+    # in-flight tracking for the legacy path).
     pr_template.write_template(
         tmp_path,
         issue="42",
@@ -92,5 +111,5 @@ def test_delete_submission_removes_the_template_when_no_state(tmp_path: Path) ->
         summary="did y",
         notes="m",
     )
-    submission.delete_submission(tmp_path)
+    submission.record_submission(tmp_path, pr_url="https://github.com/o/r/pull/9")
     assert not (tmp_path / ".vergil" / "pr-template.yml").exists()

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -16,6 +16,7 @@ from vergil_tooling.bin.vrg_submit_pr import (
     parse_args,
 )
 from vergil_tooling.lib import pr_template, worktrees
+from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -352,6 +353,33 @@ class TestTemplateMode:
     def _human_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
         monkeypatch.delenv("VRG_APP_ID", raising=False)
+
+    def test_already_submitted_worktree_does_not_resubmit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Running submit-pr inside a worktree whose PR is already submitted must
+        not push a duplicate PR; it reports the existing PR and exits cleanly."""
+        with (
+            patch("vergil_tooling.bin.vrg_submit_pr.git.repo_root", return_value=tmp_path),
+            patch(
+                "vergil_tooling.bin.vrg_submit_pr.git.current_branch",
+                return_value="feature/x",
+            ),
+            patch(
+                _MOD + ".submission.read_pr_fields",
+                side_effect=AlreadySubmittedError(
+                    pr_url="https://github.com/o/r/pull/312", pr_number=312
+                ),
+            ),
+            patch(_MOD + ".github.create_pr") as create_pr,
+        ):
+            result = main([])
+        assert result == 0
+        create_pr.assert_not_called()
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "already submitted" in combined
+        assert "312" in combined
 
     def test_template_dry_run(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         vergil = tmp_path / ".vergil"
@@ -759,6 +787,35 @@ class TestRootLaunch:
             pytest.raises(SystemExit, match="missing required field"),
         ):
             main(["--dry-run"])
+
+    def test_root_separates_in_flight_from_not_ready(self) -> None:
+        submitted = self._wt("issue-141-spike", "feature/141-spike")
+        not_ready = self._wt("issue-211-bootstrap", "feature/211-bootstrap")
+        with (
+            patch(_MOD + ".git.is_main_worktree", return_value=True),
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.require_tty"),
+            patch(
+                _MOD + ".worktrees.list_worktrees",
+                return_value=[submitted, not_ready],
+            ),
+            patch(
+                _MOD + ".submission.read_pr_fields",
+                side_effect=[
+                    AlreadySubmittedError(pr_url="https://github.com/o/r/pull/312", pr_number=312),
+                    FileNotFoundError("x"),
+                ],
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            main(["--dry-run"])
+        msg = str(exc.value)
+        assert "In flight" in msg
+        assert "issue-141-spike" in msg
+        assert "PR #312" in msg
+        assert "https://github.com/o/r/pull/312" in msg
+        assert "Not ready" in msg
+        assert "issue-211-bootstrap" in msg
 
     def test_root_no_worktrees_at_all_errors(self) -> None:
         with (


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-submit-pr now marks a worktree's state file submitted and retains it instead of deleting it, so the root scanner can list branches with open PRs under an 'In flight' group rather than mislabeling them 'not ready'.

## Issue Linkage

- Ref #1674

## Notes

- Mark-instead-of-delete (issue #1674 design): read_pr_fields raises the new AlreadySubmittedError on a submitted state file, which both feeds the grouped scanner output and guards a direct re-run inside an already-submitted worktree against pushing a duplicate PR. The retained file is in the git-ignored .vergil/ dir, so it is cleaned up for free when vrg-finalize-pr removes the worktree. The legacy pr-template.yml path still deletes on submit (no in-flight tracking). Caveat: PRs submitted before this fix had their files deleted by the old code and will still read as 'not ready' until those branches land — an accepted transitional gap in exchange for a network-free, single-source-of-truth design.