### PR TITLE
fix(finalize-pr): guard cleanup sweep against reused branch names

### DIFF
--- a/src/vergil_tooling/bin/vrg_worktree_status.py
+++ b/src/vergil_tooling/bin/vrg_worktree_status.py
@@ -91,9 +91,10 @@ def main(argv: list[str] | None = None) -> int:
     print(_render_table([_row(s) for s in statuses]))
     print()
     print(_summary(statuses))
-    # Surface UNKNOWN detail so a failed lookup is never silently hidden.
+    # Surface any captured detail so neither a failed lookup (UNKNOWN) nor a
+    # reused-branch-name mismatch (issue #1719) is silently hidden.
     for status in statuses:
-        if status.state is WorktreeState.UNKNOWN and status.detail:
+        if status.detail:
             print(f"  note: {status.worktree.branch}: {status.detail}")
     return 0
 

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -628,9 +628,15 @@ def pr_state(pr: str) -> str:
 
 
 def _first_pr_for_branch(branch: str, state: str) -> dict[str, str] | None:
-    """Return the first PR in *state* whose head is *branch*, or None."""
+    """Return the first PR in *state* whose head is *branch*, or None.
+
+    ``headRefOid`` is included so callers can confirm a name-matched PR's
+    head actually corresponds to the branch's current tip — a branch name
+    reused after a same-named PR merged matches by name but not by tip
+    (issue #1719).
+    """
     result = read_json(
-        "pr", "list", "--head", branch, "--state", state, "--json", "number,url,title"
+        "pr", "list", "--head", branch, "--state", state, "--json", "number,url,title,headRefOid"
     )
     if not isinstance(result, list) or not result:
         return None
@@ -641,6 +647,7 @@ def _first_pr_for_branch(branch: str, state: str) -> dict[str, str] | None:
         "number": str(first.get("number") or ""),
         "url": str(first.get("url") or ""),
         "title": str(first.get("title") or ""),
+        "headRefOid": str(first.get("headRefOid") or ""),
     }
 
 

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -68,16 +68,30 @@ def classify_worktree(
     ahead: int,
     dirty: bool,
     detail: str | None = None,
+    merged_head_matches_tip: bool = True,
 ) -> WorktreeStatus:
     """Map already-gathered signals to a WorktreeStatus. Pure: no I/O.
 
     A failed PR lookup yields UNKNOWN with *detail* — never a silent
     downgrade to NO_PR, which would mislabel real work as stalled.
+
+    ``merged_head_matches_tip`` guards against a reused branch name
+    (issue #1719). A closed/merged PR is matched to a branch by *name*,
+    but a name reused after that PR merged points at an entirely new tip
+    whose commits were never merged. When the merged PR's head no longer
+    equals the branch tip, the MERGED/CLOSED verdict is dropped and the
+    branch is classified by its local commits (NO_PR / DRAFT) — never
+    removable — so the straggler sweep cannot delete unmerged work.
     """
     if pr_lookup_failed:
         state = WorktreeState.UNKNOWN
     elif pr_state == "OPEN":
         state = WorktreeState.OPEN_PR
+    elif pr_state in ("MERGED", "CLOSED") and not merged_head_matches_tip:
+        # Name-matched a merged/closed PR, but the branch tip has moved
+        # past it — the name was reused. Treat the current tip as unmerged
+        # work: stalled if it has commits, an empty draft otherwise.
+        state = WorktreeState.NO_PR if ahead > 0 else WorktreeState.DRAFT
     elif pr_state == "MERGED":
         state = WorktreeState.MERGED
     elif pr_state == "CLOSED":
@@ -96,20 +110,29 @@ def classify_worktree(
     )
 
 
-def _resolve_pr_state(branch: str) -> tuple[int | None, str | None]:
-    """Resolve ``(pr_number, pr_state)`` for *branch*.
+def _resolve_pr_state(branch: str) -> tuple[int | None, str | None, str | None]:
+    """Resolve ``(pr_number, pr_state, pr_head_sha)`` for *branch*.
 
     An open PR wins; otherwise the most recent closed/merged PR (whose
     ``MERGED`` vs ``CLOSED`` state is read explicitly); otherwise
