### PR TITLE
feat(vrg-validate): add ansible-lint conditional common check

### DIFF
--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -208,7 +208,9 @@ Shared validation checks for all repos: repository profile
 validation, markdownlint on published markdown (`docs/site/**/*.md`
 and `README.md`) using the bundled canonical config, shellcheck on
 `scripts/`, yamllint on `.github/` and `docs/` YAML files, hadolint
-on `Dockerfile*`, and actionlint on `.github/workflows/`.
+on `Dockerfile*`, actionlint on `.github/workflows/`, and
+ansible-lint (using the bundled canonical config) when the repo
+carries Ansible content.
 
 | Attribute | Value |
 |---|---|

--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -9,6 +9,8 @@ Runs inside the dev container via ``vrg-container-run``:
      the bundled canonical config (issue #302, #590)
   5. hadolint on Dockerfile* files at the repo root
   6. actionlint on ``.github/workflows/``
+  7. ansible-lint when the repo carries Ansible content, using the
+     bundled canonical config (issue #1667)
 """
 
 from __future__ import annotations
@@ -103,6 +105,36 @@ def _find_yaml_files(repo_root: Path) -> list[str]:
     return sorted(set(found))
 
 
+# Explicit signal files/directories that mark a repo as carrying Ansible
+# content. Ansible playbooks are plain YAML with no unique extension, so
+# detection is heuristic — we gate on concrete, deterministic signals
+# rather than deferring to ansible-lint's own auto-detection (issue #1667).
+_ANSIBLE_FILE_SIGNALS = (
+    "ansible.cfg",
+    ".ansible-lint",
+    ".ansible-lint.yml",
+    ".ansible-lint.yaml",
+    "galaxy.yml",
+)
+_ANSIBLE_DIR_SIGNALS = ("playbooks", "roles")
+
+
+def _has_ansible_content(repo_root: Path) -> bool:
+    """Return True when the repo carries Ansible content.
+
+    Detection is signal-based: a recognized config/manifest file at the
+    repo root (``ansible.cfg``, ``.ansible-lint*``, ``galaxy.yml``), a
+    role/collection metadata file (``meta/main.yml``), or a ``playbooks/``
+    or ``roles/`` directory. Mirrors the conditional-skip behavior of the
+    other common checks — no Ansible content means the check is skipped.
+    """
+    if any((repo_root / name).is_file() for name in _ANSIBLE_FILE_SIGNALS):
+        return True
+    if (repo_root / "meta" / "main.yml").is_file():
+        return True
+    return any((repo_root / name).is_dir() for name in _ANSIBLE_DIR_SIGNALS)
+
+
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     repo_root = git.repo_root()
 
@@ -157,6 +189,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         print("Running: actionlint")
         result = subprocess.run(  # noqa: S603
             ["actionlint"],  # noqa: S607
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    if _has_ansible_content(repo_root):
+        print("Running: ansible-lint")
+        ansible_config = files("vergil_tooling.configs") / "ansible-lint.yaml"
+        result = subprocess.run(  # noqa: S603
+            ["ansible-lint", "-c", str(ansible_config)],  # noqa: S607
             check=False,
         )
         if result.returncode != 0:

--- a/src/vergil_tooling/configs/ansible-lint.yaml
+++ b/src/vergil_tooling/configs/ansible-lint.yaml
@@ -1,0 +1,11 @@
+# Canonical ansible-lint config for all managed repositories.
+#
+# Bundled with vergil-tooling and passed explicitly to ansible-lint by
+# `vrg-validate` so every repo lints Ansible content against the same
+# ruleset rather than per-repo drift (issue #1667).
+#
+# The embedded yamllint pass is left enabled (we accept the overlap with
+# the standalone yamllint check for now); the standalone pass only walks
+# repo-root, `.github/`, and `docs/site/mkdocs.yml`, so the practical
+# overlap is limited to a root-level `galaxy.yml`.
+profile: production

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -11,6 +11,7 @@ from vergil_tooling.bin.validate_common import (
     _find_markdown_files,
     _find_shell_files,
     _find_yaml_files,
+    _has_ansible_content,
     main,
 )
 
@@ -654,6 +655,135 @@ def test_main_actionlint_fails(tmp_path: Path) -> None:
         patch(
             "vergil_tooling.bin.validate_common.subprocess.run",
             side_effect=mock_run,
+        ),
+    ):
+        assert main() == 1
+
+
+# -- _has_ansible_content ----------------------------------------------------
+
+
+def test_has_ansible_content_none(tmp_path: Path) -> None:
+    assert _has_ansible_content(tmp_path) is False
+
+
+def test_has_ansible_content_ansible_cfg(tmp_path: Path) -> None:
+    (tmp_path / "ansible.cfg").write_text("[defaults]\n")
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_ansible_lint_config(tmp_path: Path) -> None:
+    (tmp_path / ".ansible-lint").write_text("profile: production\n")
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_ansible_lint_config_yml(tmp_path: Path) -> None:
+    (tmp_path / ".ansible-lint.yml").write_text("profile: production\n")
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_galaxy(tmp_path: Path) -> None:
+    (tmp_path / "galaxy.yml").write_text("namespace: acme\n")
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_meta_main(tmp_path: Path) -> None:
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "main.yml").write_text("galaxy_info: {}\n")
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_playbooks_dir(tmp_path: Path) -> None:
+    (tmp_path / "playbooks").mkdir()
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_roles_dir(tmp_path: Path) -> None:
+    (tmp_path / "roles").mkdir()
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_signal_file_must_be_file(tmp_path: Path) -> None:
+    # A directory named like a file signal must not count as content.
+    (tmp_path / "ansible.cfg").mkdir()
+    assert _has_ansible_content(tmp_path) is False
+
+
+def test_has_ansible_content_dir_signal_must_be_dir(tmp_path: Path) -> None:
+    # A file named like a directory signal must not count as content.
+    (tmp_path / "roles").write_text("not a dir\n")
+    assert _has_ansible_content(tmp_path) is False
+
+
+# -- main: ansible-lint path -------------------------------------------------
+
+
+def test_main_ansible_lint_runs_with_bundled_config(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / "ansible.cfg").write_text("[defaults]\n")
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == "ansible-lint"
+    assert call_args[1] == "-c"
+    assert call_args[2].endswith("ansible-lint.yaml")
+    assert "vergil_tooling" in call_args[2]
+
+
+def test_main_ansible_lint_skipped_without_content(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    tool_names = [call[0][0][0] for call in mock_run.call_args_list]
+    assert "ansible-lint" not in tool_names
+
+
+def test_main_ansible_lint_fails(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / "ansible.cfg").write_text("[defaults]\n")
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
         ),
     ):
         assert main() == 1


### PR DESCRIPTION
# Pull Request

## Summary

- Adds ansible-lint as a sixth conditional common check in vrg-validate, gated on signal-based Ansible-content detection and using a bundled canonical config so managed repos with Ansible content are linted automatically.

## Issue Linkage

- Ref #1667

## Notes

- Design decisions (issue open questions, confirmed with the requester): (1) detection is explicit signal-based — ansible.cfg, .ansible-lint*, galaxy.yml, meta/main.yml, or a playbooks/ or roles/ dir; (2) the yamllint overlap is accepted for now (ansible-lint's embedded yamllint stays on); standalone yamllint only walks repo-root, .github/, and docs/site/mkdocs.yml, so the practical overlap is limited to a root-level galaxy.yml; (3) the bundled config pins the production profile. The check is a no-op until a repo ships Ansible content (this repo has none), exactly like hadolint/actionlint. CI parity is automatic — PR CI runs the same vrg-validate driver. Depends on vergil-docker#342 to add the ansible-lint binary to the dev image; they should land together (or docker first).