### PR TITLE
fix(off-platform): reattach via vrg-git fetch (token-injected) instead of raw git

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -243,7 +243,9 @@ def bootstrap_volume(transport: Transport, identity: Identity, org: str, repo: s
         transport.run("mkdir", "-p", "/vergil/claude")
     else:
         print(f"  Reattaching existing checkout for {org}/{repo}...")
-        transport.run("git", "-C", path, "fetch", "--all")
+        # vrg-git (not raw git) so the installation token is injected, run inside the
+        # repo so `fetch` resolves the org from its own remote (#1790).
+        transport.run("vrg-git", "fetch", "--all", workdir=path)
 
 
 _FINGERPRINT_PATH = "/etc/vergil/vm-spec.fingerprint"

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -385,8 +385,11 @@ class TestBootstrap:
         identity = MagicMock()
         identity.auth_type = "app"
         bootstrap_volume(transport, identity, "org", "repo")
-        cmds = [list(call.args) for call in transport.run.call_args_list]
-        assert ["git", "-C", "/vergil/projects/org/repo", "fetch", "--all"] in cmds
+        # reattach fetches via vrg-git (token injection), run inside the repo so the
+        # org resolves from its own remote.
+        fetch_call = transport.run.call_args_list[-1]
+        assert list(fetch_call.args) == ["vrg-git", "fetch", "--all"]
+        assert fetch_call.kwargs["workdir"] == "/vergil/projects/org/repo"
 
 
 def _done(stdout: str = "status: done\n") -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
# Pull Request

## Summary

- bootstrap_volume's reattach branch ran raw 'git -C <path> fetch --all', bypassing the vrg-git wrapper so no installation token was injected — a destroy + re-create (preserved volume) failed at bootstrap-volume with 'could not read Username'. Switch to 'vrg-git fetch --all' run inside the repo (workdir=path) so the token is injected and the org resolves from the repo's own remote.

## Issue Linkage

- Ref #1790

## Notes

- Reattach-path sibling of #1785, surfaced validating the destroy/recreate lifecycle right after the first successful end-to-end create. Same symptom, different command (git fetch vs vrg-git clone) and different code path. Only raw-git network call in vm_cloud (grep-confirmed); fresh-clone path unaffected. Validation green: 100% coverage.