### PR TITLE
chore(vm): bump default VM-build staleness floor from 3 to 7 days

### DIFF
--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
     from vergil_tooling.lib.config import RoleOverlay, VmStanza
 
-_DEFAULT_STALE_DAYS = 3
+_DEFAULT_STALE_DAYS = 7
 
 # Backend dispatch values. "local" is the default Lima driver; "off-platform" is the
 # remote cloud (OpenTofu) driver (vergil-vm #199). The set is closed and tooling-owned

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -91,7 +91,7 @@ class TestComposeVmSpec:
         assert spec.apt_repos == (_REPO,)  # all-identity [vm] tier
         assert spec.vagrant_plugins == ()  # role-only, did not apply to audit
         assert spec.port_forwards == ("3000|10.50.0.2:3000",)  # all-identity [vm] tier only
-        assert spec.stale_days == 3
+        assert spec.stale_days == 7
 
     def test_host_override_below_declared_flags_under(self) -> None:
         spec = compose_vm_spec(

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -430,7 +430,7 @@ class TestStartStaleness:
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
-    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=9.0)
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
     def test_start_rejects_stale_vm(
         self,
@@ -446,14 +446,14 @@ class TestStartStaleness:
         result = main(["start", "--config", str(config_file)])
         assert result == 1
         captured = capsys.readouterr()
-        assert "5 days old" in captured.err
+        assert "9 days old" in captured.err
         assert "--allow-stale-vm" in captured.err
 
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")
     @patch("vergil_tooling.bin.vrg_vm.start_vm")
-    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=9.0)
     @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
     def test_start_allows_stale_with_override(
         self,
@@ -1388,7 +1388,7 @@ class TestSessionStaleness:
     @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
     @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=9.0)
     def test_session_rejects_stale_vm(
         self,
         _age: MagicMock,
@@ -1408,7 +1408,7 @@ class TestSessionStaleness:
     @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
     @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=5.0)
+    @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=9.0)
     def test_session_allows_stale_with_override(
         self,
         _age: MagicMock,


### PR DESCRIPTION
# Pull Request

## Summary

- Raise _DEFAULT_STALE_DAYS from 3 to 7 so a VM no longer goes stale over a weekend, aligning the VM-build floor with the existing session_stale_days default of 7.

## Issue Linkage

- Ref #1743

## Notes

- Changes only the override-cascade floor — no new config keys, and the 5-tier stale_days precedence is untouched. CHANGELOG is intentionally not hand-edited: this repo generates it via git-cliff from conventional commits at release time (no Unreleased section), so the chore(vm) commit carries the changelog entry. Beyond the two changes named in the issue, the staleness behavioral tests in test_vrg_vm.py needed updating: their mocked VM age of 5.0 days was stale under the old 3-day floor but fresh under 7, which silently stopped exercising the reject/override paths; bumped those mocks to 9.0 days. The issue's grep only checked for a literal 3 and missed these semantic dependencies.