### PR TITLE
fix(off-platform): wait for SSH readiness before the cloud-init probe so a boot race is not a hard fail

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -255,6 +255,21 @@ _CLOUD_INIT_LOG = "/var/log/cloud-init-output.log"
 # hammering the IAP tunnel.
 _READINESS_POLL_SECS = 20.0
 
+# `ssh` (and `gcloud compute ssh`'s tunnel) exits 255 when the transport itself
+# fails to connect — on a fresh box that is the IAP "4003: failed to connect to
+# port 22" boot race, where the instance is RUNNING but sshd is not accepting
+# yet. Keying off this code tells a transient connect failure (retry) apart from
+# cloud-init's own error(1)/degraded(2) exits (terminal).
+_CONNECT_FAILURE_RETURNCODE = 255
+
+# The SSH-readiness wait probes a trivial command on this cadence, bounded by an
+# overall timeout. The cadence is brisk because the boot race usually clears in
+# seconds; the timeout is generous because a box not answering SSH after several
+# minutes has genuinely failed to boot — distinct from cloud-init merely taking
+# a long time, which the (unbounded) cloud-init poll handles separately.
+_SSH_PROBE_INTERVAL_SECS = 5.0
+_SSH_READY_TIMEOUT_SECS = 300.0
+
 # cloud-init's terminal states (``cloud-init status`` output). "done" is the
 # only clean success; "error" and "degraded done" mean provisioning finished
 # with faults — both of which the old blocking ``status --wait`` surfaced as a
@@ -281,19 +296,68 @@ def _parse_cloud_init_status(stdout: str) -> tuple[str, str]:
     return status, detail
 
 
+def _is_connection_failure(exc: subprocess.CalledProcessError) -> bool:
+    """True when *exc* is the transport failing to connect (ssh/IAP exit 255).
+
+    Distinguishes "cannot reach the box yet" (transient — retry) from a command
+    that ran and exited nonzero (e.g. cloud-init's error/degraded states), so the
+    readiness gate never mistakes a boot race for a provisioning fault.
+    """
+    return exc.returncode == _CONNECT_FAILURE_RETURNCODE
+
+
+def _wait_for_ssh(
+    transport: Transport,
+    *,
+    timeout_secs: float = _SSH_READY_TIMEOUT_SECS,
+    poll_secs: float = _SSH_PROBE_INTERVAL_SECS,
+) -> None:
+    """Block until the guest accepts a trivial SSH command, or raise on timeout.
+
+    A fresh box's sshd is not listening the instant the instance reports
+    RUNNING, so the first probes race guest boot and the IAP tunnel fails to
+    connect (ssh exit 255 / IAP 4003). Those are "not ready yet", not failures:
+    we retry on a bounded cadence — emitting a heartbeat so the wait is visible —
+    until a trivial command succeeds. The probe runs ``quiet`` so the expected
+    connect errors do not spam the operator with misleading 4003 noise. Only an
+    exhausted timeout is terminal, and its message says the box "never became
+    reachable" (distinct from a cloud-init fault).
+    """
+    started = time.monotonic()
+    deadline = started + timeout_secs
+    while True:
+        try:
+            transport.run("true", quiet=True)
+            return
+        except subprocess.CalledProcessError as exc:
+            now = time.monotonic()
+            if now >= deadline:
+                raise RuntimeError(
+                    f"SSH never became reachable on the cloud box within "
+                    f"{int(timeout_secs)}s (last exit {exc.returncode}) — "
+                    "the box may have failed to boot"
+                ) from exc
+            beat = _readiness_heartbeat(now - started, "", "waiting for SSH (still booting)")
+            progress.emit(beat)
+            time.sleep(poll_secs)
+
+
 def _poll_cloud_init_status(transport: Transport) -> tuple[str, str]:
     """Query cloud-init once and return its ``(status, detail)``.
 
     ``cloud-init status`` exits nonzero for the error(1)/degraded(2) states, but
     the status line still rides on stdout — so we parse the captured output of a
-    failed call too. A genuine connectivity failure (SSH not up yet) produces no
-    status line, which parses to an empty status the poll loop treats as
-    non-terminal. The transport already echoes the child's stderr, so a real
-    failure is never silent.
+    failed call too. A transport-connect failure (ssh exit 255: SSH dropped /
+    not up yet) is told apart from those by its return code and yields an empty
+    status the poll loop treats as non-terminal. The probe runs ``quiet`` so a
+    transient connect drop mid-provision does not spam a raw IAP error; a real
+    cloud-init fault still surfaces via the parsed status the loop raises on.
     """
     try:
-        result = transport.run("cloud-init", "status", "--long")
+        result = transport.run("cloud-init", "status", "--long", quiet=True)
     except subprocess.CalledProcessError as exc:
