### PR TITLE
fix(release): surface audit-stage failure detail and distinguish audit crash from non-compliance

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -233,13 +233,23 @@ def main(argv: list[str] | None = None) -> int:
         all_compliant = False
 
     repo = _resolve_repo(args)
+    # Exit codes are a contract for callers (e.g. vrg-release): 0 = compliant,
+    # 1 = genuinely non-compliant, 2 = the audit could not complete. Config
+    # resolution and the GitHub state fetch can fail operationally (missing
+    # vergil.toml, HTTP 403 reading actions/permissions under an App token);
+    # those are exit 2 with a clean diagnostic, never a false "non-compliant"
+    # verdict or a raw traceback (#1691).
     try:
         config = _load_local_config(args.config) if args.config else _resolve_config(repo)
     except RuntimeError as exc:
         emit_error(str(exc))
-        return 1
+        return 2
 
-    github_diff = _audit_repo(repo, config)
+    try:
+        github_diff = _audit_repo(repo, config)
+    except (github.GitHubAPIError, RuntimeError) as exc:
+        emit_error(f"Could not audit {repo}: {exc}")
+        return 2
     _print_diff(repo, github_diff)
     if not github_diff.is_compliant():
         all_compliant = False

--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -534,6 +534,14 @@ def run_pipeline(
                 result = StageResult(stage.name, status, time.monotonic() - start, cause)
                 log.write(f"=== {stage.name}: {status} ({cause}) ===")
                 log.write(traceback.format_exc())
+                # Verbose context (e.g. a captured subprocess' stdout/stderr)
+                # rides on the exception's ``detail`` attribute but is absent
+                # from both ``str(exc)`` and the traceback. Record it in the
+                # full log so the summary's "full log →" pointer actually leads
+                # to the real reason instead of just the headline (#1691).
+                detail = getattr(exc, "detail", None)
+                if isinstance(detail, str) and detail.strip():
+                    log.write(detail)
                 renderer.end_stage(result)
                 results.append(result)
                 if stage.mode == "fail_fast":

--- a/src/vergil_tooling/lib/release/preflight.py
+++ b/src/vergil_tooling/lib/release/preflight.py
@@ -195,13 +195,22 @@ def audit_repo_config(repo: str) -> None:
         capture_output=True,
         text=True,
     )
-    if result.returncode != 0:
-        raise ReleaseError(
-            phase="preflight",
-            command=f"vrg-github-repo-config audit --repo {repo}",
-            message="Repository configuration is non-compliant.",
-            detail=result.stdout + result.stderr,
-        )
+    if result.returncode == 0:
+        return
+    # Exit 1 is a genuine compliance diff; anything else means the audit
+    # could not complete (auth/API failure, missing config). Don't conflate
+    # the two — a crash is not a non-compliance verdict (#1691). Either way
+    # the captured output rides along as detail so the real reason survives.
+    if result.returncode == 1:
+        message = "Repository configuration is non-compliant."
+    else:
+        message = "Repository configuration audit could not complete."
+    raise ReleaseError(
+        phase="preflight",
+        command=f"vrg-github-repo-config audit --repo {repo}",
+        message=message,
+        detail=result.stdout + result.stderr,
+    )
 
 
 def _check_version_not_tagged(ver: str) -> None:

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -542,6 +542,39 @@ def test_pipeline_traceback_in_log(tmp_path: Path) -> None:
     assert "Traceback" in log.read_text()
 
 
