### PR TITLE
fix(off-platform): inject GCP project into tofu env and reserve name budget for -data suffix

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from vergil_tooling.lib.vm_spec import ComposedSpec
     from vergil_tooling.lib.vm_transport import Transport
 
-_MAX_NAME = 59  # GCP instance name <=63; the module appends "-ssh" to the firewall name.
+_MAX_NAME = 58  # GCP names <=63; the volume module appends "-data" (the longest suffix).
 _HASH_LEN = 6
 
 
@@ -290,12 +290,40 @@ def _plugin_cache_dir() -> Path:
     return path
 
 
+def _resolve_project() -> str:
+    """The GCP project for the off-platform backend: ``GOOGLE_CLOUD_PROJECT`` if set,
+    else ``gcloud config get-value project``. The google OpenTofu provider does NOT read
+    gcloud config, so we resolve it here and inject it into the tofu environment.
+    """
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if not project:
+        result = subprocess.run(  # noqa: S603
+            ["gcloud", "config", "get-value", "project"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        project = result.stdout.strip()
+    if not project:
+        print(
+            "ERROR: no GCP project — set GOOGLE_CLOUD_PROJECT or run: "
+            "gcloud config set project <project>",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return project
+
+
 def _tofu_env() -> dict[str, str]:
-    """Environment for every tofu invocation: non-interactive + shared plugin cache."""
+    """Environment for every tofu invocation: non-interactive, shared plugin cache, and
+    the GCP project. The google provider reads ``GOOGLE_CLOUD_PROJECT`` (not gcloud
+    config), so without this every apply fails with ``project: required field is not set``.
+    """
     return {
         **os.environ,
         "TF_IN_AUTOMATION": "1",
         "TF_PLUGIN_CACHE_DIR": str(_plugin_cache_dir()),
+        "GOOGLE_CLOUD_PROJECT": _resolve_project(),
     }
 
 
@@ -458,23 +486,7 @@ class OffPlatformBackend:
         self.provider_label = spec.provider
 
     def _project(self) -> str:
-        project = os.environ.get("GOOGLE_CLOUD_PROJECT")
-        if not project:
-            result = subprocess.run(  # noqa: S603
-                ["gcloud", "config", "get-value", "project"],  # noqa: S607
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            project = result.stdout.strip()
-        if not project:
-            print(
-                "ERROR: no GCP project — set GOOGLE_CLOUD_PROJECT or run: "
-                "gcloud config set project <project>",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
-        return project
+        return _resolve_project()
 
     def state_dir(self) -> Path:
         return tofu_state_dir(self.state_key, self.spec.provider)

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vergil_tooling.lib import vm_cloud
 from vergil_tooling.lib.vm_cloud import (
     OffPlatformBackend,
     apply_vm,
@@ -33,6 +34,32 @@ from vergil_tooling.lib.vm_transport import IapTransport
 _RFC1035 = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
 
 
+@pytest.fixture(autouse=True)
+def _default_gcp_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The off-platform tofu env resolves the GCP project; default it so tests that
+    exercise tofu don't shell out to ``gcloud``. The _resolve_project tests clear it."""
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+
+class TestResolveProject:
+    def test_uses_env_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "from-env")
+        assert vm_cloud._resolve_project() == "from-env"
+
+    def test_falls_back_to_gcloud_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        sub = MagicMock(return_value=subprocess.CompletedProcess([], 0, stdout="from-gcloud\n"))
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.subprocess.run", sub)
+        assert vm_cloud._resolve_project() == "from-gcloud"
+
+    def test_aborts_when_no_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        sub = MagicMock(return_value=subprocess.CompletedProcess([], 0, stdout="\n"))
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.subprocess.run", sub)
+        with pytest.raises(SystemExit):
+            vm_cloud._resolve_project()
+
+
 class TestCloudName:
     def test_lowercases_and_replaces_dots(self) -> None:
         name = cloud_resource_name("vergil-user", "Logical-Minds", "MQ.Cluster")
@@ -44,9 +71,10 @@ class TestCloudName:
         b = cloud_resource_name("vergil-user", "o", "r")
         assert a == b
 
-    def test_truncates_long_names_to_59_with_hash(self) -> None:
+    def test_truncates_long_names_to_58_with_hash(self) -> None:
         name = cloud_resource_name("vergil-user", "a" * 40, "b" * 40)
-        assert len(name) <= 59
+        # 58 leaves room for the volume module's "-data" suffix within GCP's 63-char cap.
+        assert len(name) <= 58
         assert _RFC1035.fullmatch(name)
 
     def test_distinct_inputs_distinct_names_even_when_truncated(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Resolve the GCP project (GOOGLE_CLOUD_PROJECT or gcloud config) and inject it into every tofu invocation so apply no longer fails with 'project: required field is not set'; drop _MAX_NAME 59->58 so the companion vergil-vm '<name>-data' volume disk stays within GCP's 63-char limit.

## Issue Linkage

- Ref #1761

## Notes

- Surfaced by the first real off-platform 'vrg-vm create'. _resolve_project() is extracted module-level and reused by both _tofu_env() and the backend's _project() method. Ships together with vergil-vm #221 (volume disk renamed to <name>-data). Validation green: 3342 tests, 100% coverage, lint/typecheck/audit clean.