### PR TITLE
chore(config): pin Claude marketplace ref to v2.1 in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },


### PR DESCRIPTION
# Pull Request

## Summary

- Add the v2.1 source.ref to the vergil-marketplace entry in .claude/settings.json so the Claude Code plugin tracks the repo's version line, resolving the local.claude_settings.marketplace_ref non-compliance flagged by vrg-github-repo-config audit.

## Issue Linkage

- Ref #1676

## Notes

- Per-repo ad-hoc compliance fix following #1663 (which derives the marketplace ref from the vergil.toml version). The canonical data/claude_settings.json template intentionally omits the repo-specific ref, so each existing repo must add its own pin as encountered. Verified with audit_local_config(): 0 local issues. The remote half of 'vrg-github-repo-config audit' cannot be run under the agent token (actions/permissions returns 403) and was confirmed compliant by the human when the issue was reported.