+        if _is_connection_failure(exc):
+            return "", ""
         return _parse_cloud_init_status(exc.stdout or "")
     return _parse_cloud_init_status(result.stdout)
 
@@ -358,7 +422,12 @@ def _wait_for_cloud_init(
     wait-forever semantics — because the heartbeat itself is the signal the
     operator uses to decide a box is wedged and abort by hand. Raises
     ``RuntimeError`` on any cloud-init failure state so the gate still hard-fails.
+
+    First waits for SSH reachability, so the cloud-init probe (and the verbose
+    log tail, which also tunnels in) never races sshd startup and mistakes the
+    boot-time IAP 4003 connect error for a provisioning failure.
     """
+    _wait_for_ssh(transport)
     tail = _CloudInitTail(transport) if verbose else None
     if tail is not None:
         tail.start()

--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -24,8 +24,16 @@ class Transport(Protocol):
     """Execute commands inside a guest, regardless of how we reach it."""
 
     def run(
-        self, *args: str, workdir: str = _DEFAULT_WORKDIR
-    ) -> subprocess.CompletedProcess[str]: ...  # pragma: no cover
+        self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a command in the guest, raising on a nonzero exit.
+
+        ``quiet`` suppresses echoing the child's stderr on failure — for probe
+        callers (readiness polling) where a connect failure is expected and the
+        raw transport error would be misleading noise. The exception still
+        carries ``returncode``/``stderr`` for the caller to inspect.
+        """
+        ...  # pragma: no cover
 
     def pipe(
         self, cmd: str, input_data: str, *, workdir: str = _DEFAULT_WORKDIR
@@ -44,7 +52,9 @@ class LimaTransport:
     def __init__(self, instance: str) -> None:
         self.instance = instance
 
-    def run(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.CompletedProcess[str]:
+    def run(
+        self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
+    ) -> subprocess.CompletedProcess[str]:
         try:
             return subprocess.run(  # noqa: S603
                 ["limactl", "shell", "--workdir", workdir, self.instance, "--", *args],  # noqa: S607
@@ -53,7 +63,7 @@ class LimaTransport:
                 text=True,
             )
         except subprocess.CalledProcessError as exc:
-            if exc.stderr:
+            if exc.stderr and not quiet:
                 print(exc.stderr, end="", file=sys.stderr)
             raise
 
@@ -131,7 +141,9 @@ class IapTransport:
             f"--project={self.project}",
         ]
 
-    def run(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.CompletedProcess[str]:
+    def run(
+        self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
+    ) -> subprocess.CompletedProcess[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
         try:
             return subprocess.run(  # noqa: S603
@@ -141,7 +153,7 @@ class IapTransport:
                 text=True,
             )
         except subprocess.CalledProcessError as exc:
-            if exc.stderr:
+            if exc.stderr and not quiet:
                 print(exc.stderr, end="", file=sys.stderr)
             raise
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -406,6 +406,58 @@ class TestParseCloudInitStatus:
         assert vm_cloud._parse_cloud_init_status("ssh: connect: connection refused\n") == ("", "")
 
 
+class TestIsConnectionFailure:
+    def test_ssh_exit_255_is_a_connection_failure(self) -> None:
+        exc = subprocess.CalledProcessError(255, "ssh")
+        assert vm_cloud._is_connection_failure(exc) is True
+
+    def test_cloud_init_error_exit_is_not_a_connection_failure(self) -> None:
+        # cloud-init's own error(1)/degraded(2) exits are terminal faults, not
+        # transport-connect failures.
+        assert vm_cloud._is_connection_failure(subprocess.CalledProcessError(1, "x")) is False
+        assert vm_cloud._is_connection_failure(subprocess.CalledProcessError(2, "x")) is False
+
+
+class TestWaitForSsh:
+    def test_returns_once_a_trivial_command_succeeds(self) -> None:
+        transport = MagicMock()
+        transport.run.return_value = _done("")
+        vm_cloud._wait_for_ssh(transport)  # no raise
+        # The probe is a quiet trivial command, so a connect-race error is not
+        # echoed as misleading noise.
+        assert transport.run.call_args.kwargs.get("quiet") is True
+
+    def test_retries_through_connect_failures_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The box's sshd is not up at the first probe (IAP 4003 / ssh 255); the
+        # wait must retry rather than fail, then return once it answers.
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
+        emitted: list[str] = []
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", emitted.append)
+        transport = MagicMock()
+        transport.run.side_effect = [
+            subprocess.CalledProcessError(255, "ssh"),
+            subprocess.CalledProcessError(255, "ssh"),
+            _done(""),
+        ]
+        vm_cloud._wait_for_ssh(transport)  # no raise
+        assert transport.run.call_count == 3
+        assert any("waiting for SSH" in line for line in emitted)
+
+    def test_raises_after_bounded_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # sshd never comes up: bounded by the timeout, the wait raises a message
+        # distinct from a cloud-init fault ("never became reachable").
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", lambda _line: None)
+        clock = iter([0.0, 100.0, 250.0])
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.monotonic", lambda: next(clock))
+        transport = MagicMock()
+        transport.run.side_effect = subprocess.CalledProcessError(255, "ssh")
+        with pytest.raises(RuntimeError, match="never became reachable"):
+            vm_cloud._wait_for_ssh(transport, timeout_secs=200.0)
+
+
 class TestPollCloudInitStatus:
     def test_parses_successful_call(self) -> None:
         transport = MagicMock()
@@ -421,12 +473,50 @@ class TestPollCloudInitStatus:
         assert vm_cloud._poll_cloud_init_status(transport) == ("error", "boom")
 
     def test_connection_failure_yields_empty_status(self) -> None:
+        # ssh exit 255 (IAP connect failure) is distinguished from a cloud-init
+        # fault by its return code, not by parsing stdout: it yields no status so
+        # the poll loop keeps waiting.
         transport = MagicMock()
         transport.run.side_effect = subprocess.CalledProcessError(255, "ssh")
         assert vm_cloud._poll_cloud_init_status(transport) == ("", "")
 
+    def test_polls_quietly(self) -> None:
+        # The poll runs quietly so a transient connect drop mid-provision does
+        # not spam the operator with a raw IAP error.
+        transport = MagicMock()
+        transport.run.return_value = _done("status: done\n")
+        vm_cloud._poll_cloud_init_status(transport)
+        assert transport.run.call_args.kwargs.get("quiet") is True
+
 
 class TestAwaitReadiness:
+    @pytest.fixture(autouse=True)
+    def _skip_ssh_wait(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # _wait_for_ssh is exercised directly in TestWaitForSsh; stub it here so
+        # these cloud-init/marker tests need not thread an SSH probe through the
+        # transport.run side-effect lists.
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud._wait_for_ssh", lambda *a, **k: None)
+
+    def test_waits_for_ssh_before_polling_cloud_init(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The readiness gate must confirm SSH reachability before it probes
+        # cloud-init, so it never conflates a boot race with a provisioning fault.
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud._wait_for_ssh",
+            lambda *a, **k: calls.append("ssh"),
+        )
+        transport = MagicMock()
+
+        def _record_run(*args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(f"run:{args[0]}")
+            return _done("status: done\n") if args[0] == "cloud-init" else _done("fp123\n")
+
+        transport.run.side_effect = _record_run
+        await_readiness(transport, "fp123")
+        assert calls[0] == "ssh"
+        assert "run:cloud-init" in calls
+        assert calls.index("ssh") < calls.index("run:cloud-init")
+
     def test_passes_when_cloud_init_done_and_marker_matches(self) -> None:
         transport = MagicMock()
         transport.run.side_effect = [

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -1,6 +1,8 @@
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from vergil_tooling.lib.vm_transport import IapTransport, LimaTransport
 
 
@@ -192,6 +194,23 @@ class TestIapTransport:
             pass
         else:  # pragma: no cover
             raise AssertionError("expected CalledProcessError")
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_quiet_suppresses_stderr_on_error(
+        self, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # quiet=True is for probe callers where a connect failure is expected
+        # and the raw error (e.g. IAP 4003) would be misleading noise.
+        err = subprocess.CalledProcessError(255, "gcloud")
+        err.stderr = "ERROR: 4003: failed to connect to port 22"
+        mock_run.side_effect = err
+        try:
+            IapTransport("inst", "z", "p", "vergil").run("true", quiet=True)
+        except subprocess.CalledProcessError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("expected CalledProcessError")
+        assert capsys.readouterr().err == ""
 
     @patch("vergil_tooling.lib.vm_transport.os.execvp")
     def test_exec_session_tunnels_interactively(self, mock_execvp: MagicMock) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- await_readiness now waits for SSH reachability (bounded poll of a quiet trivial command) before probing cloud-init, so the IAP boot-time 4003 connect race is treated as 'still booting, retry' instead of being conflated with a cloud-init fault and hard-failing create.

## Issue Linkage

- Ref #1775

## Notes

- Three coordinated changes: (1) a new `quiet` flag on Transport.run suppresses stderr echo for expected connect failures; (2) `_wait_for_ssh` polls `true` on a brisk cadence bounded by a 300s timeout, distinguishing ssh exit 255 (connect/IAP 4003 -> retry) from terminal failures, raising 'never became reachable' only on timeout; (3) `_poll_cloud_init_status` keys off return code 255 to tell a transport-connect drop apart from cloud-init's own error/degraded exits, and runs quietly. The original hard-fail was already softened by the #1770 poll-loop refactor, but the misleading 4003 noise and the implicit (stdout-inferred) connect distinction remained; this makes the SSH-wait explicit per the issue. Ref #1775.