-    ``(None, None)`` for a branch with no PR.
+    ``(None, None, None)`` for a branch with no PR.
+
+    ``pr_head_sha`` is the closed/merged PR's head commit, used to confirm
+    the PR actually corresponds to the branch's current tip rather than a
+    same-named PR that merged before the name was reused (issue #1719). It
+    is ``None`` for an open PR, where the name match is authoritative.
     """
     open_pr = github.pr_for_branch(branch)
     if open_pr is not None:
-        return int(open_pr["number"]), "OPEN"
+        return int(open_pr["number"]), "OPEN", None
     closed = github.closed_pr_for_branch(branch)
     if closed is not None:
-        return int(closed["number"]), github.pr_state(closed["number"])
-    return None, None
+        return (
+            int(closed["number"]),
+            github.pr_state(closed["number"]),
+            closed.get("headRefOid") or None,
+        )
+    return None, None, None
 
 
 def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus:
@@ -119,11 +142,18 @@ def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus
     ``vrg-finalize-pr`` straggler sweep. A failed ``gh`` PR lookup is
     surfaced as ``UNKNOWN`` with the captured reason — never a silent
     failure that would misclassify the worktree.
+
+    For a closed/merged PR, the PR's head SHA is compared against the
+    branch's current tip. When they differ — the branch name was reused
+    after a same-named PR merged (issue #1719) — the merged verdict is
+    withheld so the branch is never classified removable; the mismatch is
+    recorded in ``detail`` rather than swallowed.
     """
     ahead = git.commits_ahead(target, worktree.branch)
     dirty = bool(git.read_output("-C", str(worktree.path), "status", "--porcelain"))
+    detail: str | None = None
     try:
-        pr_number, pr_state = _resolve_pr_state(worktree.branch)
+        pr_number, pr_state, pr_head_sha = _resolve_pr_state(worktree.branch)
     except subprocess.CalledProcessError as exc:
         detail = (exc.stderr or str(exc)).strip()
         return classify_worktree(
@@ -135,6 +165,22 @@ def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus
             dirty=dirty,
             detail=detail,
         )
+
+    merged_head_matches_tip = True
+    if pr_state in ("MERGED", "CLOSED"):
+        tip = git.commit_sha(worktree.branch)
+        # A missing head SHA is treated as a mismatch: without positive
+        # proof the PR covers this tip, withholding removal is the safe
+        # default (never delete unproven-merged work — issue #1719).
+        merged_head_matches_tip = pr_head_sha is not None and pr_head_sha == tip
+        if not merged_head_matches_tip:
+            shown = (pr_head_sha or "unknown")[:8]
+            detail = (
+                f"closed PR #{pr_number} head {shown} does not match branch "
+                f"tip {tip[:8]} — branch name reused after that PR merged "
+                f"(issue #1719); current commits are unmerged"
+            )
+
     return classify_worktree(
         worktree,
         pr_number=pr_number,
@@ -142,6 +188,8 @@ def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus
         pr_lookup_failed=False,
         ahead=ahead,
         dirty=dirty,
+        detail=detail,
+        merged_head_matches_tip=merged_head_matches_tip,
     )
 
 

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -1429,13 +1429,21 @@ class TestGetInstallationToken:
 
 
 def test_pr_for_branch_returns_first_open_pr() -> None:
-    payload = [{"number": 1423, "url": "https://github.com/o/r/pull/1423", "title": "T"}]
+    payload = [
+        {
+            "number": 1423,
+            "url": "https://github.com/o/r/pull/1423",
+            "title": "T",
+            "headRefOid": "abc123",
+        }
+    ]
     with patch("vergil_tooling.lib.github.read_json", return_value=payload) as rj:
         result = github.pr_for_branch("feature/1423-pr-interface")
     assert result == {
         "number": "1423",
         "url": "https://github.com/o/r/pull/1423",
         "title": "T",
+        "headRefOid": "abc123",
     }
     rj.assert_called_once_with(
         "pr",
@@ -1445,7 +1453,7 @@ def test_pr_for_branch_returns_first_open_pr() -> None:
         "--state",
         "open",
         "--json",
-        "number,url,title",
+        "number,url,title,headRefOid",
     )
 
 
@@ -1478,13 +1486,21 @@ def test_pr_for_branch_none_when_payload_not_dict() -> None:
 
 
 def test_closed_pr_for_branch_returns_first_closed_pr() -> None:
-    payload = [{"number": 1445, "url": "https://github.com/o/r/pull/1445", "title": "T"}]
+    payload = [
+        {
+            "number": 1445,
+            "url": "https://github.com/o/r/pull/1445",
+            "title": "T",
+            "headRefOid": "deadbeef",
+        }
+    ]
     with patch("vergil_tooling.lib.github.read_json", return_value=payload) as rj:
         result = github.closed_pr_for_branch("feature/1445-finalize-cleanup-race")
     assert result == {
         "number": "1445",
         "url": "https://github.com/o/r/pull/1445",
         "title": "T",
+        "headRefOid": "deadbeef",
     }
     rj.assert_called_once_with(
         "pr",
@@ -1494,7 +1510,7 @@ def test_closed_pr_for_branch_returns_first_closed_pr() -> None:
         "--state",
         "closed",
         "--json",
-        "number,url,title",
+        "number,url,title,headRefOid",
     )
 
 

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -1589,6 +1589,44 @@ def test_sweep_worktree_delete_decline_does_not_record(tmp_path: Path) -> None:
     deleter.assert_called_once_with("feature/3-z", tmp_path, dry_run=False)
 
 
+def test_sweep_keeps_reused_branch_name_worktree(tmp_path: Path) -> None:
+    """Issue #1719: a branch name reused after a same-named PR merged keeps a
+    worktree whose tip carries unmerged commits. Driving the REAL
+    gather_worktree_status (only its git/github primitives are stubbed)
+    proves the worktree arm withholds the merged verdict and never deletes
+    the in-progress branch."""
+    _make_profile(tmp_path, "library-release")
+    wt = Worktree(
+        path=tmp_path / ".worktrees" / "issue-286-build-buckets",
+        branch="feature/286-build-buckets",
+    )
+    _wt_mod = "vergil_tooling.lib.worktrees"
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        # The reused branch tip is NOT an ancestor of develop, so the
+        # ancestry arm never lists it — only the worktree arm can see it.
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[wt]),
+        # Real gather_worktree_status: stub only its primitives.
+        patch(_wt_mod + ".git.commits_ahead", return_value=9),
+        patch(_wt_mod + ".git.read_output", return_value=""),
+        patch(_wt_mod + ".git.commit_sha", return_value="7ead128"),
+        patch(_wt_mod + ".github.pr_for_branch", return_value=None),
+        patch(
+            _wt_mod + ".github.closed_pr_for_branch",
+            return_value={"number": "293", "url": "", "title": "docs", "headRefOid": "0ldd0cs"},
+        ),
+        patch(_wt_mod + ".github.pr_state", return_value="MERGED"),
+        patch(_MOD + "._delete_branch_and_worktree") as deleter,
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+    ):
+        result = main(["--cleanup-only"])
+    assert result == 0
+    deleter.assert_not_called()
+
+
 def test_sweep_skips_eternal_branch_worktree(tmp_path: Path) -> None:
     """A worktree checked out on an eternal branch is never classified or
     swept — the eternal guard short-circuits before gather_worktree_status."""

