### PR TITLE
fix(off-platform): shell-quote provision.env values so multi-token lists source cleanly

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -158,11 +159,16 @@ def render_provision_env(params: dict[str, str], *, vergil_user: str, home: str)
     ``params`` (from ``provision_params``, which omits unset keys) overrides the empty
     ``_PROVISION_ENV_DEFAULTS`` so every key the provision scripts source is always defined
     — provisioning runs under ``set -u`` and aborts on any unbound variable.
+
+    Every value is ``shlex.quote``-escaped: the scripts source this file (``. provision.env``),
+    so a multi-token value (EXTRA_PACKAGES' space-joined list, PORT_FORWARDS' ``|``/``;``
+    records, APT_REPOS) written raw would be parsed as a ``VAR=x cmd args`` line instead of a
+    plain assignment. (#1805)
     """
     merged = {**_PROVISION_ENV_DEFAULTS, **params}
-    lines = [f"{key}={value}" for key, value in merged.items()]
-    lines.append(f"VERGIL_USER={vergil_user}")
-    lines.append(f"HOME={home}")
+    lines = [f"{key}={shlex.quote(value)}" for key, value in merged.items()]
+    lines.append(f"VERGIL_USER={shlex.quote(vergil_user)}")
+    lines.append(f"HOME={shlex.quote(home)}")
     return "\n".join(lines)
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -237,7 +237,8 @@ class TestProvisionEnv:
         params = {"EXTRA_PACKAGES": "git vim", "NESTED_VIRT": "true", "SPEC_FINGERPRINT": "abc"}
         body = render_provision_env(params, vergil_user="vergil", home="/home/vergil")
         lines = set(body.splitlines())
-        assert "EXTRA_PACKAGES=git vim" in lines
+        # values are shell-quoted; a multi-token value gets single-quoted (#1805)
+        assert "EXTRA_PACKAGES='git vim'" in lines
         assert "NESTED_VIRT=true" in lines
         assert "SPEC_FINGERPRINT=abc" in lines
         assert "VERGIL_USER=vergil" in lines
@@ -249,9 +250,9 @@ class TestProvisionEnv:
         body = render_provision_env({}, vergil_user="vergil", home="/home/vergil")
         defined = {line.split("=", 1)[0] for line in body.splitlines()}
         assert defined >= self._CANONICAL_KEYS
-        # unset keys default to empty, matching Lima's agent.yaml.skel param block
-        assert "NESTED_VIRT=" in body.splitlines()
-        assert "APT_REPOS=" in body.splitlines()
+        # unset keys default to a shell-quoted empty string
+        assert "NESTED_VIRT=''" in body.splitlines()
+        assert "APT_REPOS=''" in body.splitlines()
 
     def test_params_override_empty_defaults(self) -> None:
         body = render_provision_env(
@@ -259,7 +260,38 @@ class TestProvisionEnv:
         )
         lines = body.splitlines()
         assert "NESTED_VIRT=true" in lines
-        assert "NESTED_VIRT=" not in lines  # the default did not leak a duplicate
+        assert "NESTED_VIRT=''" not in lines  # the default did not leak a duplicate
+
+    def test_sources_cleanly_with_multi_token_values(self) -> None:
+        # Regression (#1805): provision scripts do `. provision.env`, so values with
+        # spaces / | / ; / : must round-trip as plain assignments, not `VAR=x cmd` lines.
+        params = {
+            "EXTRA_PACKAGES": "bridge-utils qemu-system-x86 libvirt-clients",
+            "APT_REPOS": "hashicorp|https://k.example/k.gpg|https://apt.example|noble|main",
+            "PORT_FORWARDS": "3000|10.50.0.2:3000;8080|10.50.0.2:8080",
+            "VAGRANT_PLUGINS": "vagrant-libvirt",
+        }
+        body = render_provision_env(params, vergil_user="ubuntu", home="/home/ubuntu")
+        # Source the rendered body under `set -eu` and echo each var back: with the old
+        # unquoted output this aborts (`command not found`); quoted, it round-trips exactly.
+        script = (
+            f"set -eu\n{body}\n"
+            'printf "%s\\n" "$EXTRA_PACKAGES" "$APT_REPOS" "$PORT_FORWARDS"'
+            ' "$VAGRANT_PLUGINS" "$NESTED_VIRT"'
+        )
+        out = subprocess.run(  # noqa: S603
+            ["bash", "-c", script],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.splitlines()
+        assert out == [
+            "bridge-utils qemu-system-x86 libvirt-clients",
+            "hashicorp|https://k.example/k.gpg|https://apt.example|noble|main",
+            "3000|10.50.0.2:3000;8080|10.50.0.2:8080",
+            "vagrant-libvirt",
+            "",  # NESTED_VIRT default — empty
+        ]
 
 
 class TestPreflight:


### PR DESCRIPTION
# Pull Request

## Summary

- render_provision_env wrote KEY=value unquoted; the provision scripts source the file, so multi-token values (EXTRA_PACKAGES' space-joined package list, PORT_FORWARDS'/APT_REPOS' |/; records) were parsed as 'VAR=x cmd args' lines -> 'command not found' and the vars never got their values -> cloud-init error. shlex.quote each value (params + VERGIL_USER/HOME), matching Lima's quoted template params.

## Issue Linkage

- Ref #1805

## Notes

- Surfaced on the first nested/full-lab off-platform create; vergil-audit (minimal, empty values) never tripped it. Sibling of #1768 (same function). Regression test sources the rendered body under 'set -eu' and asserts each var round-trips exactly. Validation green: 100% coverage.