### PR TITLE
feat(off-platform): allow an explicit zone in the off-platform profile

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -126,6 +126,7 @@ class RoleOverlay:
     region: str | None = None
     instance: str | None = None
     volume: str | None = None
+    zone: str | None = None
 
 
 @dataclass
@@ -147,6 +148,7 @@ class VmStanza:
     region: str | None = None
     instance: str | None = None
     volume: str | None = None
+    zone: str | None = None
 
 
 # Recognized keys in a [vm] / [vm.<role>] table. apt_repos is a list of tables
@@ -172,6 +174,7 @@ _VM_KEYS = frozenset(
         "region",
         "instance",
         "volume",
+        "zone",
     }
 )
 
@@ -179,7 +182,7 @@ _VM_KEYS = frozenset(
 # string when present); the *required-when-off-platform* contract and the value
 # enums/formats are enforced at composition (compose_vm_spec), where the cascade
 # is resolved to one effective value per key.
-_VM_STR_SCALARS = ("backend", "provider", "region", "instance", "volume")
+_VM_STR_SCALARS = ("backend", "provider", "region", "instance", "volume", "zone")
 
 
 def _vm_str_scalar(raw: dict[str, Any], key: str, ctx: str, source: str) -> str | None:

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -605,11 +605,14 @@ def apply_volume(
     region: str,
     size_gib: int,
     labels: dict[str, str],
+    zone: str = "",
 ) -> tuple[str, str]:
     """Apply the persistent-volume module; return ``(volume_id, zone)``.
 
     The resolved zone is persisted to ``<state_dir>/zone`` so the VM apply and the
-    IAP transport can address the disk's zone without re-querying tofu.
+    IAP transport can address the disk's zone without re-querying tofu. ``zone`` is an
+    optional explicit GCP zone; empty falls back to the module's ``${region}-b`` default
+    (the module coalesces it away), so existing region-b volumes are unaffected (#1797).
     """
     module_dir = modules_root / "gcp" / "volume"
     state = state_dir / "volume.tfstate"
@@ -617,7 +620,13 @@ def apply_volume(
         module_dir,
         state,
         "apply",
-        {"name": name, "region": region, "size_gib": size_gib, "labels": labels},
+        {
+            "name": name,
+            "region": region,
+            "size_gib": size_gib,
+            "labels": labels,
+            "zone": zone,
+        },
     )
     out = _tofu_output(module_dir, state)
     (state_dir / "zone").write_text(out["zone"], encoding="utf-8")
@@ -843,6 +852,7 @@ class OffPlatformBackend:
             "region": self.spec.region,
             "size_gib": int(self.spec.volume.removesuffix("GiB")),
             "labels": self.labels,
+            "zone": self.spec.zone,
         }
 
     def vm_vars(self, *, zone: str, volume_id: str) -> dict[str, object]:

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -75,6 +75,9 @@ class ComposedSpec:
     region: str = ""
     instance: str = ""
     volume: str = ""
+    # Optional explicit zone (vergil-tooling #1797). Empty -> the volume module's
+    # ${region}-b default; set it to dodge a per-zone capacity stockout in the region.
+    zone: str = ""
 
     @property
     def off_platform(self) -> bool:
@@ -103,6 +106,7 @@ class _Acc:
     region: str
     instance: str
     volume: str
+    zone: str
     # Repo-declared footprint (tiers 3+4 only) — the floor an override is measured
     # against. None means the repo never declared that scalar, so no floor applies.
     declared_cpus: int | None
@@ -157,6 +161,9 @@ def _apply_overlay(acc: _Acc, overlay: VmStanza | RoleOverlay) -> None:
     if overlay.volume is not None:
         acc.volume = overlay.volume
         acc.customized = True
+    if overlay.zone is not None:
+        acc.zone = overlay.zone
+        acc.customized = True
 
 
 def compose_vm_spec(
@@ -184,6 +191,7 @@ def compose_vm_spec(
         region="",
         instance="",
         volume="",
+        zone="",
         declared_cpus=None,
         declared_mem=None,
         declared_disk=None,
@@ -216,7 +224,7 @@ def compose_vm_spec(
             acc.stale_days = cast("int", override["stale_days"])
         # The off-platform scalars also cascade through the host-override tier
         # (built-in → identity → [vm] → [vm.<identity>] → identities.toml override).
-        for key in ("backend", "provider", "region", "instance", "volume"):
+        for key in ("backend", "provider", "region", "instance", "volume", "zone"):
             if key in override:
                 setattr(acc, key, str(override[key]))
 
@@ -239,6 +247,7 @@ def compose_vm_spec(
         region=acc.region,
         instance=acc.instance,
         volume=acc.volume,
+        zone=acc.zone,
     )
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -703,6 +703,7 @@ class TestRunTofu:
             "region": "us-central1",
             "size_gib": 300,
             "labels": {"vergil-org": "o"},
+            "zone": "",
         }
         # init then apply, both non-interactive, apply auto-approved + state/var-file
         init_args = run.call_args_list[0].args[0]
@@ -970,7 +971,12 @@ class TestOffPlatformBackend:
             "region": "us-central1",
             "size_gib": 300,
             "labels": b.labels,
+            "zone": "",
         }
+
+    def test_volume_vars_carries_explicit_zone(self) -> None:
+        b = OffPlatformBackend(_off_spec(zone="us-central1-a"), "vergil-user", "o", "r")
+        assert b.volume_vars()["zone"] == "us-central1-a"
 
     def test_vm_vars_composition(self) -> None:
         b = OffPlatformBackend(_off_spec(nested=True), "vergil-user", "o", "r")

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -284,6 +284,21 @@ class TestOffPlatformCompose:
         assert spec.volume == "300GiB"
         assert spec.dedicated is True  # declaring a backend dedicates the box
 
+    def test_zone_is_optional_defaults_empty_and_overrides(self) -> None:
+        # Omitted -> "" (the volume module falls back to ${region}-b).
+        default_spec = compose_vm_spec(
+            identity="vergil-user", base=BASE, stanza=_off_platform_stanza(), override=None
+        )
+        assert default_spec.zone == ""
+        # Declared in the role tier -> carried through the cascade (#1797).
+        zoned = compose_vm_spec(
+            identity="vergil-user",
+            base=BASE,
+            stanza=_off_platform_stanza(zone="us-central1-a"),
+            override=None,
+        )
+        assert zoned.zone == "us-central1-a"
+
     def test_disk_is_carried_but_volume_is_authoritative_on_cloud(self) -> None:
         # `disk` stays at the base footprint (Lima knob); `volume` is the cloud size.
         spec = compose_vm_spec(


### PR DESCRIPTION
# Pull Request

## Summary

- Add an optional 'zone' to the off-platform [vm.*] profile so an operator can dodge a per-zone capacity stockout (hit live: n2-standard-16 unavailable in us-central1-b). zone rides the region/instance/volume cascade and flows spec.zone -> volume_vars -> apply_volume -> the volume module's var.zone. Optional: empty keeps the module's ${region}-b default, so existing region-b volumes are unaffected.

## Issue Linkage

- Ref #1797

## Notes

- Surfaced bringing up the first off-platform lab: the dispatch hard-pinned every volume/VM to ${region}-b. Volume is zonal, so changing zone for an existing volume needs destroy-volume + recreate; for a fresh/empty volume it's free. Auto-fallback across zones is a noted follow-up. Validation green: 3395 tests, 100% coverage.