--- a/tests/vergil_tooling/test_vrg_worktree_status.py
+++ b/tests/vergil_tooling/test_vrg_worktree_status.py
@@ -75,3 +75,28 @@ def test_main_surfaces_unknown_detail(capsys: pytest.CaptureFixture[str]) -> Non
     assert "gh boom" in out
     assert "0 cruft" in out
     assert "Run vrg-finalize-pr" not in out
+
+
+def test_main_surfaces_reused_branch_detail(capsys: pytest.CaptureFixture[str]) -> None:
+    """Issue #1719: a reused-branch mismatch lands as NO_PR with a detail
+    note — surfaced too, not just UNKNOWN, so the reuse never hides."""
+    statuses = [
+        _status(
+            "feature/286-build-buckets",
+            WorktreeState.NO_PR,
+            pr=293,
+            ahead=9,
+            detail="closed PR #293 head 0ldd0cs does not match branch tip 7ead128 — reused",
+        )
+    ]
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "note: feature/286-build-buckets:" in out
+    assert "#293" in out
+    assert "0 cruft" in out

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -145,6 +145,7 @@ def _classify(
     ahead: int = 0,
     dirty: bool = False,
     detail: str | None = None,
+    merged_head_matches_tip: bool = True,
 ) -> WorktreeStatus:
     return classify_worktree(
         _SAMPLE_WT,
@@ -154,6 +155,7 @@ def _classify(
         ahead=ahead,
         dirty=dirty,
         detail=detail,
+        merged_head_matches_tip=merged_head_matches_tip,
     )
 
 
@@ -200,6 +202,32 @@ def test_classify_lookup_failure_is_unknown() -> None:
     assert status.detail == "gh exploded"
 
 
+def test_classify_merged_head_mismatch_with_commits_is_stalled() -> None:
+    """Issue #1719: a merged PR whose head no longer matches the branch tip
+    (name reused) must drop to NO_PR, never MERGED/removable."""
+    status = _classify(pr_number=293, pr_state="MERGED", ahead=9, merged_head_matches_tip=False)
+    assert status.state is WorktreeState.NO_PR
+    assert status.removable is False
+
+
+def test_classify_merged_head_mismatch_zero_commits_is_draft() -> None:
+    status = _classify(pr_number=293, pr_state="MERGED", ahead=0, merged_head_matches_tip=False)
+    assert status.state is WorktreeState.DRAFT
+    assert status.removable is False
+
+
+def test_classify_closed_head_mismatch_is_not_removable() -> None:
+    status = _classify(pr_number=293, pr_state="CLOSED", ahead=4, merged_head_matches_tip=False)
+    assert status.state is WorktreeState.NO_PR
+    assert status.removable is False
+
+
+def test_classify_merged_head_match_remains_removable() -> None:
+    status = _classify(pr_number=11, pr_state="MERGED", ahead=2, merged_head_matches_tip=True)
+    assert status.state is WorktreeState.MERGED
+    assert status.removable is True
+
+
 # -- gather_worktree_status (I/O wrapper) ------------------------------------
 
 
@@ -223,10 +251,11 @@ def test_gather_merged_pr_is_removable() -> None:
     with (
         patch(_MOD + ".git.commits_ahead", return_value=1),
         patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".git.commit_sha", return_value="cafef00d"),
         patch(_MOD + ".github.pr_for_branch", return_value=None),
         patch(
             _MOD + ".github.closed_pr_for_branch",
-            return_value={"number": "11", "url": "", "title": "t"},
+            return_value={"number": "11", "url": "", "title": "t", "headRefOid": "cafef00d"},
         ),
         patch(_MOD + ".github.pr_state", return_value="MERGED"),
     ):
