### PR TITLE
feat(off-platform): add 'vrg-vm volumes' to surface persistent volumes from local tofu state

### DIFF
--- a/docs/site/docs/reference/vm-spec.md
+++ b/docs/site/docs/reference/vm-spec.md
@@ -186,6 +186,14 @@ The same `vrg-vm` verbs work, dispatched on the resolved `backend`:
   provider for cloud rows). Without cloud credentials a cloud row's
   status degrades to `unknown (no <provider> creds)` rather than
   erroring or hiding the row.
+- `volumes` — enumerates the persistent volumes (the long-lived,
+  billable, quota-consuming disks that outlive each ephemeral VM) from
+  local tofu state: `IDENTITY`, `ORG/REPO`, `DISK NAME`, `SIZE`, `ZONE`,
+  `REGION`, all read from each disk's stamped labels/attributes with no
+  network call. `--live` adds a `LIVE` column that cross-checks each disk
+  against the provider — a disk deleted out of band shows `MISSING`; an
+  unauthed/unreachable provider degrades to `unknown`. This is how you
+  identify which volume to `destroy-volume` and track SSD quota usage.
 
 Access is via the provider's identity-aware tunnel (GCP IAP) — there is
 **no public IP** and no operator-IP allow-list; authentication is the

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1488,6 +1488,132 @@ def _cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def _volume_rows() -> list[dict[str, object]]:
+    """Enumerate off-platform persistent volumes from local tofu state.
+
+    Globs ``~/.config/vergil/tofu/<state_key>/<provider>/volume.tfstate`` and
+    parses each into a display row: identity, org/repo, disk name, size, zone,
+    and region. Every field is sourced from the disk's stamped attributes and
+    ``vergil-*`` labels — no network, no gcloud — so the listing reflects exactly
+    what vrg-vm manages. A state that parses to no disk (a never-applied
+    placeholder) degrades to a row keyed by its state dir rather than dropping
+    out, so an operator still sees that the state exists.
+    """
+    rows: list[dict[str, object]] = []
+    tofu_root = Path.home() / ".config" / "vergil" / "tofu"
+    if not tofu_root.is_dir():
+        return rows
+    for volume_state in sorted(tofu_root.glob("*/*/volume.tfstate")):
+        provider_dir = volume_state.parent
+        provider = provider_dir.name
+        state_key = provider_dir.parent.name
+        parsed = vm_cloud.parse_volume_state(volume_state)
+        if parsed is None:
+            rows.append(
+                {
+                    "identity": "—",
+                    "scope": state_key,
+                    "name": "—",
+                    "size": "—",
+                    "zone": "—",
+                    "region": "—",
+                    "provider": provider,
+                }
+            )
+            continue
+        org = parsed.labels.get("vergil-org")
+        repo = parsed.labels.get("vergil-repo")
+        scope = f"{org}/{repo}" if org and repo else state_key
+        region = vm_cloud.zone_to_region(parsed.zone)
+        rows.append(
+            {
+                "identity": parsed.labels.get("vergil-identity") or "—",
+                "scope": scope,
+                "name": parsed.name or "—",
+                "size": f"{parsed.size_gib}GiB" if parsed.size_gib is not None else "—",
+                "zone": parsed.zone or "—",
+                "region": region or "—",
+                "provider": provider,
+            }
+        )
+    return rows
+
+
+def _volume_live_status(name: str, zone: str, provider: str) -> str:
+    """Best-effort live check of one volume against the cloud, never raising.
+
+    Returns the disk's live status (``READY``/``CREATING``/…) when it exists,
+    ``MISSING`` when the provider reports it absent (drift — deleted out of
+    band), or a degraded ``unknown (…)`` placeholder when the provider cannot be
+    queried (no gcloud, no creds, unknown provider). Only GCP is wired today; any
+    other provider yields the degraded placeholder rather than a false reading.
+    """
+    if provider != "gcp" or name in {"", "—"} or zone in {"", "—"}:
+        return f"unknown (no {provider} live check)"
+    try:
+        result = subprocess.run(  # noqa: S603
+            [  # noqa: S607
+                "gcloud",
+                "compute",
+                "disks",
+                "describe",
+                name,
+                f"--zone={zone}",
+                "--format=value(status)",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        return "unknown (no gcloud)"
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").lower()
+        if "not found" in stderr or "was not found" in stderr:
+            return "MISSING"
+        return f"unknown (no {provider} creds)"
+    return result.stdout.strip() or "MISSING"
+
+
+def _cmd_volumes(args: argparse.Namespace) -> int:
+    """List off-platform persistent volumes from local tofu state.
+
+    The persistent volume is the long-lived, billable, quota-consuming object
+    that outlives every ephemeral cloud VM, so it is the one off-platform object
+    an operator most needs to enumerate and identify — for cleanup (which volume
+    to ``destroy-volume``) and for cost/quota management. ``--live`` adds a column
+    that cross-checks each disk against the provider to spot drift (a disk
+    deleted out of band, or one stuck mid-create).
+    """
+    rows = _volume_rows()
+    live = getattr(args, "live", False)
+    if live:
+        for r in rows:
+            r["live"] = _volume_live_status(str(r["name"]), str(r["zone"]), str(r["provider"]))
+
+    scope_w = max([24, *(len(str(r["scope"])) for r in rows)])
+    name_w = max([20, *(len(str(r["name"])) for r in rows)])
+    header = (
+        f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'DISK NAME':<{name_w}} "
+        f"{'SIZE':<8} {'ZONE':<16} {'REGION':<14}"
+    )
+    if live:
+        header += f" {'LIVE':<22}"
+    print(header)
+    print("─" * len(header))
+    for r in rows:
+        line = (
+            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} {r['name']!s:<{name_w}} "
+            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14}"
+        )
+        if live:
+            line += f" {r['live']!s:<22}"
+        print(line)
+    if not rows:
+        print("(no off-platform volumes found)")
+    return 0
+
+
 def _vm_active_sessions(instance: str) -> dict[str, dict[str, object]]:
     """Map active session id -> its row from a running VM's resolver.
 
@@ -1906,6 +2032,25 @@ def main(argv: list[str] | None = None) -> int:
     p_list.add_argument("--archived", action="store_true", help="With --sessions: only archived")
     p_list.add_argument("--all", action="store_true", help="With --sessions: include archived too")
 
+    p_volumes = sub.add_parser(
+        "volumes",
+        help="List off-platform persistent volumes",
+        description=(
+            "List every off-platform persistent volume from local tofu state — the "
+            "long-lived, billable, quota-consuming disks that outlive each ephemeral "
+            "cloud VM. Columns: IDENTITY, ORG/REPO, DISK NAME, SIZE, ZONE, REGION, all "
+            "read from the disk's stamped labels/attributes with no network call, so the "
+            "listing reflects exactly what vrg-vm manages. --live cross-checks each disk "
+            "against the provider (a LIVE column) to spot drift: a disk deleted out of "
+            "band shows MISSING; an unauthed/unreachable provider degrades to 'unknown'."
+        ),
+    )
+    p_volumes.add_argument(
+        "--live",
+        action="store_true",
+        help="Cross-check each volume against the cloud provider (adds a LIVE column)",
+    )
+
     p_session = sub.add_parser("session", help="Launch a Claude session in a VM")
     _add_identity_args(p_session)
     p_session.add_argument(
@@ -1961,6 +2106,7 @@ def main(argv: list[str] | None = None) -> int:
         "destroy-volume": _cmd_destroy_volume,
         "rebuild": _cmd_rebuild,
         "list": _cmd_list,
+        "volumes": _cmd_volumes,
         "session": _cmd_session,
     }
     try:

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -16,6 +16,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -675,6 +676,92 @@ def read_zone(state_dir: Path) -> str:
         msg = f"no persisted zone at {zone_file} — apply the volume first"
         raise RuntimeError(msg)
     return zone_file.read_text(encoding="utf-8").strip()
+
+
+# --- Volume state parsing ----------------------------------------------------
+#
+# Each off-platform volume's tofu state carries the one resource that matters
+# for an inventory: ``google_compute_disk.data``, stamped at apply time with the
+# disk's name, size, zone, and the vergil-{identity,org,repo} labels. Parsing it
+# lets ``vrg-vm volumes`` build a full listing from purely local state — no
+# gcloud, no network — reflecting exactly what vrg-vm manages.
+
+
+@dataclass(frozen=True)
+class VolumeState:
+    """The ``google_compute_disk.data`` attributes parsed from a volume.tfstate."""
+
+    name: str
+    size_gib: int | None
+    zone: str
+    labels: dict[str, str]
+
+
+def _coerce_int(value: object) -> int | None:
+    """Best-effort int from a tofu attribute, ``None`` when it is absent/non-numeric."""
+    if isinstance(value, bool):  # bool is an int subclass; a label-like bool is not a size
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _zone_name(zone: str) -> str:
+    """Normalize a zone that may be a full selfLink URL down to its bare name."""
+    return zone.rsplit("/", 1)[-1] if zone else ""
+
+
+def zone_to_region(zone: str) -> str:
+    """Derive a GCP region from a zone name (``us-central1-a`` -> ``us-central1``).
+
+    Returns the empty string for a zone with no trailing ``-<suffix>`` (or none at
+    all), so the caller can show a placeholder rather than a malformed region.
+    """
+    if not zone or "-" not in zone:
+        return ""
+    return zone.rsplit("-", 1)[0]
+
+
+def parse_volume_state(state_file: Path) -> VolumeState | None:
+    """Parse a ``volume.tfstate``, returning the persistent disk's attributes.
+
+    Returns ``None`` when the file is absent, unreadable, malformed, or carries
+    no applied ``google_compute_disk`` resource (e.g. the ``{}`` placeholder of a
+    never-applied state). A bad state degrades to a placeholder volume row in the
+    caller rather than erroring the whole listing — there is no network call and
+    no gcloud here, only the local state file.
+    """
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    for resource in data.get("resources", []):
+        if not isinstance(resource, dict) or resource.get("type") != "google_compute_disk":
+            continue
+        instances = resource.get("instances") or []
+        if not instances or not isinstance(instances[0], dict):
+            continue
+        attrs = instances[0].get("attributes")
+        if not isinstance(attrs, dict):
+            continue
+        raw_labels = attrs.get("labels") or {}
+        labels = (
+            {str(k): str(v) for k, v in raw_labels.items()} if isinstance(raw_labels, dict) else {}
+        )
+        return VolumeState(
+            name=str(attrs.get("name", "")),
+            size_gib=_coerce_int(attrs.get("size")),
+            zone=_zone_name(str(attrs.get("zone", ""))),
+            labels=labels,
+        )
+    return None
 
 
 # --- Off-platform backend ----------------------------------------------------

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -22,11 +22,13 @@ from vergil_tooling.lib.vm_cloud import (
     destroy_volume,
     fetch_modules,
     link_cloud_claude_dirs,
+    parse_volume_state,
     preflight,
     provision_params,
     read_zone,
     render_provision_env,
     tofu_state_dir,
+    zone_to_region,
 )
 from vergil_tooling.lib.vm_spec import ComposedSpec
 from vergil_tooling.lib.vm_transport import IapTransport
@@ -987,3 +989,176 @@ class TestOffPlatformBackend:
         from vergil_tooling.lib.vm_spec import spec_fingerprint
 
         assert f"SPEC_FINGERPRINT={spec_fingerprint(_off_spec(nested=True))}" in env
+
+
+def _volume_tfstate(
+    *,
+    name: str = "vergil-lmf-cloud-data",
+    size: object = 300,
+    zone: str = "us-central1-a",
+    labels: dict[str, str] | None = None,
+) -> str:
+    """A minimal but realistic volume.tfstate carrying one google_compute_disk."""
+    if labels is None:
+        labels = {"vergil-identity": "vergil", "vergil-org": "lmf", "vergil-repo": "cloud"}
+    return json.dumps(
+        {
+            "version": 4,
+            "terraform_version": "1.8.0",
+            "resources": [
+                {
+                    "mode": "managed",
+                    "type": "google_compute_disk",
+                    "name": "data",
+                    "instances": [
+                        {
+                            "attributes": {
+                                "name": name,
+                                "size": size,
+                                "zone": zone,
+                                "labels": labels,
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+class TestZoneToRegion:
+    def test_strips_trailing_zone_suffix(self) -> None:
+        assert zone_to_region("us-central1-a") == "us-central1"
+
+    def test_multi_token_region_preserved(self) -> None:
+        assert zone_to_region("europe-west4-b") == "europe-west4"
+
+    def test_empty_zone_is_empty(self) -> None:
+        assert zone_to_region("") == ""
+
+    def test_zone_without_suffix_is_empty(self) -> None:
+        assert zone_to_region("noregion") == ""
+
+
+class TestParseVolumeState:
+    def test_parses_disk_attributes_and_labels(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(_volume_tfstate())
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.name == "vergil-lmf-cloud-data"
+        assert parsed.size_gib == 300
+        assert parsed.zone == "us-central1-a"
+        assert parsed.labels == {
+            "vergil-identity": "vergil",
+            "vergil-org": "lmf",
+            "vergil-repo": "cloud",
+        }
+
+    def test_normalizes_zone_selflink_url(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        url = "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-c"
+        state.write_text(_volume_tfstate(zone=url))
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.zone == "us-central1-c"
+
+    def test_string_size_coerced_to_int(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(_volume_tfstate(size="500"))
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.size_gib == 500
+
+    def test_non_numeric_size_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(_volume_tfstate(size="big"))
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.size_gib is None
+
+    def test_empty_placeholder_state_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text("{}")
+        assert parse_volume_state(state) is None
+
+    def test_malformed_json_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text("not json {")
+        assert parse_volume_state(state) is None
+
+    def test_missing_file_is_none(self, tmp_path: Path) -> None:
+        assert parse_volume_state(tmp_path / "absent.tfstate") is None
+
+    def test_no_applied_disk_resource_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "resources": [
+                        {"type": "google_compute_disk", "instances": []},
+                        {"type": "random_id", "instances": [{"attributes": {"hex": "abc"}}]},
+                    ],
+                }
+            )
+        )
+        assert parse_volume_state(state) is None
+
+    def test_absent_labels_yield_empty_dict(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "resources": [
+                        {
+                            "type": "google_compute_disk",
+                            "instances": [
+                                {"attributes": {"name": "d", "size": 100, "zone": "us-central1-a"}}
+                            ],
+                        }
+                    ],
+                }
+            )
+        )
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.labels == {}
+
+    def test_bool_size_is_none(self, tmp_path: Path) -> None:
+        # JSON ``true`` round-trips to a Python bool; a bool is not a disk size.
+        state = tmp_path / "volume.tfstate"
+        state.write_text(_volume_tfstate(size=True))
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.size_gib is None
+
+    def test_non_scalar_size_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(_volume_tfstate(size=[1, 2]))
+        parsed = parse_volume_state(state)
+        assert parsed is not None
+        assert parsed.size_gib is None
+
+    def test_top_level_non_object_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text("[]")
+        assert parse_volume_state(state) is None
+
+    def test_non_object_attributes_is_none(self, tmp_path: Path) -> None:
+        state = tmp_path / "volume.tfstate"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 4,
+                    "resources": [
+                        {
+                            "type": "google_compute_disk",
+                            "instances": [{"attributes": "not-an-object"}],
+                        }
+                    ],
+                }
+            )
+        )
+        assert parse_volume_state(state) is None

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3468,3 +3468,188 @@ class TestResolveVmVerbose:
         # The flag is missing entirely on non-cloud-aware parsers (getattr default).
         monkeypatch.delenv("VERGIL_VM_VERBOSE", raising=False)
         assert _resolve_vm_verbose(self._ns()) is False
+
+
+def _write_volume_state(
+    home: Path,
+    state_key: str,
+    *,
+    provider: str = "gcp",
+    name: str = "vergil-lmf-cloud-data",
+    size: object = 300,
+    zone: str = "us-central1-a",
+    labels: dict[str, str] | None = None,
+    raw: str | None = None,
+) -> Path:
+    """Plant a volume.tfstate under a fake ~/.config/vergil/tofu tree."""
+    if labels is None:
+        labels = {"vergil-identity": "vergil", "vergil-org": "lmf", "vergil-repo": "cloud"}
+    tofu = home / ".config" / "vergil" / "tofu" / state_key / provider
+    tofu.mkdir(parents=True)
+    state = tofu / "volume.tfstate"
+    if raw is not None:
+        state.write_text(raw)
+        return state
+    state.write_text(
+        json.dumps(
+            {
+                "version": 4,
+                "resources": [
+                    {
+                        "type": "google_compute_disk",
+                        "instances": [
+                            {
+                                "attributes": {
+                                    "name": name,
+                                    "size": size,
+                                    "zone": zone,
+                                    "labels": labels,
+                                }
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+    return state
+
+
+class TestVolumeRows:
+    def test_empty_when_no_tofu_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_rows
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path / "empty"))
+        assert _volume_rows() == []
+
+    def test_builds_row_from_labels_and_attributes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_rows
+
+        home = tmp_path / "home"
+        _write_volume_state(home, "vergil-lmf-cloud")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        (row,) = _volume_rows()
+        assert row["identity"] == "vergil"
+        assert row["scope"] == "lmf/cloud"
+        assert row["name"] == "vergil-lmf-cloud-data"
+        assert row["size"] == "300GiB"
+        assert row["zone"] == "us-central1-a"
+        assert row["region"] == "us-central1"
+        assert row["provider"] == "gcp"
+
+    def test_placeholder_row_for_never_applied_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_rows
+
+        home = tmp_path / "home"
+        _write_volume_state(home, "vergil-lmf-cloud", raw="{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        (row,) = _volume_rows()
+        assert row["scope"] == "vergil-lmf-cloud"  # falls back to state-dir name
+        assert row["identity"] == "—"
+        assert row["name"] == "—"
+        assert row["size"] == "—"
+
+    def test_falls_back_to_state_key_when_labels_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_rows
+
+        home = tmp_path / "home"
+        _write_volume_state(home, "vergil-x-y", labels={})
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        (row,) = _volume_rows()
+        assert row["scope"] == "vergil-x-y"
+        assert row["identity"] == "—"
+        assert row["name"] == "vergil-lmf-cloud-data"  # attributes still parse
+
+
+class TestVolumeLiveStatus:
+    def test_returns_live_status_when_present(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_live_status
+
+        completed = MagicMock(stdout="READY\n")
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run", return_value=completed):
+            assert _volume_live_status("d", "us-central1-a", "gcp") == "READY"
+
+    def test_missing_when_provider_reports_not_found(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_live_status
+
+        err = subprocess.CalledProcessError(1, "gcloud")
+        err.stderr = "ERROR: The resource 'd' was not found"
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run", side_effect=err):
+            assert _volume_live_status("d", "us-central1-a", "gcp") == "MISSING"
+
+    def test_unknown_when_no_creds(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_live_status
+
+        err = subprocess.CalledProcessError(1, "gcloud")
+        err.stderr = "ERROR: (gcloud) credentials problem"
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run", side_effect=err):
+            assert _volume_live_status("d", "us-central1-a", "gcp") == "unknown (no gcp creds)"
+
+    def test_unknown_when_gcloud_absent(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_live_status
+
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run", side_effect=FileNotFoundError):
+            assert _volume_live_status("d", "us-central1-a", "gcp") == "unknown (no gcloud)"
+
+    def test_non_gcp_provider_skips_query(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_live_status
+
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run") as run:
+            assert _volume_live_status("d", "z", "aws") == "unknown (no aws live check)"
+            run.assert_not_called()
+
+    def test_placeholder_volume_skips_query(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_live_status
+
+        with patch("vergil_tooling.bin.vrg_vm.subprocess.run") as run:
+            assert _volume_live_status("—", "—", "gcp") == "unknown (no gcp live check)"
+            run.assert_not_called()
+
+
+class TestVolumesCommand:
+    def test_lists_volumes_with_columns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        home = tmp_path / "home"
+        _write_volume_state(home, "vergil-lmf-cloud")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        assert main(["volumes"]) == 0
+        out = capsys.readouterr().out
+        assert "IDENTITY" in out
+        assert "ORG/REPO" in out
+        assert "DISK NAME" in out
+        assert "REGION" in out
+        assert "lmf/cloud" in out
+        assert "vergil-lmf-cloud-data" in out
+        assert "300GiB" in out
+        assert "us-central1-a" in out
+        assert "us-central1" in out
+        assert "LIVE" not in out  # no --live
+
+    def test_empty_listing_prints_notice(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path / "empty"))
+        assert main(["volumes"]) == 0
+        out = capsys.readouterr().out
+        assert "IDENTITY" in out  # header still printed
+        assert "no off-platform volumes found" in out
+
+    def test_live_flag_adds_column(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        home = tmp_path / "home"
+        _write_volume_state(home, "vergil-lmf-cloud")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        with patch("vergil_tooling.bin.vrg_vm._volume_live_status", return_value="READY") as live:
+            assert main(["volumes", "--live"]) == 0
+        out = capsys.readouterr().out
+        assert "LIVE" in out
+        assert "READY" in out
+        live.assert_called_once_with("vergil-lmf-cloud-data", "us-central1-a", "gcp")


### PR DESCRIPTION
# Pull Request

## Summary

- Add a 'vrg-vm volumes' subcommand that enumerates off-platform persistent volumes from local tofu state (identity, org/repo, disk name, size, zone, region), with an optional --live flag to cross-check each disk against the provider for drift.

## Issue Linkage

- Ref #1795

## Notes

- New 'volumes' subcommand reads ~/.config/vergil/tofu/*/*/volume.tfstate via vm_cloud.parse_volume_state — no network, no gcloud — so the listing reflects exactly what vrg-vm manages; --live shells out to gcloud per disk and degrades to 'unknown'/'MISSING' on failure rather than erroring. Parsing is fully defensive (malformed/never-applied state -> placeholder row). Note: off-platform *VMs* already appear in 'vrg-vm list'; the urgent gap this closes is *volumes*. Covered by new tests in test_vm_cloud.py (parse/zone helpers) and test_vrg_vm.py (rows, live status, CLI); vrg-validate green at 100% coverage. Docs updated in vm-spec.md.