### PR TITLE
fix(submit-pr): clarify linkage error and strip stray issue numbers

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import git, identity_mode
 from vergil_tooling.lib.identity_mode import IdentityMode
+from vergil_tooling.lib.linkage import normalize_linkage
 from vergil_tooling.lib.pr_workflow import engine, registry, settings
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
 from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
@@ -160,17 +161,24 @@ def _next_audit(args: argparse.Namespace, transport: LocalFileTransport) -> int:
 
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
     state = _require_state(transport)
+    try:
+        linkage, linkage_warning = normalize_linkage(args.linkage)
+    except ValueError as exc:
+        raise WorkflowError(f"report-ready: {exc}") from exc
     engine.apply_report_ready(
         state,
         title=args.title,
         summary=args.summary,
         notes=args.notes,
-        linkage=args.linkage,
+        linkage=linkage,
         head_sha=transport.head_sha(),
         now=_now(),
     )
     transport.write(state)
-    _emit({"ok": True, "status": state.status, "owner": state.owner})
+    response: dict[str, object] = {"ok": True, "status": state.status, "owner": state.owner}
+    if linkage_warning:
+        response["warning"] = linkage_warning
+    _emit(response)
     return 0
 
 

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -45,7 +45,7 @@ from pathlib import Path
 
 from vergil_tooling.lib import git, github, identity_mode, worktrees
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
-from vergil_tooling.lib.linkage import ALLOWED_LINKAGES
+from vergil_tooling.lib.linkage import ALLOWED_LINKAGES, normalize_linkage
 from vergil_tooling.lib.pr_body import build_pr_body, resolve_issue_ref
 from vergil_tooling.lib.pr_workflow import batch, submission
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
@@ -478,13 +478,12 @@ def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: b
     issue_ref = resolve_issue_ref(fields["issue"])
     branch = git.current_branch()
     target = _target_branch(base_override, fields.get("base"))
