### PR TITLE
fix(vm): bound Lima instance name under UNIX_PATH_MAX

### DIFF
--- a/docs/specs/2026-06-22-vm-instance-name-length-limit-design.md
+++ b/docs/specs/2026-06-22-vm-instance-name-length-limit-design.md
@@ -1,0 +1,183 @@
+# vrg-vm: bound the Lima instance name under UNIX_PATH_MAX
+
+- **Issue:** vergil-project/vergil-tooling#1750
+- **Status:** Approved design
+- **Date:** 2026-06-22
+
+## Problem
+
+`vrg-vm create` for a dedicated VM fails when the derived Lima instance name
+is long enough that Lima's pre-validated worst-case SSH socket path exceeds
+`UNIX_PATH_MAX` (104). Observed in the field:
+
+```text
+instance name "vergil-user.logical-minds-foundry.mq-resiliency-lab-for-linux" too long:
+".../ssh.sock.1234567890123456" must be less than UNIX_PATH_MAX=104 characters, but is 107
+```
+
+Lima validates the longest socket path it might ever create for an instance:
+
+```text
+<home>/.lima/<instance>/ssh.sock.<16-char reservation>
+```
+
+The `1234567890123456` segment is a fixed worst-case reservation inside Lima,
+not a live value — so the suffix cannot be shortened. The home prefix is fixed
+by the user. The only lever we control is the **instance name**.
+
+Renaming the repository is explicitly out of scope as a fix: the tooling must
+accommodate legitimately long `org`/`repo` names.
+
+## Root cause
+
+`vm_spec.instance_name()` joins the three tiers `identity.org.repo` with a
+single dot and applies no length bound:
+
+```python
+return _TIER_SEP.join((identity, org, repo))
+```
+
+The cloud backend already solved the analogous constraint
+(`vm_cloud.cloud_resource_name` truncates and hashes to fit GCP's 63-char
+limit; `vm_cloud.cloud_labels` provides name-independent recovery). The Lima
+path never adopted the pattern.
+
+### Why recovery is load-bearing
+
+The instance name is not just an identifier — it is currently the only channel
+for reversing a VM back into its `(identity, org, repo)` triple:
+
+- `discover_dedicated` (`vrg_vm.py`) calls `parse_instance_name` and uses the
+  recovered `org`/`repo` to map a VM to its local repo via `_classify_instance`.
+- `_all_update_targets` (`vrg_vm.py`) calls `parse_instance_name` to match a
+  VM's identity tier against configured identities.
+
+A truncated/hashed name cannot be parsed back into tiers, so the triple must be
+recoverable from a separate channel. Lima offers none that survives this:
+`limactl list --json` exposes only `name` and `status`, and the persisted
+`~/.lima/<instance>/lima.yaml` is the *expanded* template — our `param.VERGIL_*`
+substitution variables are consumed during expansion, not retained as a
+readable map.
+
+## Design
+
+### 1. Name generation — `vm_spec.instance_name`
+
+The length handling lives in `instance_name` (the Lima analog of
+`cloud_resource_name`), so every caller inherits it.
+
+1. **Base box unchanged.** Bare identity (`org`/`repo` is `None`) returns the
+   identity verbatim, as today.
+2. **Dotted name when it fits.** Compute the full `identity.org.repo` (existing
+   format, existing "identity/org must not contain a dot" rule preserved) and
+   return it verbatim when `len(full) <= budget`. This keeps every existing
+   short-named VM **byte-identical**.
+3. **Truncate + hash when over budget**, mirroring the cloud backend:
+
+   ```python
+   digest = hashlib.sha256(f"{identity}/{org}/{repo}".encode()).hexdigest()[:6]
+   keep = budget - 6 - 1  # 6 hash chars + 1 separator
+   name = f"{full[:keep].rstrip('._-')}-{digest}"
+   ```
+
+   The cloud backend strips only `'-'` because its slug contains only hyphens.
+   Here the truncated string is the dotted `full`, which can be cut mid-token or
+   mid-separator. Lima's name regex `^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$`
+   forbids adjacent separators (`.-`) and trailing separators, so we
+   `rstrip('._-')` to guarantee the prefix ends in an alphanumeric before the
+   `-<hash>` join.
+
+### 2. Budget computation
+
+Derived from the exact path Lima validates and verified against the observed
+107-char failure:
+
+```python
+UNIX_PATH_MAX = 104
+# path = <home> + "/.lima/" + <name> + "/ssh.sock." + <16-char reservation>
+def lima_name_budget(home: str | None = None) -> int:
+    home = home if home is not None else str(Path.home())
+    overhead = len("/.lima/") + len("/ssh.sock.") + 16   # 7 + 10 + 16 = 33
+    return (UNIX_PATH_MAX - 1) - len(home) - overhead     # == 70 - len(home)
+```
+
+For `/Users/pmoore` (13) the budget is 57, matching the observed boundary (the
+61-char name overflowed by 4). `home` is injectable for tests.
+
+The budget depends on `len(home)`, so the mangled name is deterministic
+**per machine**. VMs are not shared across machines, so this is sufficient; see
+Edge cases for the one consequence.
+
+**Pathological-home guard.** If the budget cannot fit `identity` plus the
+`-<hash>` suffix (`budget < len(identity) + 7`), `instance_name` raises a clear
+`SpecError` rather than emitting a name Lima will reject. This trades a confusing
+downstream `limactl` error for an explicit, early one.
+
+### 3. Recovery — per-instance sidecar
+
+- **Write.** Immediately after `limactl create` succeeds, write
+  `~/.lima/<instance>/vergil-meta.json`:
+
+  ```json
+  {"schema": 1, "identity": "...", "org": "...", "repo": "..."}
+  ```
+
+  It lives in Lima's own per-instance directory, so it is created with the VM
+  and removed by `limactl delete --force` (which deletes the whole dir). No
+  drift, no orphan cleanup, scoped to exactly one VM.
+- **Read.** A new `recover_triple(instance) -> (identity, org, repo)`:
+  reads the sidecar when present; otherwise falls back to
+  `parse_instance_name(instance)` for legacy short names and base boxes.
+- **Swap both call sites** (`discover_dedicated`, `_all_update_targets`) from
+  `parse_instance_name` to `recover_triple`.
+
+This also fixes a latent bug: a mangled name raises in `parse_instance_name`,
+which both sites catch and `continue` past — so a long-named VM would be
+silently invisible to discovery and to `vrg-vm update --all`. The sidecar makes
+mangled VMs first-class.
+
+## Components touched
+
+| File | Change |
+|---|---|
+| `lib/vm_spec.py` | `lima_name_budget()`; length handling in `instance_name`; pathological-home guard |
+| `lib/vm_spec.py` *(or a small recovery module)* | `recover_triple()`; sidecar read |
+| `bin/vrg_vm.py` | write sidecar after create; `discover_dedicated` and `_all_update_targets` use `recover_triple` |
+| `tests/...` | unit + integration coverage (below) |
+
+## Testing
+
+- **Budget math** across representative home lengths (short macOS, long macOS,
+  Linux `/home/...`), including the verified `/Users/pmoore` → 57 boundary.
+- **Name unchanged when it fits** — existing short triples round-trip byte-identical.
+- **Mangled output is valid** — assert the result matches Lima's name regex,
+  including a case engineered to truncate on a separator (exercises `rstrip('._-')`).
+- **Hash determinism** — same triple → same name on a fixed home.
+- **Pathological-home guard** — raises `SpecError`, not an invalid name.
+- **Sidecar round-trip** — write then `recover_triple` returns the triple.
+- **Fallback** — `recover_triple` returns `parse_instance_name` output when no
+  sidecar exists (legacy short name; base box).
+
+## Backward compatibility & migration
+
+- Existing short-named dedicated VMs keep identical names and resolve via the
+  `parse_instance_name` fallback — **zero migration**.
+- No over-budget VM can exist today: it would have failed at `create`, exactly
+  like the reported case. So there is nothing to rename or migrate.
+- Base boxes (bare identity) are untouched.
+
+## Edge cases
+
+- **Home-length change between create and lookup.** The resolve path recomputes
+  `instance_name` to find an existing VM. If `len(home)` changes after a VM was
+  created over-budget (rare — e.g. the user's home path is renamed), the
+  recomputed name would not match the live instance. Accepted: home-path length
+  changes are rare, and building reverse-lookup reconciliation is YAGNI. Short
+  (unmangled) VMs are unaffected because their names don't depend on the budget.
+
+## Out of scope
+
+- Relocating `LIMA_HOME` (reclaims too few characters; breaks `~/.lima`
+  assumptions elsewhere).
+- Reverse-lookup reconciliation for home-length changes (see Edge cases).
+- Any change to the cloud backend (already correct).

--- a/docs/specs/2026-06-22-vm-instance-name-length-limit-plan.md
+++ b/docs/specs/2026-06-22-vm-instance-name-length-limit-plan.md
@@ -1,0 +1,529 @@
+# Bounded Lima Instance Name Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the Lima instance name so `vrg-vm create` cannot exceed Lima's `UNIX_PATH_MAX` socket-path limit, while keeping a VM's `(identity, org, repo)` recoverable.
+
+**Architecture:** Cap `vm_spec.instance_name` to a home-aware budget with a cloud-style truncate+hash (mirroring `vm_cloud.cloud_resource_name`). When a name is mangled it can no longer be parsed back into tiers, so write a per-instance sidecar (`~/.lima/<instance>/vergil-meta.json`) at create time and recover the triple from it, falling back to `parse_instance_name` for legacy short names.
+
+**Tech Stack:** Python 3.12+, pytest, Lima (`limactl`), `uv` (dev-tree override venv).
+
+## Global Constraints
+
+- **Python floor: 3.12** — CI runs 3.12; all code must run there.
+- **Portability:** must work on macOS and Linux.
+- **Lima instance-name regex:** `^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$` — single separators only, no leading/trailing separator, no adjacent separators. Every generated name must satisfy this.
+- **`UNIX_PATH_MAX = 104`**, checked strict-less-than by Lima.
+- **No silent failures** — a corrupt sidecar raises loudly; it is never swallowed into a wrong answer.
+- **Git via `vrg-git`; commits via `vrg-commit`** (raw `git`/`gh` are denied). Work happens in worktree `.worktrees/issue-1750-vm-name-length` on branch `feature/1750-vm-name-length`.
+- **Validation:** the only full-validation command is `vrg-container-run -- vrg-validate` (run from inside the worktree). Per-step TDD uses `uv run pytest` against the dev-tree `.venv-host`.
+
+---
+
+## File Structure
+
+- `src/vergil_tooling/lib/vm_spec.py` — add `lima_name_budget()` and the length-bounding logic inside `instance_name`. This is the Lima analog of `cloud_resource_name`; the cap belongs here so every caller inherits it.
+- `src/vergil_tooling/lib/lima.py` — add `write_instance_meta()` / `read_instance_meta()`; they own the `~/.lima/<instance>/` sidecar (next to the existing `_serial_dir` helper).
+- `src/vergil_tooling/bin/vrg_vm.py` — add `recover_triple()`; switch the two recovery sites to it; write the sidecar in `_create_from_target` for dedicated boxes.
+- `tests/vergil_tooling/test_vm_spec.py` — budget + naming tests.
+- `tests/vergil_tooling/test_vrg_vm.py` — `recover_triple` + sidecar-write wiring tests.
+
+> **Dev-tree setup (once per shell, from the worktree root):**
+> ```bash
+> cd /Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1750-vm-name-length
+> UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
+> export PATH="$(pwd)/.venv-host/bin:$PATH"
+> ```
+> All `uv run pytest` steps below assume this venv.
+
+---
+
+### Task 1: Home-aware name budget
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_spec.py` (add import + helper near the `_TIER_SEP` block, ~line 279)
+- Test: `tests/vergil_tooling/test_vm_spec.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `lima_name_budget(home: str | None = None) -> int`, and module constant `_UNIX_PATH_MAX = 104`. Budget formula: `(_UNIX_PATH_MAX - 1) - len(home) - (len("/.lima/") + len("/ssh.sock.") + 16)`, i.e. `70 - len(home)`. When `home is None`, uses `str(Path.home())`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vm_spec.py` (import `lima_name_budget` alongside the existing `instance_name` import at the top):
+
+```python
+def test_lima_name_budget_subtracts_home_and_socket_overhead():
+    # 104 - 1 - len(home) - (len("/.lima/")=7 + len("/ssh.sock.")=10 + 16) == 70 - len(home)
+    assert lima_name_budget("/Users/pmoore") == 57
+    assert lima_name_budget("/root") == 65
+    assert lima_name_budget("/home/runner") == 58
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_spec.py::test_lima_name_budget_subtracts_home_and_socket_overhead -v`
+Expected: FAIL — `ImportError: cannot import name 'lima_name_budget'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/vergil_tooling/lib/vm_spec.py`, add `from pathlib import Path` to the imports (after `import re`), and add below the `_TIER_SEP = "."` line:
+
+```python
+_UNIX_PATH_MAX = 104
+# Lima validates the longest socket path it might create:
+#   <home>/.lima/<instance>/ssh.sock.<16-char worst-case reservation>
+# The reservation and "/.lima/"/"/ssh.sock." segments are fixed; only the
+# instance name is ours to bound. Strict-less-than, hence the -1.
+_SOCK_OVERHEAD = len("/.lima/") + len("/ssh.sock.") + 16  # 7 + 10 + 16 = 33
+
+
+def lima_name_budget(home: str | None = None) -> int:
+    """Max instance-name length that keeps Lima's socket path under UNIX_PATH_MAX."""
+    home = home if home is not None else str(Path.home())
+    return (_UNIX_PATH_MAX - 1) - len(home) - _SOCK_OVERHEAD
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_spec.py::test_lima_name_budget_subtracts_home_and_socket_overhead -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/vm_spec.py tests/vergil_tooling/test_vm_spec.py
+vrg-commit --type feat --scope vm \
+  --message "add home-aware Lima instance-name budget" \
+  --body "Compute the max instance-name length that keeps Lima's worst-case ssh.sock path under UNIX_PATH_MAX. Ref #1750"
+```
+
+---
+
+### Task 2: Length-bounded `instance_name`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_spec.py` (the `instance_name` function, ~line 282)
+- Test: `tests/vergil_tooling/test_vm_spec.py`
+
+**Interfaces:**
+- Consumes: `lima_name_budget` (Task 1); existing `SpecError`, `hashlib`, `_TIER_SEP`.
+- Produces: updated `instance_name(identity: str, org: str | None, repo: str | None, *, home: str | None = None) -> str`. Unchanged for base boxes and for dotted names within budget; over budget returns `f"{full[:budget-7].rstrip('._-')}-{sha256(f'{identity}/{org}/{repo}')[:6]}"`. Raises `SpecError` when `budget < len(identity) + 7`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vm_spec.py` (import `lima_name_budget` already added in Task 1; add `import re` at top if absent):
+
+```python
+_LIMA_NAME_RE = re.compile(r"^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$")
+
+
+def test_instance_name_unchanged_when_within_budget():
+    # 52 chars, fits the 57 budget for /Users/pmoore -> returned verbatim.
+    name = instance_name(
+        "vergil-user", "logical-minds-foundry", "mq-cluster-tooling", home="/Users/pmoore"
+    )
+    assert name == "vergil-user.logical-minds-foundry.mq-cluster-tooling"
+
+
+def test_instance_name_truncates_and_hashes_when_over_budget():
+    # The reported failure: 61-char full name, 57 budget.
+    name = instance_name(
+        "vergil-user", "logical-minds-foundry", "mq-resiliency-lab-for-linux",
+        home="/Users/pmoore",
+    )
+    assert len(name) <= lima_name_budget("/Users/pmoore")
+    assert _LIMA_NAME_RE.fullmatch(name)            # valid Lima instance name
+    assert name.startswith("vergil-user.logical")   # readable prefix retained
+    assert re.search(r"-[0-9a-f]{6}$", name)         # 6-char hash suffix
+
+
+def test_instance_name_truncation_is_deterministic():
+    args = ("vergil-user", "logical-minds-foundry", "mq-resiliency-lab-for-linux")
+    assert instance_name(*args, home="/Users/pmoore") == instance_name(*args, home="/Users/pmoore")
+
+
+def test_instance_name_raises_when_budget_cannot_fit_identity():
+    with pytest.raises(SpecError):
+        instance_name("vergil-user", "o", "r", home="/" + "x" * 70)
+```
+
+Ensure `import pytest` and `from vergil_tooling.lib.vm_spec import SpecError` are present in the test file (add if missing).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_spec.py -k instance_name -v`
+Expected: FAIL — `instance_name` got an unexpected keyword `home` / over-budget case returns the too-long dotted name.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the body of `instance_name` in `src/vergil_tooling/lib/vm_spec.py`:
+
+```python
+def instance_name(
+    identity: str, org: str | None, repo: str | None, *, home: str | None = None
+) -> str:
+    """Derive the Lima instance name. Bare identity = base box; ``.``-joined = dedicated.
+
+    Dedicated names are returned verbatim when they fit ``lima_name_budget``; over
+    budget they are truncated and hashed (mirroring ``vm_cloud.cloud_resource_name``)
+    so Lima's worst-case socket path stays under UNIX_PATH_MAX. ``recover_triple``
+    (vrg_vm) reverses a mangled name via the per-instance sidecar.
+    """
+    if org is None or repo is None:
+        return identity
+    for tier, value in (("identity", identity), ("org", org)):
+        if _TIER_SEP in value:
+            msg = f"{tier} name {value!r} must not contain '{_TIER_SEP}'"
+            raise ValueError(msg)
+    full = _TIER_SEP.join((identity, org, repo))
+    budget = lima_name_budget(home)
+    if len(full) <= budget:
+        return full
+    if budget < len(identity) + 7:  # 6 hash chars + 1 separator
+        msg = (
+            f"home directory too long to fit a bounded VM name for identity "
+            f"{identity!r}: budget {budget} < {len(identity) + 7}"
+        )
+        raise SpecError(msg)
+    digest = hashlib.sha256(f"{identity}/{org}/{repo}".encode()).hexdigest()[:6]
+    keep = budget - 7
+    return f"{full[:keep].rstrip('._-')}-{digest}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_spec.py -k instance_name -v`
+Expected: PASS (including the pre-existing `instance_name`/`parse_instance_name` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/vm_spec.py tests/vergil_tooling/test_vm_spec.py
+vrg-commit --type fix --scope vm \
+  --message "bound Lima instance name with truncate+hash over budget" \
+  --body "Over-budget dedicated names are truncated and hashed like the cloud backend, satisfying Lima's name regex and keeping the socket path under UNIX_PATH_MAX. Ref #1750"
+```
+
+---
+
+### Task 3: Per-instance sidecar read/write
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py` (add after `_serial_dir`, ~line 280; add `import json` is already present)
+- Test: `tests/vergil_tooling/test_vm_guest.py` *(new functions; or create `tests/vergil_tooling/test_lima_meta.py`)* — use `test_lima_meta.py`.
+
+**Interfaces:**
+- Consumes: existing `_serial_dir(instance) -> Path`, `json`, `Path`.
+- Produces:
+  - `write_instance_meta(instance: str, identity: str, org: str, repo: str) -> None` — writes `_serial_dir(instance)/"vergil-meta.json"` = `{"schema": 1, "identity": ..., "org": ..., "repo": ...}` (creates the dir if absent).
+  - `read_instance_meta(instance: str) -> dict[str, str] | None` — returns the parsed dict, or `None` if the file is absent. Raises on malformed JSON or missing keys.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/vergil_tooling/test_lima_meta.py`:
+
+```python
+import json
+
+import pytest
+
+from vergil_tooling.lib import lima
+
+
+def test_write_then_read_round_trips(tmp_path, monkeypatch):
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    lima.write_instance_meta("u.org.repo", "vergil-user", "org", "repo")
+    assert lima.read_instance_meta("u.org.repo") == {
+        "schema": 1,
+        "identity": "vergil-user",
+        "org": "org",
+        "repo": "repo",
+    }
+
+
+def test_read_returns_none_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    assert lima.read_instance_meta("missing") is None
+
+
+def test_read_raises_on_corrupt_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    d = tmp_path / ".lima" / "u.org.repo"
+    d.mkdir(parents=True)
+    (d / "vergil-meta.json").write_text("{not json")
+    with pytest.raises(json.JSONDecodeError):
+        lima.read_instance_meta("u.org.repo")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_lima_meta.py -v`
+Expected: FAIL — `AttributeError: module 'vergil_tooling.lib.lima' has no attribute 'write_instance_meta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/vergil_tooling/lib/lima.py`, add after `_serial_dir`:
+
+```python
+_META_FILE = "vergil-meta.json"
+
+
+def write_instance_meta(instance: str, identity: str, org: str, repo: str) -> None:
+    """Record (identity, org, repo) beside the instance so a mangled name stays reversible.
+
+    Lives in the instance's own ``~/.lima/<instance>/`` dir, so it is removed when
+    ``limactl delete --force`` deletes that dir — no separate cleanup, no drift.
+    """
+    meta_dir = _serial_dir(instance)
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"schema": 1, "identity": identity, "org": org, "repo": repo}
+    (meta_dir / _META_FILE).write_text(json.dumps(payload))
+
+
+def read_instance_meta(instance: str) -> dict[str, str] | None:
+    """Return the instance's recorded triple, or None if no sidecar exists.
+
+    Raises on a malformed sidecar rather than silently falling back — a corrupt
+    file is a real fault, not a missing one.
+    """
+    path = _serial_dir(instance) / _META_FILE
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    # Touch the required keys so a truncated/garbled file fails loudly here.
+    _ = (data["identity"], data["org"], data["repo"])
+    return data
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_lima_meta.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/lima.py tests/vergil_tooling/test_lima_meta.py
+vrg-commit --type feat --scope vm \
+  --message "add per-instance Lima metadata sidecar read/write" \
+  --body "Store (identity, org, repo) in ~/.lima/<instance>/vergil-meta.json so a truncated instance name stays reversible; self-cleaning with the instance dir. Ref #1750"
+```
+
+---
+
+### Task 4: `recover_triple` and switch the recovery sites
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (imports near line 46; add helper; change lines 991 and 1222)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Consumes: `read_instance_meta` (Task 3, import from `vergil_tooling.lib.lima`); `parse_instance_name` (already imported).
+- Produces: `recover_triple(instance: str) -> tuple[str, str | None, str | None]` — sidecar triple when present, else `parse_instance_name(instance)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`test_vrg_vm.py` imports symbols directly from `vergil_tooling.bin.vrg_vm` (see the `from ... import (` block at the top) and patches collaborators via string paths. Add `recover_triple` to that import block, then add these tests (patch `read_instance_meta` — which Task 4 imports into the `vrg_vm` namespace — by its dotted path):
+
+```python
+def test_recover_triple_prefers_sidecar(monkeypatch):
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.read_instance_meta",
+        lambda inst: {"schema": 1, "identity": "vergil-user", "org": "o", "repo": "r"},
+    )
+    assert recover_triple("mangled-abc123") == ("vergil-user", "o", "r")
+
+
+def test_recover_triple_falls_back_to_parse_for_legacy_name(monkeypatch):
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
+    assert recover_triple("vergil-user.acme.widgets") == ("vergil-user", "acme", "widgets")
+
+
+def test_recover_triple_falls_back_to_parse_for_base_box(monkeypatch):
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
+    assert recover_triple("vergil-user") == ("vergil-user", None, None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py -k recover_triple -v`
+Expected: FAIL — `module 'vergil_tooling.bin.vrg_vm' has no attribute 'recover_triple'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, add `read_instance_meta` and `write_instance_meta` to the existing `from vergil_tooling.lib.lima import (` block (near line 46–48). Add the helper near the other instance-name helpers (e.g. just after the imports / before `_all_update_targets`):
+
+```python
+def recover_triple(instance: str) -> tuple[str, str | None, str | None]:
+    """Reverse an instance name into (identity, org, repo).
+
+    Prefers the per-instance sidecar (the only reliable source once a long name
+    has been truncated+hashed); falls back to parsing the name for legacy short
+    names and base boxes that predate the sidecar.
+    """
+    meta = read_instance_meta(instance)
+    if meta is not None:
+        return meta["identity"], meta["org"], meta["repo"]
+    return parse_instance_name(instance)
+```
+
+Then change the two recovery sites (the `except ValueError: continue` stays — `parse_instance_name` still raises `ValueError` for genuinely unparseable legacy names):
+
+- Line ~991 in `_all_update_targets`:
+  ```python
+              try:
+                  ident, org, repo = recover_triple(inst)
+              except ValueError:
+                  continue
+  ```
+- Line ~1222 in `discover_dedicated`:
+  ```python
+          try:
+              ident, org, repo = recover_triple(name)
+          except ValueError:
+              continue
+  ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py -k recover_triple -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type fix --scope vm \
+  --message "recover VM triple via sidecar with parse fallback" \
+  --body "discover_dedicated and _all_update_targets now resolve (identity, org, repo) through recover_triple, so truncated-name VMs are no longer silently skipped. Ref #1750"
+```
+
+---
+
+### Task 5: Write the sidecar at create time
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_create_from_target`, ~line 573)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Consumes: `write_instance_meta` (imported in Task 4); `Target.identity_name`, `Target.org`, `Target.repo`, `Target.instance`.
+- Produces: side effect — after a dedicated box is created, its sidecar exists. Base boxes write no sidecar.
+
+- [ ] **Step 1: Write the failing test**
+
+`_create_from_target` only reads attributes off `target` (and `create_vm`/`write_instance_meta` are patched), so a `types.SimpleNamespace` stub is sufficient — no need to build a real `Target`/`ComposedSpec`. Add `_create_from_target` to the `from vergil_tooling.bin.vrg_vm import (...)` block and add `import types` at the top, then:
+
+```python
+def _stub_target(*, dedicated, identity_name, org, repo, instance):
+    spec = types.SimpleNamespace(
+        dedicated=dedicated, cpus=4, memory="8GiB", disk="100GiB",
+        packages=[], apt_repos=[], vagrant_plugins=[], port_forwards=[], nested=False,
+    )
+    identity = types.SimpleNamespace(
+        projects_dir="/home/user/projects", cpus=4, memory="8GiB", disk="100GiB",
+    )
+    return types.SimpleNamespace(
+        spec=spec, identity=identity, identity_name=identity_name,
+        org=org, repo=repo, instance=instance, fingerprint="fp",
+    )
+
+
+def test_create_from_target_writes_sidecar_for_dedicated(monkeypatch):
+    calls = []
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a)
+    )
+    target = _stub_target(
+        dedicated=True, identity_name="vergil-user",
+        org="acme", repo="widgets", instance="vergil-user.acme.widgets",
+    )
+    _create_from_target(target, Path("/tmp/t.yaml"))
+    assert calls == [("vergil-user.acme.widgets", "vergil-user", "acme", "widgets")]
+
+
+def test_create_from_target_skips_sidecar_for_base(monkeypatch):
+    calls = []
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a)
+    )
+    target = _stub_target(
+        dedicated=False, identity_name="vergil-user",
+        org=None, repo=None, instance="vergil-agent",
+    )
+    _create_from_target(target, Path("/tmp/t.yaml"))
+    assert calls == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py -k create_from_target -v`
+Expected: FAIL — `write_instance_meta` never called for the dedicated case.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_create_from_target`, in the `if target.spec.dedicated:` branch, after the `create_vm(...)` call returns, add:
+
+```python
+        assert target.org is not None and target.repo is not None  # dedicated invariant
+        write_instance_meta(target.instance, target.identity_name, target.org, target.repo)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py -k create_from_target -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm \
+  --message "write VM metadata sidecar on dedicated create" \
+  --body "After a dedicated box is created, persist its (identity, org, repo) sidecar so a truncated instance name remains reversible by discovery. Ref #1750"
+```
+
+---
+
+### Task 6: Full validation and PR handoff prep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full validation pipeline**
+
+Run (from the worktree root): `vrg-container-run -- vrg-validate`
+Expected: PASS (lint, typecheck, full test suite, audit, common checks).
+
+- [ ] **Step 2: Fix anything validation surfaces, re-run until green.** Commit fixes with `vrg-commit` using the matching type/scope.
+
+- [ ] **Step 3: Record PR metadata for the human handoff** (agents must not submit the PR):
+
+```bash
+vrg-pr-workflow report-ready \
+  --title "fix(vm): bound Lima instance name under UNIX_PATH_MAX" \
+  --summary "Cap instance_name via a home-aware budget with cloud-style truncate+hash; recover (identity, org, repo) from a per-instance sidecar with parse fallback." \
+  --notes "Fixes dedicated VM create failure for long org/repo names (e.g. logical-minds-foundry/mq-resiliency-lab-for-linux). No migration: existing short names are byte-identical. Ref #1750" \
+  --linkage Ref
+```
+
+Then stop — the human runs `vrg-submit-pr`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Name generation (base unchanged / dotted-when-fits / truncate+hash) → Task 2. ✓
+- Computed budget (`70 - len(home)`, injectable, guard) → Tasks 1 & 2. ✓
+- Sidecar write/read → Task 3; written at create → Task 5. ✓
+- `recover_triple` + both call sites + latent-bug fix → Task 4. ✓
+- Testing (budget math, unchanged-when-fits, regex-valid mangle, determinism, guard, sidecar round-trip, fallback) → Tasks 1–5. ✓
+- Back-compat (legacy parse fallback; base box skip) → Tasks 2, 4, 5. ✓
+- Edge case (home-length change) → documented in spec; no code (YAGNI). ✓
+
+**2. Placeholder scan:** No TBD/TODO. All test sketches use concrete imports/patches matched to the existing `test_vrg_vm.py` conventions (direct symbol imports, string-path `monkeypatch.setattr`, `SimpleNamespace` target stub) and `test_vm_spec.py` (which already imports `re`/`pytest`/`SpecError`).
+
+**3. Type consistency:** `lima_name_budget(home: str | None)` returns `int`, consumed by `instance_name` (Task 2). `write_instance_meta(instance, identity, org, repo)` arg order matches the Task 5 call and the Task 4 `recover_triple` read of `meta["identity"|"org"|"repo"]`. Sidecar schema (`schema/identity/org/repo`) is identical across Tasks 3, 4, 5.

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -49,12 +49,14 @@ from vergil_tooling.lib.lima import (
     fetch_template,
     list_vms,
     nested_virt_unsupported_reason,
+    read_instance_meta,
     shell_run,
     start_vm,
     stop_vm,
     update_plugins,
     vm_age_days,
     vm_status,
+    write_instance_meta,
 )
 from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.session import list_rows, make_name
