### PR TITLE
fix(off-platform): roll back a failed VM apply so an orphan firewall doesn't 409 every retry

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -646,24 +646,44 @@ def apply_vm(
     provision_env: str,
     labels: dict[str, str],
 ) -> dict[str, str]:
-    """Apply the VM module against the existing volume; return its outputs (host, ssh_user)."""
+    """Apply the VM module against the existing volume; return its outputs (host, ssh_user).
+
+    A VM apply creates the global ``google_compute_firewall.ssh`` before the zonal
+    instance. When the instance fails — most often a capacity stockout (#1797) — tofu
+    persists the already-created firewall to vm.tfstate but the apply errors out, so the
+    next create tries to re-create the global firewall and fails with a 409
+    ``already exists`` that blocks every retry (#1804). To keep a failed create cleanly
+    retryable we roll the partial apply back with a ``tofu destroy`` against the VM state
+    before re-raising. The VM state holds only the firewall and instance — the persistent
+    volume lives in its own state — so the rollback never touches the reusable disk.
+    """
     module_dir = modules_root / "gcp" / "vm"
     state = state_dir / "vm.tfstate"
-    _run_tofu(
-        module_dir,
-        state,
-        "apply",
-        {
-            "name": name,
-            "zone": zone,
-            "instance_type": instance_type,
-            "nested": nested,
-            "volume_id": volume_id,
-            "ssh_user": ssh_user,
-            "provision_env": provision_env,
-            "labels": labels,
-        },
-    )
+    try:
+        _run_tofu(
+            module_dir,
+            state,
+            "apply",
+            {
+                "name": name,
+                "zone": zone,
+                "instance_type": instance_type,
+                "nested": nested,
+                "volume_id": volume_id,
+                "ssh_user": ssh_user,
+                "provision_env": provision_env,
+                "labels": labels,
+            },
+        )
+    except subprocess.CalledProcessError:
+        # Best-effort rollback: tear down the partial state (the orphan firewall) so the
+        # retry starts clean. A rollback failure must never mask the real apply error, so
+        # swallow it and re-raise the original — the operator still sees why the create
+        # failed, and a stubborn orphan can be cleared with `vrg-vm destroy`.
+        print("VM apply failed — rolling back the partial state...", file=sys.stderr)
+        with contextlib.suppress(subprocess.CalledProcessError):
+            _run_tofu(module_dir, state, "destroy", {})
+        raise
     return _tofu_output(module_dir, state)
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -760,6 +760,87 @@ class TestRunTofu:
         assert data["volume_id"] == "vol-1"
         assert data["provision_env"] == "VERGIL_USER=ubuntu"
 
+    def test_apply_vm_rolls_back_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failed VM apply (e.g. capacity stockout on the instance) leaves the
+        # global firewall behind in vm.tfstate; without a rollback the next create
+        # 409s on the orphan firewall (#1804). apply_vm must tear the partial state
+        # down with a `tofu destroy` before re-raising, so the create is retryable.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        modules = tmp_path / "modules"
+        state_dir = tofu_state_dir("k", "gcp")
+        apply_err = subprocess.CalledProcessError(
+            1, ("tofu", "apply"), stderr="Error: capacity stockout (n2-standard-16)"
+        )
+
+        def _run(cmd: list[str], **_kwargs: object) -> int:
+            if "apply" in cmd:
+                raise apply_err
+            return 0
+
+        run = MagicMock(side_effect=_run)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
+
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            apply_vm(
+                modules,
+                state_dir,
+                name="vm-x",
+                zone="us-central1-a",
+                instance_type="n2-standard-16",
+                nested=True,
+                volume_id="vol-1",
+                ssh_user="ubuntu",
+                provision_env="VERGIL_USER=ubuntu",
+                labels={"vergil-org": "o"},
+            )
+        # the ORIGINAL apply error surfaces — the rollback doesn't mask the real cause
+        assert excinfo.value is apply_err
+        # a rollback destroy ran against the VM state, reusing the just-written tfvars
+        destroy_calls = [c for c in run.call_args_list if "destroy" in c.args[0]]
+        assert len(destroy_calls) == 1
+        destroy_args = destroy_calls[0].args[0]
+        assert f"-state={state_dir / 'vm.tfstate'}" in destroy_args
+        assert f"-var-file={state_dir / 'vm.tfstate.tfvars.json'}" in destroy_args
+
+    def test_apply_vm_rollback_failure_does_not_mask_original_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If the best-effort rollback itself fails, the original apply error must
+        # still be the one that surfaces — never the secondary cleanup failure.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        modules = tmp_path / "modules"
+        state_dir = tofu_state_dir("k", "gcp")
+        apply_err = subprocess.CalledProcessError(
+            1, ("tofu", "apply"), stderr="Error: capacity stockout"
+        )
+
+        def _run(cmd: list[str], **_kwargs: object) -> int:
+            if "apply" in cmd:
+                raise apply_err
+            if "destroy" in cmd:
+                raise subprocess.CalledProcessError(1, cmd, stderr="rollback boom")
+            return 0
+
+        run = MagicMock(side_effect=_run)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
+
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            apply_vm(
+                modules,
+                state_dir,
+                name="vm-x",
+                zone="us-central1-a",
+                instance_type="n2-standard-16",
+                nested=True,
+                volume_id="vol-1",
+                ssh_user="ubuntu",
+                provision_env="VERGIL_USER=ubuntu",
+                labels={"vergil-org": "o"},
+            )
+        assert excinfo.value is apply_err
+
     def test_destroy_vm_reuses_stored_tfvars(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- apply_vm now tears down the partial VM state with a best-effort tofu destroy when a VM apply fails, so the orphaned global firewall no longer 409s every subsequent create.

## Issue Linkage

- Ref #1804

## Notes

- Root cause: a VM apply creates the global google_compute_firewall.ssh before the zonal instance; when the instance fails (typically a capacity stockout, #1797) tofu persists the firewall to vm.tfstate but the apply errors out, and the next create 409s re-creating the global firewall (#1804). Fix: on a CalledProcessError, apply_vm runs 'tofu destroy' against the VM state (which holds only the firewall + instance — the persistent volume is in its own state, so the reusable disk is untouched), then re-raises the original error. The rollback is best-effort: a destroy failure is suppressed so it can never mask the real apply error, and a stubborn orphan can still be cleared with 'vrg-vm destroy'. Two new unit tests cover the rollback and the don't-mask-original-error guard; full vrg-validate is green in the container. (The host-only test_vrg_vm failures are pre-existing limactl-not-installed env failures, unrelated to this change.)