### PR TITLE
fix(vrg-vm): auto-recover a poisoned uv cache instead of bricking the VM

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -363,6 +363,20 @@ def stop_vm(instance: str) -> None:
     status = vm_status(instance)
     if status != "Running":
         return
+    # Flush the guest page cache before stopping. A non-synced shutdown can
+    # truncate files written just before the stop — notably the uv cache and
+    # tool receipt that `install_tooling` writes immediately before the
+    # rebuild's terminal `cycle-ssh` stop — which then poisons the next
+    # `vrg-vm session` update (see `_uv_tool_install`). Best-effort: a failed
+    # sync must never block the stop, but surface it rather than swallow it.
+    try:
+        shell_run(instance, "sync")
+    except subprocess.CalledProcessError:
+        print(
+            f"  WARNING: guest sync before stop failed for '{instance}' — "
+            "stopping anyway",
+            file=sys.stderr,
+        )
     _limactl("stop", instance)
 
 

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -373,8 +373,7 @@ def stop_vm(instance: str) -> None:
         shell_run(instance, "sync")
     except subprocess.CalledProcessError:
         print(
-            f"  WARNING: guest sync before stop failed for '{instance}' — "
-            "stopping anyway",
+            f"  WARNING: guest sync before stop failed for '{instance}' — stopping anyway",
             file=sys.stderr,
         )
     _limactl("stop", instance)

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -550,9 +550,21 @@ def _uv_tool_install(instance: str, install_spec: str, *, reinstall: bool) -> No
     poisoned cache leaves the VM with no tooling at all and bricks every future
     ``vrg-vm session`` until the cache is cleared by hand. So on failure, clear
     the VM's uv cache and retry the install once.
