### PR TITLE
fix(vm): expand ~ in identity projects_dir at config load

### DIFF
--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -136,6 +136,13 @@ def load_config(path: Path) -> IdentityConfig:
                 if isinstance(repo_val, dict):
                     overrides[(org_key, repo_key)] = repo_val
 
+        # Expand a leading ~ at load so every consumer gets an absolute path:
+        # Lima rejects a mountPoint starting with ~, and on-disk vergil.toml
+        # lookups (Path joins) won't resolve a literal ~. Keep "" as "" so the
+        # downstream "no projects_dir configured" check still fires.
+        raw_projects_dir = data.get("projects_dir", "")
+        projects_dir = str(Path(raw_projects_dir).expanduser()) if raw_projects_dir else ""
+
         identities[name] = Identity(
             vm_instance=data["vm_instance"],
             auth_type=data.get("auth_type", "app"),
@@ -143,7 +150,7 @@ def load_config(path: Path) -> IdentityConfig:
             app_id=str(data.get("app_id", "")),
             private_key_path=data.get("private_key_path", ""),
             claude_token_path=data.get("claude_token_path", ""),
-            projects_dir=data.get("projects_dir", ""),
+            projects_dir=projects_dir,
             vergil=data.get("vergil", ""),
             vergil_vm=data.get("vergil-vm", ""),
             model=data.get("model", ""),

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from vergil_tooling.lib.identity import (
     Identity,
@@ -117,6 +114,52 @@ def test_load_config_accepts_none_auth_type(tmp_path: Path) -> None:
     )
     cfg = load_config(p)
     assert cfg.identities["anonymous"].auth_type == "none"
+
+
+def test_load_config_expands_tilde_in_projects_dir(tmp_path: Path) -> None:
+    # A leading ~ must be expanded at load so every consumer (Lima mountPoint,
+    # which rejects ~, and on-disk vergil.toml lookups) gets an absolute path.
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.anonymous]
+        vm_instance = "anonymous"
+        auth_type = "none"
+        projects_dir = "~/dev/projects"
+    """)
+    )
+    cfg = load_config(p)
+    projects_dir = cfg.identities["anonymous"].projects_dir
+    assert not projects_dir.startswith("~")
+    assert projects_dir == str(Path.home() / "dev" / "projects")
+
+
+def test_load_config_preserves_empty_projects_dir(tmp_path: Path) -> None:
+    # Empty must stay empty — a downstream check treats "" as "not configured".
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.anonymous]
+        vm_instance = "anonymous"
+        auth_type = "none"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.identities["anonymous"].projects_dir == ""
+
+
+def test_load_config_leaves_absolute_projects_dir_unchanged(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.anonymous]
+        vm_instance = "anonymous"
+        auth_type = "none"
+        projects_dir = "/Users/someone/dev/projects"
+    """)
+    )
+    cfg = load_config(p)
+    assert cfg.identities["anonymous"].projects_dir == "/Users/someone/dev/projects"
 
 
 def test_load_config_rejects_unknown_auth_type(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- load_config now expands a leading ~ in projects_dir so a credential-less identity stanza using ~/dev/projects yields an absolute path for the Lima mountPoint and on-disk vergil.toml lookups instead of failing or silently dropping the repo overlay.

## Issue Linkage

- Ref #1705

## Notes

- Completes #1705: the auth_type=none feature landed in #1707, but the documented anonymous example (projects_dir = "~/dev/projects") failed at limactl create with 'mountPoint must not start with "~"', and would also have silently dropped the [vm.<id>] overlay (incl. required nested=true) because Path(~/...) never resolves on disk. Fix expands ~ once at config load; empty stays empty to preserve the not-configured check. 3 new tests (tilde/empty/absolute); vrg-validate green.