@@ -280,6 +282,19 @@ def _target_ref(target: Target) -> str:
     if target.org is not None:
         return f"{target.org}/{target.repo}"
     return f"--identity {target.identity_name}"
+
+
+def recover_triple(instance: str) -> tuple[str, str | None, str | None]:
+    """Reverse an instance name into (identity, org, repo).
+
+    Prefers the per-instance sidecar (the only reliable source once a long name
+    has been truncated+hashed); falls back to parsing the name for legacy short
+    names and base boxes that predate the sidecar.
+    """
+    meta = read_instance_meta(instance)
+    if meta is not None:
+        return meta["identity"], meta["org"], meta["repo"]
+    return parse_instance_name(instance)
 
 
 def _warn_under(target: Target) -> None:
@@ -988,7 +1003,7 @@ def _all_update_targets(
             targets.append((id_name, identity, identity.vm_instance))
         for inst in sorted(status):
             try:
-                ident, org, repo = parse_instance_name(inst)
+                ident, org, repo = recover_triple(inst)
             except ValueError:
                 continue
             if ident == id_name and org is not None and repo is not None:
@@ -1219,7 +1234,7 @@ def discover_dedicated(
     rows: list[DedicatedRow] = []
     for name in instances:
         try:
-            ident, org, repo = parse_instance_name(name)
+            ident, org, repo = recover_triple(name)
         except ValueError:
             continue
         if ident != identity_name or org is None or repo is None:

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -602,6 +602,10 @@ def _create_from_target(target: Target, template: Path) -> None:
             fingerprint=target.fingerprint,
             nested=target.spec.nested,
         )
+        # Persist (identity, org, repo) so recover_triple can reverse the name
+        # even after it has been truncated+hashed to fit UNIX_PATH_MAX.
+        assert target.org is not None and target.repo is not None  # dedicated invariant  # noqa: S101
+        write_instance_meta(target.instance, target.identity_name, target.org, target.repo)
     else:
         create_vm(
             target.instance,

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -293,7 +293,9 @@ def recover_triple(instance: str) -> tuple[str, str | None, str | None]:
     """
     meta = read_instance_meta(instance)
     if meta is not None:
-        return meta["identity"], meta["org"], meta["repo"]
+        # Sidecar fields are always strings on disk; the mapping is typed
+        # ``dict[str, object]`` only because it also carries an int schema.
+        return str(meta["identity"]), str(meta["org"]), str(meta["repo"])
     return parse_instance_name(instance)
 
 
@@ -604,7 +606,8 @@ def _create_from_target(target: Target, template: Path) -> None:
         )
         # Persist (identity, org, repo) so recover_triple can reverse the name
         # even after it has been truncated+hashed to fit UNIX_PATH_MAX.
-        assert target.org is not None and target.repo is not None  # dedicated invariant  # noqa: S101
+        # org/repo are guaranteed non-None for dedicated targets.
+        assert target.org is not None and target.repo is not None  # noqa: S101
         write_instance_meta(target.instance, target.identity_name, target.org, target.repo)
     else:
         create_vm(

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -279,6 +279,36 @@ def _serial_dir(instance: str) -> Path:
     return Path.home() / ".lima" / instance
 
 
+_META_FILE = "vergil-meta.json"
+
+
+def write_instance_meta(instance: str, identity: str, org: str, repo: str) -> None:
+    """Record (identity, org, repo) beside the instance so a mangled name stays reversible.
+
+    Lives in the instance's own ``~/.lima/<instance>/`` dir, so it is removed when
+    ``limactl delete --force`` deletes that dir — no separate cleanup, no drift.
+    """
+    meta_dir = _serial_dir(instance)
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"schema": 1, "identity": identity, "org": org, "repo": repo}
+    (meta_dir / _META_FILE).write_text(json.dumps(payload))
+
+
+def read_instance_meta(instance: str) -> dict[str, str] | None:
+    """Return the instance's recorded triple, or None if no sidecar exists.
+
+    Raises on a malformed sidecar rather than silently falling back — a corrupt
+    file is a real fault, not a missing one.
+    """
+    path = _serial_dir(instance) / _META_FILE
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    # Touch the required keys so a truncated/garbled file fails loudly here.
+    _ = (data["identity"], data["org"], data["repo"])
+    return data
+
+
 def _drain_serial_logs(serial_dir: Path, offsets: dict[Path, int]) -> None:
     """Emit complete new lines appended to the instance's serial logs.
 

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -294,16 +294,17 @@ def write_instance_meta(instance: str, identity: str, org: str, repo: str) -> No
     (meta_dir / _META_FILE).write_text(json.dumps(payload))
 
 
-def read_instance_meta(instance: str) -> dict[str, str] | None:
-    """Return the instance's recorded triple, or None if no sidecar exists.
+def read_instance_meta(instance: str) -> dict[str, object] | None:
+    """Return the instance's recorded metadata, or None if no sidecar exists.
 
-    Raises on a malformed sidecar rather than silently falling back — a corrupt
-    file is a real fault, not a missing one.
+    The mapping carries an int ``schema`` plus string ``identity``/``org``/``repo``,
+    hence the ``object`` value type. Raises on a malformed sidecar rather than
+    silently falling back — a corrupt file is a real fault, not a missing one.
     """
     path = _serial_dir(instance) / _META_FILE
     if not path.exists():
         return None
-    data = json.loads(path.read_text())
+    data: dict[str, object] = json.loads(path.read_text())
     # Touch the required keys so a truncated/garbled file fails loudly here.
     _ = (data["identity"], data["org"], data["repo"])
     return data

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -278,16 +279,49 @@ def _validate_backend(identity: str, acc: _Acc) -> None:
 # enforces that loudly rather than silently producing a name that won't decode.
 _TIER_SEP = "."
 
+_UNIX_PATH_MAX = 104
+# Lima validates the longest socket path it might create:
+#   <home>/.lima/<instance>/ssh.sock.<16-char worst-case reservation>
+# The "/.lima/" and "/ssh.sock." segments and the 16-char reservation are fixed;
+# only the instance name is ours to bound. Strict-less-than, hence the -1.
+_SOCK_OVERHEAD = len("/.lima/") + len("/ssh.sock.") + 16  # 7 + 10 + 16 = 33
 
-def instance_name(identity: str, org: str | None, repo: str | None) -> str:
-    """Derive the Lima instance name. Bare identity = base box; ``.``-joined = dedicated."""
+
+def lima_name_budget(home: str | None = None) -> int:
+    """Max instance-name length that keeps Lima's socket path under UNIX_PATH_MAX."""
+    home = home if home is not None else str(Path.home())
+    return (_UNIX_PATH_MAX - 1) - len(home) - _SOCK_OVERHEAD
+
+
+def instance_name(
+    identity: str, org: str | None, repo: str | None, *, home: str | None = None
+) -> str:
+    """Derive the Lima instance name. Bare identity = base box; ``.``-joined = dedicated.
+
+    Dedicated names are returned verbatim when they fit ``lima_name_budget``; over
+    budget they are truncated and hashed (mirroring ``vm_cloud.cloud_resource_name``)
+    so Lima's worst-case socket path stays under UNIX_PATH_MAX. ``recover_triple``
+    (vrg_vm) reverses a mangled name via the per-instance sidecar.
+    """
     if org is None or repo is None:
         return identity
     for tier, value in (("identity", identity), ("org", org)):
         if _TIER_SEP in value:
             msg = f"{tier} name {value!r} must not contain '{_TIER_SEP}'"
             raise ValueError(msg)
-    return _TIER_SEP.join((identity, org, repo))
+    full = _TIER_SEP.join((identity, org, repo))
+    budget = lima_name_budget(home)
+    if len(full) <= budget:
+        return full
+    if budget < len(identity) + 7:  # 6 hash chars + 1 separator
+        msg = (
+            f"home directory too long to fit a bounded VM name for identity "
+            f"{identity!r}: budget {budget} < {len(identity) + 7}"
+        )
+        raise SpecError(msg)
+    digest = hashlib.sha256(f"{identity}/{org}/{repo}".encode()).hexdigest()[:6]
+    keep = budget - 7
+    return f"{full[:keep].rstrip('._-')}-{digest}"
 
 
 def parse_instance_name(name: str) -> tuple[str, str | None, str | None]:

--- a/tests/vergil_tooling/test_lima_meta.py
+++ b/tests/vergil_tooling/test_lima_meta.py
@@ -29,9 +29,7 @@ def test_read_returns_none_when_absent(tmp_path: Path, monkeypatch: pytest.Monke
     assert lima.read_instance_meta("missing") is None
 
 
-def test_read_raises_on_corrupt_sidecar(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_raises_on_corrupt_sidecar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
     meta_dir = tmp_path / ".lima" / "u.org.repo"
     meta_dir.mkdir(parents=True)

--- a/tests/vergil_tooling/test_lima_meta.py
+++ b/tests/vergil_tooling/test_lima_meta.py
@@ -1,0 +1,40 @@
+"""Tests for the per-instance Lima metadata sidecar (vergil_tooling.lib.lima)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vergil_tooling.lib import lima
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_write_then_read_round_trips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    lima.write_instance_meta("u.org.repo", "vergil-user", "org", "repo")
+    assert lima.read_instance_meta("u.org.repo") == {
+        "schema": 1,
+        "identity": "vergil-user",
+        "org": "org",
+        "repo": "repo",
+    }
+
+
+def test_read_returns_none_when_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    assert lima.read_instance_meta("missing") is None
+
+
+def test_read_raises_on_corrupt_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    meta_dir = tmp_path / ".lima" / "u.org.repo"
+    meta_dir.mkdir(parents=True)
+    (meta_dir / "vergil-meta.json").write_text("{not json")
+    with pytest.raises(json.JSONDecodeError):
+        lima.read_instance_meta("u.org.repo")

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -14,6 +14,7 @@ from vergil_tooling.lib.vm_spec import (
     SpecError,
     compose_vm_spec,
     instance_name,
+    lima_name_budget,
     parse_instance_name,
     spec_fingerprint,
 )
@@ -381,6 +382,13 @@ class TestOffPlatformCompose:
 _LIMA_IDENTIFIER = re.compile(r"^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$")
 
 
+def test_lima_name_budget_subtracts_home_and_socket_overhead() -> None:
+    # 104 - 1 - len(home) - (len("/.lima/")=7 + len("/ssh.sock.")=10 + 16) == 70 - len(home)
+    assert lima_name_budget("/Users/pmoore") == 57
+    assert lima_name_budget("/root") == 65
+    assert lima_name_budget("/home/runner") == 58
+
+
 class TestInstanceName:
     def test_base_is_bare_identity(self) -> None:
         assert instance_name("vergil-user", None, None) == "vergil-user"
@@ -389,13 +397,19 @@ class TestInstanceName:
         assert instance_name("vergil-user", "org", None) == "vergil-user"
 
     def test_dedicated_is_dot_joined(self) -> None:
+        # Pinned home keeps the within-budget format deterministic regardless of
+        # the test runner's home-directory length.
         assert (
-            instance_name("vergil-user", "logical-minds-foundry", "mq-cluster-tooling")
+            instance_name(
+                "vergil-user", "logical-minds-foundry", "mq-cluster-tooling", home="/root"
+            )
             == "vergil-user.logical-minds-foundry.mq-cluster-tooling"
         )
 
     def test_dedicated_name_is_valid_lima_identifier(self) -> None:
-        name = instance_name("vergil-user", "logical-minds-foundry", "mq-cluster-tooling")
+        name = instance_name(
+            "vergil-user", "logical-minds-foundry", "mq-cluster-tooling", home="/root"
+        )
         assert _LIMA_IDENTIFIER.fullmatch(name)
 
     def test_roundtrip_dedicated(self) -> None:
@@ -408,9 +422,39 @@ class TestInstanceName:
 
     def test_roundtrip_dedicated_repo_with_dots(self) -> None:
         # The repo is the final tier, so dots within it round-trip intact.
-        name = instance_name("vergil-user", "acme", "foo.github.io")
+        name = instance_name("vergil-user", "acme", "foo.github.io", home="/root")
         assert _LIMA_IDENTIFIER.fullmatch(name)
         assert parse_instance_name(name) == ("vergil-user", "acme", "foo.github.io")
+
+    def test_unchanged_when_within_budget(self) -> None:
+        # 52 chars, fits the 57 budget for /Users/pmoore -> returned verbatim.
+        name = instance_name(
+            "vergil-user", "logical-minds-foundry", "mq-cluster-tooling", home="/Users/pmoore"
+        )
+        assert name == "vergil-user.logical-minds-foundry.mq-cluster-tooling"
+
+    def test_truncates_and_hashes_when_over_budget(self) -> None:
+        # The reported failure: 61-char full name, 57 budget for /Users/pmoore.
+        name = instance_name(
+            "vergil-user",
+            "logical-minds-foundry",
+            "mq-resiliency-lab-for-linux",
+            home="/Users/pmoore",
+        )
+        assert len(name) <= lima_name_budget("/Users/pmoore")
+        assert _LIMA_IDENTIFIER.fullmatch(name)  # valid Lima instance name
+        assert name.startswith("vergil-user.logical")  # readable prefix retained
+        assert re.search(r"-[0-9a-f]{6}$", name)  # 6-char hash suffix
+
+    def test_truncation_is_deterministic(self) -> None:
+        args = ("vergil-user", "logical-minds-foundry", "mq-resiliency-lab-for-linux")
+        assert instance_name(*args, home="/Users/pmoore") == instance_name(
+            *args, home="/Users/pmoore"
+        )
+
+    def test_raises_when_budget_cannot_fit_identity(self) -> None:
+        with pytest.raises(SpecError):
+            instance_name("vergil-user", "o", "r", home="/" + "x" * 70)
 
     def test_roundtrip_base(self) -> None:
         assert parse_instance_name("vergil-user") == ("vergil-user", None, None)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -30,6 +30,7 @@ from vergil_tooling.bin.vrg_vm import (
     _warn_under,
     discover_dedicated,
     main,
+    recover_triple,
     resolve_borrow,
 )
 from vergil_tooling.lib.identity import Identity, IdentityConfig
@@ -138,6 +139,28 @@ def config_file_top_model(tmp_path: Path) -> Path:
     """)
     )
     return p
+
+
+def test_recover_triple_prefers_sidecar(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.read_instance_meta",
+        lambda inst: {"schema": 1, "identity": "vergil-user", "org": "o", "repo": "r"},
+    )
+    assert recover_triple("mangled-abc123") == ("vergil-user", "o", "r")
+
+
+def test_recover_triple_falls_back_to_parse_for_legacy_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
+    assert recover_triple("vergil-user.acme.widgets") == ("vergil-user", "acme", "widgets")
+
+
+def test_recover_triple_falls_back_to_parse_for_base_box(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
+    assert recover_triple("vergil-user") == ("vergil-user", None, None)
 
 
 class TestNoSubcommand:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -7,7 +7,7 @@ import subprocess
 import textwrap
 import types
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
@@ -167,7 +167,7 @@ def test_recover_triple_falls_back_to_parse_for_base_box(
 
 def _stub_target(
     *, dedicated: bool, identity_name: str, org: str | None, repo: str | None, instance: str
-) -> types.SimpleNamespace:
+) -> Target:
     spec = types.SimpleNamespace(
         dedicated=dedicated,
         cpus=4,
@@ -182,25 +182,26 @@ def _stub_target(
     identity = types.SimpleNamespace(
         projects_dir="/home/user/projects", cpus=4, memory="8GiB", disk="100GiB"
     )
-    return types.SimpleNamespace(
-        spec=spec,
-        identity=identity,
-        identity_name=identity_name,
-        org=org,
-        repo=repo,
-        instance=instance,
-        fingerprint="fp",
+    return cast(
+        "Target",
+        types.SimpleNamespace(
+            spec=spec,
+            identity=identity,
+            identity_name=identity_name,
+            org=org,
+            repo=repo,
+            instance=instance,
+            fingerprint="fp",
+        ),
     )
 
 
 def test_create_from_target_writes_sidecar_for_dedicated(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     calls: list[tuple[str, ...]] = []
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
-    monkeypatch.setattr(
-        "vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a)
-    )
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a))
     target = _stub_target(
         dedicated=True,
         identity_name="vergil-user",
@@ -208,16 +209,16 @@ def test_create_from_target_writes_sidecar_for_dedicated(
         repo="widgets",
         instance="vergil-user.acme.widgets",
     )
-    _create_from_target(target, Path("/tmp/t.yaml"))
+    _create_from_target(target, tmp_path / "t.yaml")
     assert calls == [("vergil-user.acme.widgets", "vergil-user", "acme", "widgets")]
 
 
-def test_create_from_target_skips_sidecar_for_base(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_from_target_skips_sidecar_for_base(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     calls: list[tuple[str, ...]] = []
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
-    monkeypatch.setattr(
-        "vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a)
-    )
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a))
     target = _stub_target(
         dedicated=False,
         identity_name="vergil-user",
@@ -225,7 +226,7 @@ def test_create_from_target_skips_sidecar_for_base(monkeypatch: pytest.MonkeyPat
         repo=None,
         instance="vergil-agent",
     )
-    _create_from_target(target, Path("/tmp/t.yaml"))
+    _create_from_target(target, tmp_path / "t.yaml")
     assert calls == []
 
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import textwrap
+import types
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock, call, patch
@@ -17,6 +18,7 @@ from vergil_tooling.bin.vrg_vm import (
     Target,
     _cloud_backend,
     _CloudState,
+    _create_from_target,
     _cs_credentials,
     _cs_tofu_volume,
     _list_rows,
@@ -161,6 +163,70 @@ def test_recover_triple_falls_back_to_parse_for_base_box(
 ) -> None:
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
     assert recover_triple("vergil-user") == ("vergil-user", None, None)
+
+
+def _stub_target(
+    *, dedicated: bool, identity_name: str, org: str | None, repo: str | None, instance: str
+) -> types.SimpleNamespace:
+    spec = types.SimpleNamespace(
+        dedicated=dedicated,
+        cpus=4,
+        memory="8GiB",
+        disk="100GiB",
+        packages=[],
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
+        nested=False,
+    )
+    identity = types.SimpleNamespace(
+        projects_dir="/home/user/projects", cpus=4, memory="8GiB", disk="100GiB"
+    )
+    return types.SimpleNamespace(
+        spec=spec,
+        identity=identity,
+        identity_name=identity_name,
+        org=org,
+        repo=repo,
+        instance=instance,
+        fingerprint="fp",
+    )
+
+
+def test_create_from_target_writes_sidecar_for_dedicated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a)
+    )
+    target = _stub_target(
+        dedicated=True,
+        identity_name="vergil-user",
+        org="acme",
+        repo="widgets",
+        instance="vergil-user.acme.widgets",
+    )
+    _create_from_target(target, Path("/tmp/t.yaml"))
+    assert calls == [("vergil-user.acme.widgets", "vergil-user", "acme", "widgets")]
+
+
+def test_create_from_target_skips_sidecar_for_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a)
+    )
+    target = _stub_target(
+        dedicated=False,
+        identity_name="vergil-user",
+        org=None,
+        repo=None,
+        instance="vergil-agent",
+    )
+    _create_from_target(target, Path("/tmp/t.yaml"))
+    assert calls == []
 
 
 class TestNoSubcommand:


### PR DESCRIPTION
# Pull Request

## Summary

- Cap instance_name via a home-aware budget with cloud-style truncate+hash, and recover (identity, org, repo) from a per-instance sidecar with a parse fallback.

## Issue Linkage

- Ref #1750

## Notes

- Fixes dedicated VM create failure when the org/repo make the Lima instance name long enough that the worst-case ssh.sock path exceeds UNIX_PATH_MAX (observed with logical-minds-foundry/mq-resiliency-lab-for-linux at 107 chars). Over-budget names are truncated and hashed like the cloud backend and stay valid Lima identifiers; the triple is persisted to ~/.lima/<instance>/vergil-meta.json so discovery and update --all still resolve it. Existing short-named VMs keep byte-identical names (zero migration). Also fixes a latent bug where a non-parseable name silently dropped a VM from discovery. Ref #1750