### PR TITLE
fix(release): abort vrg-release under agent identity (human-only guard)

### DIFF
--- a/src/vergil_tooling/bin/vrg_release.py
+++ b/src/vergil_tooling/bin/vrg_release.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from vergil_tooling.lib import git, github, progress
+from vergil_tooling.lib import git, github, identity_mode, progress
 from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.handoff import run_consumer_refresh
 from vergil_tooling.lib.release.orchestrator import ReleaseState, build_stages
@@ -57,6 +57,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    # The release workflow — branch, tag, merge, finalize — is a human
+    # action, like vrg-submit-pr. Hard-abort under any agent identity before
+    # any side effect, so an agent VM cannot drive a release (issue #1694).
+    if identity_mode.is_agent():
+        print(
+            "vrg-release: releasing is a human maintainer action. Agents cannot run vrg-release.",
+            file=sys.stderr,
+        )
+        return 1
+
     repo_root = git.repo_root()
 
     resume_requested = args.resume is not None

--- a/tests/vergil_tooling/test_vrg_release.py
+++ b/tests/vergil_tooling/test_vrg_release.py
@@ -81,6 +81,22 @@ def test_main_returns_pipeline_exit_code() -> None:
         assert main([]) == 1
 
 
+def test_main_aborts_under_agent_identity(capsys: pytest.CaptureFixture[str]) -> None:
+    """vrg-release is human-only (release/merge/finalize are human actions).
+    An agent identity (user/audit) must hard-abort before any side effect —
+    no repo resolution, no pipeline — mirroring vrg-submit-pr (issue #1694)."""
+    with (
+        patch(_MOD + ".identity_mode.is_agent", return_value=True),
+        patch(_MOD + ".git") as m_git,
+        patch(_MOD + ".progress.run_pipeline") as m_pipeline,
+    ):
+        rc = main(["--output-format", "plain"])
+    assert rc == 1
+    m_pipeline.assert_not_called()
+    m_git.repo_root.assert_not_called()
+    assert "human" in capsys.readouterr().err.lower()
+
+
 def test_main_resume_with_bump_errors(capsys: pytest.CaptureFixture[str]) -> None:
     with patch(_MOD + ".git"):
         assert main(["minor", "--resume"]) == 1


### PR DESCRIPTION
# Pull Request

## Summary

- `vrg-release` is documented as human-only — branch, tag, merge and
finalize are human maintainer actions in the repo's identity model —
but unlike its sibling `vrg-submit-pr` it carried no identity guard. An
agent running under the `user` or `audit` identity could invoke it and
proceed straight into preflight and the release pipeline.

This adds the guard at the top of `main()`, immediately after
`parse_args` and before `git.repo_root()` or any other side effect,
mirroring `vrg-submit-pr`: when `identity_mode.is_agent()` is true, it
prints a release-specific message to stderr and returns exit 1.

## Issue Linkage

- Ref #1694

## Notes

- Developed test-first (red → green): `test_main_aborts_under_agent_identity`
patches `identity_mode.is_agent` true and asserts `main()` returns 1
with neither `git.repo_root()` nor the pipeline invoked — proving the
abort happens before any side effect. Full `vrg_release` suite (24
tests) and `vrg-validate` are green.

Inside the dev container, identity resolves to `human`
(`VRG_IDENTITY_MODE` is not passed through), so the existing
release-main tests are unaffected by the new guard.

Surfaced while debugging #1691: a `user`-mode agent run of `vrg-release`
reached the audit stage and hit HTTP 403 on `actions/permissions` — a
wall it should never have reached. This guard is the upstream fix; the
#1691 PR makes the audit-stage failure reporting honest if the workflow
ever errors for another reason.