### PR TITLE
feat(vrg-vm): order sessions list by workspace then slot

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1128,18 +1128,21 @@ def _list_sessions(config: IdentityConfig, args: argparse.Namespace) -> int:
 
     wanted = _selected_states(args)
     rows = [r for r in rows if r["state"] in wanted]
-    rows.sort(key=lambda r: (str(r["identity"]), cast("int", r["slot"]), str(r["path"])))
+    # Group by workspace first, then slot within a workspace; identity is the
+    # final tiebreaker so same-workspace/same-slot rows stay stably ordered.
+    rows.sort(key=lambda r: (str(r["path"]), cast("int", r["slot"]), str(r["identity"])))
 
     now = datetime.datetime.now(tz=datetime.UTC).timestamp()
     # Size the WORKSPACE column to the longest path present (36 floor), so a
-    # path wider than the historical fixed width keeps STATE/LAST ACTIVE aligned.
+    # path wider than the historical fixed width keeps SLOT/STATE/LAST ACTIVE
+    # aligned.
     ws = max([36, *(len(str(r["path"])) for r in rows)])
-    print(f"{'IDENTITY':<16} {'SLOT':<6} {'WORKSPACE':<{ws}} {'STATE':<9} {'LAST ACTIVE':<12}")
-    print(f"{'─' * 16} {'─' * 6} {'─' * ws} {'─' * 9} {'─' * 12}")
+    print(f"{'IDENTITY':<16} {'WORKSPACE':<{ws}} {'SLOT':<6} {'STATE':<9} {'LAST ACTIVE':<12}")
+    print(f"{'─' * 16} {'─' * ws} {'─' * 6} {'─' * 9} {'─' * 12}")
     for r in rows:
         slot = f"{cast('int', r['slot']):02d}"
         age = _format_age(cast("float | None", r.get("lastActive")), now)
-        print(f"{r['identity']!s:<16} {slot:<6} {r['path']!s:<{ws}} {r['state']!s:<9} {age:<12}")
+        print(f"{r['identity']!s:<16} {r['path']!s:<{ws}} {slot:<6} {r['state']!s:<9} {age:<12}")
 
     return 0
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -954,6 +954,75 @@ class TestList:
         for row in lines[2:]:
             assert row[state_col:].startswith(("active", "idle"))
 
+    @patch("vergil_tooling.bin.vrg_vm._last_activity", return_value=1700000000.0)
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session")
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_list_sessions_column_order_and_sort(
+        self,
+        mock_list: MagicMock,
+        mock_shell: MagicMock,
+        mock_names: MagicMock,
+        _age: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Columns render IDENTITY -> WORKSPACE -> SLOT, and rows sort by
+        # workspace first then slot (identity is only the final tiebreaker).
+        mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
+        mock_shell.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {
+                        "identity": "vergil-user",
+                        "slot": 2,
+                        "path": "alpha/repo",
+                        "sessionId": "s1",
+                        "state": "idle",
+                        "lastActive": 1700000000.0,
+                    },
+                    {
+                        "identity": "vergil",
+                        "slot": 1,
+                        "path": "beta/repo",
+                        "sessionId": "s2",
+                        "state": "idle",
+                        "lastActive": 1700000000.0,
+                    },
+                    {
+                        "identity": "vergil-user",
+                        "slot": 1,
+                        "path": "alpha/repo",
+                        "sessionId": "s3",
+                        "state": "idle",
+                        "lastActive": 1700000000.0,
+                    },
+                ]
+            )
+        )
+        mock_names.return_value = {
+            "s1": "vergil-user:02:alpha/repo",
+            "s2": "vergil:01:beta/repo",
+            "s3": "vergil-user:01:alpha/repo",
+        }
+        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        out = capsys.readouterr().out
+        lines = [line for line in out.splitlines() if line.strip()]
+        header = lines[0]
+        # Column order: IDENTITY, then WORKSPACE, then SLOT, then STATE.
+        assert (
+            header.index("IDENTITY")
+            < header.index("WORKSPACE")
+            < header.index("SLOT")
+            < header.index("STATE")
+        )
+        # Data rows (after header + divider) sort by workspace then slot:
+        # both alpha/repo rows precede beta/repo, slot 01 before slot 02.
+        data = lines[2:]
+        assert "alpha/repo" in data[0] and "01" in data[0]
+        assert "alpha/repo" in data[1] and "02" in data[1]
+        assert "beta/repo" in data[2]
+
 
 class TestUpdate:
     # vrg-vm update refreshes plugins too (via _update_instance); mock it so the


### PR DESCRIPTION
# Pull Request

## Summary

- Reorder the vrg-vm list --sessions table to IDENTITY/WORKSPACE/SLOT and sort rows by workspace then slot so every session for a given workspace groups together.

## Issue Linkage

- Ref #1690

## Notes

- Sort key is (workspace, slot, identity) — identity is the final tiebreaker since the issue specified workspace-then-slot without mentioning identity. The dynamic WORKSPACE column width moved with the column. Added test_list_sessions_column_order_and_sort; the existing alignment test computes STATE's offset dynamically so it still holds. Refs #1690.