### PR TITLE
fix(off-platform): module fetch 404 — use the v-tag git archive (#1755)

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -55,25 +55,28 @@ def cloud_labels(identity: str, org: str, repo: str) -> dict[str, str]:
     }
 
 
-_MODULES_URL = (
-    "https://github.com/vergil-project/vergil-vm/releases/download/"
-    "{tag}/opentofu-modules-{version}.tar.gz"
-)
+# GitHub auto-generates a source archive for any tag at this URL — a single
+# unauthenticated GET, no git/clone/checkout (the cloud analog of the raw agent.yaml
+# fetch). The version lives ONLY in the tag here: a versioned *release asset* would
+# embed the version in both the path segment and the filename, and `v2.1` is a moving
+# git tag (not a release), so there is no release coordinate to fetch. The moving tag
+# tracks the latest 2.1.x, so the archive always reflects the current opentofu/ tree.
+_MODULES_URL = "https://github.com/vergil-project/vergil-vm/archive/refs/tags/{tag}.tar.gz"
 _TAG_RE = re.compile(r"^v\d+\.\d+(\.\d+)?$")
 
 
 def fetch_modules(tag: str) -> Path:
-    """Download the vergil-vm OpenTofu module tarball at *tag* and return its modules root.
+    """Download the vergil-vm OpenTofu modules at *tag* and return their modules root.
 
-    The release asset keeps ``v<version>`` in the download path segment but the
-    filename drops the leading ``v`` (``opentofu-modules-<version>.tar.gz``). The
-    tarball roots at ``opentofu/``, so the extracted modules live under
-    ``opentofu/modules``.
+    Fetches GitHub's source archive for the tag. The archive roots at
+    ``vergil-vm-<ref>/`` (GitHub strips the leading ``v``), so the modules live under
+    ``vergil-vm-<ref>/opentofu/modules`` — found via a single-segment glob rather than
+    a fixed root.
     """
     if not _TAG_RE.fullmatch(tag):
         print(f"ERROR: invalid module tag '{tag}' (expected vN.N or vN.N.N)", file=sys.stderr)
         raise SystemExit(1)
-    url = _MODULES_URL.format(tag=tag, version=tag.lstrip("v"))
+    url = _MODULES_URL.format(tag=tag)
     tmp = Path(tempfile.mkdtemp(prefix="vergil-modules-"))
     archive = tmp / "modules.tar.gz"
     try:
@@ -84,11 +87,11 @@ def fetch_modules(tag: str) -> Path:
     except (urllib.error.URLError, tarfile.TarError, OSError) as exc:
         print(f"ERROR: failed to fetch modules from {url}: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
-    modules = tmp / "opentofu" / "modules"
-    if not modules.is_dir():
-        print(f"ERROR: module archive missing opentofu/modules ({url})", file=sys.stderr)
+    matches = sorted(tmp.glob("*/opentofu/modules"))
+    if not matches:
+        print(f"ERROR: archive missing */opentofu/modules ({url})", file=sys.stderr)
         raise SystemExit(1)
-    return modules
+    return matches[0]
 
 
 def provision_params(

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -80,26 +80,20 @@ class TestFetchModules:
             fetch_modules("not-a-tag")
 
     @patch("vergil_tooling.lib.vm_cloud.urllib.request.urlopen")
-    def test_builds_release_asset_url(self, mock_urlopen: MagicMock) -> None:
+    def test_builds_archive_url(self, mock_urlopen: MagicMock) -> None:
         mock_urlopen.return_value.__enter__.return_value.read.return_value = b"not-a-tarball"
         with pytest.raises(SystemExit):  # tar extraction of fake bytes fails loudly
             fetch_modules("v2.1.50")
         url = mock_urlopen.call_args[0][0]
-        assert url == (
-            "https://github.com/vergil-project/vergil-vm/releases/download/"
-            "v2.1.50/opentofu-modules-2.1.50.tar.gz"
-        )
+        assert url == "https://github.com/vergil-project/vergil-vm/archive/refs/tags/v2.1.50.tar.gz"
 
     @patch("vergil_tooling.lib.vm_cloud.urllib.request.urlopen")
-    def test_strips_leading_v_for_two_segment_tag(self, mock_urlopen: MagicMock) -> None:
+    def test_builds_archive_url_two_segment_tag(self, mock_urlopen: MagicMock) -> None:
         mock_urlopen.return_value.__enter__.return_value.read.return_value = b"not-a-tarball"
         with pytest.raises(SystemExit):
             fetch_modules("v2.2")
         url = mock_urlopen.call_args[0][0]
-        assert url == (
-            "https://github.com/vergil-project/vergil-vm/releases/download/"
-            "v2.2/opentofu-modules-2.2.tar.gz"
-        )
+        assert url == "https://github.com/vergil-project/vergil-vm/archive/refs/tags/v2.2.tar.gz"
 
     @patch("vergil_tooling.lib.vm_cloud.tarfile.open")
     @patch("vergil_tooling.lib.vm_cloud.urllib.request.urlopen")
@@ -120,7 +114,8 @@ class TestFetchModules:
                 return None
 
             def extractall(self, dest: str, filter: str) -> None:  # noqa: A002
-                modules = Path(dest) / "opentofu" / "modules"
+                # GitHub's source archive roots at vergil-vm-<ref>/, not opentofu/ at the top.
+                modules = Path(dest) / "vergil-vm-2.1.50" / "opentofu" / "modules"
                 modules.mkdir(parents=True)
                 created["modules"] = modules
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fix the off-platform fetch-modules 404 by downloading vergil-vm's OpenTofu modules from GitHub's auto-generated source archive at the v-tag (archive/refs/tags/{tag}.tar.gz) instead of a versioned release asset that does not exist, since v2.1 is a moving git tag rather than a release.

## Issue Linkage

- Ref #1755

## Notes

- Blocker for the off-platform backend (surfaced during the first real vrg-vm create). The old URL embedded the version in both the release tag and the filename, both from the v2.1 minor pin; vergil-vm only publishes per-patch release assets and v2.1 is a git tag (no release), so the coordinate 404d. The archive is a single unauthenticated GET (no release asset to maintain) and the moving v2.1 tag always reflects the current opentofu/ tree; modules are located via a */opentofu/modules glob since the archive roots at vergil-vm-<ref>/. Tests updated for the new URL/layout. Companion vergil-vm PR deletes the now-unused publish-modules CD job.