+class _DetailedError(Exception):
+    """Exception carrying a verbose ``detail`` attribute, like ReleaseError."""
+
+    def __init__(self) -> None:
+        self.detail = "actions.permissions: expected='selected', actual='all'"
+        super().__init__("Repository configuration is non-compliant.")
+
+
+def _boom_with_detail(ctx: object) -> None:
+    raise _DetailedError
+
+
+def test_pipeline_writes_exception_detail_to_log(tmp_path: Path) -> None:
+    """A failing stage's exception ``detail`` is recorded in the full log so
+    the real reason survives where the summary's 'full log →' pointer sends
+    the user (issue #1691)."""
+    stages = [Stage("audit", _boom_with_detail, mode="fail_fast")]
+    _pipeline(tmp_path, stages, _args())
+    log_text = next((tmp_path / ".vergil").glob("test-cmd-*.log")).read_text()
+    assert "actions.permissions: expected='selected', actual='all'" in log_text
+
+
+def test_pipeline_detail_kept_out_of_one_line_status(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The verbose detail goes to the log, not the one-line failure summary."""
+    stages = [Stage("audit", _boom_with_detail, mode="fail_fast")]
+    _pipeline(tmp_path, stages, _args())
+    out = capsys.readouterr().out
+    assert "audit — _DetailedError: Repository configuration is non-compliant." in out
+    assert "expected='selected'" not in out
+
+
 def test_add_progress_args_generates_flags() -> None:
     parser = argparse.ArgumentParser()
     stages = [Stage("audit", lambda ctx: None, mode="fail_fast", skip_flag="skip_audit")]

--- a/tests/vergil_tooling/test_release_preflight.py
+++ b/tests/vergil_tooling/test_release_preflight.py
@@ -218,13 +218,39 @@ def testaudit_repo_config_fails() -> None:
             return_value=CompletedProcess(
                 args=(),
                 returncode=1,
-                stdout="non-compliant",
+                stdout="  o/r: NON-COMPLIANT (1 issues)",
                 stderr="",
             ),
         ),
-        pytest.raises(ReleaseError, match="non-compliant"),
+        pytest.raises(ReleaseError, match="non-compliant") as exc_info,
     ):
         audit_repo_config("owner/repo")
+    # The captured audit output is carried as detail so it can be surfaced.
+    assert "NON-COMPLIANT" in (exc_info.value.detail or "")
+
+
+def testaudit_repo_config_distinguishes_crash_from_noncompliance() -> None:
+    """A non-1 exit means the audit could not complete (crash / auth / API),
+    not that the repo is non-compliant — the headline must say so, and the
+    captured output must ride along as detail (issue #1691)."""
+    from subprocess import CompletedProcess
+
+    from vergil_tooling.lib.release.preflight import audit_repo_config
+
+    with (
+        patch(
+            _MOD + ".subprocess.run",
+            return_value=CompletedProcess(
+                args=(),
+                returncode=2,
+                stdout="",
+                stderr="gh: Resource not accessible by integration (HTTP 403)",
+            ),
+        ),
+        pytest.raises(ReleaseError, match="could not complete") as exc_info,
+    ):
+        audit_repo_config("owner/repo")
+    assert "403" in (exc_info.value.detail or "")
 
 
 def test_check_version_not_tagged_passes() -> None:

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -221,9 +221,12 @@ def test_apply_github_noncompliant_applies() -> None:
     mock_apply.assert_called_once()
 
 
-def test_main_remote_config_error_exits_one_without_traceback(
+def test_main_remote_config_error_exits_two_without_traceback(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """A config-resolution failure means the audit could not run — exit 2
+    (could-not-complete), distinct from exit 1 (genuinely non-compliant),
+    so callers like vrg-release don't mislabel it (issue #1691)."""
     with (
         patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
         patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
@@ -235,13 +238,39 @@ def test_main_remote_config_error_exits_one_without_traceback(
         patch(f"{_MODULE}._audit_repo") as mock_audit,
     ):
         result = main(["apply", "--repo", "o/r"])
-    assert result == 1
+    assert result == 2
     mock_audit.assert_not_called()
     err = capsys.readouterr().err
     # The actionable message reaches stderr, emitted cleanly (no traceback).
     # Assert on substance, not the prefix: emit_error formats differ between
     # interactive (`ERROR: ...`) and CI (`::error ::...`) environments.
     assert "--config" in err
+    assert "Traceback" not in err
+
+
+def test_audit_github_api_error_exits_two_without_traceback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An API/auth failure while fetching GitHub state (e.g. HTTP 403 reading
+    actions/permissions under an App token) exits 2 with a clean diagnostic,
+    not a raw traceback and not a false 'non-compliant' verdict (issue #1691)."""
+    api_error = GitHubAPIError(
+        1,
+        ("gh", "api", "repos/o/r/actions/permissions"),
+        '{"message":"Resource not accessible by integration","status":"403"}',
+        "gh: Resource not accessible by integration (HTTP 403)",
+    )
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=_mock_local_compliant()),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(f"{_MODULE}._resolve_config"),
+        patch(f"{_MODULE}._audit_repo", side_effect=api_error),
+    ):
+        result = main(["audit", "--repo", "o/r"])
+    assert result == 2
+    err = capsys.readouterr().err
+    assert "403" in err
     assert "Traceback" not in err
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- When `vrg-release` fails at the audit stage, it reported only
"Repository configuration is non-compliant" and dropped the actual
reason. The captured audit output was stored on `ReleaseError.detail`,
but `progress.run_pipeline` built the failure cause from `str(exc)`
(the headline message only) and logged just the traceback — so the
detail reached neither the terminal nor the full `.vergil` log file.
A maintainer hit this releasing `vergil-claude-plugin` and could not
tell what was wrong.

This lands three coordinated fixes:

- **`progress.py`** — write a failing stage's exception `detail` to the
  run log, so the summary's "full log →" pointer leads to the real
  reason rather than just the headline.
- **`vrg-github-repo-config`** — give the audit a real exit-code
  contract: `0` compliant, `1` non-compliant, `2` could-not-complete.
  Config-resolution and GitHub-state-fetch failures (e.g. HTTP 403
  reading `actions/permissions` under a GitHub App token) now exit `2`
  with a clean diagnostic instead of a raw traceback or a false
  "non-compliant" verdict.
- **`preflight.audit_repo_config`** — branch on the exit code so a
  crash is labelled "audit could not complete," not "non-compliant,"
  and always carry the captured output as `detail`.

## Issue Linkage

- Ref #1691

## Notes

- Developed test-first (red → green). New/changed coverage:

- `test_progress.py` — a stage exception's `detail` is written to the
  full log; the verbose detail is kept out of the one-line status.
- `test_vrg_github_repo_config.py` — config-resolution failure and a
  GitHub API error (403) each exit `2` cleanly, with no traceback.
- `test_release_preflight.py` — exit `1` → "non-compliant"; any other
  non-zero exit → "audit could not complete"; both carry `detail`.

Affected modules' suites pass (137 tests); full `vrg-validate` is
green.

Exit-code note: the only consumer of `vrg-github-repo-config`'s exit
code is `preflight.audit_repo_config`, so widening to `0/1/2` is
contained. The pre-existing config-resolution path moved from exit `1`
to `2` (it is a could-not-complete condition); its test was updated
accordingly.

Out of scope: the underlying 403 itself — the `user`-mode GitHub App
token lacks the `administration` permission needed to read
`actions/permissions`, which is why the plugin release blocked under an
agent identity. That is a token/permission-grant question, separate
from this reporting fix.