### PR TITLE
feat(off-platform): surface cloud-init progress during await-readiness

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -675,6 +675,7 @@ class _CloudState:
     state_dir: Path
     tag: str = ""
     vergil_version: str = ""
+    verbose: bool = False
     modules_root: Path | None = None
     zone: str = ""
     volume_id: str = ""
@@ -727,7 +728,11 @@ def _cs_tofu_vm(state: _CloudState) -> None:
 
 def _cs_await_readiness(state: _CloudState) -> None:
     print("Waiting for the cloud box to be ready...")
-    vm_cloud.await_readiness(_require_transport(state), spec_fingerprint(state.target.spec))
+    vm_cloud.await_readiness(
+        _require_transport(state),
+        spec_fingerprint(state.target.spec),
+        verbose=state.verbose,
+    )
 
 
 def _cs_credentials(state: _CloudState) -> None:
@@ -785,6 +790,16 @@ def _cloud_backend(target: Target) -> OffPlatformBackend:
     return cast("OffPlatformBackend", target.backend)
 
 
+_VERBOSE_ENV_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _resolve_vm_verbose(args: argparse.Namespace) -> bool:
+    """Opt into live provisioning output via ``--verbose`` or ``VERGIL_VM_VERBOSE``."""
+    if getattr(args, "verbose", False):
+        return True
+    return os.environ.get("VERGIL_VM_VERBOSE", "").strip().lower() in _VERBOSE_ENV_TRUTHY
+
+
 def _cloud_create(
     verb: str, target: Target, args: argparse.Namespace, *, destroy_first: bool
 ) -> int:
@@ -824,6 +839,7 @@ def _cloud_create(
         state_dir=backend.state_dir(),
         tag=tag,
         vergil_version=vergil_version,
+        verbose=_resolve_vm_verbose(args),
     )
     return _run_cloud_lifecycle(verb, state, _cloud_create_stages(), args)
 
@@ -1754,6 +1770,14 @@ def main(argv: list[str] | None = None) -> int:
     p_create.add_argument(
         "--tag", default="", help="VM template version tag (default: vergil version from config)"
     )
+    p_create.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Stream live cloud-init provisioning output during await-readiness "
+            "(off-platform only; also enabled by VERGIL_VM_VERBOSE)"
+        ),
+    )
     progress.add_progress_args(p_create, ())
 
     p_start = sub.add_parser("start", help="Start VM and inject credentials")
@@ -1795,6 +1819,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     # Off-platform update delegates to rebuild, which drives the progress pipeline;
     # these flags must exist on the update parser so that delegation has them.
+    p_update.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Stream live cloud-init provisioning output during await-readiness "
+            "(off-platform only; also enabled by VERGIL_VM_VERBOSE)"
+        ),
+    )
     progress.add_progress_args(p_update, ())
 
     p_destroy = sub.add_parser("destroy", help="Destroy VM entirely")
@@ -1833,6 +1865,14 @@ def main(argv: list[str] | None = None) -> int:
         "--timeout",
         default="30m",
         help="How long to wait for VM to reach running status (default: 30m)",
