### PR TITLE
fix(off-platform): derive org from clone URL so vrg-git clone mints an installation token

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -104,6 +104,20 @@ _FLAG_DENY: dict[str, set[str]] = {
 
 _REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote", "clone"}
 
+# Owner/org of a GitHub clone URL — used to mint the installation token for
+# `clone`, which runs outside any repo (so the org can't come from a remote).
+_GITHUB_CLONE_URL_RE = re.compile(r"(?:https://github\.com/|git@github\.com:)([^/]+)/")
+
+
+def _org_from_clone_url(args: list[str]) -> str | None:
+    """Return the GitHub org/owner from the first github.com URL among clone args."""
+    for arg in args:
+        match = _GITHUB_CLONE_URL_RE.match(arg)
+        if match:
+            return match.group(1)
+    return None
+
+
 _PROTECTED_BRANCHES: set[str] = {"develop", "main"}
 _PROTECTED_PREFIXES: tuple[str, ...] = ("release/",)
 
@@ -368,7 +382,11 @@ def main(argv: list[str] | None = None) -> int:
 
     env = None
     if subcmd in _REMOTE_SUBCOMMANDS:
-        token = github.get_installation_token()
+        # clone runs outside any repo, so get_installation_token's default
+        # org-from-remote detection finds nothing — derive the org from the
+        # clone URL argument instead. (#1785)
+        org = _org_from_clone_url(argv[1:]) if subcmd == "clone" else None
+        token = github.get_installation_token(org)
         if token is not None:
             env = _git_auth_env(token)
 

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -10,6 +10,7 @@ import pytest
 
 from vergil_tooling.bin.vrg_git import (
     _noninteractive_rebase_env,
+    _org_from_clone_url,
     _parse_branch_target,
     _worktree_convention_active,
     main,
@@ -605,6 +606,21 @@ def test_returns_subprocess_exit_code() -> None:
 # -- remote token injection ---------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["https://github.com/myorg/myrepo.git", "/dest"], "myorg"),
+        (["https://github.com/myorg/myrepo"], "myorg"),
+        (["git@github.com:myorg/myrepo.git"], "myorg"),
+        (["--depth", "1", "https://github.com/myorg/myrepo.git"], "myorg"),
+        (["/local/path", "/dest"], None),
+        (["https://gitlab.com/myorg/myrepo.git"], None),
+    ],
+)
+def test_org_from_clone_url(args: list[str], expected: str | None) -> None:
+    assert _org_from_clone_url(args) == expected
+
+
 class TestRemoteTokenInjection:
     @pytest.mark.parametrize("subcmd", ["push", "pull", "fetch", "ls-remote", "clone"])
     def test_injects_token_for_remote_commands(self, subcmd: str) -> None:
@@ -625,6 +641,21 @@ class TestRemoteTokenInjection:
         assert env["GIT_CONFIG_COUNT"] == "1"
         assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
         assert "Authorization: Basic" in env["GIT_CONFIG_VALUE_0"]
+
+    def test_clone_derives_org_from_url_for_token(self) -> None:
+        # clone runs outside any repo, so the org must come from the URL, not a remote.
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_git.github.get_installation_token",
+                return_value="ghs_token_123",
+            ) as mock_token,
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "clone"], returncode=0, stdout="", stderr=""
+            )
+            main(["clone", "https://github.com/myorg/myrepo.git", "/dest"])
+        mock_token.assert_called_once_with("myorg")
 
     @pytest.mark.parametrize("subcmd", ["status", "log", "diff", "add", "branch"])
     def test_no_injection_for_local_commands(self, subcmd: str) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-git clone reached GitHub but got no auth token ('could not read Username'): get_installation_token() with no org falls back to _detect_org(), which reads the current repo's remote — but clone runs outside any repo, so the org was None and no token was minted. Derive the org from the clone URL argument and pass it explicitly; push/pull/fetch unchanged.

## Issue Linkage

- Ref #1785

## Notes

- Completes #1780 (which allowed clone + wired token injection but couldn't resolve the org outside a repo). Seventh layer of the first real off-platform create; the clone now authenticates with the vergil-audit installation token. App config still must be present on the box (~/.config/vergil/app.{env,pem}, injected by the credentials step) — flagged for verification. Validation green: 3393 tests, 100% coverage.