### PR TITLE
fix(off-platform): allow 'git clone' in vrg-git for off-platform volume bootstrap

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -55,6 +55,10 @@ _ALLOWED_SIMPLE: set[str] = {
     "push",
     "fetch",
     "pull",
+    # A network "create": the off-platform volume bootstrap runs `vrg-git clone
+    # <url> <dest>` on the cloud box (vm_cloud.bootstrap_volume). Gated like the other
+    # remote ops — identity-token injection via _REMOTE_SUBCOMMANDS. (#1780)
+    "clone",
     "checkout",
     "switch",
     "stash",
@@ -98,7 +102,7 @@ _FLAG_DENY: dict[str, set[str]] = {
 }
 
 
-_REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote"}
+_REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote", "clone"}
 
 _PROTECTED_BRANCHES: set[str] = {"develop", "main"}
 _PROTECTED_PREFIXES: tuple[str, ...] = ("release/",)

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -71,6 +71,7 @@ _ALLOWED_SIMPLE = [
     "push",
     "fetch",
     "pull",
+    "clone",
     "checkout",
     "switch",
     "stash",
@@ -605,7 +606,7 @@ def test_returns_subprocess_exit_code() -> None:
 
 
 class TestRemoteTokenInjection:
-    @pytest.mark.parametrize("subcmd", ["push", "pull", "fetch", "ls-remote"])
+    @pytest.mark.parametrize("subcmd", ["push", "pull", "fetch", "ls-remote", "clone"])
     def test_injects_token_for_remote_commands(self, subcmd: str) -> None:
         with (
             patch(


### PR DESCRIPTION
# Pull Request

## Summary

- Add 'clone' to vrg-git's _ALLOWED_SIMPLE and _REMOTE_SUBCOMMANDS so the off-platform bootstrap_volume's 'vrg-git clone <url> <dest>' is permitted and receives the identity's installation token. The other gates are already clone-safe (not in _FLAG_DENY; worktree check returns early outside checkout/switch); host-level identity-based auth works for a clone run outside any repo.

## Issue Linkage

- Ref #1780

## Notes

- Fifth and (hopefully) final layer of the first real off-platform create: provisioning, credentials, and tooling all succeeded; bootstrap-volume failed only because vrg-git's allowlist forbade the very subcommand the dispatch calls. No new exposure. Validation green: 3386 tests (clone added to both the allowed-subcommand and token-injection parametrizations), lint/typecheck/audit clean.