+    )
+    p_rebuild.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Stream live cloud-init provisioning output during await-readiness "
+            "(off-platform only; also enabled by VERGIL_VM_VERBOSE)"
+        ),
     )
     progress.add_progress_args(p_rebuild, ())
 

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -11,6 +12,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -221,19 +224,147 @@ def bootstrap_volume(transport: Transport, identity: Identity, org: str, repo: s
 
 
 _FINGERPRINT_PATH = "/etc/vergil/vm-spec.fingerprint"
+_CLOUD_INIT_LOG = "/var/log/cloud-init-output.log"
+
+# How often the readiness gate re-queries cloud-init and emits an elapsed
+# heartbeat. cloud-init provisioning on a fresh box runs many minutes, so a
+# ~20s cadence gives the operator a steady "still alive" signal without
+# hammering the IAP tunnel.
+_READINESS_POLL_SECS = 20.0
+
+# cloud-init's terminal states (``cloud-init status`` output). "done" is the
+# only clean success; "error" and "degraded done" mean provisioning finished
+# with faults — both of which the old blocking ``status --wait`` surfaced as a
+# nonzero exit, so we preserve that by treating them as hard failures.
+_CLOUD_INIT_DONE = "done"
+_CLOUD_INIT_FAILED = frozenset({"error", "degraded done"})
 
 
-def await_readiness(transport: Transport, fingerprint: str) -> None:
-    """Synthesize a hard-fail readiness gate for a cloud box.
+def _parse_cloud_init_status(stdout: str) -> tuple[str, str]:
+    """Pull ``(status, detail)`` from ``cloud-init status --long`` output.
 
-    Waits for cloud-init to finish, then confirms the stamped spec fingerprint
-    matches the freshly composed one. Either failure raises ``RuntimeError`` so
-    the create pipeline aborts loudly (no half-ready box).
+    Returns empty strings for any field not present — e.g. a transient SSH
+    failure yields no ``status:`` line, which the caller reads as "not ready
+    yet" and keeps polling.
+    """
+    status = ""
+    detail = ""
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if line.startswith("status:"):
+            status = line.split(":", 1)[1].strip()
+        elif line.startswith("detail:"):
+            detail = line.split(":", 1)[1].strip()
+    return status, detail
+
+
+def _poll_cloud_init_status(transport: Transport) -> tuple[str, str]:
+    """Query cloud-init once and return its ``(status, detail)``.
+
+    ``cloud-init status`` exits nonzero for the error(1)/degraded(2) states, but
+    the status line still rides on stdout — so we parse the captured output of a
+    failed call too. A genuine connectivity failure (SSH not up yet) produces no
+    status line, which parses to an empty status the poll loop treats as
+    non-terminal. The transport already echoes the child's stderr, so a real
+    failure is never silent.
     """
     try:
-        transport.run("cloud-init", "status", "--wait")
+        result = transport.run("cloud-init", "status", "--long")
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError("cloud-init did not complete on the cloud box — rebuild the VM") from exc
+        return _parse_cloud_init_status(exc.stdout or "")
+    return _parse_cloud_init_status(result.stdout)
+
+
+def _readiness_heartbeat(elapsed: float, status: str, detail: str) -> str:
+    """One elapsed-vs-stage line, mirroring the Lima backend's ``[elapsed]`` beat."""
+    stage = detail or status or "connecting"
+    return f"[cloud-init] {progress.format_elapsed(elapsed)} elapsed — {stage}"
+
+
+class _CloudInitTail:
+    """Background ``tail -f`` of the guest cloud-init log, relayed to the renderer.
+
+    Opt-in (``--verbose`` / ``VERGIL_VM_VERBOSE``) live provisioning output. The
+    poll loop owns readiness; this is display-only, so a tail that never starts
+    (older box, missing log) degrades to heartbeats rather than failing the gate.
+    """
+
+    def __init__(self, transport: Transport) -> None:
+        self._transport = transport
+        self._proc: subprocess.Popen[str] | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        # Spawn synchronously so ``_proc`` is set before the poll loop runs —
+        # the thread only drains stdout, keeping ``stop()`` race-free.
+        try:
+            # ``-n +1`` replays the log from the top so output already written
+            # before we attached is not lost.
+            self._proc = self._transport.popen("sudo", "tail", "-n", "+1", "-f", _CLOUD_INIT_LOG)
+        except OSError as exc:  # spawning the tunnel failed — degrade to heartbeats
+            progress.emit(f"[cloud-init] live tail unavailable: {exc}")
+            return
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+        self._thread.start()
+
+    def _drain(self) -> None:
+        assert self._proc is not None  # noqa: S101 — start() set it before spawning the thread
+        assert self._proc.stdout is not None  # noqa: S101 — Popen(stdout=PIPE) guarantees it
+        for raw in self._proc.stdout:
+            line = raw.rstrip("\n")
+            if line:
+                progress.emit(f"[cloud-init] {line}")
+
+    def stop(self) -> None:
+        if self._proc is not None:
+            self._proc.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                self._proc.wait(timeout=5)
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+
+def _wait_for_cloud_init(
+    transport: Transport, *, verbose: bool, poll_secs: float = _READINESS_POLL_SECS
+) -> None:
+    """Poll cloud-init to completion, emitting an elapsed heartbeat each cycle.
+
+    Replaces a single blocking ``cloud-init status --wait`` (silent for the whole
+    provisioning window) with a poll loop so the create pipeline shows steady
+    progress. There is deliberately no timeout — matching ``--wait``'s
+    wait-forever semantics — because the heartbeat itself is the signal the
+    operator uses to decide a box is wedged and abort by hand. Raises
+    ``RuntimeError`` on any cloud-init failure state so the gate still hard-fails.
+    """
+    tail = _CloudInitTail(transport) if verbose else None
+    if tail is not None:
+        tail.start()
+    started = time.monotonic()
+    try:
+        while True:
+            status, detail = _poll_cloud_init_status(transport)
+            if status == _CLOUD_INIT_DONE:
+                return
+            if status in _CLOUD_INIT_FAILED:
+                raise RuntimeError(
+                    f"cloud-init reported '{status}' on the cloud box — rebuild the VM"
+                )
+            progress.emit(_readiness_heartbeat(time.monotonic() - started, status, detail))
+            time.sleep(poll_secs)
+    finally:
+        if tail is not None:
+            tail.stop()
+
+
+def await_readiness(transport: Transport, fingerprint: str, *, verbose: bool = False) -> None:
+    """Synthesize a hard-fail readiness gate for a cloud box.
+
+    Waits for cloud-init to finish — emitting an elapsed/stage heartbeat each
+    poll, plus a live log tail when ``verbose`` — then confirms the stamped spec
+    fingerprint matches the freshly composed one. Either failure raises
+    ``RuntimeError`` so the create pipeline aborts loudly (no half-ready box).
+    """
+    _wait_for_cloud_init(transport, verbose=verbose)
     try:
         result = transport.run("cat", _FINGERPRINT_PATH)
     except subprocess.CalledProcessError as exc:

--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -31,6 +31,10 @@ class Transport(Protocol):
         self, cmd: str, input_data: str, *, workdir: str = _DEFAULT_WORKDIR
     ) -> None: ...  # pragma: no cover
 
