### PR TITLE
feat(vrg-gh): grant the USER agent identity issue edit rights

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -44,7 +44,6 @@ _DENIED_AGENT: dict[str, dict[str, str]] = {
     "issue": {
         "close": "Issue close requires a human maintainer.",
         "reopen": "Issue reopen requires a human maintainer.",
-        "edit": "Issue edit requires a human maintainer.",
     },
 }
 

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -452,7 +452,6 @@ class TestAgentDenials:
         [
             ("issue", "close"),
             ("issue", "reopen"),
-            ("issue", "edit"),
             ("pr", "edit"),
             ("pr", "merge"),
         ],
@@ -463,6 +462,20 @@ class TestAgentDenials:
         assert main([top, sub]) != 0
         err = capsys.readouterr().err
         assert "denied" in err.lower()
+
+    def test_issue_edit_allowed_for_user_agent(self) -> None:
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "edit", "42", "--add-label", "chore"])
+        assert rc == 0
+        args = mock_run.call_args[0][0]
+        assert args[:3] == ["gh", "issue", "edit"]
 
     def test_issue_close_says_human_maintainer(self, capsys: pytest.CaptureFixture[str]) -> None:
         main(["issue", "close", "42"])
@@ -595,6 +608,7 @@ class TestAuditAllowlist:
             ("issue", "view"),
             ("issue", "list"),
             ("issue", "create"),
+            ("issue", "edit"),
             ("run", "list"),
             ("repo", "view"),
             ("label", "list"),


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the issue-edit denial from _DENIED_AGENT so the USER (vergil-user) agent identity inherits 'issue edit' from the base allowlist, while AUDIT stays read-only and issue close/reopen remain human-only.

## Issue Linkage

- Ref #1681

## Notes

- One-line denial removal in src/vergil_tooling/bin/vrg_gh.py plus test updates. Scope is USER only: AUDIT is blocked earlier by the allowlist gate (_ALLOWED_AUDIT has no 'issue' key), now covered by an added audit-denied case. Tests: dropped (issue, edit) from the agent-denied set, added a positive USER issue-edit test, and added (issue, edit) to the audit-denied set. Validation green via vrg-container-run -- vrg-validate. Ref #1681.