### PR TITLE
fix(off-platform): always define all provision.env keys so set -u scripts don't abort

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -134,9 +134,32 @@ def provision_params(
     return params
 
 
+# Every provision/*.sh sources provision.env under ``set -u`` and reads these keys
+# directly (no ``${VAR:-}`` default), so the body must DEFINE all of them even when the
+# spec leaves them unset — otherwise the script aborts on an unbound variable. The set and
+# its empty defaults mirror Lima's ``agent.yaml.skel`` ``param:`` block byte-for-byte (the
+# backend-neutral contract): Lima's template substitutes every ``.Param.*`` to empty, so
+# the cloud writer must do the same. ``provision_params`` omits unset keys (correct for
+# Lima's ``--set`` path), so we re-establish the full set here.
+_PROVISION_ENV_DEFAULTS = {
+    "EXTRA_PACKAGES": "",
+    "APT_REPOS": "",
+    "VAGRANT_PLUGINS": "",
+    "SPEC_FINGERPRINT": "",
+    "NESTED_VIRT": "",
+    "PORT_FORWARDS": "",
+}
+
+
 def render_provision_env(params: dict[str, str], *, vergil_user: str, home: str) -> str:
-    """Render the cloud ``provision.env`` body: the shared params plus VERGIL_USER/HOME."""
-    lines = [f"{key}={value}" for key, value in params.items()]
+    """Render the cloud ``provision.env`` body: the full canonical key set plus VERGIL_USER/HOME.
+
+    ``params`` (from ``provision_params``, which omits unset keys) overrides the empty
+    ``_PROVISION_ENV_DEFAULTS`` so every key the provision scripts source is always defined
+    — provisioning runs under ``set -u`` and aborts on any unbound variable.
+    """
+    merged = {**_PROVISION_ENV_DEFAULTS, **params}
+    lines = [f"{key}={value}" for key, value in merged.items()]
     lines.append(f"VERGIL_USER={vergil_user}")
     lines.append(f"HOME={home}")
     return "\n".join(lines)

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -218,6 +218,18 @@ class TestProvisionParams:
 
 
 class TestProvisionEnv:
+    # The keys every provision/*.sh sources under `set -u` — must always be defined.
+    _CANONICAL_KEYS = frozenset(
+        {
+            "EXTRA_PACKAGES",
+            "APT_REPOS",
+            "VAGRANT_PLUGINS",
+            "SPEC_FINGERPRINT",
+            "NESTED_VIRT",
+            "PORT_FORWARDS",
+        }
+    )
+
     def test_renders_key_value_body(self) -> None:
         params = {"EXTRA_PACKAGES": "git vim", "NESTED_VIRT": "true", "SPEC_FINGERPRINT": "abc"}
         body = render_provision_env(params, vergil_user="vergil", home="/home/vergil")
@@ -227,6 +239,24 @@ class TestProvisionEnv:
         assert "SPEC_FINGERPRINT=abc" in lines
         assert "VERGIL_USER=vergil" in lines
         assert "HOME=/home/vergil" in lines
+
+    def test_minimal_params_still_define_every_canonical_key(self) -> None:
+        # Regression (#1768): a minimal spec must NOT leave keys undefined, or each
+        # provision script aborts on `unbound variable` under `set -u`.
+        body = render_provision_env({}, vergil_user="vergil", home="/home/vergil")
+        defined = {line.split("=", 1)[0] for line in body.splitlines()}
+        assert defined >= self._CANONICAL_KEYS
+        # unset keys default to empty, matching Lima's agent.yaml.skel param block
+        assert "NESTED_VIRT=" in body.splitlines()
+        assert "APT_REPOS=" in body.splitlines()
+
+    def test_params_override_empty_defaults(self) -> None:
+        body = render_provision_env(
+            {"NESTED_VIRT": "true"}, vergil_user="vergil", home="/home/vergil"
+        )
+        lines = body.splitlines()
+        assert "NESTED_VIRT=true" in lines
+        assert "NESTED_VIRT=" not in lines  # the default did not leak a duplicate
 
 
 class TestPreflight:


### PR DESCRIPTION
# Pull Request

## Summary

- render_provision_env now emits the full canonical provisioning key set (EXTRA_PACKAGES, APT_REPOS, VAGRANT_PLUGINS, SPEC_FINGERPRINT, NESTED_VIRT, PORT_FORWARDS) with empty defaults overridden by provision_params, so a minimal spec no longer leaves keys undefined and aborts each set -u provision script on 'unbound variable'.

## Issue Linkage

- Ref #1768

## Notes

- Confirmed on the failed off-platform box: provision.env had only SPEC_FINGERPRINT/VERGIL_USER/HOME, and 40/50/60/70/80-*.sh aborted on unbound APT_REPOS/EXTRA_PACKAGES/NESTED_VIRT/PORT_FORWARDS. Defaults mirror Lima's agent.yaml.skel param block byte-for-byte; provision_params is unchanged. Validation green: 3344 tests, lint/typecheck/audit clean. Secondary to the egress blocker vergil-vm#226 (Cloud NAT) — both needed for a clean provision.