### PR TITLE
feat(pr): batch the submit/finalize/release pipeline over multiple PRs

### DIFF
--- a/docs/site/docs/reference/dev/finalize-pr.md
+++ b/docs/site/docs/reference/dev/finalize-pr.md
@@ -158,9 +158,34 @@ Inspects the most recent CD workflow run on the target branch and fails
 if it did not succeed. Docs publishing is async and used to fail
 silently (issue #303).
 
+## Batch mode (comma-list / `--all`)
+
+A comma-separated PR argument (`vrg-finalize-pr 123,124,125`) or `--all`
+(every open PR in `.worktrees/`) finalizes several PRs as a single
+serialized batch (issue #1673). Each item runs
+`vrg-finalize-pr <pr> --skip-post-checks` (merge + cleanup, deferring
+the post-merge checks); after every item merges, one end-of-batch
+`vrg-finalize-pr --cleanup-only` runs validation and the CD check, then
+— with `--release`/`--install` — a single `vrg-release`.
+
+Unlike `vrg-submit-pr`'s batch, these PRs are already open, so each one
+that lands behind another will `update-branch` and re-run its gate
+(the normal serialized-merge cost). For zero-waste CI, submit the batch
+with `vrg-submit-pr --all --finalize` instead, which rebases each branch
+before opening its PR.
+
+The batch asks **one** confirmation up front (skipped with `--yes`) and
+is **fail-fast**: the first failure stops it and prints a
+`merged` / `failed` / `not started` summary. The single-PR modes are
+unchanged.
+
+The `--skip-post-checks` flag (used internally by the batch) finalizes a
+PR but skips the validation and CD-check stages and never chains a
+release — the batch runs those once at the end.
+
 ## Exit Codes
 
 | Code | Meaning |
 | ---- | ------- |
 | 0 | Finalization complete, or declined at a confirmation prompt |
-| 1 | Provenance violation, unmergeable PR (draft, conflicts, failed checks, stuck behind), not run from main worktree, non-TTY stdin or stdout in inference mode, dirty working tree, failed validation, or failed CD run |
+| 1 | Provenance violation, unmergeable PR (draft, conflicts, failed checks, stuck behind), not run from main worktree, non-TTY stdin or stdout in inference mode, dirty working tree, failed validation, failed CD run, or a batch item failed |

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -127,6 +127,37 @@ failure modes split cleanly:
 Like the rest of the tool, `--finalize` is human-only — the agent
 identity gate runs before either mode.
 
+## Batch mode (`--all` / `--select`)
+
+Selecting two or more ready worktrees submits them as a single
+serialized batch (issue #1673). Use `--all` for every ready worktree,
+or `--select <tokens>` for a comma-separated subset matched by issue
+number or worktree directory name (e.g. `--select 1673,1681`); an
+unmatched or ambiguous token is a hard error that names it. A single
+selection runs the unchanged single-PR path.
+
+The batch is optimized so each expensive CI gate runs **exactly once**.
+For each worktree in turn it:
+
+1. **rebases the branch onto the latest `develop`** — the step that
+   guarantees the gate runs against the final state, so a later merge
+   is never `BEHIND` and never re-runs CI;
+2. submits the PR;
+3. with `--finalize`/`--release`/`--install`, finalizes it
+   (`vrg-finalize-pr <url> --skip-post-checks` — merge and cleanup,
+   deferring validation).
+
+After every item merges, post-merge validation and the CD check run
+**once**, then — with `--release`/`--install` — a single `vrg-release`
+ships all the changes in one version bump.
+
+The batch asks **one** confirmation up front (skipped with `--yes`),
+then runs unattended. It is **fail-fast**: the first failure (rebase
+conflict, red gate, merge conflict, provenance violation) stops the
+batch and prints a `merged` / `failed` / `not started` summary.
+Already-merged PRs stay merged; re-running picks up only the remaining
+ready worktrees.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/docs/specs/2026-06-17-batch-pr-pipeline-design.md
+++ b/docs/specs/2026-06-17-batch-pr-pipeline-design.md
@@ -1,0 +1,244 @@
+# Batch PR pipeline: submit → finalize → release in one pass
+
+- **Issue:** [#1673](https://github.com/vergil-project/vergil-tooling/issues/1673)
+- **Status:** Design (approved in brainstorming; pending implementation plan)
+- **Date:** 2026-06-17
+
+## Problem
+
+We increasingly submit many small PRs in rapid succession. The single-PR
+pipeline — `vrg-submit-pr` → `vrg-finalize-pr` → `vrg-release` (optionally
+`--install`) — is smooth, but there is no way to push a *batch* through it.
+
+When several PRs are open at once and finalized in parallel, they race: the
+first to merge advances `develop`, which forces every other PR `BEHIND`. Each
+must update its branch and re-run its CI gate; the next merge invalidates the
+rest again. With N PRs this produces a cascade of redundant gate runs where
+only one run per PR is ever load-bearing. On GitHub-hosted runners this is
+merely wasteful; once CI moves to self-hosted Forgejo, runner capacity is
+finite and the waste is no longer free.
+
+Merging into a single shared branch is inherently serial — `develop` cannot be
+updated in parallel — so the work is single-threaded regardless. Attempting to
+parallelize only spends CI on runs that are immediately invalidated.
+
+## Goal
+
+Make the whole `submit → finalize → release → install` pipeline work on a
+**batch** of PRs exactly as it works for one today, optimized so that each
+expensive CI gate runs **exactly once**. If the work is effectively
+single-threaded, embrace single-threading rather than parallelize into waste.
+
+## Non-goals / out of scope
+
+- **Merge queues.** Rejected after research (see below). They optimize
+  throughput by *spending more* CI, and the migration target (Forgejo) has no
+  merge queue.
+- **Flipping the default to `--no-finalize`.** The human floated making finalize
+  the default for single-PR runs. That changes long-standing single-PR muscle
+  memory and deserves its own decision; this spec leaves the current default
+  (no finalize unless `--finalize`/`--release`/`--install`) alone.
+- **Cross-PR dependency detection / stacked-PR ordering.** Items are processed
+  in selection order; a dependency is satisfied by ordering the dependency
+  first (the rebase-on-`develop` step picks up its merged changes). Unresolvable
+  overlap surfaces as a rebase or merge conflict, which stops the batch.
+
+## Why not a merge queue
+
+Research (2026-06-17), data separated from judgment:
+
+**Data.**
+
+- Forgejo has **no merge queue** — it is an open, unimplemented feature request
+  ([forgejo#5102](https://codeberg.org/forgejo/forgejo/issues/5102), no
+  milestone as of 2026-06-02). Forgejo today offers only auto-merge.
+- Gitea (Forgejo's upstream) is the same: auto-merge only, no merge
+  queue/train.
+- GitHub's merge queue builds speculative merge commits (tests A against base,
+  B against base+A, …) and **runs CI twice** — once on the PR branch, again on
+  the `merge_group` branch — which by GitHub's own docs *increases* total CI
+  minutes.
+
+**Judgment.**
+
+- A merge queue is a *throughput* optimization that spends more CI to merge
+  faster. Our goal is the inverse: minimize expensive gate runs, accepting
+  single-threading. It optimizes the wrong axis for us.
+- Building on GitHub's merge queue would lock us to GitHub precisely as we
+  migrate to Forgejo, against this repo's forge-agnostic design.
+- A single-threaded batch orchestrator inside `vrg` tooling rides the same
+  `gh`/forge abstraction we already use, so it works identically on GitHub and
+  Forgejo and runs N PRs in exactly N gate runs.
+
+## Architecture
+
+Two entry points share one orchestrator.
+
+- **Optimal path — `vrg-submit-pr` batch.** Selecting ≥2 ready worktrees runs
+  the fully-lazy loop: rebase each branch on the latest `develop` → open its PR
+  → gate once → merge, one at a time. Zero wasted CI by construction. This is
+  the primary path.
+- **Convenience path — `vrg-finalize-pr` batch.** Open PRs ad hoc, then hand
+  `vrg-finalize-pr` a comma-separated list (or `--all` open PRs in
+  `.worktrees/`) to serialize the merges. Because those PRs are already open,
+  this path *does* incur the `BEHIND` → update → re-run CI cost — inherent to
+  having opened them up front. It is the "drain these safely" tool, not the
+  zero-waste one. The existing `pr_merge.wait_and_merge` already handles the
+  `BEHIND` updates.
+
+Both delegate to a new shared module **`lib/pr_workflow/batch.py`**: an ordered,
+fail-fast serial loop taking a per-item step callback (submit-batch does
+rebase + submit + merge; finalize-batch does merge-only), running
+`vrg-release`/`--install` **once at the end**, and printing a state report.
+
+**Single-PR invocations of both commands are unchanged.** One selected item is
+the special case that flows through today's code. The `≥2` branch is the only
+new path.
+
+**Identity gate is unchanged.** Batch is human-only, exactly like `vrg-submit-pr`
+today; agents remain blocked.
+
+## Selection & invocation
+
+### `vrg-submit-pr`
+
+- **Interactive (TTY, no selection flags):** the existing single-select menu
+  over *ready* worktrees becomes a **checkbox multi-select**. The
+  ready / in-flight / not-ready classification (`_choose_submit_worktree`) is
+  reused unchanged; only the picker widget changes.
+- **Non-interactive:** `--all` selects every ready worktree; `--select <tokens>`
+  takes a comma-separated list where each token matches a worktree by **issue
+  number** or **directory name** (e.g. `--select 1673,1681` or
+  `--select issue-1673-foo`). Unmatched or ambiguous tokens are a hard error
+  that names them — no silent skips.
+- **Branching:** 0 ready → today's error; 1 selected → today's single-PR path,
+  untouched; ≥2 → batch orchestrator.
+
+### `vrg-finalize-pr`
+
+- The `pr` positional accepts a **comma-separated list** of PR numbers/URLs;
+  `--all` finalizes every open PR found in `.worktrees/`.
+- Interactive inference with >1 PR becomes a checkbox multi-select (today it is
+  single-choice disambiguation).
+
+### Cascade flags
+
+`--finalize` / `--release` / `--install` / `--yes` / `--dry-run` keep their
+current meaning and apply to the whole batch. `--release`/`--install` trigger
+the single end-of-batch release (normalization stays install ⇒ release ⇒
+finalize).
+
+## The per-item pipeline (core mechanism)
+
+For a **submit-batch**, each item runs this sequence in order:
+
+1. **Rebase on latest `develop`** *(new — the efficiency win).*
+   `git fetch origin develop`, then rebase the item's branch onto
+   `origin/develop` inside its worktree. This guarantees the gate runs against
+   the final state, so each expensive CI run is load-bearing and is never
+   re-triggered by a later merge. A rebase conflict stops the batch.
+2. **Submit.** Push `--force-with-lease`, create the PR, `record_submission`
+   (reuses `_push_branch` / `_create_pr`).
+3. **Finalize.** Provenance check → `wait_and_merge` (squash) → cleanup (switch
+   to `develop`, fast-forward sync, delete merged branch + worktree, prune).
+   Reuses the existing finalize stages.
+
+**finalize-batch** is the same loop minus steps 1–2: merge-only per item
+(relying on `wait_and_merge`'s `BEHIND` → update handling).
+
+### Deferred validation
+
+A single `vrg-finalize-pr` today runs container validation + the CD check after
+its merge. Running that after every item would mean N container builds per
+batch. Instead the batch runs **merge + cleanup per item, but container
+validation and the CD check once, after the final merge.** Rationale: each PR
+already passed its own gate before merging, so per-item local re-validation is
+largely redundant; the single end-of-batch run is the integration check across
+all merged changes.
+
+### Release once
+
+After all items merge and the end-of-batch validation passes, if
+`--release`/`--install` was given, `vrg-release [--install]` runs **exactly
+once** — one version bump shipping all N changes. It does not run if any item
+failed.
+
+## Interaction model (design invariant)
+
+**One confirmation up front, then the batch runs to completion unattended.**
+This is a governing invariant, not a convenience:
+
+- The orchestrator shows the **full plan up front** (the ordered list of what it
+  will rebase / submit / finalize, and whether it will release) and takes
+  **one** confirmation. `--yes` skips it; `--dry-run` prints the plan and exits.
+- Per-item steps run with their individual confirmations **pre-suppressed** (the
+  orchestrator threads `assume_yes` through), so no "Submit this PR?" /
+  "Finalize PR #N?" prompt fires mid-batch.
+- A fail-fast stop is a **terminal halt that reports state** — it does *not*
+  prompt for retry/skip/abort.
+- The only two ways the batch ever pauses are the single up-front confirm and
+  `--dry-run`. Everything else is hands-off.
+
+## Error handling & resumability
+
+**Fail-fast.** The batch stops at the first failure of any item: rebase
+conflict, gate red (`wait_and_merge` `MergeAbortError`), merge conflict, or
+provenance violation. No later items start; `vrg-release` does not run.
+
+**State on stop is always clean and reportable.**
+
+- Items already merged are fully done — branches and worktrees cleaned up.
+- The failed item is left where it failed: a rebase failure means its PR was
+  never opened; a gate failure means its PR is open and red.
+- Unstarted items are untouched.
+
+The summary names all three buckets — *merged*, *failed (with reason)*, *not
+started* — so the stop point is unambiguous.
+
+**Resumability falls out of the selection scan; no state file, no `--resume`.**
+Re-running `vrg-submit-pr --all --finalize` after a fix:
+
+- skips merged items (their worktrees no longer exist);
+- skips the failed item *if its PR is already open* (the scan classifies it
+  "in-flight" and excludes it — finish that one via pr-watch or a
+  finalize-batch);
+- re-includes the failed item if it never opened (rebase failure) once fixed;
+- picks up the not-started items.
+
+The deferred end-of-batch validation and release simply run at the end of
+whatever the re-run completes.
+
+## Components
+
+1. **`vrg-submit-pr`** — multi-select checkbox UI, `--all` / `--select` flags;
+   the `≥2` branch delegates to the orchestrator.
+2. **`vrg-finalize-pr`** — comma-separated PR list + `--all`; the multi-item
+   branch delegates to the orchestrator (merge-only per item).
+3. **`lib/pr_workflow/batch.py`** *(new)* — the shared serial loop: ordered
+   items, per-item step callback, fail-fast, single up-front confirm,
+   release-once-at-end, deferred end-of-batch validation, state-report summary.
+4. **`lib/worktrees.py`** — extend selection with a checkbox multi-select
+   (`select_worktrees`) alongside the existing single `select_worktree`.
+5. **Auto-rebase helper** *(new)* — fetch `origin/develop` + rebase a branch
+   inside its worktree; used by submit-batch per item.
+
+## Testing
+
+- **Orchestrator loop (unit):** with a fake per-item step — success runs all
+  items in order; first failure stops the rest; `vrg-release` is called exactly
+  once on full success and never when any item failed; the up-front confirm
+  fires once and no per-item prompt fires.
+- **Selection (unit):** `--all` picks all ready; `--select` matching by issue
+  number and by worktree name; unmatched token errors and names the token;
+  0/1/≥2 branching (1 → single-PR path untouched).
+- **Lazy rebase (unit):** clean rebase proceeds; rebase conflict raises and
+  stops the batch with the correct report bucket.
+- **Deferred validation (unit):** container-validation + CD-check invoked once
+  after the final merge, not per item.
+- **State report (unit):** merged / failed-with-reason / not-started buckets are
+  accurate at the stop point.
+- **Regression:** single-PR `vrg-submit-pr` and `vrg-finalize-pr` behavior is
+  unchanged.
+- **`--dry-run`:** prints the full ordered plan and makes no changes.
+
+All tests run under the existing suite via `vrg-container-run -- vrg-validate`.

--- a/docs/specs/2026-06-17-batch-pr-pipeline-plan.md
+++ b/docs/specs/2026-06-17-batch-pr-pipeline-plan.md
@@ -1,0 +1,1521 @@
+# Batch PR pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `vrg-submit-pr` and `vrg-finalize-pr` drive a *batch* of PRs through the existing submit → finalize → release pipeline single-threaded, so each expensive CI gate runs exactly once.
+
+**Architecture:** A new generic orchestrator (`lib/pr_workflow/batch.py`) runs items through a per-item callback serially, fail-fast, then runs end-of-batch post-steps (validation, one release) only on full success. `vrg-submit-pr` (rebase → submit → finalize-item) and `vrg-finalize-pr` (merge-item) each build the item list and per-item callback, reusing the existing single-PR machinery via subprocess chaining (the established pattern). One up-front confirmation; per-item prompts are pre-suppressed.
+
+**Tech Stack:** Python 3.12+, argparse, `subprocess`, pytest with `unittest.mock`. Spec: `docs/specs/2026-06-17-batch-pr-pipeline-design.md`.
+
+**Conventions for every commit in this plan:**
+- Use `vrg-commit --type <t> --scope <s> --message "<m>" --body "<b>"` — raw `git commit` is denied. `vrg-commit` resolves co-authors itself; do not add a `Co-Authored-By` trailer.
+- Stage with `vrg-git add <paths>` before committing.
+- Run all work from inside the worktree `.worktrees/issue-1673-batch-pr/`.
+- Validation command (whole suite): `vrg-container-run -- vrg-validate`. To run one test file fast during a task, use `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest <path> -v` (the dev-tree override venv; see CLAUDE.md). Final gate before any PR is always `vrg-container-run -- vrg-validate`.
+
+---
+
+## File structure
+
+**New files:**
+- `src/vergil_tooling/lib/pr_workflow/batch.py` — generic serial orchestrator + report types.
+- `tests/vergil_tooling/pr_workflow/test_batch.py` — orchestrator unit tests.
+
+**Modified files:**
+- `src/vergil_tooling/lib/repo_init.py` — add `prompt_multi_choice`.
+- `src/vergil_tooling/lib/worktrees.py` — add `select_worktrees`, `match_worktrees`, `rebase_onto`.
+- `src/vergil_tooling/bin/vrg_finalize_pr.py` — `--skip-post-checks` flag; comma-list / `--all` batch mode.
+- `src/vergil_tooling/bin/vrg_submit_pr.py` — `--all` / `--select` flags; factor `_submit_one`; batch mode.
+- `tests/vergil_tooling/test_repo_init.py`, `test_worktrees.py`, `test_vrg_finalize_pr.py`, `test_vrg_submit_pr.py` — extend.
+
+---
+
+## Task 1: Batch report types
+
+**Files:**
+- Create: `src/vergil_tooling/lib/pr_workflow/batch.py`
+- Test: `tests/vergil_tooling/pr_workflow/test_batch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/vergil_tooling/pr_workflow/test_batch.py
+"""Tests for the batch orchestrator (vergil_tooling.lib.pr_workflow.batch)."""
+
+from __future__ import annotations
+
+from vergil_tooling.lib.pr_workflow.batch import (
+    BatchReport,
+    ItemOutcome,
+    ItemResult,
+)
+
+
+def test_all_merged_true_only_when_every_item_merged() -> None:
+    merged = BatchReport(items=[ItemResult("a", ItemOutcome.MERGED)])
+    assert merged.all_merged is True
+
+    mixed = BatchReport(
+        items=[
+            ItemResult("a", ItemOutcome.MERGED),
+            ItemResult("b", ItemOutcome.FAILED, "boom"),
+        ]
+    )
+    assert mixed.all_merged is False
+
+
+def test_all_merged_false_when_empty() -> None:
+    assert BatchReport().all_merged is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/pr_workflow/test_batch.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'vergil_tooling.lib.pr_workflow.batch'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/vergil_tooling/lib/pr_workflow/batch.py
+"""Single-threaded, fail-fast batch orchestrator for the PR pipeline.
+
+Runs a sequence of items through a per-item ``process`` callback one at a
+time, stopping at the first failure (fail-fast). Completed items are
+reported MERGED, the failed one FAILED with its reason, and the rest
+NOT_STARTED. Post-steps (end-of-batch validation, a single release) run
+only when every item merged cleanly.
+
+The whole run is gated by exactly one up-front confirmation: per-item
+prompts are pre-suppressed by the callers (they thread ``assume_yes``), so
+once confirmed the batch runs unattended. (Issue #1673.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from vergil_tooling.lib.confirm import confirm
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+class BatchAbort(Exception):
+    """A per-item step (or post-step) failed; the message is the reason.
+
+    Callers convert expected failures (rebase conflict, gate red, merge
+    abort, provenance violation, non-zero subprocess) into this so the
+    orchestrator can record them and stop without masking unexpected bugs,
+    which propagate.
+    """
+
+
+class ItemOutcome(StrEnum):
+    MERGED = "merged"
+    FAILED = "failed"
+    NOT_STARTED = "not-started"
+
+
+@dataclass(frozen=True)
+class ItemResult:
+    label: str
+    outcome: ItemOutcome
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class PostStep:
+    name: str
+    run: Callable[[], None]
+
+
+@dataclass
+class BatchReport:
+    items: list[ItemResult] = field(default_factory=list)
+    post_failure: str | None = None
+
+    @property
+    def all_merged(self) -> bool:
+        return bool(self.items) and all(i.outcome is ItemOutcome.MERGED for i in self.items)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/pr_workflow/test_batch.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/pr_workflow/batch.py tests/vergil_tooling/pr_workflow/test_batch.py
+vrg-commit --type feat --scope batch --message "add batch report types (#1673)" --body "ItemOutcome/ItemResult/BatchReport/PostStep/BatchAbort scaffold for the serial PR batch orchestrator. Ref #1673"
+```
+
+---
+
+## Task 2: `run_batch` orchestrator loop
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/pr_workflow/batch.py` (append `run_batch` + `format_report`)
+- Test: `tests/vergil_tooling/pr_workflow/test_batch.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/vergil_tooling/pr_workflow/test_batch.py
+from unittest.mock import patch
+
+from vergil_tooling.lib.pr_workflow.batch import (
+    BatchAbort,
+    PostStep,
+    format_report,
+    run_batch,
+)
+
+_MOD = "vergil_tooling.lib.pr_workflow.batch"
+
+
+def _confirm_yes():
+    return patch(_MOD + ".confirm", return_value=True)
+
+
+def test_all_items_processed_in_order_on_success() -> None:
+    seen: list[str] = []
+    with _confirm_yes():
+        report = run_batch(
+            ["a", "b", "c"],
+            process=seen.append,
+            label=lambda it: it,
+            plan=["do a", "do b", "do c"],
+            assume_yes=True,
+        )
+    assert seen == ["a", "b", "c"]
+    assert report.all_merged is True
+
+
+def test_first_failure_stops_and_marks_rest_not_started() -> None:
+    def process(it: str) -> None:
+        if it == "b":
+            raise BatchAbort("gate red")
+
+    with _confirm_yes():
+        report = run_batch(
+            ["a", "b", "c"],
+            process=process,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+        )
+    outcomes = [(i.label, i.outcome.value, i.reason) for i in report.items]
+    assert outcomes == [
+        ("a", "merged", None),
+        ("b", "failed", "gate red"),
+        ("c", "not-started", None),
+    ]
+    assert report.all_merged is False
+
+
+def test_post_steps_run_once_on_full_success() -> None:
+    calls: list[str] = []
+    with _confirm_yes():
+        run_batch(
+            ["a"],
+            process=lambda it: None,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+            post_steps=[PostStep("release", lambda: calls.append("release"))],
+        )
+    assert calls == ["release"]
+
+
+def test_post_steps_skipped_when_any_item_failed() -> None:
+    calls: list[str] = []
+
+    def process(it: str) -> None:
+        raise BatchAbort("nope")
+
+    with _confirm_yes():
+        report = run_batch(
+            ["a"],
+            process=process,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+            post_steps=[PostStep("release", lambda: calls.append("release"))],
+        )
+    assert calls == []
+    assert report.post_failure is None
+
+
+def test_post_step_failure_recorded_not_raised() -> None:
+    def boom() -> None:
+        raise BatchAbort("release blew up")
+
+    with _confirm_yes():
+        report = run_batch(
+            ["a"],
+            process=lambda it: None,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+            post_steps=[PostStep("release", boom)],
+        )
+    assert report.post_failure == "release: release blew up"
+
+
+def test_decline_marks_all_not_started_and_runs_nothing() -> None:
+    seen: list[str] = []
+    with patch(_MOD + ".confirm", return_value=False):
+        report = run_batch(
+            ["a", "b"],
+            process=seen.append,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=False,
+        )
+    assert seen == []
+    assert [i.outcome.value for i in report.items] == ["not-started", "not-started"]
+
+
+def test_format_report_groups_buckets() -> None:
+    report = BatchReport(
+        items=[
+            ItemResult("a", ItemOutcome.MERGED),
+            ItemResult("b", ItemOutcome.FAILED, "gate red"),
+            ItemResult("c", ItemOutcome.NOT_STARTED),
+        ]
+    )
+    out = format_report(report)
+    assert "Merged:" in out
+    assert "a" in out
+    assert "Failed:" in out
+    assert "b — gate red" in out
+    assert "Not started:" in out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/pr_workflow/test_batch.py -v`
+Expected: FAIL — `ImportError: cannot import name 'run_batch'`.
+
+- [ ] **Step 3: Write implementation (append to `batch.py`)**
+
+```python
+def run_batch(
+    items: Sequence[Any],
+    process: Callable[[Any], None],
+    *,
+    label: Callable[[Any], str],
+    plan: Sequence[str],
+    assume_yes: bool,
+    post_steps: Sequence[PostStep] = (),
+) -> BatchReport:
+    """Run *items* through *process* serially, fail-fast, then *post_steps*.
+
+    Prints *plan* and asks exactly one confirmation (skipped with
+    *assume_yes*). On decline, returns an all-NOT_STARTED report and runs
+    nothing. Each item that raises ``BatchAbort`` stops the batch: it is
+    recorded FAILED and the remaining items NOT_STARTED. ``post_steps`` run
+    in order only when every item merged; a post-step ``BatchAbort`` is
+    recorded in ``post_failure`` (never un-doing a merge) and stops the
+    remaining post-steps.
+    """
+    report = BatchReport()
+
+    print("Batch plan:")
+    for line in plan:
+        print(f"  {line}")
+    if not confirm("\nRun this batch?", assume_yes=assume_yes, default=False):
+        print("Aborted.")
+        report.items = [ItemResult(label(it), ItemOutcome.NOT_STARTED) for it in items]
+        return report
+
+    stopped = False
+    for it in items:
+        if stopped:
+            report.items.append(ItemResult(label(it), ItemOutcome.NOT_STARTED))
+            continue
+        try:
+            process(it)
+        except BatchAbort as exc:
+            report.items.append(ItemResult(label(it), ItemOutcome.FAILED, str(exc)))
+            stopped = True
+        else:
+            report.items.append(ItemResult(label(it), ItemOutcome.MERGED))
+
+    if report.all_merged:
+        for step in post_steps:
+            try:
+                step.run()
+            except BatchAbort as exc:
+                report.post_failure = f"{step.name}: {exc}"
+                break
+
+    return report
+
+
+def format_report(report: BatchReport) -> str:
+    """Render the merged / failed / not-started buckets as a summary block."""
+    lines = ["", "Batch summary:"]
+    for bucket, outcome in (
+        ("Merged", ItemOutcome.MERGED),
+        ("Failed", ItemOutcome.FAILED),
+        ("Not started", ItemOutcome.NOT_STARTED),
+    ):
+        members = [i for i in report.items if i.outcome is outcome]
+        if not members:
+            continue
+        lines.append(f"  {bucket}:")
+        for i in members:
+            suffix = f" — {i.reason}" if i.reason else ""
+            lines.append(f"    {i.label}{suffix}")
+    if report.post_failure:
+        lines.append(f"  Post-step failed: {report.post_failure}")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/pr_workflow/test_batch.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/pr_workflow/batch.py tests/vergil_tooling/pr_workflow/test_batch.py
+vrg-commit --type feat --scope batch --message "add run_batch serial orchestrator (#1673)" --body "Fail-fast serial loop with one up-front confirm, NOT_STARTED for the tail after a failure, and post-steps that run only on full success. Ref #1673"
+```
+
+---
+
+## Task 3: `prompt_multi_choice` (terminal multi-select)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/repo_init.py` (add `prompt_multi_choice` next to `prompt_choice`)
+- Test: `tests/vergil_tooling/test_repo_init.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/vergil_tooling/test_repo_init.py  (create if absent; otherwise append)
+"""Tests for vergil_tooling.lib.repo_init prompts."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from vergil_tooling.lib.repo_init import prompt_multi_choice
+
+_MOD = "vergil_tooling.lib.repo_init"
+
+
+def test_multi_choice_numbers() -> None:
+    with patch("builtins.input", return_value="1,3"):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [0, 2]
+
+
+def test_multi_choice_all() -> None:
+    with patch("builtins.input", return_value="all"):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [0, 1, 2]
+
+
+def test_multi_choice_space_separated_and_dedup_sorted() -> None:
+    with patch("builtins.input", return_value="3 1 1"):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [0, 2]
+
+
+def test_multi_choice_reprompts_on_out_of_range(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("builtins.input", side_effect=["9", "2"]):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [1]
+    assert "between 1 and 3" in capsys.readouterr().out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_repo_init.py -v`
+Expected: FAIL — `ImportError: cannot import name 'prompt_multi_choice'`.
+
+- [ ] **Step 3: Write implementation (add to `repo_init.py`, after `prompt_choice`)**
+
+```python
+def prompt_multi_choice(label: str, options: list[str]) -> list[int]:
+    """Present a numbered list; return the chosen 0-based indices.
+
+    Accepts a comma- or space-separated list of numbers, or ``all`` for
+    every option. Re-prompts on invalid or out-of-range input or an empty
+    selection — the caller wants at least one.
+    """
+    print(f"\n{label}:")
+    for i, opt in enumerate(options, 1):
+        print(f"  {i}. {opt}")
+    while True:
+        raw = input("  Select (comma-separated numbers, or 'all'): ").strip().lower()
+        if raw == "all":
+            return list(range(len(options)))
+        tokens = [t for t in raw.replace(",", " ").split() if t]
+        try:
+            chosen = sorted({int(t) for t in tokens})
+        except ValueError:
+            print(f"  Enter numbers between 1 and {len(options)}, or 'all'.")
+            continue
+        if chosen and all(1 <= n <= len(options) for n in chosen):
+            return [n - 1 for n in chosen]
+        print(f"  Enter numbers between 1 and {len(options)}, or 'all'.")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_repo_init.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/repo_init.py tests/vergil_tooling/test_repo_init.py
+vrg-commit --type feat --scope repo-init --message "add prompt_multi_choice (#1673)" --body "Terminal checkbox-style multi-select: comma/space numbers or 'all'. Used by worktree batch selection. Ref #1673"
+```
+
+---
+
+## Task 4: `worktrees.select_worktrees` and `match_worktrees`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/worktrees.py` (add two functions; import `prompt_multi_choice`)
+- Test: `tests/vergil_tooling/test_worktrees.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/vergil_tooling/test_worktrees.py
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vergil_tooling.lib.worktrees import Worktree, match_worktrees, select_worktrees
+
+_WT_MOD = "vergil_tooling.lib.worktrees"
+
+
+def _wt(name: str, branch: str) -> Worktree:
+    return Worktree(path=Path(f"/repo/.worktrees/{name}"), branch=branch)
+
+
+def test_select_worktrees_single_skips_prompt() -> None:
+    wt = _wt("issue-1-foo", "feature/1-foo")
+    assert select_worktrees([wt], purpose="p", labels=["foo"]) == [wt]
+
+
+def test_select_worktrees_multi_uses_prompt_indices() -> None:
+    a = _wt("issue-1-a", "feature/1-a")
+    b = _wt("issue-2-b", "feature/2-b")
+    c = _wt("issue-3-c", "feature/3-c")
+    with (
+        patch(_WT_MOD + ".require_tty"),
+        patch(_WT_MOD + ".prompt_multi_choice", return_value=[0, 2]),
+    ):
+        assert select_worktrees([a, b, c], purpose="p", labels=["a", "b", "c"]) == [a, c]
+
+
+def test_match_worktrees_by_issue_number_and_name_in_token_order() -> None:
+    a = _wt("issue-1673-foo", "feature/1673-foo")
+    b = _wt("issue-1681-bar", "feature/1681-bar")
+    assert match_worktrees([a, b], ["1681", "issue-1673-foo"]) == [b, a]
+
+
+def test_match_worktrees_unmatched_token_errors() -> None:
+    a = _wt("issue-1-a", "feature/1-a")
+    with pytest.raises(ValueError, match="no ready worktree matches: 999"):
+        match_worktrees([a], ["999"])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_worktrees.py -v -k "select_worktrees or match_worktrees"`
+Expected: FAIL — `ImportError: cannot import name 'match_worktrees'`.
+
+- [ ] **Step 3: Write implementation (add to `worktrees.py`)**
+
+Update the existing import line near the top:
+
+```python
+from vergil_tooling.lib.repo_init import prompt_choice, prompt_multi_choice
+```
+
+Append these functions:
+
+```python
+def select_worktrees(
+    candidates: list[Worktree],
+    *,
+    purpose: str,
+    labels: list[str],
+) -> list[Worktree]:
+    """Choose one or more candidate worktrees via a checkbox-style menu.
+
+    A single candidate is returned without prompting. With several, a TTY is
+    required and a multi-select menu (numbers or 'all') is shown. ``labels``
+    parallels ``candidates`` one-to-one.
+    """
+    if not candidates:
+        msg = "select_worktrees requires at least one candidate"
+        raise ValueError(msg)
+    if len(candidates) == 1:
+        return [candidates[0]]
+    require_tty(purpose)
+    return [candidates[i] for i in prompt_multi_choice(purpose, labels)]
+
+
+def match_worktrees(candidates: list[Worktree], tokens: list[str]) -> list[Worktree]:
+    """Resolve *tokens* (issue numbers or worktree dir names) to worktrees.
+
+    Each token matches a candidate by directory name (``wt.path.name``) or by
+    the issue number in a canonical ``issue-<N>-<slug>`` name. Result order
+    follows *tokens*. Unmatched or ambiguous tokens raise ``ValueError``
+    naming them — never a silent skip.
+    """
+    by_name = {wt.path.name: wt for wt in candidates}
+    by_issue: dict[str, list[Worktree]] = {}
+    for wt in candidates:
+        name = wt.path.name
+        if name.startswith("issue-") and len(name.split("-", 2)) >= 2:
+            by_issue.setdefault(name.split("-", 2)[1], []).append(wt)
+
+    selected: list[Worktree] = []
+    unmatched: list[str] = []
+    ambiguous: list[str] = []
+    for raw in tokens:
+        tok = raw.strip()
+        if tok in by_name:
+            selected.append(by_name[tok])
+        elif tok in by_issue and len(by_issue[tok]) == 1:
+            selected.append(by_issue[tok][0])
+        elif tok in by_issue:
+            ambiguous.append(tok)
+        else:
+            unmatched.append(tok)
+
+    if unmatched or ambiguous:
+        parts = []
+        if unmatched:
+            parts.append(f"no ready worktree matches: {', '.join(unmatched)}")
+        if ambiguous:
+            parts.append(f"ambiguous (multiple worktrees): {', '.join(ambiguous)}")
+        raise ValueError("; ".join(parts))
+    return selected
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_worktrees.py -v -k "select_worktrees or match_worktrees"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/worktrees.py tests/vergil_tooling/test_worktrees.py
+vrg-commit --type feat --scope worktrees --message "add multi-select and token matching (#1673)" --body "select_worktrees (checkbox multi-select) and match_worktrees (issue number or dir name, fail on unmatched/ambiguous) for batch selection. Ref #1673"
+```
+
+---
+
+## Task 5: `worktrees.rebase_onto` (lazy rebase helper)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/worktrees.py` (add `rebase_onto`)
+- Test: `tests/vergil_tooling/test_worktrees.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/vergil_tooling/test_worktrees.py
+import subprocess
+
+from vergil_tooling.lib.worktrees import rebase_onto
+
+
+def test_rebase_onto_fetches_then_rebases() -> None:
+    wt = _wt("issue-1-a", "feature/1-a")
+    with patch(_WT_MOD + ".git.run") as run:
+        rebase_onto(wt, "develop")
+    assert run.call_args_list[0].args == ("-C", str(wt.path), "fetch", "origin", "develop")
+    assert run.call_args_list[1].args == ("-C", str(wt.path), "rebase", "origin/develop")
+
+
+def test_rebase_onto_propagates_conflict() -> None:
+    wt = _wt("issue-1-a", "feature/1-a")
+    err = subprocess.CalledProcessError(1, ["git", "rebase"])
+    with (
+        patch(_WT_MOD + ".git.run", side_effect=[None, err]),
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        rebase_onto(wt, "develop")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_worktrees.py -v -k rebase_onto`
+Expected: FAIL — `ImportError: cannot import name 'rebase_onto'`.
+
+- [ ] **Step 3: Write implementation (add to `worktrees.py`)**
+
+```python
+def rebase_onto(worktree: Worktree, base: str) -> None:
+    """Fetch *base* from origin and rebase *worktree*'s branch onto it.
+
+    Run via ``git -C`` so the batch orchestrator can process each worktree
+    without changing the process CWD. This is the step that makes a batch's
+    CI gate run exactly once: rebasing onto the current ``develop`` before
+    the PR opens means the gate runs against the final state and the later
+    merge is not ``BEHIND``. A rebase conflict raises
+    ``subprocess.CalledProcessError`` for the caller to convert to a
+    ``BatchAbort``.
+    """
+    git.run("-C", str(worktree.path), "fetch", "origin", base)
+    git.run("-C", str(worktree.path), "rebase", f"origin/{base}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_worktrees.py -v -k rebase_onto`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/worktrees.py tests/vergil_tooling/test_worktrees.py
+vrg-commit --type feat --scope worktrees --message "add rebase_onto helper (#1673)" --body "Fetch origin/<base> and rebase a worktree's branch onto it via git -C, so a batch can rebase each item before submit (the zero-waste-CI mechanism). Ref #1673"
+```
+
+---
+
+## Task 6: `vrg-finalize-pr --skip-post-checks`
+
+Lets a batch finalize each item (merge + cleanup) while deferring container
+validation, the CD check, and any release to the end of the batch.
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_finalize_pr.py` (`parse_args`, `build_stages`, `main`)
+- Test: `tests/vergil_tooling/test_vrg_finalize_pr.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/vergil_tooling/test_vrg_finalize_pr.py
+from vergil_tooling.bin.vrg_finalize_pr import build_stages, parse_args
+
+
+def test_skip_post_checks_drops_validation_and_cd() -> None:
+    names = {s.name for s in build_stages(include_pr=True, include_post_checks=False)}
+    assert "validation" not in names
+    assert "cd-check" not in names
+    assert {"provenance", "merge", "cleanup"} <= names
+
+
+def test_default_keeps_post_checks() -> None:
+    names = {s.name for s in build_stages(include_pr=True, include_post_checks=True)}
+    assert {"validation", "cd-check"} <= names
+
+
+def test_skip_post_checks_flag_parses() -> None:
+    assert parse_args(["123", "--skip-post-checks"]).skip_post_checks is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py -v -k "skip_post_checks or post_checks"`
+Expected: FAIL — `TypeError: build_stages() got an unexpected keyword argument 'include_post_checks'` / `AttributeError: ... 'skip_post_checks'`.
+
+- [ ] **Step 3: Implement**
+
+In `parse_args`, add the flag (after `--install`):
+
+```python
+    parser.add_argument(
+        "--skip-post-checks",
+        action="store_true",
+        help="Skip the post-merge validation and CD-status stages (and any "
+        "release chain). Used by the batch orchestrator, which runs those "
+        "once at the end of the batch (issue #1673).",
+    )
+```
+
+Replace `build_stages` with:
+
+```python
+def build_stages(*, include_pr: bool, include_post_checks: bool = True) -> tuple[Stage, ...]:
+    """Assemble the pipeline for the resolved mode.
+
+    provenance/merge run only when a PR was given or inferred; cleanup always
+    runs. validation and cd-check run unless *include_post_checks* is False
+    (the batch path defers them to one end-of-batch run, issue #1673); they
+    are fail_defer so a validation failure still surfaces the CD status.
+    """
+    stages: list[Stage] = []
+    if include_pr:
+        stages.append(Stage("provenance", _stage_provenance, "fail_fast"))
+        stages.append(Stage("merge", _stage_merge, "fail_fast"))
+    stages.append(Stage("cleanup", _stage_cleanup, "fail_fast"))
+    if include_post_checks:
+        stages.append(Stage("validation", _stage_validation, "fail_defer"))
+        stages.append(Stage("cd-check", _stage_cd_check, "fail_defer"))
+    return tuple(stages)
+```
+
+In `main`, thread the flag into the pipeline build and suppress the release
+chain when post-checks are skipped. Replace the `run_pipeline` call's
+`build_stages(...)` argument and guard the release:
+
+```python
+    rc = progress.run_pipeline(
+        ctx,
+        build_stages(
+            include_pr=args.pr is not None,
+            include_post_checks=not args.skip_post_checks,
+        ),
+        command="vrg-finalize-pr",
+        label="vrg-finalize-pr",
+        args=args,
+        repo_root=root,
+    )
+
+    # --release cascade (issue #1634): never chains when post-checks are
+    # skipped — release is the batch orchestrator's single end-of-batch step.
+    if rc != 0 or not args.release or args.skip_post_checks:
+        return rc
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py -v`
+Expected: PASS (new + existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_finalize_pr.py tests/vergil_tooling/test_vrg_finalize_pr.py
+vrg-commit --type feat --scope finalize-pr --message "add --skip-post-checks (#1673)" --body "Skip validation/cd-check stages and the release chain so a batch can finalize each item and run those once at the end. Ref #1673"
+```
+
+---
+
+## Task 7: `vrg-finalize-pr` batch mode (comma-list / `--all`)
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_finalize_pr.py` (`parse_args`, `main`; add helpers `_resolve_open_prs`, `_run_finalize_batch`)
+- Test: `tests/vergil_tooling/test_vrg_finalize_pr.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/vergil_tooling/test_vrg_finalize_pr.py
+from unittest.mock import MagicMock, patch
+
+from vergil_tooling.bin.vrg_finalize_pr import _parse_pr_list, _run_finalize_batch
+
+_FIN_MOD = "vergil_tooling.bin.vrg_finalize_pr"
+
+
+def test_parse_pr_list_splits_and_trims() -> None:
+    assert _parse_pr_list("123, 124 ,125") == ["123", "124", "125"]
+    assert _parse_pr_list("123") == ["123"]
+
+
+def test_finalize_batch_runs_each_item_then_release_once() -> None:
+    runs: list[tuple[str, ...]] = []
+
+    def fake_run(cmd, **_kwargs):
+        runs.append(tuple(cmd))
+        return MagicMock(returncode=0)
+
+    with (
+        patch(_FIN_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_FIN_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_finalize_batch(
+            ["123", "124"],
+            root=Path("/repo"),
+            release=True,
+            install=False,
+            assume_yes=True,
+        )
+    assert rc == 0
+    # two per-item finalizes with --skip-post-checks
+    assert ("vrg-finalize-pr", "123", "--skip-post-checks") in runs
+    assert ("vrg-finalize-pr", "124", "--skip-post-checks") in runs
+    # one end-of-batch validation cleanup and one release
+    assert ("vrg-finalize-pr", "--cleanup-only") in runs
+    assert ("vrg-release",) in runs
+
+
+def test_finalize_batch_stops_on_item_failure_no_release() -> None:
+    def fake_run(cmd, **_kwargs):
+        rc = 1 if "123" in cmd else 0
+        return MagicMock(returncode=rc)
+
+    with (
+        patch(_FIN_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_FIN_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_finalize_batch(
+            ["123", "124"],
+            root=Path("/repo"),
+            release=True,
+            install=False,
+            assume_yes=True,
+        )
+    assert rc == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py -v -k "pr_list or finalize_batch"`
+Expected: FAIL — `ImportError: cannot import name '_parse_pr_list'`.
+
+- [ ] **Step 3: Implement**
+
+Add the `--all` flag in `parse_args` (inside the mutually-exclusive `target`
+group, alongside `pr` and `--cleanup-only`):
+
+```python
+    target.add_argument(
+        "--all",
+        dest="all_prs",
+        action="store_true",
+        help="Finalize every open PR found in .worktrees/ as a serial batch "
+        "(issue #1673).",
+    )
+```
+
+Add helpers near the top of the module (after the imports / `_CD_WORKFLOW_NAME`):
+
+```python
+def _parse_pr_list(value: str) -> list[str]:
+    """Split a comma-separated PR argument into trimmed, non-empty tokens."""
+    return [tok.strip() for tok in value.split(",") if tok.strip()]
+
+
+def _resolve_open_prs(root: Path) -> list[str]:
+    """Return the URLs of every open PR in canonical worktrees, branch-sorted.
+
+    Deterministic order (by branch name) so a batch is reproducible. Skips
+    worktrees with no open PR, printing why — no silent exclusions.
+    """
+    urls: list[str] = []
+    for wt in sorted(worktrees.list_worktrees(root), key=lambda w: w.branch):
+        pr = github.pr_for_branch(wt.branch)
+        if pr is None:
+            print(f"  {wt.path.name}: no open PR for {wt.branch} — skipping")
+            continue
+        urls.append(pr["url"])
+    return urls
+```
+
+Add the batch runner:
+
+```python
+def _run_finalize_batch(
+    prs: list[str],
+    *,
+    root: Path,
+    release: bool,
+    install: bool,
+    assume_yes: bool,
+) -> int:
+    """Finalize *prs* serially, fail-fast, then validate + release once.
+
+    Each item shells out to ``vrg-finalize-pr <pr> --skip-post-checks`` (merge
+    + cleanup, no validation). On full success, one end-of-batch
+    ``vrg-finalize-pr --cleanup-only`` runs validation + the CD check, then a
+    single ``vrg-release [--install]`` if requested (issue #1673).
+    """
+
+    def _finalize_item(pr: str) -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", pr, "--skip-post-checks"),  # noqa: S607
+            cwd=root,
+            check=False,
+        )
+        if result.returncode != 0:
+            msg = f"vrg-finalize-pr {pr} --skip-post-checks exited {result.returncode}"
+            raise batch.BatchAbort(msg)
+
+    def _validate() -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
+            cwd=root,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise batch.BatchAbort(f"end-of-batch validation exited {result.returncode}")
+
+    def _release() -> None:
+        cmd = ("vrg-release", "--install") if install else ("vrg-release",)
+        result = subprocess.run(cmd, cwd=root, check=False)  # noqa: S603,S607
+        if result.returncode != 0:
+            raise batch.BatchAbort(f"{' '.join(cmd)} exited {result.returncode}")
+
+    post_steps = [batch.PostStep("validation", _validate)]
+    if release:
+        post_steps.append(batch.PostStep("release", _release))
+
+    plan = [f"finalize PR {pr}" for pr in prs]
+    plan.append("then: validate develop once" + (", then release" if release else ""))
+
+    report = batch.run_batch(
+        prs,
+        _finalize_item,
+        label=lambda pr: f"PR {pr}",
+        plan=plan,
+        assume_yes=assume_yes,
+        post_steps=post_steps,
+    )
+    print(batch.format_report(report))
+    return 0 if report.all_merged and report.post_failure is None else 1
+```
+
+Add the imports at the top of the module:
+
+```python
+from vergil_tooling.lib.pr_workflow import batch
+```
+
+Wire batch detection into `main`, immediately after `root = git.repo_root()`
+and before the single-PR inference block:
+
+```python
+    # Batch mode (issue #1673): an explicit comma-list or --all finalizes
+    # several PRs serially. A single PR (or none) falls through to the
+    # unchanged single-PR pipeline below.
+    if args.all_prs:
+        prs = _resolve_open_prs(root)
+        if not prs:
+            print("vrg-finalize-pr --all: no open PRs found in worktrees.")
+            return 0
+        return _run_finalize_batch(
+            prs, root=root, release=args.release, install=args.install, assume_yes=args.yes
+        )
+    if args.pr is not None and "," in args.pr:
+        prs = _parse_pr_list(args.pr)
+        return _run_finalize_batch(
+            prs, root=root, release=args.release, install=args.install, assume_yes=args.yes
+        )
+```
+
+> Note: `args.all_prs` exists because the new `--all` flag uses
+> `dest="all_prs"`. The single-PR `_parse_pr_list` path triggers only when a
+> comma is present, so a bare `vrg-finalize-pr 123` is unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_finalize_pr.py -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_finalize_pr.py tests/vergil_tooling/test_vrg_finalize_pr.py
+vrg-commit --type feat --scope finalize-pr --message "add batch finalize via comma-list/--all (#1673)" --body "Serial fail-fast finalize of multiple PRs, each --skip-post-checks, then one end-of-batch validation and a single release. Ref #1673"
+```
+
+---
+
+## Task 8: Factor `_submit_one` out of `vrg-submit-pr` template mode
+
+Prepares submit-pr for batch reuse without changing single-PR behavior.
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_submit_pr.py` (extract `_submit_one`; `_run_template_mode` calls it)
+- Test: `tests/vergil_tooling/test_vrg_submit_pr.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/vergil_tooling/test_vrg_submit_pr.py
+from vergil_tooling.bin.vrg_submit_pr import _submit_one
+
+
+def test_submit_one_pushes_creates_records_and_returns_url() -> None:
+    fields = {
+        "issue": "1673",
+        "title": "Batch",
+        "summary": "s",
+        "notes": "",
+        "linkage": "Ref",
+        "base": "origin/develop",
+    }
+    with (
+        patch(_MOD + ".submission.read_pr_fields", return_value=fields),
+        patch(_MOD + ".git.current_branch", return_value="feature/1673-x"),
+        patch(_MOD + "._push_branch") as push,
+        patch(_MOD + "._create_pr", return_value="https://example/pull/9") as create,
+        patch(_MOD + ".submission.record_submission") as record,
+        patch(_MOD + ".resolve_issue_ref", return_value="#1673"),
+        patch(_MOD + ".build_pr_body", return_value="BODY"),
+    ):
+        url = _submit_one(Path("/repo/.worktrees/issue-1673-x"), base_override=None, assume_yes=True)
+    assert url == "https://example/pull/9"
+    push.assert_called_once_with("feature/1673-x")
+    create.assert_called_once()
+    record.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_submit_pr.py -v -k submit_one`
+Expected: FAIL — `ImportError: cannot import name '_submit_one'`.
+
+- [ ] **Step 3: Implement — extract `_submit_one`, have `_run_template_mode` call it**
+
+Add `_submit_one` (it is the body of today's `_run_template_mode` from
+`read_pr_fields` through `record_submission`, minus the cascade, returning the
+URL; the per-PR confirm is governed by `assume_yes`):
+
+```python
+def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: bool) -> str:
+    """Read the worktree's PR fields, push, create the PR, record it, return URL.
+
+    Raises ``SystemExit`` (via the field readers) on a not-ready worktree and
+    re-raises push/create failures. The per-PR "Submit this PR?" confirm is
+    pre-answered when *assume_yes* — the batch path passes True so the single
+    up-front batch confirm is the only gate (issue #1673).
+    """
+    fields = submission.read_pr_fields(worktree_root)
+    issue_ref = resolve_issue_ref(fields["issue"])
+    branch = git.current_branch()
+    target = _target_branch(base_override, fields.get("base"))
+    linkage = fields.get("linkage", "Ref")
+    if linkage not in ALLOWED_LINKAGES:
+        msg = (
+            f"linkage '{linkage}' in the PR submission fields is not allowed; "
+            f"use: {', '.join(ALLOWED_LINKAGES)}."
+        )
+        raise SystemExit(f"vrg-submit-pr: {msg}")
+    pr_body = build_pr_body(
+        summary=fields["summary"],
+        linkage=linkage,
+        issue_ref=issue_ref,
+        notes=fields.get("notes", ""),
+    )
+    print("=== PR from template ===")
+    print(f"Title:  {fields['title']}")
+    print(f"Base:   {target}")
+    print(f"Branch: {branch}")
+    print(f"Issue:  {issue_ref}")
+    if not confirm("\nSubmit this PR?", assume_yes=assume_yes):
+        msg = "submission declined at the per-PR confirm"
+        raise SystemExit(f"vrg-submit-pr: {msg}")
+    print(f"Ensuring branch '{branch}' is pushed to origin...")
+    _push_branch(branch)
+    print("Creating PR...")
+    pr_url = _create_pr(target_branch=target, title=fields["title"], pr_body=pr_body)
+    submission.record_submission(worktree_root, pr_url=pr_url)
+    print(f"PR created: {pr_url}")
+    return pr_url
+```
+
+Then simplify the single-PR `_run_template_mode` so that, after the
+already-submitted / not-ready guards and the `dry_run` branch, it delegates:
+
+```python
+    pr_url = _submit_one(root, base_override=args.base, assume_yes=args.yes)
+    if args.finalize:
+        rc = _chain_finalize(pr_url, release=args.release, install=args.install)
+        if rc != 0:
+            return rc
+        _print_cascade_summary(pr_url, released=args.release, installed=args.install)
+        return 0
+    print(f"Done. PR URL: {pr_url}")
+    _print_pr_watch(pr_url)
+    return 0
+```
+
+> The `AlreadySubmittedError` / `FileNotFoundError` / `TemplateError` guards and
+> the `dry_run` body preview stay in `_run_template_mode` exactly as they are
+> today — only the push/create/record tail moves into `_submit_one`.
+
+- [ ] **Step 4: Run the full submit-pr test file to verify no regression**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_submit_pr.py -v`
+Expected: PASS (new `submit_one` test + all existing tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_submit_pr.py tests/vergil_tooling/test_vrg_submit_pr.py
+vrg-commit --type refactor --scope submit-pr --message "extract _submit_one for reuse (#1673)" --body "Factor the push/create/record tail of template mode into _submit_one so batch mode can call it per item. Single-PR behavior unchanged. Ref #1673"
+```
+
+---
+
+## Task 9: `vrg-submit-pr` batch selection + orchestration
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_submit_pr.py` (`parse_args`; refactor `_choose_submit_worktree` → `_ready_worktrees`; add `_run_submit_batch`; wire `_run_template_mode`)
+- Test: `tests/vergil_tooling/test_vrg_submit_pr.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/vergil_tooling/test_vrg_submit_pr.py
+from unittest.mock import MagicMock
+
+from vergil_tooling.lib.worktrees import Worktree
+from vergil_tooling.bin.vrg_submit_pr import _run_submit_batch
+
+
+def _wt(name: str) -> Worktree:
+    n = name.split("-")[1]
+    return Worktree(path=Path(f"/repo/.worktrees/{name}"), branch=f"feature/{n}-x")
+
+
+def test_submit_batch_rebases_submits_then_finalizes_each_and_releases_once() -> None:
+    a, b = _wt("issue-1-a"), _wt("issue-2-b")
+    finalize_calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd, **_kwargs):
+        finalize_calls.append(tuple(cmd))
+        return MagicMock(returncode=0)
+
+    with (
+        patch(_MOD + ".worktrees.rebase_onto") as rebase,
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", side_effect=["https://x/pull/1", "https://x/pull/2"]),
+        patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a, b], base="develop", finalize=True, release=True, install=False, assume_yes=True
+        )
+    assert rc == 0
+    assert rebase.call_count == 2
+    assert ("vrg-finalize-pr", "https://x/pull/1", "--skip-post-checks") in finalize_calls
+    assert ("vrg-finalize-pr", "https://x/pull/2", "--skip-post-checks") in finalize_calls
+    assert ("vrg-finalize-pr", "--cleanup-only") in finalize_calls
+    assert ("vrg-release",) in finalize_calls
+
+
+def test_submit_batch_rebase_conflict_stops_batch() -> None:
+    import subprocess
+
+    a, b = _wt("issue-1-a"), _wt("issue-2-b")
+    with (
+        patch(_MOD + ".worktrees.rebase_onto", side_effect=subprocess.CalledProcessError(1, "git")),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one") as submit,
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a, b], base="develop", finalize=True, release=False, install=False, assume_yes=True
+        )
+    assert rc == 1
+    submit.assert_not_called()  # rebase failed before submit
+
+
+def test_all_and_select_flags_parse() -> None:
+    assert parse_args(["--all"]).all_worktrees is True
+    assert parse_args(["--select", "1,2"]).select == "1,2"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_submit_pr.py -v -k "submit_batch or all_and_select"`
+Expected: FAIL — `ImportError: cannot import name '_run_submit_batch'`.
+
+- [ ] **Step 3: Implement**
+
+Add imports at the top of `vrg_submit_pr.py`:
+
+```python
+from vergil_tooling.lib.pr_workflow import batch
+```
+
+Add the flags in `parse_args` (after `--install`):
+
+```python
+    parser.add_argument(
+        "--all",
+        dest="all_worktrees",
+        action="store_true",
+        help="Select every ready worktree for a batch submission (issue #1673).",
+    )
+    parser.add_argument(
+        "--select",
+        default=None,
+        help="Comma-separated list of ready worktrees to batch-submit, by issue "
+        "number or worktree directory name (issue #1673).",
+    )
+```
+
+Refactor `_choose_submit_worktree` so the ready-list gathering is reusable.
+Extract a `_ready_worktrees` function that returns the `(Worktree, fields)`
+pairs and raises the same "nothing submittable" `SystemExit` as today; keep
+`_choose_submit_worktree` as the single-select wrapper:
+
+```python
+def _ready_worktrees(root: Path) -> list[tuple[worktrees.Worktree, dict[str, str]]]:
+    """Return submittable ``(worktree, fields)`` pairs, or SystemExit if none.
+
+    Same classification (ready / in-flight / not-ready) and same
+    no-submittable-worktrees error as the single-select path; shared by the
+    single picker and the batch selector (issue #1673).
+    """
+    ready: list[tuple[worktrees.Worktree, dict[str, str]]] = []
+    in_flight: list[str] = []
+    not_ready: list[str] = []
+    for wt in worktrees.list_worktrees(root):
+        try:
+            fields = submission.read_pr_fields(wt.path)
+        except AlreadySubmittedError as exc:
+            ref = f"PR #{exc.pr_number}" if exc.pr_number is not None else "open PR"
+            in_flight.append(f"{wt.path.name}: {ref} ({exc.pr_url})")
+            continue
+        except FileNotFoundError:
+            not_ready.append(f"{wt.path.name}: no .vergil/pr-workflow.json or pr-template.yml")
+            continue
+        except (pr_template.TemplateError, WorkflowError) as exc:
+            not_ready.append(f"{wt.path.name}: {exc}")
+            continue
+        ready.append((wt, fields))
+
+    if not ready:
+        lines = ["vrg-submit-pr: no submittable worktrees found."]
+        if in_flight:
+            lines.append("")
+            lines.append("  In flight (open PR — nothing to do):")
+            lines.extend(f"    {entry}" for entry in in_flight)
+        if not_ready:
+            lines.append("")
+            lines.append("  Not ready (no submission metadata yet):")
+            lines.extend(f"    {entry}" for entry in not_ready)
+        if not in_flight and not not_ready:
+            lines.append("  (no .worktrees/ entries exist)")
+        raise SystemExit("\n".join(lines))
+    return ready
+```
+
+Then rewrite `_choose_submit_worktree` to use it (single-select unchanged):
+
+```python
+def _choose_submit_worktree(root: Path) -> Path:
+    """At the repo root, pick the single template-ready worktree to submit."""
+    worktrees.require_tty("vrg-submit-pr from the repo root")
+    ready = _ready_worktrees(root)
+    if len(ready) == 1:
+        wt, fields = ready[0]
+        print(f"Using worktree {wt.path.name} (issue {fields['issue']}: {fields['title']})")
+        return wt.path
+    labels = [f"{wt.path.name} — issue {f['issue']}: {f['title']}" for wt, f in ready]
+    chosen = worktrees.select_worktree(
+        [wt for wt, _ in ready], purpose="Multiple submittable worktrees", labels=labels
+    )
+    return chosen.path
+```
+
+Add the batch selector (resolves `--all` / `--select` / interactive multi):
+
+```python
+def _select_batch_worktrees(root: Path, args: argparse.Namespace) -> list[worktrees.Worktree]:
+    """Resolve the batch's worktrees from --all, --select, or a checkbox menu."""
+    ready = _ready_worktrees(root)
+    candidates = [wt for wt, _ in ready]
+    fields_by_name = {wt.path.name: f for wt, f in ready}
+    if args.all_worktrees:
+        return candidates
+    if args.select is not None:
+        tokens = [t.strip() for t in args.select.split(",") if t.strip()]
+        try:
+            return worktrees.match_worktrees(candidates, tokens)
+        except ValueError as exc:
+            raise SystemExit(f"vrg-submit-pr --select: {exc}") from exc
+    labels = [
+        f"{wt.path.name} — issue {fields_by_name[wt.path.name]['issue']}: "
+        f"{fields_by_name[wt.path.name]['title']}"
+        for wt in candidates
+    ]
+    return worktrees.select_worktrees(
+        candidates, purpose="Select worktrees to batch-submit", labels=labels
+    )
+```
+
+Add the batch orchestration:
+
+```python
+def _run_submit_batch(
+    selected: list[worktrees.Worktree],
+    *,
+    base: str,
+    finalize: bool,
+    release: bool,
+    install: bool,
+    assume_yes: bool,
+) -> int:
+    """Submit (and optionally finalize) *selected* worktrees as a serial batch.
+
+    Per item: rebase the branch on the latest *base* (the zero-waste-CI step),
+    chdir in, submit, chdir back, and — when *finalize* — shell out to
+    ``vrg-finalize-pr <url> --skip-post-checks``. On full success, one
+    end-of-batch validation and a single release run if requested (#1673).
+    """
+    main_root = git.main_worktree_root()
+
+    def _process(wt: worktrees.Worktree) -> None:
+        try:
+            worktrees.rebase_onto(wt, base)
+        except subprocess.CalledProcessError as exc:
+            raise batch.BatchAbort(f"rebase onto origin/{base} failed: {exc}") from exc
+        os.chdir(wt.path)
+        try:
+            pr_url = _submit_one(wt.path, base_override=base, assume_yes=True)
+        finally:
+            os.chdir(main_root)
+        if finalize:
+            result = subprocess.run(  # noqa: S603
+                ("vrg-finalize-pr", pr_url, "--skip-post-checks"),  # noqa: S607
+                cwd=main_root,
+                check=False,
+            )
+            if result.returncode != 0:
+                raise batch.BatchAbort(
+                    f"vrg-finalize-pr {pr_url} --skip-post-checks exited {result.returncode}"
+                )
+
+    def _validate() -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
+            cwd=main_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise batch.BatchAbort(f"end-of-batch validation exited {result.returncode}")
+
+    def _release() -> None:
+        cmd = ("vrg-release", "--install") if install else ("vrg-release",)
+        result = subprocess.run(cmd, cwd=main_root, check=False)  # noqa: S603,S607
+        if result.returncode != 0:
+            raise batch.BatchAbort(f"{' '.join(cmd)} exited {result.returncode}")
+
+    post_steps: list[batch.PostStep] = []
+    if finalize:
+        post_steps.append(batch.PostStep("validation", _validate))
+        if release:
+            post_steps.append(batch.PostStep("release", _release))
+
+    plan = [
+        f"rebase + submit {wt.path.name}" + (" + finalize" if finalize else "")
+        for wt in selected
+    ]
+    if finalize:
+        plan.append("then: validate develop once" + (", then release" if release else ""))
+
+    report = batch.run_batch(
+        selected,
+        _process,
+        label=lambda wt: wt.path.name,
+        plan=plan,
+        assume_yes=assume_yes,
+        post_steps=post_steps,
+    )
+    print(batch.format_report(report))
+    return 0 if report.all_merged and report.post_failure is None else 1
+```
+
+Wire selection into `_run_template_mode`. Replace the current
+"`if git.is_main_worktree():`" block at the top so a multi-selection routes to
+the batch:
+
+```python
+    if git.is_main_worktree():
+        # Batch when --all/--select is given, or interactively when >1 ready
+        # worktree is picked. A single selection falls through to the
+        # unchanged single-PR path below.
+        if args.all_worktrees or args.select is not None:
+            selected = _select_batch_worktrees(root, args)
+            base = _target_branch(args.base) if args.base else "develop"
+            return _run_submit_batch(
+                selected,
+                base=base,
+                finalize=args.finalize,
+                release=args.release,
+                install=args.install,
+                assume_yes=args.yes,
+            )
+        wt_path = _choose_submit_worktree(root)
+        os.chdir(wt_path)
+        root = wt_path
+```
+
+> Interactive multi-select (no flags, several ready worktrees) is deferred to a
+> follow-up to keep this task focused: today's no-flag path uses
+> `_choose_submit_worktree` (single-select). The batch entry points in this task
+> are `--all` and `--select`. Add the no-flag checkbox routing only after these
+> land. (Recorded so the omission is explicit, not silent.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `UV_PROJECT_ENVIRONMENT=.venv-host uv run pytest tests/vergil_tooling/test_vrg_submit_pr.py -v`
+Expected: PASS (new batch tests + all existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_submit_pr.py tests/vergil_tooling/test_vrg_submit_pr.py
+vrg-commit --type feat --scope submit-pr --message "add batch submit via --all/--select (#1673)" --body "Rebase-per-item, submit, finalize each --skip-post-checks, then validate and release once. Fail-fast; single up-front confirm. Ref #1673"
+```
+
+---
+
+## Task 10: Docs + full validation gate
+
+**Files:**
+- Modify: `CLAUDE.md` (and/or `docs/`) — document the batch flags
+- Verify: whole suite green
+
+- [ ] **Step 1: Document the new flags**
+
+Add a short subsection under the PR-submission docs noting:
+- `vrg-submit-pr --all|--select <issues> [--finalize|--release|--install]` — batch submit.
+- `vrg-finalize-pr <pr1,pr2,...>|--all [--release|--install]` — batch finalize.
+- One confirmation up front; fail-fast; release runs once at the end.
+
+Keep prose paraphrased and concise (match existing CLAUDE.md tone).
+
+- [ ] **Step 2: Run the full validation suite (the real gate)**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS — lint, typecheck, tests, audit, common checks all green.
+
+- [ ] **Step 3: Fix anything the suite flags**, re-run until green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+vrg-git add CLAUDE.md docs
+vrg-commit --type docs --scope batch --message "document batch submit/finalize flags (#1673)" --body "Document --all/--select on vrg-submit-pr and the comma-list/--all batch on vrg-finalize-pr. Ref #1673"
+```
+
+---
+
+## Self-review notes (author checklist — completed)
+
+- **Spec coverage:** two entry points → Tasks 7 (finalize) + 9 (submit);
+  shared orchestrator → Tasks 1–2; multi-select + `--all`/`--select` → Tasks
+  3, 4, 9; lazy rebase → Tasks 5, 9; fail-fast + report → Task 2; release-once
+  → Tasks 7, 9; deferred validation → Tasks 6, 7, 9; one-up-front-confirm
+  invariant → Task 2 (`run_batch`) + `assume_yes=True` threaded in 7/9.
+- **Known intentional scope cut:** interactive *no-flag* multi-select on
+  `vrg-submit-pr` is deferred (Task 9 note). `--all`/`--select` are the batch
+  entry points shipped here. This is called out explicitly, not silent.
+- **Type consistency:** `BatchAbort`, `PostStep`, `run_batch`, `format_report`,
+  `BatchReport.all_merged`, `ItemOutcome` names match across Tasks 1–2 and
+  their consumers in Tasks 7 and 9. `build_stages(include_pr=, include_post_checks=)`
+  matches between Task 6 and the `main` wiring. `_submit_one(worktree_root, *,
+  base_override, assume_yes)` matches between Tasks 8 and 9.

--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -192,8 +192,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--all",
         dest="all_prs",
         action="store_true",
-        help="Finalize every open PR found in .worktrees/ as a serial batch "
-        "(issue #1673).",
+        help="Finalize every open PR found in .worktrees/ as a serial batch (issue #1673).",
     )
     parser.add_argument("--target-branch", default="develop", help="Target branch to switch to")
     parser.add_argument(

--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -138,6 +138,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--install through, so vrg-release runs the consumer-refresh install "
         "step (issue #1643)",
     )
+    parser.add_argument(
+        "--skip-post-checks",
+        action="store_true",
+        help="Skip the post-merge validation and CD-status stages (and any "
+        "release chain). Used by the batch orchestrator, which runs those "
+        "once at the end of the batch (issue #1673).",
+    )
     add_yes_argument(parser)
     progress.add_progress_args(parser, ())
     return parser.parse_args(argv)
@@ -565,26 +572,24 @@ def _stage_cd_check(ctx: FinalizeContext) -> None:
     raise FinalizeError("most recent CD workflow run did not succeed")
 
 
-def build_stages(*, include_pr: bool) -> tuple[Stage, ...]:
+def build_stages(*, include_pr: bool, include_post_checks: bool = True) -> tuple[Stage, ...]:
     """Assemble the pipeline for the resolved mode.
 
-    provenance/merge run only when a PR was given or inferred; cleanup,
-    validation, and cd-check always run. validation and cd-check are
-    fail_defer so a validation failure still surfaces the CD status —
+    provenance/merge run only when a PR was given or inferred; cleanup always
+    runs. validation and cd-check run unless *include_post_checks* is False
+    (the batch path defers them to one end-of-batch run, issue #1673); they
+    are fail_defer so a validation failure still surfaces the CD status —
     matching the pre-pipeline control flow.
     """
-    common = (
-        Stage("cleanup", _stage_cleanup, "fail_fast"),
-        Stage("validation", _stage_validation, "fail_defer"),
-        Stage("cd-check", _stage_cd_check, "fail_defer"),
-    )
-    if not include_pr:
-        return common
-    return (
-        Stage("provenance", _stage_provenance, "fail_fast"),
-        Stage("merge", _stage_merge, "fail_fast"),
-        *common,
-    )
+    stages: list[Stage] = []
+    if include_pr:
+        stages.append(Stage("provenance", _stage_provenance, "fail_fast"))
+        stages.append(Stage("merge", _stage_merge, "fail_fast"))
+    stages.append(Stage("cleanup", _stage_cleanup, "fail_fast"))
+    if include_post_checks:
+        stages.append(Stage("validation", _stage_validation, "fail_defer"))
+        stages.append(Stage("cd-check", _stage_cd_check, "fail_defer"))
+    return tuple(stages)
 
 
 def _chain_release(root: Path, *, install: bool = False) -> int:
@@ -661,7 +666,10 @@ def main(argv: list[str] | None = None) -> int:
     ctx = FinalizeContext(args=args, root=root)
     rc = progress.run_pipeline(
         ctx,
-        build_stages(include_pr=args.pr is not None),
+        build_stages(
+            include_pr=args.pr is not None,
+            include_post_checks=not args.skip_post_checks,
+        ),
         command="vrg-finalize-pr",
         label="vrg-finalize-pr",
         args=args,
@@ -671,8 +679,10 @@ def main(argv: list[str] | None = None) -> int:
     # --release cascade (issue #1634): chain into vrg-release only after a
     # clean finalize. A non-zero pipeline must not trigger a release, and the
     # hand-off happens here — after run_pipeline has closed its live display —
-    # so the two renderers never nest (cf. issue #1470).
-    if rc != 0 or not args.release:
+    # so the two renderers never nest (cf. issue #1470). --skip-post-checks
+    # never chains: release is the batch orchestrator's single end-of-batch
+    # step (issue #1673).
+    if rc != 0 or not args.release or args.skip_post_checks:
         return rc
     if args.dry_run:
         target = "vrg-release --install" if args.install else "vrg-release"

--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -55,6 +55,7 @@ from vergil_tooling.lib import (
 )
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.container_cache import clean_branch_images
+from vergil_tooling.lib.pr_workflow import batch
 from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.repo_init import prompt_choice
 
@@ -68,6 +69,87 @@ _ETERNAL_BY_MODEL: dict[str, list[str]] = {
     "library-release": ["develop", "main"],
     "application-promotion": ["develop", "release", "main"],
 }
+
+
+def _parse_pr_list(value: str) -> list[str]:
+    """Split a comma-separated PR argument into trimmed, non-empty tokens."""
+    return [tok.strip() for tok in value.split(",") if tok.strip()]
+
+
+def _resolve_open_prs(root: Path) -> list[str]:
+    """Return the URLs of every open PR in canonical worktrees, branch-sorted.
+
+    Deterministic order (by branch name) so a batch is reproducible. Skips
+    worktrees with no open PR, printing why — no silent exclusions.
+    """
+    urls: list[str] = []
+    for wt in sorted(worktrees.list_worktrees(root), key=lambda w: w.branch):
+        pr = github.pr_for_branch(wt.branch)
+        if pr is None:
+            print(f"  {wt.path.name}: no open PR for {wt.branch} — skipping")
+            continue
+        urls.append(pr["url"])
+    return urls
+
+
+def _run_finalize_batch(
+    prs: list[str],
+    *,
+    root: Path,
+    release: bool,
+    install: bool,
+    assume_yes: bool,
+) -> int:
+    """Finalize *prs* serially, fail-fast, then validate + release once.
+
+    Each item shells out to ``vrg-finalize-pr <pr> --skip-post-checks`` (merge
+    + cleanup, no validation). On full success, one end-of-batch
+    ``vrg-finalize-pr --cleanup-only`` runs validation + the CD check, then a
+    single ``vrg-release [--install]`` if requested (issue #1673).
+    """
+
+    def _finalize_item(pr: str) -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", pr, "--skip-post-checks"),  # noqa: S607
+            cwd=root,
+            check=False,
+        )
+        if result.returncode != 0:
+            msg = f"vrg-finalize-pr {pr} --skip-post-checks exited {result.returncode}"
+            raise batch.BatchAbortError(msg)
+
+    def _validate() -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
+            cwd=root,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise batch.BatchAbortError(f"end-of-batch validation exited {result.returncode}")
+
+    def _release() -> None:
+        cmd = ("vrg-release", "--install") if install else ("vrg-release",)
+        result = subprocess.run(cmd, cwd=root, check=False)  # noqa: S603,S607
+        if result.returncode != 0:
+            raise batch.BatchAbortError(f"{' '.join(cmd)} exited {result.returncode}")
+
+    post_steps = [batch.PostStep("validation", _validate)]
+    if release:
+        post_steps.append(batch.PostStep("release", _release))
+
+    plan = [f"finalize PR {pr}" for pr in prs]
+    plan.append("then: validate develop once" + (", then release" if release else ""))
+
+    report = batch.run_batch(
+        prs,
+        _finalize_item,
+        label=lambda pr: f"PR {pr}",
+        plan=plan,
+        assume_yes=assume_yes,
+        post_steps=post_steps,
+    )
+    print(batch.format_report(report))
+    return 0 if report.all_merged and report.post_failure is None else 1
 
 
 class FinalizeError(Exception):
@@ -105,6 +187,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Skip PR inference and merge; run cleanup without prompting "
         "or reading stdin (non-interactive release path).",
+    )
+    target.add_argument(
+        "--all",
+        dest="all_prs",
+        action="store_true",
+        help="Finalize every open PR found in .worktrees/ as a serial batch "
+        "(issue #1673).",
     )
     parser.add_argument("--target-branch", default="develop", help="Target branch to switch to")
     parser.add_argument(
@@ -648,6 +737,23 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     root = git.repo_root()
+
+    # Batch mode (issue #1673): an explicit comma-list or --all finalizes
+    # several PRs serially. A single PR (or none) falls through to the
+    # unchanged single-PR pipeline below.
+    if args.all_prs:
+        prs = _resolve_open_prs(root)
+        if not prs:
+            print("vrg-finalize-pr --all: no open PRs found in worktrees.")
+            return 0
+        return _run_finalize_batch(
+            prs, root=root, release=args.release, install=args.install, assume_yes=args.yes
+        )
+    if args.pr is not None and "," in args.pr:
+        prs = _parse_pr_list(args.pr)
+        return _run_finalize_batch(
+            prs, root=root, release=args.release, install=args.install, assume_yes=args.yes
+        )
 
     # --cleanup-only is the scriptable release path: no inference, no
     # prompts, no stdin reads — args.pr stays None and only the

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -48,7 +48,7 @@ from vergil_tooling.lib import git, github, identity_mode, pr_template, worktree
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.linkage import ALLOWED_LINKAGES
 from vergil_tooling.lib.pr_body import build_pr_body, resolve_issue_ref
-from vergil_tooling.lib.pr_workflow import submission
+from vergil_tooling.lib.pr_workflow import batch, submission
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
 
 
@@ -84,6 +84,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Run the full cascade through the install step: implies --release "
         "(hence --finalize) and passes --install through so vrg-release runs the "
         "consumer-refresh install commands (issue #1643)",
+    )
+    parser.add_argument(
+        "--all",
+        dest="all_worktrees",
+        action="store_true",
+        help="Select every ready worktree for a batch submission (issue #1673).",
+    )
+    parser.add_argument(
+        "--select",
+        default=None,
+        help="Comma-separated list of ready worktrees to batch-submit, by issue "
+        "number or worktree directory name (issue #1673).",
     )
     add_yes_argument(parser)
     return parser.parse_args(argv)
@@ -262,23 +274,13 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
     return 0
 
 
-def _choose_submit_worktree(root: Path) -> Path:
-    """At the repo root, pick the template-ready worktree to submit from.
+def _ready_worktrees(root: Path) -> list[tuple[worktrees.Worktree, dict[str, str]]]:
+    """Return submittable ``(worktree, fields)`` pairs, or SystemExit if none.
 
-    Candidates are worktrees with submittable PR fields — a valid
-    ``.vergil/pr-workflow.json`` (with PR metadata) or the legacy
-    ``.vergil/pr-template.yml`` — the agent-written signal that the issue
-    is ready for submission.
-    One candidate is auto-picked (the existing y/N preview still
-    confirms); several prompt a menu; none is an error that names each
-    skipped worktree and why.
-
-    Root launches are interactive by requirement regardless of how many
-    candidates exist — even the auto-picked path ends in a y/N confirm —
-    so the TTY guard fires up front, not per-prompt.
+    Same classification (ready / in-flight / not-ready) and same
+    no-submittable-worktrees error as the single-select path; shared by the
+    single picker and the batch selector (issue #1673).
     """
-    worktrees.require_tty("vrg-submit-pr from the repo root")
-
     ready: list[tuple[worktrees.Worktree, dict[str, str]]] = []
     in_flight: list[str] = []
     not_ready: list[str] = []
@@ -310,6 +312,19 @@ def _choose_submit_worktree(root: Path) -> Path:
         if not in_flight and not not_ready:
             lines.append("  (no .worktrees/ entries exist)")
         raise SystemExit("\n".join(lines))
+    return ready
+
+
+def _choose_submit_worktree(root: Path) -> Path:
+    """At the repo root, pick the single template-ready worktree to submit from.
+
+    One candidate is auto-picked (the existing y/N preview still confirms);
+    several prompt a menu; none is an error that names each skipped worktree
+    and why. Root launches are interactive by requirement, so the TTY guard
+    fires up front, not per-prompt.
+    """
+    worktrees.require_tty("vrg-submit-pr from the repo root")
+    ready = _ready_worktrees(root)
 
     if len(ready) == 1:
         wt, fields = ready[0]
@@ -323,6 +338,107 @@ def _choose_submit_worktree(root: Path) -> Path:
         labels=labels,
     )
     return chosen.path
+
+
+def _select_batch_worktrees(root: Path, args: argparse.Namespace) -> list[worktrees.Worktree]:
+    """Resolve the batch's worktrees from --all, --select, or a checkbox menu."""
+    ready = _ready_worktrees(root)
+    candidates = [wt for wt, _ in ready]
+    fields_by_name = {wt.path.name: f for wt, f in ready}
+    if args.all_worktrees:
+        return candidates
+    if args.select is not None:
+        tokens = [t.strip() for t in args.select.split(",") if t.strip()]
+        try:
+            return worktrees.match_worktrees(candidates, tokens)
+        except ValueError as exc:
+            raise SystemExit(f"vrg-submit-pr --select: {exc}") from exc
+    labels = [
+        f"{wt.path.name} — issue {fields_by_name[wt.path.name]['issue']}: "
+        f"{fields_by_name[wt.path.name]['title']}"
+        for wt in candidates
+    ]
+    return worktrees.select_worktrees(
+        candidates, purpose="Select worktrees to batch-submit", labels=labels
+    )
+
+
+def _run_submit_batch(
+    selected: list[worktrees.Worktree],
+    *,
+    base: str,
+    finalize: bool,
+    release: bool,
+    install: bool,
+    assume_yes: bool,
+) -> int:
+    """Submit (and optionally finalize) *selected* worktrees as a serial batch.
+
+    Per item: rebase the branch on the latest *base* (the zero-waste-CI step),
+    chdir in, submit, chdir back, and — when *finalize* — shell out to
+    ``vrg-finalize-pr <url> --skip-post-checks``. On full success, one
+    end-of-batch validation and a single release run if requested (#1673).
+    """
+    main_root = git.main_worktree_root()
+
+    def _process(wt: worktrees.Worktree) -> None:
+        try:
+            worktrees.rebase_onto(wt, base)
+        except subprocess.CalledProcessError as exc:
+            raise batch.BatchAbortError(f"rebase onto origin/{base} failed: {exc}") from exc
+        os.chdir(wt.path)
+        try:
+            pr_url = _submit_one(wt.path, base_override=base, assume_yes=True)
+        finally:
+            os.chdir(main_root)
+        if finalize:
+            result = subprocess.run(  # noqa: S603
+                ("vrg-finalize-pr", pr_url, "--skip-post-checks"),  # noqa: S607
+                cwd=main_root,
+                check=False,
+            )
+            if result.returncode != 0:
+                raise batch.BatchAbortError(
+                    f"vrg-finalize-pr {pr_url} --skip-post-checks exited {result.returncode}"
+                )
+
+    def _validate() -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
+            cwd=main_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise batch.BatchAbortError(f"end-of-batch validation exited {result.returncode}")
+
+    def _release() -> None:
+        cmd = ("vrg-release", "--install") if install else ("vrg-release",)
+        result = subprocess.run(cmd, cwd=main_root, check=False)  # noqa: S603,S607
+        if result.returncode != 0:
+            raise batch.BatchAbortError(f"{' '.join(cmd)} exited {result.returncode}")
+
+    post_steps: list[batch.PostStep] = []
+    if finalize:
+        post_steps.append(batch.PostStep("validation", _validate))
+        if release:
+            post_steps.append(batch.PostStep("release", _release))
+
+    plan = [
+        f"rebase + submit {wt.path.name}" + (" + finalize" if finalize else "") for wt in selected
+    ]
+    if finalize:
+        plan.append("then: validate develop once" + (", then release" if release else ""))
+
+    report = batch.run_batch(
+        selected,
+        _process,
+        label=lambda wt: wt.path.name,
+        plan=plan,
+        assume_yes=assume_yes,
+        post_steps=post_steps,
+    )
+    print(batch.format_report(report))
+    return 0 if report.all_merged and report.post_failure is None else 1
 
 
 def _push_create_record(
@@ -396,6 +512,21 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     # which `.worktrees/` worktree to submit from and move there. The
     # invoking shell is unaffected — chdir applies to this process only.
     if git.is_main_worktree():
+        # Batch when --all/--select is given. A single selection falls through
+        # to the unchanged single-PR path below (issue #1673). Interactive
+        # no-flag multi-select is a deliberate follow-up: the no-flag path
+        # stays single-select via _choose_submit_worktree.
+        if args.all_worktrees or args.select is not None:
+            selected = _select_batch_worktrees(root, args)
+            base = _target_branch(args.base) if args.base else "develop"
+            return _run_submit_batch(
+                selected,
+                base=base,
+                finalize=args.finalize,
+                release=args.release,
+                install=args.install,
+                assume_yes=args.yes,
+            )
         wt_path = _choose_submit_worktree(root)
         os.chdir(wt_path)
         root = wt_path

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -325,6 +325,70 @@ def _choose_submit_worktree(root: Path) -> Path:
     return chosen.path
 
 
+def _push_create_record(
+    *,
+    worktree_root: Path,
+    branch: str,
+    target: str,
+    title: str,
+    pr_body: str,
+) -> str:
+    """Push the branch, create the PR, record submission, return the URL.
+
+    The shared submit tail used by both single-PR template mode and the batch
+    ``_submit_one``. Pushes with the human's host credentials (the superset of
+    any agent's rights) so a branch touching ``.github/workflows/`` still
+    pushes.
+    """
+    print(f"Ensuring branch '{branch}' is pushed to origin...")
+    _push_branch(branch)
+    print("Creating PR...")
+    pr_url = _create_pr(target_branch=target, title=title, pr_body=pr_body)
+    submission.record_submission(worktree_root, pr_url=pr_url)
+    print(f"PR created: {pr_url}")
+    return pr_url
+
+
+def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: bool) -> str:
+    """Read the worktree's PR fields, push, create the PR, record it, return URL.
+
+    Self-contained submit for one worktree, used by the batch orchestrator.
+    Propagates ``AlreadySubmittedError`` / ``FileNotFoundError`` /
+    ``TemplateError`` / ``WorkflowError`` from the field readers and raises
+    ``SystemExit`` on a forbidden linkage or a declined confirm. The per-PR
+    confirm is pre-answered when *assume_yes* — the batch path passes True so
+    the single up-front batch confirm is the only gate (issue #1673).
+    """
+    fields = submission.read_pr_fields(worktree_root)
+    issue_ref = resolve_issue_ref(fields["issue"])
+    branch = git.current_branch()
+    target = _target_branch(base_override, fields.get("base"))
+    linkage = fields.get("linkage", "Ref")
+    if linkage not in ALLOWED_LINKAGES:
+        msg = (
+            f"vrg-submit-pr: linkage '{linkage}' in the PR submission fields is not "
+            f"allowed; use: {', '.join(ALLOWED_LINKAGES)}."
+        )
+        raise SystemExit(msg)
+    pr_body = build_pr_body(
+        summary=fields["summary"],
+        linkage=linkage,
+        issue_ref=issue_ref,
+        notes=fields.get("notes", ""),
+    )
+    print(f"=== Submitting issue {issue_ref}: {fields['title']} ===")
+    print(f"    base {target}, branch {branch}")
+    if not confirm("\nSubmit this PR?", assume_yes=assume_yes):
+        raise SystemExit("vrg-submit-pr: submission declined at the per-PR confirm")
+    return _push_create_record(
+        worktree_root=worktree_root,
+        branch=branch,
+        target=target,
+        title=fields["title"],
+        pr_body=pr_body,
+    )
+
+
 def _run_template_mode(args: argparse.Namespace) -> int:
     root = Path(git.repo_root())
 
@@ -397,17 +461,13 @@ def _run_template_mode(args: argparse.Namespace) -> int:
         print("Aborted.")
         return 1
 
-    # Ensure-pushed: push with the human's host credentials before creating
-    # the PR. The human is the superset of any agent's rights, so this push
-    # succeeds even for branches that touch .github/workflows/ — which the
-    # agent's own push would have been rejected for.
-    print(f"Ensuring branch '{branch}' is pushed to origin...")
-    _push_branch(branch)
-
-    print("Creating PR...")
-    pr_url = _create_pr(target_branch=target, title=title, pr_body=pr_body)
-    submission.record_submission(root, pr_url=pr_url)
-    print(f"PR created: {pr_url}")
+    pr_url = _push_create_record(
+        worktree_root=root,
+        branch=branch,
+        target=target,
+        title=title,
+        pr_body=pr_body,
+    )
     if args.finalize:
         rc = _chain_finalize(pr_url, release=args.release, install=args.install)
         if rc != 0:

--- a/src/vergil_tooling/lib/pr_workflow/batch.py
+++ b/src/vergil_tooling/lib/pr_workflow/batch.py
@@ -60,3 +60,76 @@ class BatchReport:
     @property
     def all_merged(self) -> bool:
         return bool(self.items) and all(i.outcome is ItemOutcome.MERGED for i in self.items)
+
+
+def run_batch(
+    items: Sequence[Any],
+    process: Callable[[Any], None],
+    *,
+    label: Callable[[Any], str],
+    plan: Sequence[str],
+    assume_yes: bool,
+    post_steps: Sequence[PostStep] = (),
+) -> BatchReport:
+    """Run *items* through *process* serially, fail-fast, then *post_steps*.
+
+    Prints *plan* and asks exactly one confirmation (skipped with
+    *assume_yes*). On decline, returns an all-NOT_STARTED report and runs
+    nothing. Each item that raises ``BatchAbort`` stops the batch: it is
+    recorded FAILED and the remaining items NOT_STARTED. ``post_steps`` run
+    in order only when every item merged; a post-step ``BatchAbort`` is
+    recorded in ``post_failure`` (never un-doing a merge) and stops the
+    remaining post-steps.
+    """
+    report = BatchReport()
+
+    print("Batch plan:")
+    for line in plan:
+        print(f"  {line}")
+    if not confirm("\nRun this batch?", assume_yes=assume_yes, default=False):
+        print("Aborted.")
+        report.items = [ItemResult(label(it), ItemOutcome.NOT_STARTED) for it in items]
+        return report
+
+    stopped = False
+    for it in items:
+        if stopped:
+            report.items.append(ItemResult(label(it), ItemOutcome.NOT_STARTED))
+            continue
+        try:
+            process(it)
+        except BatchAbort as exc:
+            report.items.append(ItemResult(label(it), ItemOutcome.FAILED, str(exc)))
+            stopped = True
+        else:
+            report.items.append(ItemResult(label(it), ItemOutcome.MERGED))
+
+    if report.all_merged:
+        for step in post_steps:
+            try:
+                step.run()
+            except BatchAbort as exc:
+                report.post_failure = f"{step.name}: {exc}"
+                break
+
+    return report
+
+
+def format_report(report: BatchReport) -> str:
+    """Render the merged / failed / not-started buckets as a summary block."""
+    lines = ["", "Batch summary:"]
+    for bucket, outcome in (
+        ("Merged", ItemOutcome.MERGED),
+        ("Failed", ItemOutcome.FAILED),
+        ("Not started", ItemOutcome.NOT_STARTED),
+    ):
+        members = [i for i in report.items if i.outcome is outcome]
+        if not members:
+            continue
+        lines.append(f"  {bucket}:")
+        for i in members:
+            suffix = f" — {i.reason}" if i.reason else ""
+            lines.append(f"    {i.label}{suffix}")
+    if report.post_failure:
+        lines.append(f"  Post-step failed: {report.post_failure}")
+    return "\n".join(lines)

--- a/src/vergil_tooling/lib/pr_workflow/batch.py
+++ b/src/vergil_tooling/lib/pr_workflow/batch.py
@@ -1,0 +1,62 @@
+"""Single-threaded, fail-fast batch orchestrator for the PR pipeline.
+
+Runs a sequence of items through a per-item ``process`` callback one at a
+time, stopping at the first failure (fail-fast). Completed items are
+reported MERGED, the failed one FAILED with its reason, and the rest
+NOT_STARTED. Post-steps (end-of-batch validation, a single release) run
+only when every item merged cleanly.
+
+The whole run is gated by exactly one up-front confirmation: per-item
+prompts are pre-suppressed by the callers (they thread ``assume_yes``), so
+once confirmed the batch runs unattended. (Issue #1673.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from vergil_tooling.lib.confirm import confirm
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+class BatchAbort(Exception):
+    """A per-item step (or post-step) failed; the message is the reason.
+
+    Callers convert expected failures (rebase conflict, gate red, merge
+    abort, provenance violation, non-zero subprocess) into this so the
+    orchestrator can record them and stop without masking unexpected bugs,
+    which propagate.
+    """
+
+
+class ItemOutcome(StrEnum):
+    MERGED = "merged"
+    FAILED = "failed"
+    NOT_STARTED = "not-started"
+
+
+@dataclass(frozen=True)
+class ItemResult:
+    label: str
+    outcome: ItemOutcome
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class PostStep:
+    name: str
+    run: Callable[[], None]
+
+
+@dataclass
+class BatchReport:
+    items: list[ItemResult] = field(default_factory=list)
+    post_failure: str | None = None
+
+    @property
+    def all_merged(self) -> bool:
+        return bool(self.items) and all(i.outcome is ItemOutcome.MERGED for i in self.items)

--- a/src/vergil_tooling/lib/pr_workflow/batch.py
+++ b/src/vergil_tooling/lib/pr_workflow/batch.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 
-class BatchAbort(Exception):
+class BatchAbortError(Exception):
     """A per-item step (or post-step) failed; the message is the reason.
 
     Callers convert expected failures (rebase conflict, gate red, merge
@@ -75,9 +75,9 @@ def run_batch(
 
     Prints *plan* and asks exactly one confirmation (skipped with
     *assume_yes*). On decline, returns an all-NOT_STARTED report and runs
-    nothing. Each item that raises ``BatchAbort`` stops the batch: it is
+    nothing. Each item that raises ``BatchAbortError`` stops the batch: it is
     recorded FAILED and the remaining items NOT_STARTED. ``post_steps`` run
-    in order only when every item merged; a post-step ``BatchAbort`` is
+    in order only when every item merged; a post-step ``BatchAbortError`` is
     recorded in ``post_failure`` (never un-doing a merge) and stops the
     remaining post-steps.
     """
@@ -98,7 +98,7 @@ def run_batch(
             continue
         try:
             process(it)
-        except BatchAbort as exc:
+        except BatchAbortError as exc:
             report.items.append(ItemResult(label(it), ItemOutcome.FAILED, str(exc)))
             stopped = True
         else:
@@ -108,7 +108,7 @@ def run_batch(
         for step in post_steps:
             try:
                 step.run()
-            except BatchAbort as exc:
+            except BatchAbortError as exc:
                 report.post_failure = f"{step.name}: {exc}"
                 break
 

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -79,6 +79,31 @@ def prompt_choice(label: str, options: list[str], *, default: str = "") -> str:
         print(f"  Enter a number between 1 and {len(options)}.")
 
 
+def prompt_multi_choice(label: str, options: list[str]) -> list[int]:
+    """Present a numbered list; return the chosen 0-based indices.
+
+    Accepts a comma- or space-separated list of numbers, or ``all`` for
+    every option. Re-prompts on invalid or out-of-range input or an empty
+    selection — the caller wants at least one.
+    """
+    print(f"\n{label}:")
+    for i, opt in enumerate(options, 1):
+        print(f"  {i}. {opt}")
+    while True:
+        raw = input("  Select (comma-separated numbers, or 'all'): ").strip().lower()
+        if raw == "all":
+            return list(range(len(options)))
+        tokens = [t for t in raw.replace(",", " ").split() if t]
+        try:
+            chosen = sorted({int(t) for t in tokens})
+        except ValueError:
+            print(f"  Enter numbers between 1 and {len(options)}, or 'all'.")
+            continue
+        if chosen and all(1 <= n <= len(options) for n in chosen):
+            return [n - 1 for n in chosen]
+        print(f"  Enter numbers between 1 and {len(options)}, or 'all'.")
+
+
 def prompt_language(*, default: str = "") -> str:
     """Prompt for the primary language, with an explicit no-language option.
 

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -16,7 +16,7 @@ from enum import StrEnum
 from pathlib import Path
 
 from vergil_tooling.lib import git, github
-from vergil_tooling.lib.repo_init import prompt_choice
+from vergil_tooling.lib.repo_init import prompt_choice, prompt_multi_choice
 
 
 @dataclass(frozen=True)
@@ -218,3 +218,63 @@ def select_worktree(
     require_tty(purpose)
     chosen = prompt_choice(purpose, labels)
     return candidates[labels.index(chosen)]
+
+
+def select_worktrees(
+    candidates: list[Worktree],
+    *,
+    purpose: str,
+    labels: list[str],
+) -> list[Worktree]:
+    """Choose one or more candidate worktrees via a checkbox-style menu.
+
+    A single candidate is returned without prompting. With several, a TTY is
+    required and a multi-select menu (numbers or 'all') is shown. ``labels``
+    parallels ``candidates`` one-to-one.
+    """
+    if not candidates:
+        msg = "select_worktrees requires at least one candidate"
+        raise ValueError(msg)
+    if len(candidates) == 1:
+        return [candidates[0]]
+    require_tty(purpose)
+    return [candidates[i] for i in prompt_multi_choice(purpose, labels)]
+
+
+def match_worktrees(candidates: list[Worktree], tokens: list[str]) -> list[Worktree]:
+    """Resolve *tokens* (issue numbers or worktree dir names) to worktrees.
+
+    Each token matches a candidate by directory name (``wt.path.name``) or by
+    the issue number in a canonical ``issue-<N>-<slug>`` name. Result order
+    follows *tokens*. Unmatched or ambiguous tokens raise ``ValueError``
+    naming them — never a silent skip.
+    """
+    by_name = {wt.path.name: wt for wt in candidates}
+    by_issue: dict[str, list[Worktree]] = {}
+    for wt in candidates:
+        name = wt.path.name
+        if name.startswith("issue-") and len(name.split("-", 2)) >= 2:
+            by_issue.setdefault(name.split("-", 2)[1], []).append(wt)
+
+    selected: list[Worktree] = []
+    unmatched: list[str] = []
+    ambiguous: list[str] = []
+    for raw in tokens:
+        tok = raw.strip()
+        if tok in by_name:
+            selected.append(by_name[tok])
+        elif tok in by_issue and len(by_issue[tok]) == 1:
+            selected.append(by_issue[tok][0])
+        elif tok in by_issue:
+            ambiguous.append(tok)
+        else:
+            unmatched.append(tok)
+
+    if unmatched or ambiguous:
+        parts = []
+        if unmatched:
+            parts.append(f"no ready worktree matches: {', '.join(unmatched)}")
+        if ambiguous:
+            parts.append(f"ambiguous (multiple worktrees): {', '.join(ambiguous)}")
+        raise ValueError("; ".join(parts))
+    return selected

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -278,3 +278,18 @@ def match_worktrees(candidates: list[Worktree], tokens: list[str]) -> list[Workt
             parts.append(f"ambiguous (multiple worktrees): {', '.join(ambiguous)}")
         raise ValueError("; ".join(parts))
     return selected
+
+
+def rebase_onto(worktree: Worktree, base: str) -> None:
+    """Fetch *base* from origin and rebase *worktree*'s branch onto it.
+
+    Run via ``git -C`` so the batch orchestrator can process each worktree
+    without changing the process CWD. This is the step that makes a batch's
+    CI gate run exactly once: rebasing onto the current ``develop`` before
+    the PR opens means the gate runs against the final state and the later
+    merge is not ``BEHIND``. A rebase conflict raises
+    ``subprocess.CalledProcessError`` for the caller to convert to a
+    ``BatchAbort``.
+    """
+    git.run("-C", str(worktree.path), "fetch", "origin", base)
+    git.run("-C", str(worktree.path), "rebase", f"origin/{base}")

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -289,7 +289,7 @@ def rebase_onto(worktree: Worktree, base: str) -> None:
     the PR opens means the gate runs against the final state and the later
     merge is not ``BEHIND``. A rebase conflict raises
     ``subprocess.CalledProcessError`` for the caller to convert to a
-    ``BatchAbort``.
+    ``BatchAbortError``.
     """
     git.run("-C", str(worktree.path), "fetch", "origin", base)
     git.run("-C", str(worktree.path), "rebase", f"origin/{base}")

--- a/tests/vergil_tooling/pr_workflow/test_batch.py
+++ b/tests/vergil_tooling/pr_workflow/test_batch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from vergil_tooling.lib.pr_workflow.batch import (
-    BatchAbort,
+    BatchAbortError,
     BatchReport,
     ItemOutcome,
     ItemResult,
@@ -55,7 +55,7 @@ def test_all_items_processed_in_order_on_success() -> None:
 def test_first_failure_stops_and_marks_rest_not_started() -> None:
     def process(it: str) -> None:
         if it == "b":
-            raise BatchAbort("gate red")
+            raise BatchAbortError("gate red")
 
     with _confirm_yes():
         report = run_batch(
@@ -92,7 +92,7 @@ def test_post_steps_skipped_when_any_item_failed() -> None:
     calls: list[str] = []
 
     def process(it: str) -> None:
-        raise BatchAbort("nope")
+        raise BatchAbortError("nope")
 
     with _confirm_yes():
         report = run_batch(
@@ -109,7 +109,7 @@ def test_post_steps_skipped_when_any_item_failed() -> None:
 
 def test_post_step_failure_recorded_not_raised() -> None:
     def boom() -> None:
-        raise BatchAbort("release blew up")
+        raise BatchAbortError("release blew up")
 
     with _confirm_yes():
         report = run_batch(

--- a/tests/vergil_tooling/pr_workflow/test_batch.py
+++ b/tests/vergil_tooling/pr_workflow/test_batch.py
@@ -1,0 +1,26 @@
+"""Tests for the batch orchestrator (vergil_tooling.lib.pr_workflow.batch)."""
+
+from __future__ import annotations
+
+from vergil_tooling.lib.pr_workflow.batch import (
+    BatchReport,
+    ItemOutcome,
+    ItemResult,
+)
+
+
+def test_all_merged_true_only_when_every_item_merged() -> None:
+    merged = BatchReport(items=[ItemResult("a", ItemOutcome.MERGED)])
+    assert merged.all_merged is True
+
+    mixed = BatchReport(
+        items=[
+            ItemResult("a", ItemOutcome.MERGED),
+            ItemResult("b", ItemOutcome.FAILED, "boom"),
+        ]
+    )
+    assert mixed.all_merged is False
+
+
+def test_all_merged_false_when_empty() -> None:
+    assert BatchReport().all_merged is False

--- a/tests/vergil_tooling/pr_workflow/test_batch.py
+++ b/tests/vergil_tooling/pr_workflow/test_batch.py
@@ -151,3 +151,11 @@ def test_format_report_groups_buckets() -> None:
     assert "Failed:" in out
     assert "b — gate red" in out
     assert "Not started:" in out
+
+
+def test_format_report_includes_post_failure() -> None:
+    report = BatchReport(
+        items=[ItemResult("a", ItemOutcome.MERGED)],
+        post_failure="release: boom",
+    )
+    assert "Post-step failed: release: boom" in format_report(report)

--- a/tests/vergil_tooling/pr_workflow/test_batch.py
+++ b/tests/vergil_tooling/pr_workflow/test_batch.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from vergil_tooling.lib.pr_workflow.batch import (
+    BatchAbort,
     BatchReport,
     ItemOutcome,
     ItemResult,
+    PostStep,
+    format_report,
+    run_batch,
 )
+
+_MOD = "vergil_tooling.lib.pr_workflow.batch"
+
+
+def _confirm_yes():
+    return patch(_MOD + ".confirm", return_value=True)
 
 
 def test_all_merged_true_only_when_every_item_merged() -> None:
@@ -24,3 +36,118 @@ def test_all_merged_true_only_when_every_item_merged() -> None:
 
 def test_all_merged_false_when_empty() -> None:
     assert BatchReport().all_merged is False
+
+
+def test_all_items_processed_in_order_on_success() -> None:
+    seen: list[str] = []
+    with _confirm_yes():
+        report = run_batch(
+            ["a", "b", "c"],
+            process=seen.append,
+            label=lambda it: it,
+            plan=["do a", "do b", "do c"],
+            assume_yes=True,
+        )
+    assert seen == ["a", "b", "c"]
+    assert report.all_merged is True
+
+
+def test_first_failure_stops_and_marks_rest_not_started() -> None:
+    def process(it: str) -> None:
+        if it == "b":
+            raise BatchAbort("gate red")
+
+    with _confirm_yes():
+        report = run_batch(
+            ["a", "b", "c"],
+            process=process,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+        )
+    outcomes = [(i.label, i.outcome.value, i.reason) for i in report.items]
+    assert outcomes == [
+        ("a", "merged", None),
+        ("b", "failed", "gate red"),
+        ("c", "not-started", None),
+    ]
+    assert report.all_merged is False
+
+
+def test_post_steps_run_once_on_full_success() -> None:
+    calls: list[str] = []
+    with _confirm_yes():
+        run_batch(
+            ["a"],
+            process=lambda it: None,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+            post_steps=[PostStep("release", lambda: calls.append("release"))],
+        )
+    assert calls == ["release"]
+
+
+def test_post_steps_skipped_when_any_item_failed() -> None:
+    calls: list[str] = []
+
+    def process(it: str) -> None:
+        raise BatchAbort("nope")
+
+    with _confirm_yes():
+        report = run_batch(
+            ["a"],
+            process=process,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+            post_steps=[PostStep("release", lambda: calls.append("release"))],
+        )
+    assert calls == []
+    assert report.post_failure is None
+
+
+def test_post_step_failure_recorded_not_raised() -> None:
+    def boom() -> None:
+        raise BatchAbort("release blew up")
+
+    with _confirm_yes():
+        report = run_batch(
+            ["a"],
+            process=lambda it: None,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=True,
+            post_steps=[PostStep("release", boom)],
+        )
+    assert report.post_failure == "release: release blew up"
+
+
+def test_decline_marks_all_not_started_and_runs_nothing() -> None:
+    seen: list[str] = []
+    with patch(_MOD + ".confirm", return_value=False):
+        report = run_batch(
+            ["a", "b"],
+            process=seen.append,
+            label=lambda it: it,
+            plan=[],
+            assume_yes=False,
+        )
+    assert seen == []
+    assert [i.outcome.value for i in report.items] == ["not-started", "not-started"]
+
+
+def test_format_report_groups_buckets() -> None:
+    report = BatchReport(
+        items=[
+            ItemResult("a", ItemOutcome.MERGED),
+            ItemResult("b", ItemOutcome.FAILED, "gate red"),
+            ItemResult("c", ItemOutcome.NOT_STARTED),
+        ]
+    )
+    out = format_report(report)
+    assert "Merged:" in out
+    assert "a" in out
+    assert "Failed:" in out
+    assert "b — gate red" in out
+    assert "Not started:" in out

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -22,6 +22,7 @@ from vergil_tooling.lib.repo_init import (
     prompt_choice,
     prompt_free_text,
     prompt_language,
+    prompt_multi_choice,
     prompt_yes_no,
     render_cd_workflow,
     render_ci_workflow,
@@ -1255,3 +1256,24 @@ def test_render_claude_settings_other_version() -> None:
     data = json.loads(render_claude_settings("v2.0"))
     src = data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]
     assert src["ref"] == "v2.0"
+
+
+def test_multi_choice_numbers() -> None:
+    with patch("builtins.input", return_value="1,3"):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [0, 2]
+
+
+def test_multi_choice_all() -> None:
+    with patch("builtins.input", return_value="all"):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [0, 1, 2]
+
+
+def test_multi_choice_space_separated_and_dedup_sorted() -> None:
+    with patch("builtins.input", return_value="3 1 1"):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [0, 2]
+
+
+def test_multi_choice_reprompts_on_out_of_range(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("builtins.input", side_effect=["9", "2"]):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [1]
+    assert "between 1 and 3" in capsys.readouterr().out

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -1277,3 +1277,9 @@ def test_multi_choice_reprompts_on_out_of_range(capsys: pytest.CaptureFixture[st
     with patch("builtins.input", side_effect=["9", "2"]):
         assert prompt_multi_choice("pick", ["a", "b", "c"]) == [1]
     assert "between 1 and 3" in capsys.readouterr().out
+
+
+def test_multi_choice_reprompts_on_non_integer(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("builtins.input", side_effect=["x", "2"]):
+        assert prompt_multi_choice("pick", ["a", "b", "c"]) == [1]
+    assert "between 1 and 3" in capsys.readouterr().out

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -16,7 +16,10 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     FinalizeContext,
     FinalizeError,
     _check_cd_workflow_status,
+    _parse_pr_list,
+    _resolve_open_prs,
     _resolve_strategy,
+    _run_finalize_batch,
     _stage_cd_check,
     _stage_merge,
     _stage_provenance,
@@ -1794,3 +1797,136 @@ def test_default_keeps_post_checks() -> None:
 
 def test_skip_post_checks_flag_parses() -> None:
     assert parse_args(["123", "--skip-post-checks"]).skip_post_checks is True
+
+
+_FIN_MOD = "vergil_tooling.bin.vrg_finalize_pr"
+
+
+def test_parse_pr_list_splits_and_trims() -> None:
+    assert _parse_pr_list("123, 124 ,125") == ["123", "124", "125"]
+    assert _parse_pr_list("123") == ["123"]
+
+
+def test_finalize_batch_runs_each_item_then_release_once() -> None:
+    runs: list[tuple[str, ...]] = []
+
+    def fake_run(cmd, **_kwargs):
+        runs.append(tuple(cmd))
+        return MagicMock(returncode=0)
+
+    with (
+        patch(_FIN_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_FIN_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_finalize_batch(
+            ["123", "124"],
+            root=Path("/repo"),
+            release=True,
+            install=False,
+            assume_yes=True,
+        )
+    assert rc == 0
+    assert ("vrg-finalize-pr", "123", "--skip-post-checks") in runs
+    assert ("vrg-finalize-pr", "124", "--skip-post-checks") in runs
+    assert ("vrg-finalize-pr", "--cleanup-only") in runs
+    assert ("vrg-release",) in runs
+
+
+def test_finalize_batch_stops_on_item_failure_no_release() -> None:
+    def fake_run(cmd, **_kwargs):
+        rc = 1 if "123" in cmd else 0
+        return MagicMock(returncode=rc)
+
+    with (
+        patch(_FIN_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_FIN_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_finalize_batch(
+            ["123", "124"],
+            root=Path("/repo"),
+            release=True,
+            install=False,
+            assume_yes=True,
+        )
+    assert rc == 1
+
+
+def test_resolve_open_prs_skips_worktrees_without_pr() -> None:
+    wts = [
+        Worktree(path=Path("/r/.worktrees/issue-2-b"), branch="feature/2-b"),
+        Worktree(path=Path("/r/.worktrees/issue-1-a"), branch="feature/1-a"),
+    ]
+
+    def pr_for(branch: str):
+        return {"url": f"https://x/{branch}"} if branch == "feature/1-a" else None
+
+    with (
+        patch(_FIN_MOD + ".worktrees.list_worktrees", return_value=wts),
+        patch(_FIN_MOD + ".github.pr_for_branch", side_effect=pr_for),
+    ):
+        # branch-sorted: feature/1-a precedes feature/2-b; only 1-a has a PR
+        assert _resolve_open_prs(Path("/r")) == ["https://x/feature/1-a"]
+
+
+def test_finalize_batch_validation_failure_reported() -> None:
+    def fake_run(cmd, **_kwargs):
+        rc = 1 if tuple(cmd)[:2] == ("vrg-finalize-pr", "--cleanup-only") else 0
+        return MagicMock(returncode=rc)
+
+    with (
+        patch(_FIN_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_FIN_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_finalize_batch(
+            ["123"], root=Path("/repo"), release=False, install=False, assume_yes=True
+        )
+    assert rc == 1
+
+
+def test_finalize_batch_release_failure_reported() -> None:
+    def fake_run(cmd, **_kwargs):
+        rc = 1 if tuple(cmd)[0] == "vrg-release" else 0
+        return MagicMock(returncode=rc)
+
+    with (
+        patch(_FIN_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_FIN_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_finalize_batch(
+            ["123"], root=Path("/repo"), release=True, install=False, assume_yes=True
+        )
+    assert rc == 1
+
+
+def test_main_all_routes_to_batch() -> None:
+    with (
+        patch(_FIN_MOD + ".git.is_main_worktree", return_value=True),
+        patch(_FIN_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_FIN_MOD + "._resolve_open_prs", return_value=["u1", "u2"]),
+        patch(_FIN_MOD + "._run_finalize_batch", return_value=0) as run_batch,
+    ):
+        rc = main(["--all"])
+    assert rc == 0
+    run_batch.assert_called_once()
+
+
+def test_main_all_no_open_prs_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(_FIN_MOD + ".git.is_main_worktree", return_value=True),
+        patch(_FIN_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_FIN_MOD + "._resolve_open_prs", return_value=[]),
+    ):
+        rc = main(["--all"])
+    assert rc == 0
+    assert "no open PRs" in capsys.readouterr().out
+
+
+def test_main_comma_list_routes_to_batch() -> None:
+    with (
+        patch(_FIN_MOD + ".git.is_main_worktree", return_value=True),
+        patch(_FIN_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_FIN_MOD + "._run_finalize_batch", return_value=0) as run_batch,
+    ):
+        rc = main(["123,124"])
+    assert rc == 0
+    run_batch.assert_called_once()

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -1778,3 +1778,19 @@ def test_install_failure_points_at_release_install_rerun(
         result = main(["--install"])
     assert result == 2
     assert "vrg-release --install" in capsys.readouterr().err
+
+
+def test_skip_post_checks_drops_validation_and_cd() -> None:
+    names = {s.name for s in build_stages(include_pr=True, include_post_checks=False)}
+    assert "validation" not in names
+    assert "cd-check" not in names
+    assert {"provenance", "merge", "cleanup"} <= names
+
+
+def test_default_keeps_post_checks() -> None:
+    names = {s.name for s in build_stages(include_pr=True, include_post_checks=True)}
+    assert {"validation", "cd-check"} <= names
+
+
+def test_skip_post_checks_flag_parses() -> None:
+    assert parse_args(["123", "--skip-post-checks"]).skip_post_checks is True

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -11,6 +11,7 @@ import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
+    _submit_one,
     _target_branch,
     main,
     parse_args,
@@ -1331,3 +1332,30 @@ class TestInstallFlag:
         assert result != 0
         mock_run.assert_not_called()
         assert "human maintainer" in capsys.readouterr().err.lower()
+
+
+def test_submit_one_pushes_creates_records_and_returns_url() -> None:
+    fields = {
+        "issue": "1673",
+        "title": "Batch",
+        "summary": "s",
+        "notes": "",
+        "linkage": "Ref",
+        "base": "origin/develop",
+    }
+    with (
+        patch(_MOD + ".submission.read_pr_fields", return_value=fields),
+        patch(_MOD + ".git.current_branch", return_value="feature/1673-x"),
+        patch(_MOD + "._push_branch") as push,
+        patch(_MOD + "._create_pr", return_value="https://example/pull/9") as create,
+        patch(_MOD + ".submission.record_submission") as record,
+        patch(_MOD + ".resolve_issue_ref", return_value="#1673"),
+        patch(_MOD + ".build_pr_body", return_value="BODY"),
+    ):
+        url = _submit_one(
+            Path("/repo/.worktrees/issue-1673-x"), base_override=None, assume_yes=True
+        )
+    assert url == "https://example/pull/9"
+    push.assert_called_once_with("feature/1673-x")
+    create.assert_called_once()
+    record.assert_called_once()

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -12,6 +12,7 @@ import pytest
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
     _run_submit_batch,
+    _select_batch_worktrees,
     _submit_one,
     _target_branch,
     main,
@@ -1417,3 +1418,154 @@ def test_submit_batch_rebase_conflict_stops_batch() -> None:
 def test_all_and_select_flags_parse() -> None:
     assert parse_args(["--all"]).all_worktrees is True
     assert parse_args(["--select", "1,2"]).select == "1,2"
+
+
+def _ready_pair(name: str, num: str) -> tuple[Worktree, dict[str, str]]:
+    wt = Worktree(path=Path(f"/r/.worktrees/{name}"), branch=f"feature/{num}-x")
+    return (wt, {"issue": num, "title": "T"})
+
+
+def test_select_batch_all_returns_all_candidates() -> None:
+    ready = [_ready_pair("issue-1-a", "1"), _ready_pair("issue-2-b", "2")]
+    with patch(_MOD + "._ready_worktrees", return_value=ready):
+        out = _select_batch_worktrees(Path("/r"), parse_args(["--all"]))
+    assert [w.path.name for w in out] == ["issue-1-a", "issue-2-b"]
+
+
+def test_select_batch_select_tokens() -> None:
+    ready = [_ready_pair("issue-1-a", "1"), _ready_pair("issue-2-b", "2")]
+    with patch(_MOD + "._ready_worktrees", return_value=ready):
+        out = _select_batch_worktrees(Path("/r"), parse_args(["--select", "2"]))
+    assert [w.path.name for w in out] == ["issue-2-b"]
+
+
+def test_select_batch_bad_token_exits() -> None:
+    ready = [_ready_pair("issue-1-a", "1")]
+    with (
+        patch(_MOD + "._ready_worktrees", return_value=ready),
+        pytest.raises(SystemExit, match="--select"),
+    ):
+        _select_batch_worktrees(Path("/r"), parse_args(["--select", "999"]))
+
+
+def test_select_batch_interactive_uses_multi_select() -> None:
+    ready = [_ready_pair("issue-1-a", "1"), _ready_pair("issue-2-b", "2")]
+    with (
+        patch(_MOD + "._ready_worktrees", return_value=ready),
+        patch(_MOD + ".worktrees.select_worktrees", return_value=[ready[0][0]]) as sw,
+    ):
+        out = _select_batch_worktrees(Path("/r"), parse_args([]))
+    assert out == [ready[0][0]]
+    sw.assert_called_once()
+
+
+def test_submit_one_bad_linkage_exits() -> None:
+    fields = {"issue": "1", "title": "T", "summary": "s", "notes": "", "linkage": "Closes"}
+    with (
+        patch(_MOD + ".submission.read_pr_fields", return_value=fields),
+        patch(_MOD + ".resolve_issue_ref", return_value="#1"),
+        patch(_MOD + ".git.current_branch", return_value="feature/1-x"),
+        pytest.raises(SystemExit, match="linkage"),
+    ):
+        _submit_one(Path("/r"), base_override=None, assume_yes=True)
+
+
+def test_submit_one_declined_exits() -> None:
+    fields = {"issue": "1", "title": "T", "summary": "s", "notes": "", "linkage": "Ref"}
+    with (
+        patch(_MOD + ".submission.read_pr_fields", return_value=fields),
+        patch(_MOD + ".resolve_issue_ref", return_value="#1"),
+        patch(_MOD + ".git.current_branch", return_value="feature/1-x"),
+        patch(_MOD + ".build_pr_body", return_value="BODY"),
+        patch(_MOD + ".confirm", return_value=False),
+        pytest.raises(SystemExit, match="declined"),
+    ):
+        _submit_one(Path("/r"), base_override=None, assume_yes=False)
+
+
+def test_submit_batch_finalize_failure_stops() -> None:
+    a = _batch_wt("issue-1-a")
+    with (
+        patch(_MOD + ".worktrees.rebase_onto"),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", return_value="https://x/pull/1"),
+        patch(_MOD + ".subprocess.run", return_value=MagicMock(returncode=1)),
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a], base="develop", finalize=True, release=False, install=False, assume_yes=True
+        )
+    assert rc == 1
+
+
+def test_submit_batch_validation_failure_reported() -> None:
+    a = _batch_wt("issue-1-a")
+
+    def fake_run(cmd, **_kwargs):
+        rc = 1 if tuple(cmd)[:2] == ("vrg-finalize-pr", "--cleanup-only") else 0
+        return MagicMock(returncode=rc)
+
+    with (
+        patch(_MOD + ".worktrees.rebase_onto"),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", return_value="https://x/pull/1"),
+        patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a], base="develop", finalize=True, release=False, install=False, assume_yes=True
+        )
+    assert rc == 1
+
+
+def test_submit_batch_release_install_failure_reported() -> None:
+    a = _batch_wt("issue-1-a")
+
+    def fake_run(cmd, **_kwargs):
+        rc = 1 if tuple(cmd)[0] == "vrg-release" else 0
+        return MagicMock(returncode=rc)
+
+    with (
+        patch(_MOD + ".worktrees.rebase_onto"),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", return_value="https://x/pull/1"),
+        patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a], base="develop", finalize=True, release=True, install=True, assume_yes=True
+        )
+    assert rc == 1
+
+
+def test_submit_batch_no_finalize_just_submits() -> None:
+    a = _batch_wt("issue-1-a")
+    with (
+        patch(_MOD + ".worktrees.rebase_onto"),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", return_value="https://x/pull/1"),
+        patch(_MOD + ".subprocess.run", return_value=MagicMock(returncode=0)) as run,
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a], base="develop", finalize=False, release=False, install=False, assume_yes=True
+        )
+    assert rc == 0
+    run.assert_not_called()  # no finalize, no post-steps
+
+
+def test_main_batch_routes_to_run_submit_batch() -> None:
+    with (
+        patch(_MOD + ".identity_mode.is_agent", return_value=False),
+        patch(_MOD + ".git.is_main_worktree", return_value=True),
+        patch(_MOD + ".git.repo_root", return_value="/r"),
+        patch(_MOD + "._select_batch_worktrees", return_value=["wt"]),
+        patch(_MOD + "._run_submit_batch", return_value=0) as run_batch,
+    ):
+        rc = main(["--all", "--finalize", "--base", "develop"])
+    assert rc == 0
+    run_batch.assert_called_once()

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
+    _run_submit_batch,
     _submit_one,
     _target_branch,
     main,
@@ -18,6 +19,7 @@ from vergil_tooling.bin.vrg_submit_pr import (
 )
 from vergil_tooling.lib import pr_template, worktrees
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError
+from vergil_tooling.lib.worktrees import Worktree
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -1359,3 +1361,59 @@ def test_submit_one_pushes_creates_records_and_returns_url() -> None:
     push.assert_called_once_with("feature/1673-x")
     create.assert_called_once()
     record.assert_called_once()
+
+
+def _batch_wt(name: str) -> Worktree:
+    num = name.split("-")[1]
+    return Worktree(path=Path(f"/repo/.worktrees/{name}"), branch=f"feature/{num}-x")
+
+
+def test_submit_batch_rebases_submits_then_finalizes_each_and_releases_once() -> None:
+    a, b = _batch_wt("issue-1-a"), _batch_wt("issue-2-b")
+    finalize_calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd, **_kwargs):
+        finalize_calls.append(tuple(cmd))
+        return MagicMock(returncode=0)
+
+    with (
+        patch(_MOD + ".worktrees.rebase_onto") as rebase,
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", side_effect=["https://x/pull/1", "https://x/pull/2"]),
+        patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a, b], base="develop", finalize=True, release=True, install=False, assume_yes=True
+        )
+    assert rc == 0
+    assert rebase.call_count == 2
+    assert ("vrg-finalize-pr", "https://x/pull/1", "--skip-post-checks") in finalize_calls
+    assert ("vrg-finalize-pr", "https://x/pull/2", "--skip-post-checks") in finalize_calls
+    assert ("vrg-finalize-pr", "--cleanup-only") in finalize_calls
+    assert ("vrg-release",) in finalize_calls
+
+
+def test_submit_batch_rebase_conflict_stops_batch() -> None:
+    a, b = _batch_wt("issue-1-a"), _batch_wt("issue-2-b")
+    with (
+        patch(
+            _MOD + ".worktrees.rebase_onto",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one") as submit,
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [a, b], base="develop", finalize=True, release=False, install=False, assume_yes=True
+        )
+    assert rc == 1
+    submit.assert_not_called()
+
+
+def test_all_and_select_flags_parse() -> None:
+    assert parse_args(["--all"]).all_worktrees is True
+    assert parse_args(["--select", "1,2"]).select == "1,2"

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -309,6 +309,25 @@ def test_match_worktrees_unmatched_token_errors() -> None:
         match_worktrees([a], ["999"])
 
 
+def test_match_worktrees_skips_non_issue_named() -> None:
+    # A worktree name that is not canonical issue-<N>-... is matched only by
+    # directory name; it never populates the issue-number index.
+    a = _wt("scratch", "feature/scratch")
+    assert match_worktrees([a], ["scratch"]) == [a]
+
+
+def test_match_worktrees_ambiguous_issue_number_errors() -> None:
+    a = _wt("issue-5-a", "feature/5-a")
+    b = _wt("issue-5-b", "feature/5-b")
+    with pytest.raises(ValueError, match="ambiguous .multiple worktrees.: 5"):
+        match_worktrees([a, b], ["5"])
+
+
+def test_select_worktrees_empty_raises() -> None:
+    with pytest.raises(ValueError, match="at least one candidate"):
+        select_worktrees([], purpose="p", labels=[])
+
+
 def test_rebase_onto_fetches_then_rebases() -> None:
     wt = _wt("issue-1-a", "feature/1-a")
     with patch(_MOD + ".git.run") as run:

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -16,6 +16,7 @@ from vergil_tooling.lib.worktrees import (
     gather_worktree_status,
     list_worktrees,
     match_worktrees,
+    rebase_onto,
     require_tty,
     select_worktree,
     select_worktrees,
@@ -306,3 +307,21 @@ def test_match_worktrees_unmatched_token_errors() -> None:
     a = _wt("issue-1-a", "feature/1-a")
     with pytest.raises(ValueError, match="no ready worktree matches: 999"):
         match_worktrees([a], ["999"])
+
+
+def test_rebase_onto_fetches_then_rebases() -> None:
+    wt = _wt("issue-1-a", "feature/1-a")
+    with patch(_MOD + ".git.run") as run:
+        rebase_onto(wt, "develop")
+    assert run.call_args_list[0].args == ("-C", str(wt.path), "fetch", "origin", "develop")
+    assert run.call_args_list[1].args == ("-C", str(wt.path), "rebase", "origin/develop")
+
+
+def test_rebase_onto_propagates_conflict() -> None:
+    wt = _wt("issue-1-a", "feature/1-a")
+    err = subprocess.CalledProcessError(1, ["git", "rebase"])
+    with (
+        patch(_MOD + ".git.run", side_effect=[None, err]),
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        rebase_onto(wt, "develop")

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -15,8 +15,10 @@ from vergil_tooling.lib.worktrees import (
     classify_worktree,
     gather_worktree_status,
     list_worktrees,
+    match_worktrees,
     require_tty,
     select_worktree,
+    select_worktrees,
     worktree_for_branch,
 )
 
@@ -272,3 +274,35 @@ def test_gather_pr_lookup_failure_is_unknown() -> None:
         status = gather_worktree_status(_SAMPLE_WT, target="develop")
     assert status.state is WorktreeState.UNKNOWN
     assert "boom" in (status.detail or "")
+
+
+def _wt(name: str, branch: str) -> Worktree:
+    return Worktree(path=Path(f"/repo/.worktrees/{name}"), branch=branch)
+
+
+def test_select_worktrees_single_skips_prompt() -> None:
+    wt = _wt("issue-1-foo", "feature/1-foo")
+    assert select_worktrees([wt], purpose="p", labels=["foo"]) == [wt]
+
+
+def test_select_worktrees_multi_uses_prompt_indices() -> None:
+    a = _wt("issue-1-a", "feature/1-a")
+    b = _wt("issue-2-b", "feature/2-b")
+    c = _wt("issue-3-c", "feature/3-c")
+    with (
+        patch(_MOD + ".require_tty"),
+        patch(_MOD + ".prompt_multi_choice", return_value=[0, 2]),
+    ):
+        assert select_worktrees([a, b, c], purpose="p", labels=["a", "b", "c"]) == [a, c]
+
+
+def test_match_worktrees_by_issue_number_and_name_in_token_order() -> None:
+    a = _wt("issue-1673-foo", "feature/1673-foo")
+    b = _wt("issue-1681-bar", "feature/1681-bar")
+    assert match_worktrees([a, b], ["1681", "issue-1673-foo"]) == [b, a]
+
+
+def test_match_worktrees_unmatched_token_errors() -> None:
+    a = _wt("issue-1-a", "feature/1-a")
+    with pytest.raises(ValueError, match="no ready worktree matches: 999"):
+        match_worktrees([a], ["999"])


### PR DESCRIPTION
# Pull Request

## Summary

- Add a single-threaded, fail-fast batch orchestrator so vrg-submit-pr (--all/--select) and vrg-finalize-pr (comma-list/--all) drive many PRs through submit -> finalize -> release in one pass, rebasing each branch onto the latest develop before its gate so each expensive CI run happens exactly once.

## Issue Linkage

- Ref #1673

## Notes

- Implements #1673. Design and plan: docs/specs/2026-06-17-batch-pr-pipeline-{design,plan}.md.

Key decisions (from brainstorming): merge queues were rejected after research — Forgejo (the migration target) has none, and GitHub's doubles CI minutes; a vrg-native single-threaded orchestrator is forge-agnostic and runs N PRs in N gate runs. The zero-waste mechanism is the per-item rebase onto origin/develop before each PR opens, so the merge is never BEHIND. Batch is fail-fast with a merged/failed/not-started report; re-running is resumable via the existing ready-worktree scan (no state file). Release runs once at the end. One up-front confirmation, then unattended (per-item prompts pre-suppressed).

New shared module lib/pr_workflow/batch.py (run_batch + report types); worktrees gains select_worktrees/match_worktrees/rebase_onto; repo_init gains prompt_multi_choice; vrg-finalize-pr gains --skip-post-checks. Single-PR behavior unchanged.

Scope note: interactive no-flag multi-select on vrg-submit-pr is intentionally deferred to a follow-up (documented in the plan); --all/--select are the batch entry points here.

100% branch coverage maintained; full vrg-validate green in-container.