@@ -240,15 +269,59 @@ def test_gather_dirty_overlay_blocks_removal() -> None:
     with (
         patch(_MOD + ".git.commits_ahead", return_value=1),
         patch(_MOD + ".git.read_output", return_value=" M file.py"),
+        patch(_MOD + ".git.commit_sha", return_value="cafef00d"),
         patch(_MOD + ".github.pr_for_branch", return_value=None),
         patch(
             _MOD + ".github.closed_pr_for_branch",
-            return_value={"number": "11", "url": "", "title": "t"},
+            return_value={"number": "11", "url": "", "title": "t", "headRefOid": "cafef00d"},
         ),
         patch(_MOD + ".github.pr_state", return_value="MERGED"),
     ):
         status = gather_worktree_status(_SAMPLE_WT, target="develop")
+    assert status.state is WorktreeState.MERGED
     assert status.dirty is True
+    assert status.removable is False
+
+
+def test_gather_reused_branch_name_is_not_removable() -> None:
+    """Issue #1719: a branch name reused after a same-named PR merged must
+    not be classified MERGED — its current tip carries unmerged work."""
+    with (
+        patch(_MOD + ".git.commits_ahead", return_value=9),
+        patch(_MOD + ".git.read_output", return_value=""),
+        # The local tip is a fresh commit; the merged PR points at an old one.
+        patch(_MOD + ".git.commit_sha", return_value="7ead128"),
+        patch(_MOD + ".github.pr_for_branch", return_value=None),
+        patch(
+            _MOD + ".github.closed_pr_for_branch",
+            return_value={"number": "293", "url": "", "title": "docs", "headRefOid": "0ldd0cs"},
+        ),
+        patch(_MOD + ".github.pr_state", return_value="MERGED"),
+    ):
+        status = gather_worktree_status(_SAMPLE_WT, target="develop")
+    assert status.state is WorktreeState.NO_PR
+    assert status.removable is False
+    assert status.detail is not None
+    assert "#293" in status.detail
+    assert "reused" in status.detail
+
+
+def test_gather_missing_head_sha_withholds_removal() -> None:
+    """Without a head SHA to prove the merge covers this tip, removal is
+    withheld — never delete unproven-merged work (issue #1719)."""
+    with (
+        patch(_MOD + ".git.commits_ahead", return_value=2),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".git.commit_sha", return_value="7ead128"),
+        patch(_MOD + ".github.pr_for_branch", return_value=None),
+        patch(
+            _MOD + ".github.closed_pr_for_branch",
+            return_value={"number": "11", "url": "", "title": "t", "headRefOid": ""},
+        ),
+        patch(_MOD + ".github.pr_state", return_value="MERGED"),
+    ):
+        status = gather_worktree_status(_SAMPLE_WT, target="develop")
+    assert status.state is WorktreeState.NO_PR
     assert status.removable is False
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-finalize-pr's worktree-arm cleanup now verifies a closed/merged PR's head SHA matches the branch's current tip before treating it as removable, closing a silent data-loss path where a branch name reused after a same-named PR merged was deleted as 'merged' despite carrying unmerged commits.

## Issue Linkage

- Ref #1719

## Notes

- Root cause: gather_worktree_status matched merged PRs by branch name only, so a reused name inherited a prior PR's MERGED verdict. Fix adds a head-SHA-vs-tip check; on mismatch (or missing head SHA) the merged verdict is withheld and the branch falls to NO_PR/DRAFT (never removable), with the mismatch surfaced in vrg-worktree-status detail rather than swallowed. closed_pr_for_branch/pr_for_branch now return headRefOid. The ancestry arm needed no change — a reused branch's non-ancestor tip is never listed by git branch --merged. Covered by classify/gather unit tests, a worktree-status surfacing test, and a finalize-level integration test driving the real gather path.