### PR TITLE
feat(vrg-pr-workflow): reject auto-close keywords in report-ready/report-fixes at entry

### DIFF
--- a/src/vergil_tooling/lib/commit_message.py
+++ b/src/vergil_tooling/lib/commit_message.py
@@ -33,9 +33,19 @@ AUTOCLOSE_RE = re.compile(
 )
 
 
+def find_autoclose(text: str) -> str | None:
+    """Return the first GitHub auto-close reference in *text*, or None.
+
+    The returned substring (e.g. ``"Closes #299"``) is suitable for naming the
+    offending text in an error message.
+    """
+    match = AUTOCLOSE_RE.search(text)
+    return match.group(0) if match else None
+
+
 def contains_autoclose(body: str) -> bool:
     """Return True if *body* contains a GitHub auto-close keyword."""
-    return bool(AUTOCLOSE_RE.search(body))
+    return find_autoclose(body) is not None
 
 
 def build_commit_message(

--- a/src/vergil_tooling/lib/pr_workflow/engine.py
+++ b/src/vergil_tooling/lib/pr_workflow/engine.py
@@ -10,9 +10,33 @@ from __future__ import annotations
 
 from typing import Any
 
+from vergil_tooling.lib.commit_message import find_autoclose
 from vergil_tooling.lib.pr_workflow import registry
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
 from vergil_tooling.lib.pr_workflow.state import CHECK_STATUSES, MODES, WorkflowState
+
+
+def _reject_autoclose(verb: str, **fields: str | None) -> None:
+    """Reject any PR-metadata field that carries a GitHub auto-close keyword.
+
+    On merge, GitHub auto-closes the linked issue when the PR body contains
+    ``Closes/Fixes/Resolves #N`` — violating the fleet policy that an issue
+    stays open until its post-merge workflows succeed. The structured
+    ``--issue`` already emits ``Ref #N``; the free-text fields must never carry
+    an issue-*closing* reference. Rejecting at entry (before state is written)
+    keeps the keyword from ever reaching ``.vergil/pr-workflow.json`` or the
+    rendered PR body; the submit-time check stays as defense-in-depth."""
+    for flag, value in fields.items():
+        if value is None:
+            continue
+        match = find_autoclose(value)
+        if match:
+            raise WorkflowError(
+                f'{verb}: --{flag} contains an auto-close keyword ("{match}"). '
+                "Issues must stay open until post-merge workflows succeed; the "
+                'structured --issue already emits "Ref #N". '
+                'Use "Ref #N" or drop the reference.'
+            )
 
 
 def init_state(
@@ -87,6 +111,7 @@ def apply_report_ready(
     """USER's initial done-signal. In paired mode it hands the turn to AUDIT; in
     solo mode there is no audit, so it goes straight to approved."""
     _require_owner(state, "user")
+    _reject_autoclose("report-ready", title=title, summary=summary, notes=notes)
     state.pr_metadata = {"title": title, "summary": summary, "notes": notes, "linkage": linkage}
     state.git["head_sha"] = head_sha
     if state.mode == "solo":
@@ -128,6 +153,7 @@ def apply_report_fixes(
     runaway-round cap, spec §9). ``max_rounds`` is supplied by the CLI from
     ``settings.max_rounds``; the default keeps the engine usable standalone."""
     _require_owner(state, "user")
+    _reject_autoclose("report-fixes", title=title, summary=summary, notes=notes)
     revisions = {
         key: value
         for key, value in (("title", title), ("summary", summary), ("notes", notes))

--- a/tests/vergil_tooling/pr_workflow/test_engine_reports.py
+++ b/tests/vergil_tooling/pr_workflow/test_engine_reports.py
@@ -130,6 +130,50 @@ def test_report_ready_rejects_out_of_turn() -> None:
         _ready(state)
 
 
+@pytest.mark.parametrize("bad", ["Closes #1", "Fixes #2", "Resolves #3"])
+def test_report_ready_rejects_autoclose_in_notes(bad: str) -> None:
+    state = _paired_owned_by_user()
+    with pytest.raises(WorkflowError, match=r"--notes contains an auto-close keyword"):
+        engine.apply_report_ready(
+            state, title="t", summary="s", notes=bad, linkage="Ref", head_sha="h1", now=_NOW
+        )
+    # Rejected at entry: no state was written.
+    assert state.pr_metadata is None
+    assert state.owner == "user"
+
+
+@pytest.mark.parametrize("field", ["title", "summary", "notes"])
+def test_report_ready_rejects_autoclose_in_any_field(field: str) -> None:
+    state = _paired_owned_by_user()
+    kwargs = {"title": "t", "summary": "s", "notes": "n"}
+    kwargs[field] = "Closes #299"
+    with pytest.raises(WorkflowError, match=rf"--{field} contains an auto-close keyword"):
+        engine.apply_report_ready(state, linkage="Ref", head_sha="h1", now=_NOW, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "ok",
+    ["Ref #1", "fix(rdqm): right-size matrices (#300)", "see #287", "the fix touches #287 files"],
+)
+def test_report_ready_accepts_safe_fields(ok: str) -> None:
+    state = _paired_owned_by_user()
+    engine.apply_report_ready(
+        state, title=ok, summary=ok, notes=ok, linkage="Ref", head_sha="h1", now=_NOW
+    )
+    assert state.pr_metadata == {"title": ok, "summary": ok, "notes": ok, "linkage": "Ref"}
+
+
+def test_report_fixes_rejects_autoclose_revision() -> None:
+    state = _paired_owned_by_user()
+    _ready(state)
+    _run_review(state, fail=check_ids()[0])  # owner user, last_reviewed h1
+    with pytest.raises(WorkflowError, match=r"report-fixes: --notes contains an auto-close"):
+        engine.apply_report_fixes(state, head_sha="h2", note=None, now=_NOW, notes="Fixes #2")
+    # Rejected at entry: the round was not bumped and the metadata is untouched.
+    assert state.round == 0
+    assert state.pr_metadata == {"title": "t", "summary": "s", "notes": "n", "linkage": "Ref"}
+
+
 def test_review_all_pass_approves_and_hands_to_user() -> None:
     state = _paired_owned_by_user()
     _ready(state)

--- a/tests/vergil_tooling/test_commit_message.py
+++ b/tests/vergil_tooling/test_commit_message.py
@@ -8,6 +8,7 @@ from vergil_tooling.lib.commit_message import (
     ALLOWED_TYPES,
     build_commit_message,
     contains_autoclose,
+    find_autoclose,
 )
 
 
@@ -77,3 +78,14 @@ def test_contains_autoclose_detects_keywords(body: str) -> None:
 )
 def test_contains_autoclose_allows_safe_bodies(body: str) -> None:
     assert contains_autoclose(body) is False
+
+
+def test_find_autoclose_returns_the_matched_reference() -> None:
+    assert find_autoclose("notes begin: Closes #299 and more") == "Closes #299"
+    assert find_autoclose("Resolved owner/repo#42") == "Resolved owner/repo#42"
+
+
+def test_find_autoclose_returns_none_for_safe_text() -> None:
+    assert find_autoclose("Ref #42") is None
+    assert find_autoclose("fix(rdqm): right-size matrices (#300)") is None
+    assert find_autoclose("the fix touches #287 files") is None


### PR DESCRIPTION
# Pull Request

## Summary

- report-ready and report-fixes now reject any title/summary/notes carrying a GitHub auto-close keyword before writing state, so the keyword can never reach the workflow file or the rendered PR body.

## Issue Linkage

- Ref #1735

## Notes

- Detection reuses the anywhere-in-text AUTOCLOSE_RE via a new find_autoclose helper in commit_message.py. Valid flows are unaffected: bare #N, Ref #N, conventional-commit titles like fix(rdqm): right-size matrices (#300), and prose where the keyword is not adjacent to the issue number all pass. The submit-time check is retained as defense-in-depth. Regression tests cover the rejected and accepted cases at both the helper and engine levels. Ref #1735