+
+    The retry escalates to ``--force``. The same unclean stop also corrupts the
+    tool *receipt*: uv removes the entry but, unable to read the receipt, cannot
+    enumerate the tool's entry points, so the ``vrg-*`` executables orphan in
+    ``~/.local/bin``. Clearing the cache fixes the wheel, but the retry would
+    then die with "Executable already exists" — only ``--force`` replaces
+    existing entry points (``--reinstall`` alone does not), so the retry must
+    force to fully recover.
     """
     flag = "--reinstall " if reinstall else ""
     install_cmd = f'export PATH="$HOME/.local/bin:$PATH" && uv tool install {flag}"{install_spec}"'
+    retry_cmd = (
+        'export PATH="$HOME/.local/bin:$PATH" && '
+        f'uv tool install --force --reinstall "{install_spec}"'
+    )
     try:
         shell_run(instance, "bash", "-c", install_cmd)
         return
@@ -567,7 +579,7 @@ def _uv_tool_install(instance: str, install_spec: str, *, reinstall: bool) -> No
             "-c",
             'export PATH="$HOME/.local/bin:$PATH" && uv cache clean',
         )
-        shell_run(instance, "bash", "-c", install_cmd)
+        shell_run(instance, "bash", "-c", retry_cmd)
 
 
 def install_tooling(instance: str, tag: str) -> None:

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -497,9 +497,12 @@ class TestStartStopVm:
             start_vm("vergil-agent")
         mock.assert_called_once()
 
+    @patch("vergil_tooling.lib.lima.shell_run")
     @patch("vergil_tooling.lib.lima._limactl")
     @patch("vergil_tooling.lib.lima.vm_status", return_value="Running")
-    def test_stop_calls_limactl(self, _status: MagicMock, mock: MagicMock) -> None:
+    def test_stop_calls_limactl(
+        self, _status: MagicMock, mock: MagicMock, _mock_shell: MagicMock
+    ) -> None:
         stop_vm("vergil-agent")
         mock.assert_called_once_with("stop", "vergil-agent")
 
@@ -508,6 +511,45 @@ class TestStartStopVm:
     def test_stop_skips_if_stopped(self, _status: MagicMock, mock: MagicMock) -> None:
         stop_vm("vergil-agent")
         mock.assert_not_called()
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima.vm_status", return_value="Running")
+    def test_stop_syncs_guest_before_stopping(
+        self, _status: MagicMock, mock_limactl: MagicMock, mock_shell: MagicMock
+    ) -> None:
+        # Flush the guest page cache before the VM stops so the just-written uv
+        # cache/receipt are not truncated by a non-synced shutdown.
+        manager = MagicMock()
+        manager.attach_mock(mock_shell, "shell_run")
+        manager.attach_mock(mock_limactl, "limactl")
+        stop_vm("vergil-agent")
+        mock_shell.assert_called_once_with("vergil-agent", "sync")
+        mock_limactl.assert_called_once_with("stop", "vergil-agent")
+        assert [c[0] for c in manager.mock_calls] == ["shell_run", "limactl"]
+
+    @patch(
+        "vergil_tooling.lib.lima.shell_run",
+        side_effect=subprocess.CalledProcessError(1, "sync"),
+    )
+    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima.vm_status", return_value="Running")
+    def test_stop_proceeds_when_sync_fails(
+        self, _status: MagicMock, mock_limactl: MagicMock, _mock_shell: MagicMock
+    ) -> None:
+        # The sync is best-effort: a failed flush must never block the stop.
+        stop_vm("vergil-agent")
+        mock_limactl.assert_called_once_with("stop", "vergil-agent")
+
+    @patch("vergil_tooling.lib.lima.shell_run")
+    @patch("vergil_tooling.lib.lima._limactl")
+    @patch("vergil_tooling.lib.lima.vm_status", return_value="Stopped")
+    def test_stop_skips_sync_if_stopped(
+        self, _status: MagicMock, mock_limactl: MagicMock, mock_shell: MagicMock
+    ) -> None:
+        stop_vm("vergil-agent")
+        mock_shell.assert_not_called()
+        mock_limactl.assert_not_called()
 
 
 class TestDeleteVm:

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -1171,6 +1171,25 @@ class TestToolingInstallSelfHeal:
 
     @patch("vergil_tooling.lib.lima.shell_pipe")
     @patch("vergil_tooling.lib.lima.shell_run")
+    def test_retry_forces_over_orphaned_executables(
+        self, mock_run: MagicMock, _mock_pipe: MagicMock
+    ) -> None:
+        # A poisoned cache + invalid receipt leaves orphaned `vrg-*` executables
+        # in ~/.local/bin. Clearing the cache fixes the wheel, but the retry then
+        # dies on "Executable already exists" unless it forces. So the retry must
+        # escalate to --force; the first attempt must not (a healthy version bump
+        # should not force-replace entry points).
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        mock_run.side_effect = [subprocess.CalledProcessError(1, "uv"), ok, ok]
+        update_tooling("vergil-agent", "v2.0")
+        installs = [c for c in self._cmds(mock_run) if "uv tool install" in c]
+        assert len(installs) == 2
+        first_attempt, retry = installs
+        assert "--force" not in first_attempt
+        assert "--force" in retry
+
+    @patch("vergil_tooling.lib.lima.shell_pipe")
+    @patch("vergil_tooling.lib.lima.shell_run")
     def test_update_propagates_when_retry_also_fails(
         self, mock_run: MagicMock, _mock_pipe: MagicMock
     ) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Escalate the tooling self-heal retry to --force --reinstall so it clears orphaned executables left by an invalid receipt, and sync the guest before stopping the VM so the just-written uv cache/receipt are not truncated by a non-synced shutdown.

## Issue Linkage

- Ref #1724

## Notes

- Two halves of the same failure (issue #1724). Recovery: _uv_tool_install's retry now forces over the 'Executable already exists' guard that --reinstall alone hit after a cache clean — verified against uv 0.11.21 help ('--force ... replace any existing entry points'). Prevention: stop_vm runs a best-effort guest 'sync' before limactl stop; a failed sync warns but never blocks the stop. New tests assert the retry forces (first attempt does not), and that stop_vm syncs-before-stop, proceeds when sync fails, and skips both when already stopped. Full vrg-validate green.