### PR TITLE
feat(vrg-worktree-status): show pr-workflow prep state in a WORKFLOW column

### DIFF
--- a/docs/specs/2026-06-22-worktree-status-workflow-column-design.md
+++ b/docs/specs/2026-06-22-worktree-status-workflow-column-design.md
@@ -57,8 +57,9 @@ loader so its schema stays single-sourced.
   error" without a magic string):
   - **Absent** — no `.vergil/pr-workflow.json`. Renders `-`.
   - **Loaded** — carries `workflow_status: str` (the raw `status`) and
-    `pr_prepared: bool` (`pr_metadata` populated → the `vrg-submit-pr`
-    gate).
+    `pr_prepared: bool` (`pr_metadata` populated **and** not yet
+    `submitted` → exactly the `vrg-submit-pr` ready gate, which skips
+    already-submitted worktrees via `AlreadySubmittedError`).
   - **Error** — carries a `reason: str`. Renders `unknown` + a note.
   Concretely this can be a small tagged field (e.g. `workflow_status:
   str | None` for Absent/Loaded plus a `workflow_error: str | None`
@@ -87,12 +88,15 @@ loader so its schema stays single-sourced.
     already use for "nothing here".
   - **Error** → `unknown` (see Error handling below).
 - Summary line: append a neutral, trailing sentence
-  `N PR prepared.` where `N = count(status.pr_prepared)`. It keys off
-  `pr_prepared` (`pr_metadata` present), **not** the status string —
-  so a worktree in `reviewing`, `approved`, or `changes-requested`
-  with metadata already written all count. Existing
-  `active/stalled/cruft` counts and the "Run vrg-finalize-pr to clean
-  cruft." line are untouched.
+  `N PR prepared.` (always shown, including `0 PR prepared.`, so its
+  absence is never mistaken for the feature being missing) where
+  `N = count(status.pr_prepared)`. It keys off `pr_prepared`
+  (`pr_metadata` present and not yet submitted), **not** the status
+  string — so a worktree in `reviewing`, `approved`, or
+  `changes-requested` with metadata already written all count, while an
+  already-submitted one does not. Existing `active/stalled/cruft`
+  counts and the "Run vrg-finalize-pr to clean cruft." line are
+  untouched.
 
 ## Data flow
 
@@ -144,6 +148,38 @@ Extend `tests/vergil_tooling/test_vrg_worktree_status.py` (and
 Tests mock the pr-workflow loader / status gathering the same way the
 existing suite mocks `list_worktrees` and `gather_worktree_status`, so
 no real `git`/`gh`/filesystem pr-workflow files are required.
+
+## Implementation plan (TDD)
+
+Built test-first, red→green per step. Concrete touch points:
+
+1. **`lib/worktrees.py` — probe helper.** Add
+   `_probe_pr_workflow(worktree) -> tuple[str | None, str | None, bool]`
+   returning `(workflow_status, workflow_error, pr_prepared)`. Reads via
+   `LocalFileTransport(worktree.path).read()`. Absent file →
+   `(None, None, False)`. Loaded → `(state.status, None,
+   state.pr_metadata is not None and state.submitted is None)`. A
+   `WorkflowError`/`OSError` (malformed/unreadable) →
+   `(None, str(exc), False)` — caught explicitly, never swallowed.
+   *Tested directly with real files under `tmp_path` (no mocks).*
+2. **`lib/worktrees.py` — `WorktreeStatus` fields.** Add
+   `workflow_status: str | None = None`, `workflow_error: str | None =
+   None`, `pr_prepared: bool = False` (all defaulted, so existing
+   constructors and `classify_worktree` are untouched).
+3. **`lib/worktrees.py` — attach in `gather_worktree_status`.** Probe
+   once near the top; attach the three fields onto the classified
+   `WorktreeStatus` via `dataclasses.replace` at both return sites
+   (keeps `classify_worktree` focused on lifecycle only).
+4. **`bin/vrg_worktree_status.py` — render.** Add `WORKFLOW` to
+   `_COLUMNS` between `STATE` and `AHEAD`; in `_row` map the probe to a
+   cell (`workflow_error` → `unknown`; else `workflow_status` or `-`).
+   In `_summary` append `N PR prepared.`. In `main`'s note loop, emit a
+   `pr-workflow unreadable: <reason>` note when `workflow_error` is set.
+5. **Tests.** `test_worktrees.py` for `_probe_pr_workflow` (absent /
+   loaded-prepared / loaded-submitted / loaded-no-metadata / malformed)
+   and a `gather_*` test asserting the fields attach;
+   `test_vrg_worktree_status.py` for the column verbatim, `-` absent,
+   `unknown` + note on error, and the prepared count.
 
 ## Out of scope / future
 

--- a/docs/specs/2026-06-22-worktree-status-workflow-column-design.md
+++ b/docs/specs/2026-06-22-worktree-status-workflow-column-design.md
@@ -1,0 +1,152 @@
+# Design: `vrg-worktree-status` — WORKFLOW column for pr-workflow prep state
+
+- **Issue:** [#1729](https://github.com/vergil-project/vergil-tooling/issues/1729)
+- **Date:** 2026-06-22
+- **Status:** Approved (brainstorm)
+
+## Overview
+
+`vrg-worktree-status` reports, per worktree, whether GitHub has a PR
+(the `PR`/`STATE` columns) but not whether the **local PR handoff file**
+(`.vergil/pr-workflow.json`) has been prepared for submission. When
+several stalled worktrees all sit on `no-pr`, there is no way to tell
+which ones an agent has actually prepared (via
+`vrg-pr-workflow report-ready`) from which are still mid-implementation.
+
+This change adds a single observability signal: a `WORKFLOW` column
+showing each worktree's raw pr-workflow `status`, and a neutral
+`N PR prepared.` count on the summary line. It lets a human scan the
+table and pick which worktrees are ready to hand to `vrg-submit-pr`.
+
+## Purpose
+
+Surface the pr-workflow prep state that already gates `vrg-submit-pr`,
+so the human running the submit step does not have to open each
+`.vergil/pr-workflow.json` by hand to learn which worktrees are
+submittable.
+
+The "prepared" definition reuses the **same signal** `vrg-submit-pr`
+already uses to build its ready set (`_ready_worktrees()` →
+`pr_metadata` present), so what status *flags* as prepared and what
+submit *accepts* stay consistent.
+
+## Non-goals
+
+- **No new behavior in `vrg-submit-pr`.** Batch submission of every
+  prepared worktree already exists as `vrg-submit-pr --all` (issue
+  #1673). This change does not add a `--select all` alias or otherwise
+  touch submit-pr — one spelling is enough.
+- **Observability-only.** The new column makes **no GitHub calls**; it
+  reads the local file only. STATE/cruft classification, sort order,
+  and the cruft summary are unchanged.
+- No `--json` output, no non-zero exit based on prep state (YAGNI;
+  consistent with the v1 status spec).
+
+## Architecture
+
+A thin extension of the existing `lib/worktrees.py` → `bin/
+vrg_worktree_status.py` split. The library gathers the new signal and
+exposes it on the status dataclass; the bin renders the column and
+extends the summary. The pr-workflow file is read through the existing
+loader so its schema stays single-sourced.
+
+### `lib/worktrees.py` — gather the signal
+
+- Extend the `WorktreeStatus` dataclass to carry the probe as **three
+  distinct cases** (so the renderer can tell "no file" from "read
+  error" without a magic string):
+  - **Absent** — no `.vergil/pr-workflow.json`. Renders `-`.
+  - **Loaded** — carries `workflow_status: str` (the raw `status`) and
+    `pr_prepared: bool` (`pr_metadata` populated → the `vrg-submit-pr`
+    gate).
+  - **Error** — carries a `reason: str`. Renders `unknown` + a note.
+  Concretely this can be a small tagged field (e.g. `workflow_status:
+  str | None` for Absent/Loaded plus a `workflow_error: str | None`
+  carrying the reason for the Error case, with `pr_prepared` always
+  `False` outside the Loaded case). The exact encoding is a plan-level
+  detail; the three cases and their renderings are the contract.
+- In `gather_worktree_status(worktree, *, target)`, read the
+  worktree's local pr-workflow file (each `Worktree` already carries an
+  absolute `path`) via the existing `lib/pr_workflow/` loader
+  (`WorkflowState` / `LocalFileTransport`). Do **not** re-parse the JSON
+  by hand — reuse the loader so the schema definition is not
+  duplicated.
+- A genuinely absent file is the **normal** case: `workflow_status =
+  None`, `pr_prepared = False`. No error.
+
+### `bin/vrg_worktree_status.py` — render
+
+- Add `WORKFLOW` to `_COLUMNS`, positioned **between `STATE` and
+  `AHEAD`**. The dynamic column-width logic already in `_render_table`
+  needs no change.
+- Cell value, by probe case:
+  - **Loaded** → the `workflow_status` string, rendered **verbatim**
+    (e.g. `approved`, `reviewing`, `implementing`, `changes-requested`,
+    `escalated`, `error`).
+  - **Absent** → `-`, matching the dash convention `PR` and `DIRTY`
+    already use for "nothing here".
+  - **Error** → `unknown` (see Error handling below).
+- Summary line: append a neutral, trailing sentence
+  `N PR prepared.` where `N = count(status.pr_prepared)`. It keys off
+  `pr_prepared` (`pr_metadata` present), **not** the status string —
+  so a worktree in `reviewing`, `approved`, or `changes-requested`
+  with metadata already written all count. Existing
+  `active/stalled/cruft` counts and the "Run vrg-finalize-pr to clean
+  cruft." line are untouched.
+
+## Data flow
+
+```
+list_worktrees(repo_root)
+  → for each Worktree:
+      gather_worktree_status(wt, target=…)
+        ├─ ahead / dirty / PR resolution   (unchanged)
+        └─ read wt/.vergil/pr-workflow.json via pr_workflow loader   (NEW)
+              ├─ no file      → workflow_status=None,  pr_prepared=False
+              ├─ loaded ok    → workflow_status=state.status,
+              │                 pr_prepared=(state.pr_metadata is not None)
+              └─ read/parse error → workflow_status=<unknown sentinel>,
+                                    note appended, pr_prepared=False
+  → sort (unchanged) → _render_table (+WORKFLOW col) → summary (+prepared count)
+```
+
+## Error handling (no silent failures)
+
+If `.vergil/pr-workflow.json` exists but is unreadable, malformed, or
+fails to load, the column renders `unknown` and a **per-worktree note**
+is emitted stating the worktree and the reason — mirroring how the
+existing `UNKNOWN` PR-lookup state surfaces a reason in the notes
+section. We never render `-` (which means "no file") over a real read
+error, and we never swallow the exception. A missing file is the only
+case that maps to `-`.
+
+`pr_prepared` is `False` on any error path, so an unreadable file is
+never counted as prepared.
+
+## Testing
+
+Extend `tests/vergil_tooling/test_vrg_worktree_status.py` (and
+`tests/.../test_worktrees.py` for the gather-level signal):
+
+1. **Status verbatim** — a worktree whose pr-workflow `status` is
+   `approved` renders `approved` in the `WORKFLOW` column.
+2. **No file → `-`** — a worktree with no `.vergil/pr-workflow.json`
+   renders `-`.
+3. **Read/parse error → `unknown` + note** — a malformed file renders
+   `unknown` and emits a per-worktree note; the worktree is not counted
+   as prepared.
+4. **Prepared count** — the summary `N PR prepared.` reflects the
+   number of worktrees with `pr_metadata` present (and excludes
+   no-file and error worktrees).
+5. **Column alignment** — mixed values (long `changes-requested`,
+   short `-`) stay aligned under the dynamic-width renderer.
+
+Tests mock the pr-workflow loader / status gathering the same way the
+existing suite mocks `list_worktrees` and `gather_worktree_status`, so
+no real `git`/`gh`/filesystem pr-workflow files are required.
+
+## Out of scope / future
+
+- A `--ready`/filter flag to show only prepared worktrees (YAGNI; the
+  column already makes them scannable).
+- Any change to `vrg-submit-pr` selectors.

--- a/src/vergil_tooling/bin/vrg_worktree_status.py
+++ b/src/vergil_tooling/bin/vrg_worktree_status.py
@@ -28,7 +28,7 @@ _SORT_RANK = {
     WorktreeState.CLOSED: 5,
 }
 
-_COLUMNS = ("WORKTREE", "BRANCH", "PR", "STATE", "AHEAD", "DIRTY")
+_COLUMNS = ("WORKTREE", "BRANCH", "PR", "STATE", "WORKFLOW", "AHEAD", "DIRTY")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -43,6 +43,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _workflow_cell(status: WorktreeStatus) -> str:
+    """Render the pr-workflow prep signal: 'unknown' on a read error, the raw
+    status verbatim when the file loaded, '-' when there is no file yet."""
+    if status.workflow_error is not None:
+        return "unknown"
+    return status.workflow_status if status.workflow_status is not None else "-"
+
+
 def _row(status: WorktreeStatus) -> tuple[str, ...]:
     pr = f"#{status.pr_number}" if status.pr_number is not None else "-"
     return (
@@ -50,6 +58,7 @@ def _row(status: WorktreeStatus) -> tuple[str, ...]:
         status.worktree.branch,
         pr,
         status.state.value,
+        _workflow_cell(status),
         str(status.ahead),
         "yes" if status.dirty else "-",
     )
@@ -67,10 +76,12 @@ def _summary(statuses: list[WorktreeStatus]) -> str:
     total = len(statuses)
     cruft = sum(1 for s in statuses if s.removable)
     stalled = sum(1 for s in statuses if s.state is WorktreeState.NO_PR)
+    prepared = sum(1 for s in statuses if s.pr_prepared)
     active = total - cruft - stalled
     line = (
         f"{total} worktrees — {active} active, "
-        f"{stalled} stalled (no-pr), {cruft} cruft (removable)."
+        f"{stalled} stalled (no-pr), {cruft} cruft (removable). "
+        f"{prepared} PR prepared."
     )
     if cruft:
         line += " Run vrg-finalize-pr to clean cruft."
@@ -92,10 +103,16 @@ def main(argv: list[str] | None = None) -> int:
     print()
     print(_summary(statuses))
     # Surface any captured detail so neither a failed lookup (UNKNOWN) nor a
-    # reused-branch-name mismatch (issue #1719) is silently hidden.
+    # reused-branch-name mismatch (issue #1719) is silently hidden. An
+    # unreadable pr-workflow file (the WORKFLOW 'unknown' cell) gets its reason
+    # surfaced too, never a silent failure.
     for status in statuses:
         if status.detail:
             print(f"  note: {status.worktree.branch}: {status.detail}")
+        if status.workflow_error:
+            print(
+                f"  note: {status.worktree.branch}: pr-workflow unreadable: {status.workflow_error}"
+            )
     return 0
 
 

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 
 from vergil_tooling.lib import git, github
+from vergil_tooling.lib.pr_workflow.errors import WorkflowError
+from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
 from vergil_tooling.lib.repo_init import prompt_choice, prompt_multi_choice
 
 
@@ -48,6 +50,12 @@ class WorktreeStatus:
     ahead: int
     dirty: bool
     detail: str | None = None
+    # Local pr-workflow handoff signals (.vergil/pr-workflow.json). Defaulted so
+    # classify_worktree and the finalize sweep, which do not gather them, are
+    # unaffected; gather_worktree_status attaches them. See _probe_pr_workflow.
+    workflow_status: str | None = None
+    workflow_error: str | None = None
+    pr_prepared: bool = False
 
     @property
     def removable(self) -> bool:
@@ -135,6 +143,31 @@ def _resolve_pr_state(branch: str) -> tuple[int | None, str | None, str | None]:
     return None, None, None
 
 
+def _probe_pr_workflow(worktree: Worktree) -> tuple[str | None, str | None, bool]:
+    """Read the worktree's local ``.vergil/pr-workflow.json`` prep signals.
+
+    Returns ``(workflow_status, workflow_error, pr_prepared)``:
+
+    - **Absent file** (the normal pre-report-ready case) →
+      ``(None, None, False)``.
+    - **Loaded** → ``(state.status, None, prepared)`` where ``prepared`` is
+      ``True`` only when PR metadata is present *and* the worktree is not yet
+      marked submitted — exactly the ``vrg-submit-pr`` ready gate (which skips
+      already-submitted worktrees).
+    - **Unreadable/malformed** → ``(None, <reason>, False)``. The error is
+      captured and surfaced by the caller, never swallowed; a real read error
+      is not collapsed into the "no file" case.
+    """
+    try:
+        state = LocalFileTransport(worktree.path).read()
+    except (WorkflowError, OSError) as exc:
+        return None, str(exc), False
+    if state is None:
+        return None, None, False
+    prepared = state.pr_metadata is not None and state.submitted is None
+    return state.status, None, prepared
+
+
 def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus:
     """Gather local + remote signals for *worktree* and classify it.
 
@@ -151,19 +184,31 @@ def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus
     """
     ahead = git.commits_ahead(target, worktree.branch)
     dirty = bool(git.read_output("-C", str(worktree.path), "status", "--porcelain"))
+    workflow_status, workflow_error, pr_prepared = _probe_pr_workflow(worktree)
+
+    def _with_workflow(status: WorktreeStatus) -> WorktreeStatus:
+        return replace(
+            status,
+            workflow_status=workflow_status,
+            workflow_error=workflow_error,
+            pr_prepared=pr_prepared,
+        )
+
     detail: str | None = None
     try:
         pr_number, pr_state, pr_head_sha = _resolve_pr_state(worktree.branch)
     except subprocess.CalledProcessError as exc:
         detail = (exc.stderr or str(exc)).strip()
-        return classify_worktree(
-            worktree,
-            pr_number=None,
-            pr_state=None,
-            pr_lookup_failed=True,
-            ahead=ahead,
-            dirty=dirty,
-            detail=detail,
+        return _with_workflow(
+            classify_worktree(
+                worktree,
+                pr_number=None,
+                pr_state=None,
+                pr_lookup_failed=True,
+                ahead=ahead,
+                dirty=dirty,
+                detail=detail,
+            )
         )
 
     merged_head_matches_tip = True
@@ -181,15 +226,17 @@ def gather_worktree_status(worktree: Worktree, *, target: str) -> WorktreeStatus
                 f"(issue #1719); current commits are unmerged"
             )
 
-    return classify_worktree(
-        worktree,
-        pr_number=pr_number,
-        pr_state=pr_state,
-        pr_lookup_failed=False,
-        ahead=ahead,
-        dirty=dirty,
-        detail=detail,
-        merged_head_matches_tip=merged_head_matches_tip,
+    return _with_workflow(
+        classify_worktree(
+            worktree,
+            pr_number=pr_number,
+            pr_state=pr_state,
+            pr_lookup_failed=False,
+            ahead=ahead,
+            dirty=dirty,
+            detail=detail,
+            merged_head_matches_tip=merged_head_matches_tip,
+        )
     )
 
 

--- a/tests/vergil_tooling/test_vrg_worktree_status.py
+++ b/tests/vergil_tooling/test_vrg_worktree_status.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from vergil_tooling.bin.vrg_worktree_status import main
+from vergil_tooling.bin.vrg_worktree_status import _row, main
 from vergil_tooling.lib.worktrees import Worktree, WorktreeState, WorktreeStatus
 
 if TYPE_CHECKING:
@@ -23,11 +23,82 @@ def _status(
     ahead: int = 0,
     dirty: bool = False,
     detail: str | None = None,
+    workflow_status: str | None = None,
+    workflow_error: str | None = None,
+    pr_prepared: bool = False,
 ) -> WorktreeStatus:
     wt = Worktree(path=Path(f"/repo/.worktrees/{branch.replace('/', '-')}"), branch=branch)
     return WorktreeStatus(
-        worktree=wt, state=state, pr_number=pr, ahead=ahead, dirty=dirty, detail=detail
+        worktree=wt,
+        state=state,
+        pr_number=pr,
+        ahead=ahead,
+        dirty=dirty,
+        detail=detail,
+        workflow_status=workflow_status,
+        workflow_error=workflow_error,
+        pr_prepared=pr_prepared,
     )
+
+
+# Column index of WORKFLOW in a rendered row (between STATE and AHEAD).
+_WORKFLOW_COL = 4
+
+
+def test_row_renders_loaded_workflow_status_verbatim() -> None:
+    row = _row(_status("feature/1-x", WorktreeState.NO_PR, ahead=1, workflow_status="approved"))
+    assert row[_WORKFLOW_COL] == "approved"
+
+
+def test_row_renders_dash_when_no_workflow_file() -> None:
+    row = _row(_status("feature/1-x", WorktreeState.NO_PR, ahead=1))
+    assert row[_WORKFLOW_COL] == "-"
+
+
+def test_row_renders_unknown_on_workflow_read_error() -> None:
+    row = _row(_status("feature/1-x", WorktreeState.NO_PR, ahead=1, workflow_error="bad json"))
+    assert row[_WORKFLOW_COL] == "unknown"
+
+
+def test_main_summary_reports_prepared_count(capsys: pytest.CaptureFixture[str]) -> None:
+    statuses = [
+        _status(
+            "feature/1-a",
+            WorktreeState.NO_PR,
+            ahead=1,
+            workflow_status="approved",
+            pr_prepared=True,
+        ),
+        _status("feature/2-b", WorktreeState.NO_PR, ahead=1, workflow_status="implementing"),
+    ]
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "WORKFLOW" in out
+    assert "1 PR prepared." in out
+
+
+def test_main_surfaces_workflow_read_error_note(capsys: pytest.CaptureFixture[str]) -> None:
+    statuses = [
+        _status("feature/3-c", WorktreeState.NO_PR, ahead=1, workflow_error="not valid JSON"),
+    ]
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "unknown" in out
+    assert "note: feature/3-c:" in out
+    assert "not valid JSON" in out
+    assert "0 PR prepared." in out
 
 
 def test_main_groups_cruft_last_and_summarizes(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -8,10 +8,12 @@ from unittest.mock import patch
 
 import pytest
 
+from vergil_tooling.lib.pr_workflow.state import WorkflowState
 from vergil_tooling.lib.worktrees import (
     Worktree,
     WorktreeState,
     WorktreeStatus,
+    _probe_pr_workflow,
     classify_worktree,
     gather_worktree_status,
     list_worktrees,
@@ -348,6 +350,97 @@ def test_gather_pr_lookup_failure_is_unknown() -> None:
         status = gather_worktree_status(_SAMPLE_WT, target="develop")
     assert status.state is WorktreeState.UNKNOWN
     assert "boom" in (status.detail or "")
+
+
+# -- _probe_pr_workflow (local .vergil/pr-workflow.json) ---------------------
+
+
+def _write_state(worktree_root: Path, **overrides: object) -> None:
+    """Write a valid pr-workflow.json under *worktree_root* with overrides."""
+    state = WorkflowState(
+        issue="42",
+        branch="feature/42-x",
+        base="origin/develop",
+        mode="solo",
+        owner="user",
+        status="implementing",
+        round=1,
+        created_at="2026-06-22T00:00:00Z",
+        updated_at="2026-06-22T00:00:00Z",
+        participants={},
+        git={},
+    )
+    for key, value in overrides.items():
+        setattr(state, key, value)
+    target = worktree_root / ".vergil"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "pr-workflow.json").write_text(state.to_json())
+
+
+def test_probe_absent_file_is_not_prepared(tmp_path: Path) -> None:
+    wt = Worktree(path=tmp_path, branch="feature/42-x")
+    assert _probe_pr_workflow(wt) == (None, None, False)
+
+
+def test_probe_loaded_with_metadata_is_prepared(tmp_path: Path) -> None:
+    _write_state(
+        tmp_path,
+        status="approved",
+        pr_metadata={"title": "t", "summary": "s", "notes": "n", "linkage": "Ref"},
+    )
+    wt = Worktree(path=tmp_path, branch="feature/42-x")
+    assert _probe_pr_workflow(wt) == ("approved", None, True)
+
+
+def test_probe_already_submitted_is_not_prepared(tmp_path: Path) -> None:
+    _write_state(
+        tmp_path,
+        status="approved",
+        pr_metadata={"title": "t", "summary": "s", "notes": "n", "linkage": "Ref"},
+        submitted={"pr_url": "https://example/pull/9", "pr_number": 9},
+    )
+    wt = Worktree(path=tmp_path, branch="feature/42-x")
+    status, error, prepared = _probe_pr_workflow(wt)
+    assert status == "approved"
+    assert error is None
+    assert prepared is False
+
+
+def test_probe_no_metadata_is_not_prepared(tmp_path: Path) -> None:
+    _write_state(tmp_path, status="implementing")
+    wt = Worktree(path=tmp_path, branch="feature/42-x")
+    assert _probe_pr_workflow(wt) == ("implementing", None, False)
+
+
+def test_probe_malformed_file_reports_error(tmp_path: Path) -> None:
+    target = tmp_path / ".vergil"
+    target.mkdir(parents=True)
+    (target / "pr-workflow.json").write_text("{not valid json")
+    wt = Worktree(path=tmp_path, branch="feature/42-x")
+    status, error, prepared = _probe_pr_workflow(wt)
+    assert status is None
+    assert error is not None
+    assert prepared is False
+
+
+def test_gather_attaches_pr_workflow_probe(tmp_path: Path) -> None:
+    _write_state(
+        tmp_path,
+        status="approved",
+        pr_metadata={"title": "t", "summary": "s", "notes": "n", "linkage": "Ref"},
+    )
+    wt = Worktree(path=tmp_path, branch="feature/42-x")
+    with (
+        patch(_MOD + ".git.commits_ahead", return_value=3),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".github.pr_for_branch", return_value=None),
+        patch(_MOD + ".github.closed_pr_for_branch", return_value=None),
+    ):
+        status = gather_worktree_status(wt, target="develop")
+    assert status.state is WorktreeState.NO_PR
+    assert status.workflow_status == "approved"
+    assert status.workflow_error is None
+    assert status.pr_prepared is True
 
 
 def _wt(name: str, branch: str) -> Worktree:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a WORKFLOW column and an 'N PR prepared' summary count to vrg-worktree-status so it is visible at a glance which worktrees an agent has prepared for vrg-submit-pr.

## Issue Linkage

- Ref #1729

## Notes

- New WORKFLOW column (between STATE and AHEAD) shows each worktree's raw pr-workflow status from .vergil/pr-workflow.json verbatim, '-' when no file exists, and 'unknown' plus a per-worktree note on a read/parse error (no silent failures). The summary gains a neutral 'N PR prepared.' count keyed off pr_metadata present AND not yet submitted — exactly vrg-submit-pr's ready gate. gather_worktree_status probes the file via the existing pr-workflow loader (schema stays single-sourced) and attaches the signals via dataclasses.replace, leaving classify_worktree and the finalize sweep untouched. Observability-only: no GitHub calls for the new column. Built test-first; full vrg-validate passes. Design spec: docs/specs/2026-06-22-worktree-status-workflow-column-design.md.