### PR TITLE
fix(vrg-vm): enumerate off-platform VMs in update --all and session listing

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -986,8 +986,9 @@ def _cmd_update(args: argparse.Namespace) -> int:
         return _cmd_update_all(args)
 
     # Off-platform boxes are stateless: there is no in-place tooling update —
-    # the disposable VM is rebuilt instead. (--all stays Lima-only and skips
-    # off-platform repos; it never resolves a cloud target.)
+    # the disposable VM is rebuilt instead. A targeted `update <off-platform>` does
+    # that rebuild here; bulk `--all` never rebuilds them silently — it enumerates
+    # and reports them (see _cmd_update_all / _report_off_platform_not_updated).
     if _resolve_target(args).spec.off_platform:
         return _cmd_rebuild(args)
 
@@ -1034,12 +1035,35 @@ def _all_update_targets(
     return targets
 
 
+def _report_off_platform_not_updated(vms: list[OffPlatformVm]) -> None:
+    """Name every off-platform box that ``update --all`` does not touch (issue #1803).
+
+    Off-platform 'update' is a full rebuild of a stateless box (destructive, slow,
+    quota-bound), so bulk ``--all`` deliberately never rebuilds them — but it must
+    not *silently* skip them either (the original bug: a running off-platform box
+    got no tooling update and no warning). Each box is reported with the targeted
+    command that would rebuild it.
+    """
+    if not vms:
+        return
+    count = len(vms)
+    noun = "box" if count == 1 else "boxes"
+    print(
+        f"\n{count} off-platform {noun} NOT updated by --all "
+        f"(off-platform 'update' is a full rebuild — run it per box):"
+    )
+    for vm in vms:
+        print(f"  - {vm.scope} [{vm.provider}]: vrg-vm update {vm.update_ref}")
+
+
 def _cmd_update_all(args: argparse.Namespace) -> int:
     """Update vergil-tooling in every existing VM owned by a configured identity.
 
     Fail-deferred by design: every VM in the list is attempted even after one
     fails; non-running VMs are skipped and reported; any failure makes the
-    final exit code non-zero — only after all attempts have completed.
+    final exit code non-zero — only after all attempts have completed. Off-platform
+    boxes are enumerated across backends and reported (never silently skipped, never
+    bulk-rebuilt); reporting them is not a failure, so it never affects the exit code.
     """
     if args.workspace or args.identity:
         print(
@@ -1053,7 +1077,8 @@ def _cmd_update_all(args: argparse.Namespace) -> int:
     status = {vm["name"]: vm["status"] for vm in list_vms()}
 
     targets = _all_update_targets(config, status)
-    if not targets:
+    off_platform = _off_platform_vms()
+    if not targets and not off_platform:
         print("No VMs found.")
         return 0
 
@@ -1083,10 +1108,14 @@ def _cmd_update_all(args: argparse.Namespace) -> int:
             failed.append((instance, reason))
 
     total = len(targets)
-    print(
-        f"Update complete: {len(updated)} updated, {len(skipped)} skipped, "
-        f"{len(failed)} failed (of {total} VMs)."
-    )
+    if total:
+        print(
+            f"Update complete: {len(updated)} updated, {len(skipped)} skipped, "
+            f"{len(failed)} failed (of {total} VMs)."
+        )
+
+    _report_off_platform_not_updated(off_platform)
+
     if failed:
         names = ", ".join(f"'{inst}' ({reason})" for inst, reason in failed)
         print(f"failed to update {len(failed)} of {total}: {names}", file=sys.stderr)
@@ -1420,31 +1449,92 @@ def _cloud_status(state_dir: Path, state_key: str) -> str:
     return result.stdout.strip()
 
 
-def _cloud_list_rows() -> list[dict[str, object]]:
+@dataclass(frozen=True)
+class OffPlatformVm:
+    """One off-platform VM reconstructed from local tofu state — no network.
+
+    ``identity`` / ``org`` / ``repo`` come from the persistent disk's ``vergil-*``
+    labels (``None`` for a never-applied or unlabeled state). ``status`` is the raw
+    best-effort cloud status (``"RUNNING"`` for a live box; ``""`` when the provider
+    cannot be reached). ``state_dir`` is the ``<state_key>/<provider>`` tofu
+    directory; ``name`` is both the state key and the deterministic cloud resource
+    name (the gcloud instance name).
+    """
+
+    name: str
+    provider: str
+    state_dir: Path
+    identity: str | None
+    org: str | None
+    repo: str | None
+    status: str
+
+    @property
+    def is_running(self) -> bool:
+        return self.status == "RUNNING"
+
+    @property
+    def scope(self) -> str:
+        """Human label for the box: ``org/repo`` when labeled, else the resource name."""
+        if self.org and self.repo:
+            return f"{self.org}/{self.repo}"
+        return self.name
+
+    @property
+    def update_ref(self) -> str:
+        """How an operator re-addresses this box for a targeted ``vrg-vm update``."""
+        if self.org and self.repo:
+            return f"{self.org}/{self.repo}"
+        if self.identity:
+            return f"--identity {self.identity}"
+        return self.name
+
+
+def _off_platform_vms() -> list[OffPlatformVm]:
     """Enumerate off-platform VMs from local tofu state under ~/.config/vergil/tofu.
 
-    Each ``<state_key>/<provider>/volume.tfstate`` is one off-platform VM. STATUS
-    comes from a best-effort cloud query; an unauthed/unreachable provider yields a
-    degraded ``unknown (no <provider> creds)`` placeholder rather than dropping the
-    row or erroring the list.
+    The cross-backend companion to ``list_vms()`` (which sees only Lima): every
+    ``<state_key>/<provider>/volume.tfstate`` is one off-platform box. Identity /
+    org / repo are recovered from the disk's ``vergil-*`` labels; STATUS is a
+    best-effort cloud query that degrades to ``""`` rather than raising. Shared by
+    every fan-out-over-all-VMs caller (``list``, ``update --all``, session listing)
+    so none of them silently sees only Lima boxes (issue #1803).
     """
-    rows: list[dict[str, object]] = []
+    vms: list[OffPlatformVm] = []
     tofu_root = Path.home() / ".config" / "vergil" / "tofu"
     if not tofu_root.is_dir():
-        return rows
+        return vms
     for volume_state in sorted(tofu_root.glob("*/*/volume.tfstate")):
         provider_dir = volume_state.parent
         provider = provider_dir.name
         state_key = provider_dir.parent.name
-        raw = _cloud_status(provider_dir, state_key)
-        status = raw or f"unknown (no {provider} creds)"
-        rows.append(
-            {
-                "scope": state_key,
-                "backend": provider,
-                "status": status,
-            }
+        parsed = vm_cloud.parse_volume_state(volume_state)
+        labels = parsed.labels if parsed else {}
+        vms.append(
+            OffPlatformVm(
+                name=state_key,
+                provider=provider,
+                state_dir=provider_dir,
+                identity=labels.get("vergil-identity"),
+                org=labels.get("vergil-org"),
+                repo=labels.get("vergil-repo"),
+                status=_cloud_status(provider_dir, state_key),
+            )
         )
+    return vms
+
+
+def _cloud_list_rows() -> list[dict[str, object]]:
+    """Display rows for off-platform VMs (the cloud half of ``vrg-vm list``).
+
+    Reuses the shared ``_off_platform_vms()`` enumeration; an unauthed/unreachable
+    provider yields a degraded ``unknown (no <provider> creds)`` placeholder rather
+    than dropping the row or erroring the list.
+    """
+    rows: list[dict[str, object]] = []
+    for vm in _off_platform_vms():
+        status = vm.status or f"unknown (no {vm.provider} creds)"
+        rows.append({"scope": vm.name, "backend": vm.provider, "status": status})
     return rows
 
 
@@ -1627,6 +1717,20 @@ def _vm_active_sessions(instance: str) -> dict[str, dict[str, object]]:
     return {row["sessionId"]: row for row in rows if row.get("state") == "active"}
 
 
+def _off_platform_active_sessions(vm: OffPlatformVm) -> dict[str, dict[str, object]]:
+    """Map active session id -> row from a running off-platform box over IAP.
+
+    The cloud analog of ``_vm_active_sessions``: the same
+    ``vrg-vm-resolve-session --list-json`` query, but carried over the IAP SSH
+    transport instead of limactl. The box owns its own roster, so it is the only
+    source for a live session's name — exactly as for a Lima box.
+    """
+    transport = vm_cloud.off_platform_transport(vm.name, vm.state_dir)
+    result = transport.run("vrg-vm-resolve-session", "--list-json")
+    rows = json.loads(result.stdout)
+    return {row["sessionId"]: row for row in rows if row.get("state") == "active"}
+
+
 def _format_age(last_active: float | None, now: float) -> str:
     if last_active is None:
         return "unknown"
@@ -1656,6 +1760,21 @@ def _list_sessions(config: IdentityConfig, args: argparse.Namespace) -> int:
     for identity in config.identities.values():
         if vm_map.get(identity.vm_instance) == "Running":
             active_rows.update(_vm_active_sessions(identity.vm_instance))
+
+    # Off-platform boxes live in tofu state, not Lima, so list_vms() never sees
+    # them; query each running one's roster over IAP the same way (issue #1803). A
+    # query failure (no creds, unreachable, malformed) degrades to a warning rather
+    # than erroring the whole listing.
+    for vm in _off_platform_vms():
+        if not vm.is_running:
+            continue
+        try:
+            active_rows.update(_off_platform_active_sessions(vm))
+        except (subprocess.CalledProcessError, OSError, json.JSONDecodeError, RuntimeError) as exc:
+            print(
+                f"WARNING: could not query sessions on off-platform box '{vm.scope}': {exc}",
+                file=sys.stderr,
+            )
 
     projects = Path.home() / ".claude" / "projects"
     names = name_by_session(projects)
@@ -1940,7 +2059,9 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help=(
             "Update every VM owned by a configured identity (fail-deferred: all VMs "
-            "are attempted even if one fails; non-running VMs are skipped and reported)"
+            "are attempted even if one fails; non-running VMs are skipped and reported). "
+            "Off-platform boxes are reported but not rebuilt — run 'vrg-vm update <box>' "
+            "per box to rebuild one."
         ),
     )
     # Off-platform update delegates to rebuild, which drives the progress pipeline;

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -785,6 +785,19 @@ def _effective_ssh_user() -> str:
     return os.environ.get("VRG_OFF_PLATFORM_SSH_USER", _DEFAULT_SSH_USER)
 
 
+def off_platform_transport(name: str, state_dir: Path) -> IapTransport:
+    """Build an IAP transport for an already-applied off-platform box from local state.
+
+    Mirrors :meth:`OffPlatformBackend.transport` but sourced purely from the
+    persisted tofu state (the resource ``name`` plus the apply ``zone`` file), so a
+    fan-out enumerator can reach a running box without composing its full spec.
+    Raises ``RuntimeError`` (via :func:`read_zone`) when no zone has been persisted
+    — i.e. the volume was never applied and there is nothing to reach.
+    """
+    zone = read_zone(state_dir)
+    return IapTransport(name, zone, _resolve_project(), _effective_ssh_user())
+
+
 class OffPlatformBackend:
     """Cloud (OpenTofu + GCP) backend behind the ``Backend`` protocol.
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -22,6 +22,7 @@ from vergil_tooling.lib.vm_cloud import (
     destroy_volume,
     fetch_modules,
     link_cloud_claude_dirs,
+    off_platform_transport,
     parse_volume_state,
     preflight,
     provision_params,
@@ -826,6 +827,28 @@ class TestReadZone:
     def test_missing_zone_raises(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="no persisted zone"):
             read_zone(tmp_path)
+
+
+class TestOffPlatformTransport:
+    def test_builds_iap_from_local_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A fan-out enumerator reaches a running box from purely local state:
+        # resource name + the persisted zone file, no spec composition.
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "proj-env")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / "zone").write_text("us-central1-b")
+        transport = off_platform_transport("vergil-lmf-cloud", state_dir)
+        assert isinstance(transport, IapTransport)
+        assert transport.host == "vergil-lmf-cloud"
+        assert transport.zone == "us-central1-b"
+        assert transport.project == "proj-env"
+        assert transport.ssh_user == "ubuntu"
+
+    def test_raises_when_zone_not_persisted(self, tmp_path: Path) -> None:
+        with pytest.raises(RuntimeError, match="no persisted zone"):
+            off_platform_transport("vergil-lmf-cloud", tmp_path / "absent")
 
 
 def _off_spec(**kw: object) -> ComposedSpec:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -850,6 +850,14 @@ class TestRebuild:
 
 
 class TestList:
+    # Default: no off-platform boxes, so Lima-focused list/session tests stay
+    # hermetic regardless of the host's real ~/.config/vergil/tofu (and never try
+    # to SSH a real box). Off-platform tests override this with their own patch.
+    @pytest.fixture(autouse=True)
+    def _no_off_platform(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm._off_platform_vms", return_value=[]) as m:
+            yield m
+
     @patch("vergil_tooling.bin.vrg_vm.vm_probe", return_value=(0, 0, None))
     @patch("vergil_tooling.bin.vrg_vm.list_vms")
     def test_list_shows_identities(
@@ -1136,6 +1144,119 @@ class TestList:
         assert "alpha/repo" in data[1] and "02" in data[1]
         assert "beta/repo" in data[2]
 
+    @patch("vergil_tooling.bin.vrg_vm._last_activity", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session", return_value={})
+    @patch("vergil_tooling.bin.vrg_vm._off_platform_active_sessions")
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[])
+    def test_list_sessions_includes_off_platform_roster(
+        self,
+        _list: MagicMock,
+        _shell: MagicMock,
+        mock_cloud_sessions: MagicMock,
+        _names: MagicMock,
+        _age: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # A running off-platform box's live sessions were invisible (list_vms()
+        # never sees the box). Now they are queried over IAP and merged in.
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="vergil",
+                org="lmf",
+                repo="cloud",
+                status="RUNNING",
+            )
+        ]
+        mock_cloud_sessions.return_value = {
+            "c1": {
+                "identity": "vergil",
+                "slot": 1,
+                "path": "lmf/cloud",
+                "sessionId": "c1",
+                "state": "active",
+                "lastActive": 1748000000.0,
+            }
+        }
+        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        mock_cloud_sessions.assert_called_once()
+        out = capsys.readouterr().out
+        assert "lmf/cloud" in out
+        assert "active" in out
+
+    @patch("vergil_tooling.bin.vrg_vm._last_activity", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session", return_value={})
+    @patch("vergil_tooling.bin.vrg_vm._off_platform_active_sessions")
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[])
+    def test_list_sessions_off_platform_query_failure_warns(
+        self,
+        _list: MagicMock,
+        _shell: MagicMock,
+        mock_cloud_sessions: MagicMock,
+        _names: MagicMock,
+        _age: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # A failed roster query (no creds, unreachable, malformed) must degrade to
+        # a warning, never erroring the whole listing.
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="vergil",
+                org="lmf",
+                repo="cloud",
+                status="RUNNING",
+            )
+        ]
+        mock_cloud_sessions.side_effect = subprocess.CalledProcessError(255, "gcloud ssh")
+        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        err = capsys.readouterr().err
+        assert "could not query sessions on off-platform box 'lmf/cloud'" in err
+
+    @patch("vergil_tooling.bin.vrg_vm._off_platform_active_sessions")
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session", return_value={})
+    @patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[])
+    def test_list_sessions_skips_non_running_off_platform(
+        self,
+        _list: MagicMock,
+        _names: MagicMock,
+        _shell: MagicMock,
+        mock_cloud_sessions: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+    ) -> None:
+        # A non-running off-platform box is never queried (no live roster to read).
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="vergil",
+                org="lmf",
+                repo="cloud",
+                status="TERMINATED",
+            )
+        ]
+        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        mock_cloud_sessions.assert_not_called()
+
 
 class TestUpdate:
     # vrg-vm update refreshes plugins too (via _update_instance); mock it so the
@@ -1265,6 +1386,14 @@ class TestUpdateAll:
     @pytest.fixture(autouse=True)
     def _mock_update_plugins(self) -> Iterator[MagicMock]:
         with patch("vergil_tooling.bin.vrg_vm.update_plugins") as m:
+            yield m
+
+    # Default: no off-platform boxes, so the Lima-focused tests stay hermetic
+    # regardless of the host's real ~/.config/vergil/tofu. Tests that exercise the
+    # off-platform report override this with their own patch.
+    @pytest.fixture(autouse=True)
+    def _no_off_platform(self) -> Iterator[MagicMock]:
+        with patch("vergil_tooling.bin.vrg_vm._off_platform_vms", return_value=[]) as m:
             yield m
 
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
@@ -1472,6 +1601,80 @@ class TestUpdateAll:
         assert result == 0
         mock_update.assert_not_called()
         assert "No VMs found" in capsys.readouterr().out
+
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_reports_off_platform_boxes_instead_of_silently_skipping(
+        self,
+        mock_list: MagicMock,
+        mock_update: MagicMock,
+        _ver: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The bug: off-platform boxes are invisible to list_vms(), so --all never
+        # touched them and said nothing. Now they are enumerated across backends
+        # and reported with the per-box rebuild command — never bulk-rebuilt, never
+        # silent — and reporting them is not a failure.
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="lmf",
+                org="lmf",
+                repo="cloud",
+                status="RUNNING",
+            )
+        ]
+        result = main(["update", "--all", "--config", str(config_file)])
+        assert result == 0
+        # The Lima box was still updated normally.
+        mock_update.assert_called_once_with(ANY, None, fallback_tag="v2.0")
+        out = capsys.readouterr().out
+        assert "1 off-platform box NOT updated" in out
+        assert "lmf/cloud" in out
+        assert "vrg-vm update lmf/cloud" in out
+
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_reports_off_platform_when_no_lima_vms(
+        self,
+        mock_list: MagicMock,
+        mock_update: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Off-platform boxes must surface even when there are no Lima VMs at all —
+        # the old "No VMs found." early return hid them in that case.
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        mock_list.return_value = []
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="lmf",
+                org=None,
+                repo=None,
+                status="",
+            )
+        ]
+        result = main(["update", "--all", "--config", str(config_file)])
+        assert result == 0
+        mock_update.assert_not_called()
+        out = capsys.readouterr().out
+        assert "No VMs found" not in out
+        assert "1 off-platform box NOT updated" in out
+        # Unlabeled state -> addressed by identity rather than org/repo.
+        assert "vrg-vm update --identity lmf" in out
 
 
 class TestSessionStaleness:
@@ -3381,6 +3584,97 @@ class TestCloudList:
 
         monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path / "empty"))
         assert _cloud_list_rows() == []
+
+    def test_off_platform_vms_recovers_identity_from_labels(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _off_platform_vms
+
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        # A real applied volume state carries the persistent disk with vergil-* labels.
+        state = {
+            "resources": [
+                {
+                    "type": "google_compute_disk",
+                    "instances": [
+                        {
+                            "attributes": {
+                                "name": "vergil-lmf-cloud-data",
+                                "size": 100,
+                                "zone": "us-central1-a",
+                                "labels": {
+                                    "vergil-identity": "lmf",
+                                    "vergil-org": "lmf",
+                                    "vergil-repo": "cloud",
+                                },
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+        (tofu / "volume.tfstate").write_text(json.dumps(state))
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+        # No persisted zone file -> _cloud_status degrades to "" without raising.
+        vms = _off_platform_vms()
+        assert len(vms) == 1
+        vm = vms[0]
+        assert vm.name == "vergil-lmf-cloud"
+        assert vm.provider == "gcp"
+        assert (vm.identity, vm.org, vm.repo) == ("lmf", "lmf", "cloud")
+        assert vm.scope == "lmf/cloud"
+        assert vm.update_ref == "lmf/cloud"
+        assert vm.status == ""
+        assert vm.is_running is False
+
+    def test_off_platform_vm_unlabeled_falls_back_to_resource_name(self) -> None:
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        # A never-applied / unlabeled state has no identity or org/repo, so both the
+        # display scope and the targeted ref fall back to the resource name.
+        vm = OffPlatformVm(
+            name="vergil-orphan",
+            provider="gcp",
+            state_dir=Path("/x/gcp"),
+            identity=None,
+            org=None,
+            repo=None,
+            status="",
+        )
+        assert vm.scope == "vergil-orphan"
+        assert vm.update_ref == "vergil-orphan"
+
+    def test_off_platform_active_sessions_queries_over_transport(self) -> None:
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm, _off_platform_active_sessions
+
+        vm = OffPlatformVm(
+            name="vergil-lmf-cloud",
+            provider="gcp",
+            state_dir=Path("/x/gcp"),
+            identity="vergil",
+            org="lmf",
+            repo="cloud",
+            status="RUNNING",
+        )
+        transport = MagicMock()
+        transport.run.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {"sessionId": "c1", "state": "active", "path": "lmf/cloud"},
+                    {"sessionId": "c2", "state": "idle", "path": "lmf/cloud"},
+                ]
+            )
+        )
+        with patch(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.off_platform_transport", return_value=transport
+        ) as mk:
+            rows = _off_platform_active_sessions(vm)
+        mk.assert_called_once_with("vergil-lmf-cloud", Path("/x/gcp"))
+        transport.run.assert_called_once_with("vrg-vm-resolve-session", "--list-json")
+        # Only the active row is retained, keyed by session id.
+        assert set(rows) == {"c1"}
 
 
 class TestCloudUnderProvision:


### PR DESCRIPTION
# Pull Request

## Summary

- Route the 'all VMs' fan-out commands (update --all, list --sessions) through a shared cross-backend enumerator so they no longer silently skip off-platform boxes that live in OpenTofu state rather than Lima.

## Issue Linkage

- Ref #1803

## Notes

- Scope is the core fix only (per implementer/human decision): update --all now reports off-platform boxes with the per-box rebuild command instead of silently skipping, and never bulk-rebuilds; list --sessions queries each running off-platform box's roster over IAP, degrading to a warning on failure. The optional --rebuild-off-platform opt-in from the issue's Proposed section was deliberately deferred (bulk rebuild is destructive/quota-bound). _cloud_list_rows (vrg-vm list) was reimplemented on the shared enumerator with identical output. New vm_cloud.off_platform_transport() builds an IAP transport from local state. Validation green (vrg-validate, 100% coverage).