-    linkage = fields.get("linkage", "Ref")
-    if linkage not in ALLOWED_LINKAGES:
-        msg = (
-            f"vrg-submit-pr: linkage '{linkage}' in the PR submission fields is not "
-            f"allowed; use: {', '.join(ALLOWED_LINKAGES)}."
-        )
-        raise SystemExit(msg)
+    try:
+        linkage, linkage_warning = normalize_linkage(fields.get("linkage", "Ref"))
+    except ValueError as exc:
+        raise SystemExit(f"vrg-submit-pr: {exc}") from exc
+    if linkage_warning:
+        print(f"vrg-submit-pr: {linkage_warning}", file=sys.stderr)
     pr_body = build_pr_body(
         summary=fields["summary"],
         linkage=linkage,
@@ -554,19 +553,19 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     branch = git.current_branch()
     target = _target_branch(args.base, fields.get("base"))
     title = fields["title"]
-    linkage = fields.get("linkage", "Ref")
     notes = fields.get("notes", "")
 
-    # Belt-and-suspenders: the oracle validates linkage at report-ready, but
-    # guard the value used to build the PR body so a forbidden auto-close
-    # keyword can never reach the PR regardless of how the fields were obtained.
-    if linkage not in ALLOWED_LINKAGES:
-        print(
-            f"vrg-submit-pr: linkage '{linkage}' in the PR submission fields is not "
-            f"allowed; use: {', '.join(ALLOWED_LINKAGES)}.",
-            file=sys.stderr,
-        )
+    # Belt-and-suspenders: the oracle normalizes linkage at report-ready, but
+    # guard the value used to build the PR body so a forbidden keyword can never
+    # reach the PR regardless of how the fields were obtained. A keyword carrying
+    # a stray issue number is unambiguous, so strip it and warn rather than fail.
+    try:
+        linkage, linkage_warning = normalize_linkage(fields.get("linkage", "Ref"))
+    except ValueError as exc:
+        print(f"vrg-submit-pr: {exc}", file=sys.stderr)
         return 1
+    if linkage_warning:
+        print(f"vrg-submit-pr: {linkage_warning}", file=sys.stderr)
     pr_body = build_pr_body(
         summary=fields["summary"],
         linkage=linkage,

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -25,6 +25,52 @@ AUTOCLOSE_RE = re.compile(
     re.MULTILINE | re.IGNORECASE,
 )
 
+# A linkage *value* in the PR submission fields: a bare keyword, optionally
+# followed by an issue reference (``#42`` or ``org/repo#42``). The reference is
+# matched so it can be stripped — the issue number is appended automatically
+# when the PR body is rendered, so it must not be carried on the keyword.
+LINKAGE_VALUE_RE = re.compile(
+    r"^\s*(?P<keyword>[A-Za-z]+)"
+    r"(?:\s+(?:[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+)?\s*$"
+)
+
+
+def normalize_linkage(value: str) -> tuple[str, str | None]:
+    """Validate and normalize a PR issue-linkage value to a bare keyword.
+
+    The linkage stored in the PR submission fields must be a *bare* allowed
+    keyword (e.g. ``Ref``); the issue number is appended automatically when the
+    PR body is built. Passing the keyword *with* the issue number
+    (``Ref #1761``) is a common and unambiguous mistake, so strip the number and
+    return a warning rather than hard-failing.
+
+    Returns a ``(canonical, warning)`` pair:
+
+    - ``canonical`` is the bare allowed keyword to use downstream.
+    - ``warning`` is a human-readable note when a stray issue number was
+      stripped, or ``None`` when *value* was already a clean bare keyword.
+
+    Raises ``ValueError`` with a user-ready message when *value* is not a
+    recognized linkage keyword (the message states the contract and echoes the
+    offending value so the caller can surface it verbatim).
+    """
+    match = LINKAGE_VALUE_RE.match(value)
+    keyword = match.group("keyword") if match else None
+    if keyword not in ALLOWED_LINKAGES:
+        allowed = ", ".join(ALLOWED_LINKAGES)
+        raise ValueError(
+            f"linkage must be a bare keyword (one of: {allowed}) — the issue "
+            f"number is added automatically; got {value!r}. "
+            f"Pass just {ALLOWED_LINKAGES[0]!r}."
+        )
+    if value.strip() == keyword:
+        return keyword, None
+    warning = (
+        f"linkage {value!r} includes an issue number; using bare {keyword!r} "
+        "(the issue number is appended automatically)."
+    )
+    return keyword, warning
+
 
 def extract_tracking_issue(text: str) -> int | None:
     """Return the tracking issue number from a ``Ref #N`` match.

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -120,6 +120,65 @@ def test_solo_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
     assert state["history"][0]["action"] == "init"
 
 
+def test_report_ready_strips_issue_number_from_linkage_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    repo = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, "next", "--issue", "1534", "--no-audit") == 0
+    capsys.readouterr()
+
+    assert (
+        _run(
+            monkeypatch,
+            repo,
+            "report-ready",
+            "--title",
+            "feat: x",
+            "--summary",
+            "did x",
+            "--notes",
+            "n",
+            "--linkage",
+            "Ref #1761",
+        )
+        == 0
+    )
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "approved"
+    assert "Ref #1761" in out["warning"]
+
+    state = json.loads((repo / ".vergil" / "pr-workflow.json").read_text())
+    assert state["pr_metadata"]["linkage"] == "Ref"
+
+
+def test_report_ready_rejects_unrecognized_linkage_keyword(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    repo = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, "next", "--issue", "1534", "--no-audit") == 0
+    capsys.readouterr()
+
+    assert (
+        _run(
+            monkeypatch,
+            repo,
+            "report-ready",
+            "--title",
+            "feat: x",
+            "--summary",
+            "did x",
+            "--notes",
+            "n",
+            "--linkage",
+            "Refs #1761",
+        )
+        == 1
+    )
+    err = capsys.readouterr().err
+    assert "bare keyword" in err
+    assert "Refs #1761" in err
+
+
 def test_audit_on_solo_file_exits_clean(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:

--- a/tests/vergil_tooling/test_linkage.py
+++ b/tests/vergil_tooling/test_linkage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from vergil_tooling.lib.linkage import extract_tracking_issue
+from vergil_tooling.lib.linkage import extract_tracking_issue, normalize_linkage
 
 
 def test_ref_simple() -> None:
@@ -56,3 +56,48 @@ def test_multiple_refs_raises_value_error() -> None:
 
 def test_autoclose_keyword_not_matched() -> None:
     assert extract_tracking_issue("Fixes #42") is None
+
+
+def test_normalize_bare_keyword_no_warning() -> None:
+    assert normalize_linkage("Ref") == ("Ref", None)
+
+
+def test_normalize_bare_keyword_trims_whitespace() -> None:
+    assert normalize_linkage("  Ref  ") == ("Ref", None)
+
+
+def test_normalize_strips_issue_number_and_warns() -> None:
+    canonical, warning = normalize_linkage("Ref #1761")
+    assert canonical == "Ref"
+    assert warning is not None
+    assert "Ref #1761" in warning
+    assert "Ref" in warning
+
+
+def test_normalize_strips_cross_repo_reference() -> None:
+    canonical, warning = normalize_linkage("Ref org/repo#42")
+    assert canonical == "Ref"
+    assert warning is not None
+
+
+def test_normalize_rejects_wrong_keyword_with_number() -> None:
+    """The 'Refs #N' round-trip case: wrong keyword, clear contract message."""
+    with pytest.raises(ValueError, match="bare keyword") as exc:
+        normalize_linkage("Refs #1761")
+    assert "Refs #1761" in str(exc.value)
+    assert "Ref" in str(exc.value)
+
+
+def test_normalize_rejects_autoclose_keyword() -> None:
+    with pytest.raises(ValueError, match="bare keyword"):
+        normalize_linkage("Closes")
+
+
+def test_normalize_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="bare keyword"):
+        normalize_linkage("")
+
+
+def test_normalize_rejects_trailing_garbage() -> None:
+    with pytest.raises(ValueError, match="bare keyword"):
+        normalize_linkage("Ref #1761 extra")

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -631,6 +631,32 @@ class TestTemplateMode:
         assert "linkage" in err.lower()
         assert "Ref" in err
 
+    def test_template_strips_issue_number_from_linkage_and_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A linkage carrying the issue number is stripped to the bare keyword,
+        warned about, and the PR proceeds — no hard fail (issue #1765)."""
+        _write_workflow_state(tmp_path, title="fix", summary="Fix", linkage="Ref #1761")
+        with (
+            patch("vergil_tooling.bin.vrg_submit_pr.git.repo_root", return_value=tmp_path),
+            patch(
+                "vergil_tooling.bin.vrg_submit_pr.git.current_branch",
+                return_value="feature/x",
+            ),
+            patch("vergil_tooling.bin.vrg_submit_pr.git.run"),
+            patch(
+                "vergil_tooling.bin.vrg_submit_pr.github.create_pr",
+                return_value="https://github.com/pr/8",
+            ),
+            patch("builtins.input", return_value="y"),
+        ):
+            result = main([])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Ref #1761" in captured.err
+        # The rendered body carries the bare keyword with the auto-appended number.
+        assert "Ref #42" in captured.out
+
     def test_template_mode_reports_unready_workflow(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -1491,9 +1491,28 @@ def test_submit_one_bad_linkage_exits() -> None:
         patch(_MOD + ".submission.read_pr_fields", return_value=fields),
         patch(_MOD + ".resolve_issue_ref", return_value="#1"),
         patch(_MOD + ".git.current_branch", return_value="feature/1-x"),
-        pytest.raises(SystemExit, match="linkage"),
+        pytest.raises(SystemExit, match="bare keyword"),
     ):
         _submit_one(Path("/r"), base_override=None, assume_yes=True)
+
+
+def test_submit_one_strips_issue_number_from_linkage_and_warns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A linkage carrying the issue number is unambiguous: strip it, warn, proceed."""
+    fields = {"issue": "1", "title": "T", "summary": "s", "notes": "", "linkage": "Ref #1761"}
+    with (
+        patch(_MOD + ".submission.read_pr_fields", return_value=fields),
+        patch(_MOD + ".resolve_issue_ref", return_value="#1"),
+        patch(_MOD + ".git.current_branch", return_value="feature/1-x"),
+        patch(_MOD + ".build_pr_body", return_value="BODY") as build,
+        patch(_MOD + ".confirm", return_value=True),
+        patch(_MOD + "._push_create_record", return_value="https://example/pull/1"),
+    ):
+        url = _submit_one(Path("/r"), base_override=None, assume_yes=True)
+    assert url == "https://example/pull/1"
+    assert build.call_args.kwargs["linkage"] == "Ref"
+    assert "Ref #1761" in capsys.readouterr().err
 
 
 def test_submit_one_declined_exits() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the confusing exact-membership linkage rejection with a shared normalize_linkage() that strips an unambiguous keyword+#N to the bare keyword and warns, and otherwise states the contract and echoes the offending value.

## Issue Linkage

- Ref #1765

## Notes

- Root cause: linkage validation was exact-membership ('Ref' only) with an error that just listed the allowed keyword, so 'Ref #1761' produced 'use: Ref' — a no-op-looking suggestion that hid the real fix (drop the #N). Changes: (1) new lib/linkage.normalize_linkage() returns (canonical, warning) — strips a stray issue number and warns, raises a contract-stating ValueError otherwise; (2) both duplicated vrg-submit-pr call sites now delegate to it; (3) report-ready normalizes at the earliest entry point and surfaces the strip warning in its JSON response. Behavior change: a linkage carrying its issue number is now accepted (stripped + warned) rather than hard-failing, per the issue's suggestion. Coverage 100%; vrg-validate green.