+    def popen(
+        self, *args: str, workdir: str = _DEFAULT_WORKDIR
+    ) -> subprocess.Popen[str]: ...  # pragma: no cover
+
     def exec_session(self, workdir: str, inner: str) -> NoReturn: ...  # pragma: no cover
 
 
@@ -76,6 +80,14 @@ class LimaTransport:
             if exc.stderr:
                 print(exc.stderr, end="", file=sys.stderr)
             raise
+
+    def popen(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.Popen[str]:
+        return subprocess.Popen(  # noqa: S603
+            ["limactl", "shell", "--workdir", workdir, self.instance, "--", *args],  # noqa: S607
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
 
     def exec_session(self, workdir: str, inner: str) -> NoReturn:
         os.environ["LIMA_SHELLENV_ALLOW"] = _TERMINAL_ENV_VARS
@@ -147,6 +159,19 @@ class IapTransport:
             if exc.stderr:
                 print(exc.stderr, end="", file=sys.stderr)
             raise
+
+    def popen(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.Popen[str]:
+        remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
+        # Long-running streaming child (e.g. ``tail -f``): the caller drains
+        # stdout line-by-line and terminates it. stderr is folded into stdout so
+        # a guest-side error (missing log, permission denied) surfaces in the
+        # stream rather than vanishing.
+        return subprocess.Popen(  # noqa: S603
+            [*self._base(), f"--command={remote}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
 
     def exec_session(self, workdir: str, inner: str) -> NoReturn:
         remote = f"cd {workdir} && {inner}"

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -359,26 +359,99 @@ class TestBootstrap:
         assert ["git", "-C", "/vergil/projects/org/repo", "fetch", "--all"] in cmds
 
 
+def _done(stdout: str = "status: done\n") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], 0, stdout=stdout, stderr="")
+
+
+class TestParseCloudInitStatus:
+    def test_extracts_status_and_detail(self) -> None:
+        out = "----\nstatus: running\ndetail: running modules:config\nboot: enabled\n"
+        assert vm_cloud._parse_cloud_init_status(out) == ("running", "running modules:config")
+
+    def test_status_only_leaves_detail_empty(self) -> None:
+        assert vm_cloud._parse_cloud_init_status("status: done\n") == ("done", "")
+
+    def test_no_status_line_is_empty(self) -> None:
+        # A bare SSH/connection failure prints no status line at all.
+        assert vm_cloud._parse_cloud_init_status("ssh: connect: connection refused\n") == ("", "")
+
+
+class TestPollCloudInitStatus:
+    def test_parses_successful_call(self) -> None:
+        transport = MagicMock()
+        transport.run.return_value = _done("status: running\ndetail: foo\n")
+        assert vm_cloud._poll_cloud_init_status(transport) == ("running", "foo")
+
+    def test_parses_status_from_nonzero_exit(self) -> None:
+        # cloud-init exits 1/2 for error/degraded but still prints the status line.
+        transport = MagicMock()
+        transport.run.side_effect = subprocess.CalledProcessError(
+            1, "cloud-init", output="status: error\ndetail: boom\n"
+        )
+        assert vm_cloud._poll_cloud_init_status(transport) == ("error", "boom")
+
+    def test_connection_failure_yields_empty_status(self) -> None:
+        transport = MagicMock()
+        transport.run.side_effect = subprocess.CalledProcessError(255, "ssh")
+        assert vm_cloud._poll_cloud_init_status(transport) == ("", "")
+
+
 class TestAwaitReadiness:
     def test_passes_when_cloud_init_done_and_marker_matches(self) -> None:
         transport = MagicMock()
         transport.run.side_effect = [
-            subprocess.CompletedProcess([], 0, stdout="status: done\n", stderr=""),
-            subprocess.CompletedProcess([], 0, stdout="fp123\n", stderr=""),
+            _done("status: done\n"),
+            _done("fp123\n"),
         ]
         await_readiness(transport, "fp123")  # no raise
 
-    def test_raises_when_cloud_init_fails(self) -> None:
+    def test_raises_when_cloud_init_reports_error(self) -> None:
         transport = MagicMock()
-        transport.run.side_effect = subprocess.CalledProcessError(1, "cloud-init")
-        with pytest.raises(RuntimeError):
+        transport.run.return_value = _done("status: error\ndetail: provision failed\n")
+        with pytest.raises(RuntimeError, match="error"):
             await_readiness(transport, "fp123")
+
+    def test_raises_when_cloud_init_degraded(self) -> None:
+        transport = MagicMock()
+        transport.run.return_value = _done("status: degraded done\n")
+        with pytest.raises(RuntimeError, match="degraded done"):
+            await_readiness(transport, "fp123")
+
+    def test_polls_through_running_then_done(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Two "running" polls (each emits a heartbeat) before "done", then marker.
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
+        emitted: list[str] = []
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", emitted.append)
+        transport = MagicMock()
+        transport.run.side_effect = [
+            _done("status: running\ndetail: config\n"),
+            _done("status: running\ndetail: final\n"),
+            _done("status: done\n"),
+            _done("fp123\n"),
+        ]
+        await_readiness(transport, "fp123")
+        beats = [line for line in emitted if line.startswith("[cloud-init]")]
+        assert len(beats) == 2
+        assert "elapsed" in beats[0]
+        assert "config" in beats[0]
+
+    def test_tolerates_transient_connection_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An early SSH failure (no status) must not abort — keep polling to done.
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", lambda _line: None)
+        transport = MagicMock()
+        transport.run.side_effect = [
+            subprocess.CalledProcessError(255, "ssh"),
+            _done("status: done\n"),
+            _done("fp123\n"),
+        ]
+        await_readiness(transport, "fp123")  # no raise
 
     def test_raises_when_marker_mismatched(self) -> None:
         transport = MagicMock()
         transport.run.side_effect = [
-            subprocess.CompletedProcess([], 0, stdout="status: done\n", stderr=""),
-            subprocess.CompletedProcess([], 0, stdout="different\n", stderr=""),
+            _done("status: done\n"),
+            _done("different\n"),
         ]
         with pytest.raises(RuntimeError):
             await_readiness(transport, "fp123")
@@ -386,11 +459,57 @@ class TestAwaitReadiness:
     def test_raises_when_marker_read_fails(self) -> None:
         transport = MagicMock()
         transport.run.side_effect = [
-            subprocess.CompletedProcess([], 0, stdout="status: done\n", stderr=""),
+            _done("status: done\n"),
             subprocess.CalledProcessError(1, "cat"),
         ]
         with pytest.raises(RuntimeError):
             await_readiness(transport, "fp123")
+
+    def test_verbose_streams_log_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # verbose=True attaches a live tail; its lines are relayed and it is
+        # terminated once cloud-init is done.
+        emitted: list[str] = []
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", emitted.append)
+        transport = MagicMock()
+        transport.run.side_effect = [
+            _done("status: done\n"),
+            _done("fp123\n"),
+        ]
+        fake_proc = MagicMock()
+        # A blank line in the stream is skipped (not relayed as an empty beat).
+        fake_proc.stdout = iter(["Cloud-init running module foo\n", "\n", "package installed\n"])
+        transport.popen.return_value = fake_proc
+        await_readiness(transport, "fp123", verbose=True)
+        popen_args = list(transport.popen.call_args.args)
+        assert "tail" in popen_args
+        assert vm_cloud._CLOUD_INIT_LOG in popen_args
+        assert "[cloud-init] Cloud-init running module foo" in emitted
+        fake_proc.terminate.assert_called_once()
+
+    def test_non_verbose_does_not_tail(self) -> None:
+        transport = MagicMock()
+        transport.run.side_effect = [
+            _done("status: done\n"),
+            _done("fp123\n"),
+        ]
+        await_readiness(transport, "fp123")
+        transport.popen.assert_not_called()
+
+    def test_verbose_tail_failure_degrades_to_heartbeat(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If spawning the tail tunnel fails, the gate must still complete on the
+        # heartbeat path rather than aborting the build.
+        emitted: list[str] = []
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", emitted.append)
+        transport = MagicMock()
+        transport.popen.side_effect = OSError("no gcloud")
+        transport.run.side_effect = [
+            _done("status: done\n"),
+            _done("fp123\n"),
+        ]
+        await_readiness(transport, "fp123", verbose=True)  # no raise
+        assert any("live tail unavailable" in line for line in emitted)
 
 
 class TestCloudClaudeLayout:

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -100,6 +100,24 @@ class TestLimaTransport:
         assert "--workdir=/work" in cmd
         assert cmd[-3:] == ["bash", "-c", "exec bash"]
 
+    @patch("vergil_tooling.lib.vm_transport.subprocess.Popen")
+    def test_popen_streams_via_limactl_shell(self, mock_popen: MagicMock) -> None:
+        LimaTransport("vm-x").popen("tail", "-f", "/log", workdir="/work")
+        args = mock_popen.call_args[0][0]
+        assert args == [
+            "limactl",
+            "shell",
+            "--workdir",
+            "/work",
+            "vm-x",
+            "--",
+            "tail",
+            "-f",
+            "/log",
+        ]
+        assert mock_popen.call_args[1]["stdout"] == subprocess.PIPE
+        assert mock_popen.call_args[1]["stderr"] == subprocess.STDOUT
+
 
 class TestIapTransport:
     @patch("vergil_tooling.lib.vm_transport.subprocess.run")
@@ -182,3 +200,14 @@ class TestIapTransport:
         assert cmd[:4] == ["gcloud", "compute", "ssh", "vergil@inst"]
         assert "--tunnel-through-iap" in cmd
         assert cmd[-3:] == ["--", "-t", "cd /work && exec bash"]
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.Popen")
+    def test_popen_streams_over_iap_tunnel(self, mock_popen: MagicMock) -> None:
+        IapTransport("inst", "z", "p", "vergil").popen(
+            "sudo", "tail", "-f", "/var/log/cloud-init-output.log", workdir="/work"
+        )
+        args = mock_popen.call_args[0][0]
+        assert args[:4] == ["gcloud", "compute", "ssh", "vergil@inst"]
+        assert args[-1] == "--command=cd /work && sudo tail -f /var/log/cloud-init-output.log"
+        assert mock_popen.call_args[1]["stdout"] == subprocess.PIPE
+        assert mock_popen.call_args[1]["stderr"] == subprocess.STDOUT

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -28,6 +28,7 @@ from vergil_tooling.bin.vrg_vm import (
     _read_repo_vm,
     _resolve,
     _resolve_target,
+    _resolve_vm_verbose,
     _target_ref,
     _warn_under,
     discover_dedicated,
@@ -3154,6 +3155,34 @@ class TestCloudCreate:
         m["bootstrap_volume"].assert_called_once()
         m["link_cloud_claude_dirs"].assert_called_once()
         m["destroy_vm"].assert_not_called()
+        # await-readiness defaults to non-verbose (heartbeat only).
+        assert m["await_readiness"].call_args.kwargs["verbose"] is False
+
+    def test_cloud_create_verbose_flag_streams_provisioning(
+        self, _cloud_repo: Path, tmp_path: Path
+    ) -> None:
+        with _CloudPatches(tmp_path / "state") as m:
+            result = main(
+                [
+                    "create",
+                    "lmf/cloud",
+                    "--config",
+                    str(_cloud_repo),
+                    "--output-format",
+                    "plain",
+                    "--verbose",
+                ]
+            )
+        assert result == 0
+        assert m["await_readiness"].call_args.kwargs["verbose"] is True
+
+    def test_cloud_create_verbose_via_env(
+        self, _cloud_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VERGIL_VM_VERBOSE", "1")
+        with _CloudPatches(tmp_path / "state") as m:
+            main(["create", "lmf/cloud", "--config", str(_cloud_repo), "--output-format", "plain"])
+        assert m["await_readiness"].call_args.kwargs["verbose"] is True
 
     def test_cloud_create_cleans_up_modules(self, _cloud_repo: Path, tmp_path: Path) -> None:
         state = tmp_path / "state"
@@ -3417,3 +3446,25 @@ class TestCloudUnderProvision:
             m["transport"].return_value = transport
             main(["session", "lmf/cloud", "--config", str(cfg)])
         assert "under-provisioned" not in capsys.readouterr().err
+
+
+class TestResolveVmVerbose:
+    def _ns(self, **kw: object) -> argparse.Namespace:
+        return argparse.Namespace(**kw)
+
+    def test_flag_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VERGIL_VM_VERBOSE", raising=False)
+        assert _resolve_vm_verbose(self._ns(verbose=True)) is True
+
+    def test_env_truthy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VERGIL_VM_VERBOSE", "yes")
+        assert _resolve_vm_verbose(self._ns(verbose=False)) is True
+
+    def test_env_falsey(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VERGIL_VM_VERBOSE", "0")
+        assert _resolve_vm_verbose(self._ns(verbose=False)) is False
+
+    def test_absent_flag_and_env_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The flag is missing entirely on non-cloud-aware parsers (getattr default).
+        monkeypatch.delenv("VERGIL_VM_VERBOSE", raising=False)
+        assert _resolve_vm_verbose(self._ns()) is False


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the silent blocking 'cloud-init status --wait' in the cloud await-readiness phase with a polling heartbeat (elapsed + stage every ~20s) plus an opt-in live log tail (--verbose / VERGIL_VM_VERBOSE), so operators can distinguish a still-provisioning box from a hung one.

## Issue Linkage

- Ref #1767

## Notes

- Failure semantics preserved: cloud-init error/degraded states raise RuntimeError and the fingerprint-marker check is unchanged; there is intentionally no timeout (matching --wait's wait-forever behavior — the heartbeat is the abort signal). The live tail rides on a new Transport.popen streaming primitive (added to both Iap and Lima transports for protocol parity) and is display-only: it degrades to heartbeats if it cannot attach, never affecting the gate. --verbose is wired onto create/rebuild/update. Full validation (vrg-validate) green in-container, 100% coverage. Ref #1767.