### PR TITLE
fix(off-platform): update a running box in place over IAP instead of rebuilding

### DIFF
--- a/docs/site/docs/reference/vm-spec.md
+++ b/docs/site/docs/reference/vm-spec.md
@@ -179,13 +179,20 @@ The same `vrg-vm` verbs work, dispatched on the resolved `backend`:
   volume; the data reattaches intact.
 - `destroy-volume` — the **only** command that deletes the persistent
   volume. Guarded: retype `org/repo` to confirm, or pass `--yes`.
-- `update` — maps to `rebuild` (off-platform is rebuild-not-update).
+- `update` — refreshes vergil-tooling and Claude plugins **in place**
+  over the IAP tunnel on a running box (seconds, non-disruptive), exactly
+  like a Lima box. `rebuild` is reserved for what genuinely needs a fresh
+  image (a new base image or changed provision scripts), not a tooling
+  bump. `update --all` includes off-platform boxes and updates each running
+  one in place; a non-running box is skipped and reported. Two boxes that
+  share an `org/repo` (one per identity) stay distinct by their identity.
 - `stop` / `start` / `restart` — **not supported**. Off-platform VMs
   are ephemeral; use `destroy` / `create`.
 - `list` — gains a `BACKEND` column (`local` for Lima rows, the
-  provider for cloud rows). Without cloud credentials a cloud row's
-  status degrades to `unknown (no <provider> creds)` rather than
-  erroring or hiding the row.
+  provider for cloud rows). Cloud rows carry their box's `IDENTITY` so
+  two boxes sharing an `org/repo` (one per identity) stay distinct.
+  Without cloud credentials a cloud row's status degrades to
+  `unknown (no <provider> creds)` rather than erroring or hiding the row.
 - `volumes` — enumerates the persistent volumes (the long-lived,
   billable, quota-consuming disks that outlive each ephemeral VM) from
   local tofu state: `IDENTITY`, `ORG/REPO`, `DISK NAME`, `SIZE`, `ZONE`,

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -53,7 +53,6 @@ from vergil_tooling.lib.lima import (
     shell_run,
     start_vm,
     stop_vm,
-    update_plugins,
     vm_age_days,
     vm_status,
     write_instance_meta,
@@ -68,6 +67,7 @@ from vergil_tooling.lib.vm_guest import (
     install_tooling,
     link_claude_dirs,
     try_update_tooling,
+    update_plugins,
     update_tooling,
     vm_probe,
     vm_spec_status,
@@ -513,8 +513,10 @@ def _st_update_tooling(state: _LifecycleState) -> None:
 def _st_update_plugins(state: _LifecycleState) -> None:
     # Warn-mode stage: a failed plugin refresh surfaces as ⚠ and the lifecycle
     # continues, the same warn-and-continue contract as update-tooling. Plugins
-    # are VM-local; this advances them to the latest published versions.
-    update_plugins(state.target.instance)
+    # are guest-local; this advances them to the latest published versions over
+    # whichever transport the backend provides (Lima or off-platform IAP).
+    transport = state.target.backend.transport(state.target.instance)
+    update_plugins(transport)
 
 
 def _st_cycle_ssh(state: _LifecycleState) -> None:
@@ -961,11 +963,17 @@ def _cmd_restart(args: argparse.Namespace) -> int:
     return 0
 
 
-def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -> None:
-    """Update tooling and plugins in one running VM, printing the version transition."""
-    print(f"Updating vergil-tooling in VM '{instance}' (identity: {name})...")
+def _update_over_transport(
+    transport: Transport, label: str, tag: str | None, fallback: str
+) -> None:
+    """Update tooling and plugins in one running box, printing the version transition.
 
-    transport = LimaTransport(instance)
+    Transport-generic core shared by the Lima and off-platform update paths
+    (#1812): an off-platform box updates in place over its IAP transport exactly
+    as a Lima box does over limactl — no rebuild.
+    """
+    print(f"Updating vergil-tooling in {label}...")
+
     before = get_tooling_version(transport)
     update_tooling(transport, tag, fallback_tag=fallback)
     after = get_tooling_version(transport)
@@ -978,19 +986,57 @@ def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -
     elif after:
         print(f"  vergil-tooling: {after}")
 
-    update_plugins(instance)
+    update_plugins(transport)
+
+
+def _update_instance(instance: str, name: str, tag: str | None, fallback: str) -> None:
+    """Update tooling and plugins in one running Lima VM over its limactl transport."""
+    _update_over_transport(
+        LimaTransport(instance), f"VM '{instance}' (identity: {name})", tag, fallback
+    )
+
+
+def _cmd_update_off_platform(target: Target, args: argparse.Namespace) -> int:
+    """Update tooling and plugins in a running off-platform box in place over IAP.
+
+    In-place is correct for a *running* off-platform box (#1812): the tooling
+    update is transport-generic, so it runs over the box's IAP transport exactly
+    as Lima runs over limactl — seconds, non-disruptive, no capacity/quota risk.
+    Rebuild (``vrg-vm rebuild``) stays reserved for what genuinely needs a fresh
+    image (a new base image or changed provision scripts), not a tooling bump.
+    """
+    backend = _cloud_backend(target)
+    status = backend.status()
+    if status != "Running":
+        effective = status or "Not Created"
+        # Identity-qualified hint: two off-platform boxes can share an org/repo
+        # (one per identity), so the start command must carry --identity (#1812).
+        start_ref = f"{target.org}/{target.repo} --identity {target.identity_name}"
+        print(
+            f"ERROR: off-platform VM '{backend.name}' is not running (status: {effective}).\n"
+            f"Start it first: vrg-vm start {start_ref}",
+            file=sys.stderr,
+        )
+        return 1
+
+    tag = args.tag if args.tag else None
+    fallback = resolve_vergil_version(target.config, target.identity)
+    label = f"off-platform box '{backend.name}' (identity: {target.identity_name})"
+    _update_over_transport(backend.transport(), label, tag, fallback)
+
+    print("Update complete.")
+    return 0
 
 
 def _cmd_update(args: argparse.Namespace) -> int:
     if args.all:
         return _cmd_update_all(args)
 
-    # Off-platform boxes are stateless: there is no in-place tooling update —
-    # the disposable VM is rebuilt instead. A targeted `update <off-platform>` does
-    # that rebuild here; bulk `--all` never rebuilds them silently — it enumerates
-    # and reports them (see _cmd_update_all / _report_off_platform_not_updated).
-    if _resolve_target(args).spec.off_platform:
-        return _cmd_rebuild(args)
+    # Off-platform boxes update IN PLACE over IAP — same transport-generic tooling
+    # update as Lima, no rebuild (#1812, correcting #1803's stateless premise).
+    target = _resolve_target(args)
+    if target.spec.off_platform:
+        return _cmd_update_off_platform(target, args)
 
     name, identity, config, instance = _resolve_instance(args)
 
@@ -1035,35 +1081,33 @@ def _all_update_targets(
     return targets
 
 
-def _report_off_platform_not_updated(vms: list[OffPlatformVm]) -> None:
-    """Name every off-platform box that ``update --all`` does not touch (issue #1803).
+def _off_platform_fallback(config: IdentityConfig, vm: OffPlatformVm) -> str:
+    """Resolve the fallback vergil tag for an off-platform box from its labeled identity.
 
-    Off-platform 'update' is a full rebuild of a stateless box (destructive, slow,
-    quota-bound), so bulk ``--all`` deliberately never rebuilds them — but it must
-    not *silently* skip them either (the original bug: a running off-platform box
-    got no tooling update and no warning). Each box is reported with the targeted
-    command that would rebuild it.
+    The box's own tooling-tag marker is authoritative — ``update_tooling`` reads it
+    and this fallback applies only to a box with no marker. Resolve it from the
+    box's labeled identity when that identity is still configured, otherwise the
+    config-level default; raise (deferred by the caller) when neither is set.
     """
-    if not vms:
-        return
-    count = len(vms)
-    noun = "box" if count == 1 else "boxes"
-    print(
-        f"\n{count} off-platform {noun} NOT updated by --all "
-        f"(off-platform 'update' is a full rebuild — run it per box):"
-    )
-    for vm in vms:
-        print(f"  - {vm.scope} [{vm.provider}]: vrg-vm update {vm.update_ref}")
+    identity = config.identities.get(vm.identity) if vm.identity else None
+    if identity is not None:
+        return resolve_vergil_version(config, identity)
+    if config.vergil:
+        return config.vergil
+    print("ERROR: no 'vergil' version configured in identities.toml", file=sys.stderr)
+    raise SystemExit(1)
 
 
 def _cmd_update_all(args: argparse.Namespace) -> int:
     """Update vergil-tooling in every existing VM owned by a configured identity.
 
-    Fail-deferred by design: every VM in the list is attempted even after one
-    fails; non-running VMs are skipped and reported; any failure makes the
+    Fail-deferred by design: every box in the list is attempted even after one
+    fails; non-running boxes are skipped and reported; any failure makes the
     final exit code non-zero — only after all attempts have completed. Off-platform
-    boxes are enumerated across backends and reported (never silently skipped, never
-    bulk-rebuilt); reporting them is not a failure, so it never affects the exit code.
+    boxes are enumerated across backends and updated IN PLACE over IAP, exactly
+    like Lima boxes (#1812, correcting #1803 which skipped-and-reported them on the
+    false premise that off-platform update means a rebuild). Two off-platform boxes
+    that share an org/repo (one per identity) stay distinct via their identity label.
     """
     if args.workspace or args.identity:
         print(
@@ -1107,14 +1151,39 @@ def _cmd_update_all(args: argparse.Namespace) -> int:
             print(f"ERROR: failed to update VM '{instance}': {reason}", file=sys.stderr)
             failed.append((instance, reason))
 
-    total = len(targets)
-    if total:
-        print(
-            f"Update complete: {len(updated)} updated, {len(skipped)} skipped, "
-            f"{len(failed)} failed (of {total} VMs)."
-        )
+    for vm in off_platform:
+        box = f"off-platform box '{vm.label}'"
+        if not vm.is_running:
+            print(f"Skipping {box} (status: {vm.status or 'Not Created'})")
+            skipped.append(vm.label)
+            continue
+        try:
+            fallback = _off_platform_fallback(config, vm)
+            transport = vm_cloud.off_platform_transport(vm.name, vm.state_dir)
+            _update_over_transport(transport, box, tag, fallback)
+            updated.append(vm.label)
+        except subprocess.CalledProcessError as exc:
+            reason = f"exit status {exc.returncode}"
+            print(f"ERROR: failed to update {box}: {reason}", file=sys.stderr)
+            failed.append((vm.label, reason))
+        except SystemExit as exc:
+            reason = f"aborted (exit {exc.code})"
+            print(f"ERROR: failed to update {box}: {reason}", file=sys.stderr)
+            failed.append((vm.label, reason))
+        except RuntimeError as exc:
+            # off_platform_transport raises RuntimeError when no zone is persisted
+            # (volume never applied), and update_plugins raises it on a plugin
+            # failure. Both are deferred like any other box failure.
+            reason = str(exc)
+            print(f"ERROR: failed to update {box}: {reason}", file=sys.stderr)
+            failed.append((vm.label, reason))
 
-    _report_off_platform_not_updated(off_platform)
+    # total is always > 0 here: the empty case returned "No VMs found." above.
+    total = len(targets) + len(off_platform)
+    print(
+        f"Update complete: {len(updated)} updated, {len(skipped)} skipped, "
+        f"{len(failed)} failed (of {total} VMs)."
+    )
 
     if failed:
         names = ", ".join(f"'{inst}' ({reason})" for inst, reason in failed)
@@ -1481,10 +1550,31 @@ class OffPlatformVm:
         return self.name
 
     @property
+    def label(self) -> str:
+        """Identity-qualified human label, so two boxes for the same org/repo stay distinct.
+
+        A repo with both a ``vergil-user`` and ``vergil-audit`` off-platform box has
+        two state dirs sharing one org/repo; ``scope`` alone collapses them into
+        identical lines (#1812). Carrying the identity keeps every box addressable.
+        """
+        if self.identity:
+            return f"{self.scope} [{self.identity}]"
+        return self.scope
+
+    @property
     def update_ref(self) -> str:
-        """How an operator re-addresses this box for a targeted ``vrg-vm update``."""
+        """How an operator re-addresses this box for a targeted ``vrg-vm update``.
+
+        Identity-qualified: a labeled box is reached by ``<org>/<repo> --identity
+        <identity>`` (two identities can share one org/repo), an unlabeled one by
+        ``--identity <identity>`` alone, falling back to the resource name only
+        when even the identity is unknown (#1812).
+        """
         if self.org and self.repo:
-            return f"{self.org}/{self.repo}"
+            base = f"{self.org}/{self.repo}"
+            if self.identity:
+                return f"{base} --identity {self.identity}"
+            return base
         if self.identity:
             return f"--identity {self.identity}"
         return self.name
@@ -1529,12 +1619,21 @@ def _cloud_list_rows() -> list[dict[str, object]]:
 
     Reuses the shared ``_off_platform_vms()`` enumeration; an unauthed/unreachable
     provider yields a degraded ``unknown (no <provider> creds)`` placeholder rather
-    than dropping the row or erroring the list.
+    than dropping the row or erroring the list. Each row carries the box's identity
+    so two boxes sharing an org/repo (one per identity) stay distinct in the listing
+    rather than collapsing into identical lines (#1812).
     """
     rows: list[dict[str, object]] = []
     for vm in _off_platform_vms():
         status = vm.status or f"unknown (no {vm.provider} creds)"
-        rows.append({"scope": vm.name, "backend": vm.provider, "status": status})
+        rows.append(
+            {
+                "identity": vm.identity or "—",
+                "scope": vm.scope,
+                "backend": vm.provider,
+                "status": status,
+            }
+        )
     return rows
 
 
@@ -1571,7 +1670,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
 
     for r in _cloud_list_rows():
         print(
-            f"{'—':<14} {r['scope']!s:<40} {r['backend']!s:<13} {r['status']!s:<11} "
+            f"{r['identity']!s:<14} {r['scope']!s:<40} {r['backend']!s:<13} {r['status']!s:<11} "
             f"{'—':<5} {'—':<7} {'—':<7} {'—':<7} {'—':<7} {'—':<22}"
         )
 
@@ -2048,7 +2147,9 @@ def main(argv: list[str] | None = None) -> int:
     _add_identity_args(p_restart)
     _add_workspace_arg(p_restart)
 
-    p_update = sub.add_parser("update", help="Reinstall vergil-tooling inside a running VM")
+    p_update = sub.add_parser(
+        "update", help="Reinstall vergil-tooling and refresh plugins in a running box (in place)"
+    )
     _add_identity_args(p_update)
     _add_workspace_arg(p_update)
     p_update.add_argument(
@@ -2058,20 +2159,10 @@ def main(argv: list[str] | None = None) -> int:
         "--all",
         action="store_true",
         help=(
-            "Update every VM owned by a configured identity (fail-deferred: all VMs "
-            "are attempted even if one fails; non-running VMs are skipped and reported). "
-            "Off-platform boxes are reported but not rebuilt — run 'vrg-vm update <box>' "
-            "per box to rebuild one."
-        ),
-    )
-    # Off-platform update delegates to rebuild, which drives the progress pipeline;
-    # these flags must exist on the update parser so that delegation has them.
-    p_update.add_argument(
-        "--verbose",
-        action="store_true",
-        help=(
-            "Stream live cloud-init provisioning output during await-readiness "
-            "(off-platform only; also enabled by VERGIL_VM_VERBOSE)"
+            "Update every box owned by a configured identity (fail-deferred: all "
+            "boxes are attempted even if one fails; non-running boxes are skipped and "
+            "reported). Off-platform boxes are updated in place over IAP, exactly "
+            "like Lima boxes — no rebuild."
         ),
     )
     progress.add_progress_args(p_update, ())

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import platform
 import re
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -406,72 +405,6 @@ def stop_vm(instance: str) -> None:
 
 def delete_vm(instance: str) -> None:
     _limactl("delete", "--force", instance)
-
-
-# Prepended to every in-VM `claude` invocation. claude itself is on the base
-# PATH (/usr/bin/claude, from apt node + `npm install -g`), but exporting PATH
-# explicitly — exactly as update_tooling does — keeps resolution independent of
-# the interactive environment. The VM's login shell is zsh (vergil-vm `chsh -s
-# /bin/zsh`), configured via ~/.zshenv / /etc/environment, so a bash login shell
-# would source none of its config; a non-login `bash -c` with an explicit PATH
-# avoids depending on any of that.
-_PLUGIN_PATH_EXPORT = 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
-
-
-def update_plugins(instance: str) -> None:
-    """Refresh enabled Claude Code plugins inside the VM.
-
-    Plugins are installed VM-locally from their GitHub marketplaces (declared
-    in the copied settings.json); they are deliberately not shared from the
-    host (see docs/site/docs/guides/agent-vm-claude-share-set.md). This
-    refreshes marketplace metadata and then advances each enabled plugin to its
-    latest version, mirroring how update_tooling advances vergil-tooling.
-
-    `claude plugin update` has no bulk form: it requires a specific plugin id
-    and honours the plugin's scope (user vs project), which differ across the
-    set. So enumerate the installed plugins with `claude plugin list --json`
-    and update each enabled one with its own scope. Updates apply on the next
-    Claude restart, which every new session triggers.
-
-    Best-effort across the set: one plugin failing does not block the others;
-    failures are collected and surfaced by raising afterwards (never swallowed).
-    """
-    print("  Refreshing Claude plugins...")
-    shell_run(
-        instance,
-        "bash",
-        "-c",
-        f"{_PLUGIN_PATH_EXPORT} && claude plugin marketplace update",
-    )
-    listing = shell_run(
-        instance,
-        "bash",
-        "-c",
-        f"{_PLUGIN_PATH_EXPORT} && claude plugin list --json",
-    )
-    plugins = json.loads(listing.stdout)
-
-    failures: list[str] = []
-    for plugin in plugins:
-        if not plugin.get("enabled"):
-            continue
-        pid = plugin["id"]
-        scope = plugin.get("scope", "user")
-        print(f"    updating {pid} ({scope})...")
-        cmd = (
-            f"{_PLUGIN_PATH_EXPORT} && claude plugin update "
-            f"{shlex.quote(pid)} --scope {shlex.quote(scope)}"
-        )
-        try:
-            shell_run(instance, "bash", "-c", cmd)
-        except subprocess.CalledProcessError:
-            failures.append(pid)
-
-    if failures:
-        joined = ", ".join(failures)
-        msg = f"failed to update plugin(s): {joined}"
-        print(f"ERROR: {msg}", file=sys.stderr)
-        raise RuntimeError(msg)
 
 
 def vm_age_days(instance: str) -> float | None:

--- a/src/vergil_tooling/lib/vm_guest.py
+++ b/src/vergil_tooling/lib/vm_guest.py
@@ -292,6 +292,74 @@ def try_update_tooling(
         return False
 
 
+# Prepended to every in-guest `claude` invocation. claude itself is on the base
+# PATH (/usr/bin/claude, from apt node + `npm install -g`), but exporting PATH
+# explicitly — exactly as update_tooling does — keeps resolution independent of
+# the interactive environment. The guest's login shell is zsh (vergil-vm `chsh -s
+# /bin/zsh`), configured via ~/.zshenv / /etc/environment, so a bash login shell
+# would source none of its config; a non-login `bash -c` with an explicit PATH
+# avoids depending on any of that.
+_PLUGIN_PATH_EXPORT = 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
+
+
+def update_plugins(transport: Transport) -> None:
+    """Refresh enabled Claude Code plugins inside the guest.
+
+    Plugins are installed guest-locally from their GitHub marketplaces (declared
+    in the copied settings.json); they are deliberately not shared from the
+    host (see docs/site/docs/guides/agent-vm-claude-share-set.md). This
+    refreshes marketplace metadata and then advances each enabled plugin to its
+    latest version, mirroring how update_tooling advances vergil-tooling.
+
+    Transport-generic (#1812): the same refresh runs over a local Lima instance
+    or a remote off-platform box, so an in-place off-platform ``update`` reaches
+    the plugins over IAP without a rebuild.
+
+    `claude plugin update` has no bulk form: it requires a specific plugin id
+    and honours the plugin's scope (user vs project), which differ across the
+    set. So enumerate the installed plugins with `claude plugin list --json`
+    and update each enabled one with its own scope. Updates apply on the next
+    Claude restart, which every new session triggers.
+
+    Best-effort across the set: one plugin failing does not block the others;
+    failures are collected and surfaced by raising afterwards (never swallowed).
+    """
+    print("  Refreshing Claude plugins...")
+    transport.run(
+        "bash",
+        "-c",
+        f"{_PLUGIN_PATH_EXPORT} && claude plugin marketplace update",
+    )
+    listing = transport.run(
+        "bash",
+        "-c",
+        f"{_PLUGIN_PATH_EXPORT} && claude plugin list --json",
+    )
+    plugins = json.loads(listing.stdout)
+
+    failures: list[str] = []
+    for plugin in plugins:
+        if not plugin.get("enabled"):
+            continue
+        pid = plugin["id"]
+        scope = plugin.get("scope", "user")
+        print(f"    updating {pid} ({scope})...")
+        cmd = (
+            f"{_PLUGIN_PATH_EXPORT} && claude plugin update "
+            f"{shlex.quote(pid)} --scope {shlex.quote(scope)}"
+        )
+        try:
+            transport.run("bash", "-c", cmd)
+        except subprocess.CalledProcessError:
+            failures.append(pid)
+
+    if failures:
+        joined = ", ".join(failures)
+        msg = f"failed to update plugin(s): {joined}"
+        print(f"ERROR: {msg}", file=sys.stderr)
+        raise RuntimeError(msg)
+
+
 _CLAUDE_CONFIG_FILES = ("CLAUDE.md", "settings.json")
 
 

--- a/tests/vergil_tooling/test_lima.py
+++ b/tests/vergil_tooling/test_lima.py
@@ -20,7 +20,6 @@ from vergil_tooling.lib.lima import (
     shell_run,
     start_vm,
     stop_vm,
-    update_plugins,
     vm_age_days,
     vm_status,
 )
@@ -804,59 +803,3 @@ class TestProvisionMonitor:
         with patch("vergil_tooling.lib.lima.progress.emit") as m_emit:
             _provision_monitor(tmp_path, "30m", stop, poll_secs=0.01, heartbeat_secs=0.03)
         assert [c.args[0] for c in m_emit.call_args_list] == ["[guest] final line"]
-
-
-class TestUpdatePlugins:
-    _LISTING = json.dumps(
-        [
-            {"id": "paad@paad", "scope": "user", "enabled": True},
-            {"id": "frontend-design@official", "scope": "user", "enabled": False},
-            {"id": "vergil@vergil-marketplace", "scope": "project", "enabled": True},
-        ]
-    )
-
-    def _fake_shell(self) -> MagicMock:
-        def side_effect(_instance: str, *args: str, **_kw: object) -> MagicMock:
-            cmd = args[-1]
-            out = self._LISTING if "plugin list --json" in cmd else ""
-            return MagicMock(stdout=out, returncode=0)
-
-        mock = MagicMock(side_effect=side_effect)
-        return mock
-
-    @patch("vergil_tooling.lib.lima.shell_run")
-    def test_refreshes_marketplaces_then_updates_enabled_plugins(self, mock_run: MagicMock) -> None:
-        mock_run.side_effect = self._fake_shell().side_effect
-        update_plugins("vergil-agent")
-        cmds = [c.args[-1] for c in mock_run.call_args_list]
-        # Marketplace metadata refreshed first, then the installed list is read.
-        assert any("claude plugin marketplace update" in c for c in cmds)
-        assert any("claude plugin list --json" in c for c in cmds)
-        # Each ENABLED plugin updated with its own scope; no bulk update exists.
-        assert any("claude plugin update paad@paad --scope user" in c for c in cmds)
-        assert any(
-            "claude plugin update vergil@vergil-marketplace --scope project" in c for c in cmds
-        )
-        # Disabled plugins are left alone.
-        assert not any("frontend-design" in c for c in cmds)
-        # Every call is a non-login bash -c with an explicit PATH export, so claude
-        # resolves regardless of the VM's zsh-configured interactive environment.
-        for c in mock_run.call_args_list:
-            assert c.args[:3] == ("vergil-agent", "bash", "-c")
-            assert "export PATH=" in c.args[-1]
-
-    @patch("vergil_tooling.lib.lima.shell_run")
-    def test_raises_after_attempting_all_when_a_plugin_fails(self, mock_run: MagicMock) -> None:
-        def side_effect(_instance: str, *args: str, **_kw: object) -> MagicMock:
-            cmd = args[-1]
-            if "claude plugin update paad@paad" in cmd:
-                raise subprocess.CalledProcessError(1, "claude plugin update")
-            out = self._LISTING if "plugin list --json" in cmd else ""
-            return MagicMock(stdout=out, returncode=0)
-
-        mock_run.side_effect = side_effect
-        with pytest.raises(RuntimeError, match="paad@paad"):
-            update_plugins("vergil-agent")
-        # Best-effort: the other enabled plugin is still attempted before raising.
-        cmds = [c.args[-1] for c in mock_run.call_args_list]
-        assert any("claude plugin update vergil@vergil-marketplace" in c for c in cmds)

--- a/tests/vergil_tooling/test_vm_guest.py
+++ b/tests/vergil_tooling/test_vm_guest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -18,6 +19,7 @@ from vergil_tooling.lib.vm_guest import (
     link_claude_dirs,
     read_fingerprint,
     try_update_tooling,
+    update_plugins,
     update_tooling,
     vm_occupancy,
     vm_probe,
@@ -711,3 +713,61 @@ class TestVmProbe:
         transport = _transport()
         transport.run.side_effect = subprocess.CalledProcessError(1, "limactl")
         assert vm_probe(transport, fingerprint=True) == (0, 0, None)
+
+
+class TestUpdatePlugins:
+    # update_plugins is transport-generic (#1812): the same refresh drives a Lima
+    # box over limactl or an off-platform box over IAP — only the transport differs.
+    _LISTING = json.dumps(
+        [
+            {"id": "paad@paad", "scope": "user", "enabled": True},
+            {"id": "frontend-design@official", "scope": "user", "enabled": False},
+            {"id": "vergil@vergil-marketplace", "scope": "project", "enabled": True},
+        ]
+    )
+
+    def _fake_transport(self) -> MagicMock:
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            out = self._LISTING if "plugin list --json" in cmd else ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        return transport
+
+    def test_refreshes_marketplaces_then_updates_enabled_plugins(self) -> None:
+        transport = self._fake_transport()
+        update_plugins(transport)
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        # Marketplace metadata refreshed first, then the installed list is read.
+        assert any("claude plugin marketplace update" in c for c in cmds)
+        assert any("claude plugin list --json" in c for c in cmds)
+        # Each ENABLED plugin updated with its own scope; no bulk update exists.
+        assert any("claude plugin update paad@paad --scope user" in c for c in cmds)
+        assert any(
+            "claude plugin update vergil@vergil-marketplace --scope project" in c for c in cmds
+        )
+        # Disabled plugins are left alone.
+        assert not any("frontend-design" in c for c in cmds)
+        # Every call is a non-login bash -c with an explicit PATH export, so claude
+        # resolves regardless of the guest's zsh-configured interactive environment.
+        for c in transport.run.call_args_list:
+            assert c.args[:2] == ("bash", "-c")
+            assert "export PATH=" in c.args[-1]
+
+    def test_raises_after_attempting_all_when_a_plugin_fails(self) -> None:
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "claude plugin update paad@paad" in cmd:
+                raise subprocess.CalledProcessError(1, "claude plugin update")
+            out = self._LISTING if "plugin list --json" in cmd else ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        with pytest.raises(RuntimeError, match="paad@paad"):
+            update_plugins(transport)
+        # Best-effort: the other enabled plugin is still attempted before raising.
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        assert any("claude plugin update vergil@vergil-marketplace" in c for c in cmds)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -15,6 +15,7 @@ import pytest
 from vergil_tooling.bin.vrg_vm import (
     BorrowError,
     DedicatedRow,
+    OffPlatformVm,
     Target,
     _cloud_backend,
     _CloudState,
@@ -1290,7 +1291,9 @@ class TestUpdate:
     ) -> None:
         result = main(["update", "--config", str(config_file)])
         assert result == 0
-        _mock_update_plugins.assert_called_once_with("vergil-agent")
+        # update_plugins is now transport-generic; it receives the box's transport.
+        _mock_update_plugins.assert_called_once()
+        _assert_transport(_mock_update_plugins, "vergil-agent")
 
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
@@ -1602,24 +1605,27 @@ class TestUpdateAll:
         mock_update.assert_not_called()
         assert "No VMs found" in capsys.readouterr().out
 
+    @patch("vergil_tooling.bin.vrg_vm.vm_cloud.off_platform_transport")
     @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.list_vms")
-    def test_reports_off_platform_boxes_instead_of_silently_skipping(
+    def test_updates_off_platform_boxes_in_place(
         self,
         mock_list: MagicMock,
         mock_update: MagicMock,
         _ver: MagicMock,
+        mock_transport: MagicMock,
         _no_off_platform: MagicMock,
         config_file: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # The bug: off-platform boxes are invisible to list_vms(), so --all never
-        # touched them and said nothing. Now they are enumerated across backends
-        # and reported with the per-box rebuild command — never bulk-rebuilt, never
-        # silent — and reporting them is not a failure.
+        # #1812: --all updates a running off-platform box IN PLACE over IAP, exactly
+        # like a Lima box — no rebuild, no skip-and-report (the #1803 behavior this
+        # corrects). The box's identity qualifies its label.
         from vergil_tooling.bin.vrg_vm import OffPlatformVm
 
+        fake_transport = MagicMock()
+        mock_transport.return_value = fake_transport
         mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
         _no_off_platform.return_value = [
             OffPlatformVm(
@@ -1634,25 +1640,30 @@ class TestUpdateAll:
         ]
         result = main(["update", "--all", "--config", str(config_file)])
         assert result == 0
-        # The Lima box was still updated normally.
-        mock_update.assert_called_once_with(ANY, None, fallback_tag="v2.0")
+        # Both boxes updated in place: Lima over limactl, off-platform over IAP.
+        assert mock_update.call_count == 2
+        mock_transport.assert_called_once_with("vergil-lmf-cloud", Path("/x/gcp"))
+        assert fake_transport in [c.args[0] for c in mock_update.call_args_list]
         out = capsys.readouterr().out
-        assert "1 off-platform box NOT updated" in out
-        assert "lmf/cloud" in out
-        assert "vrg-vm update lmf/cloud" in out
+        assert "off-platform box 'lmf/cloud [lmf]'" in out
+        assert "2 updated" in out
+        assert "NOT updated" not in out
 
+    @patch("vergil_tooling.bin.vrg_vm.vm_cloud.off_platform_transport")
     @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.list_vms")
-    def test_reports_off_platform_when_no_lima_vms(
+    def test_skips_non_running_off_platform_box(
         self,
         mock_list: MagicMock,
         mock_update: MagicMock,
+        mock_transport: MagicMock,
         _no_off_platform: MagicMock,
         config_file: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # Off-platform boxes must surface even when there are no Lima VMs at all —
-        # the old "No VMs found." early return hid them in that case.
+        # A non-running off-platform box can't be reached over IAP, so it is skipped
+        # and reported (not silently dropped, not bulk-rebuilt) — and it surfaces even
+        # with no Lima VMs, so the old "No VMs found." early return must not hide it.
         from vergil_tooling.bin.vrg_vm import OffPlatformVm
 
         mock_list.return_value = []
@@ -1662,19 +1673,178 @@ class TestUpdateAll:
                 provider="gcp",
                 state_dir=Path("/x/gcp"),
                 identity="lmf",
-                org=None,
-                repo=None,
+                org="lmf",
+                repo="cloud",
                 status="",
             )
         ]
         result = main(["update", "--all", "--config", str(config_file)])
         assert result == 0
         mock_update.assert_not_called()
+        mock_transport.assert_not_called()
         out = capsys.readouterr().out
         assert "No VMs found" not in out
-        assert "1 off-platform box NOT updated" in out
-        # Unlabeled state -> addressed by identity rather than org/repo.
-        assert "vrg-vm update --identity lmf" in out
+        assert "Skipping off-platform box 'lmf/cloud [lmf]' (status: Not Created)" in out
+        assert "1 skipped" in out
+
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_off_platform_boxes_distinguished_by_identity(
+        self,
+        mock_list: MagicMock,
+        _mock_update: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The reporter bug: two off-platform boxes for the SAME org/repo (one per
+        # identity) collapsed into identical, identity-less lines. Each must now be
+        # distinguishable by its identity (#1812).
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        mock_list.return_value = []
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-vergil-user-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/user/gcp"),
+                identity="vergil-user",
+                org="lmf",
+                repo="cloud",
+                status="",
+            ),
+            OffPlatformVm(
+                name="vergil-vergil-audit-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/audit/gcp"),
+                identity="vergil-audit",
+                org="lmf",
+                repo="cloud",
+                status="",
+            ),
+        ]
+        result = main(["update", "--all", "--config", str(config_file)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "lmf/cloud [vergil-user]" in out
+        assert "lmf/cloud [vergil-audit]" in out
+        assert "2 skipped" in out
+
+    @pytest.mark.parametrize(
+        "exc",
+        [subprocess.CalledProcessError(1, "uv tool install"), SystemExit(1)],
+    )
+    @patch("vergil_tooling.bin.vrg_vm.vm_cloud.off_platform_transport")
+    @patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None)
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_off_platform_update_failure_is_deferred(
+        self,
+        mock_list: MagicMock,
+        mock_update: MagicMock,
+        _ver: MagicMock,
+        mock_transport: MagicMock,
+        _no_off_platform: MagicMock,
+        exc: Exception,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Fail-deferred: a failing off-platform box is reported and makes the exit
+        # code non-zero, but never aborts the run (parity with the Lima path).
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        mock_transport.return_value = MagicMock()
+        mock_update.side_effect = exc
+        mock_list.return_value = []
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="lmf",
+                org="lmf",
+                repo="cloud",
+                status="RUNNING",
+            )
+        ]
+        result = main(["update", "--all", "--config", str(config_file)])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "failed to update off-platform box 'lmf/cloud [lmf]'" in err
+        assert "1 of 1" in err
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_cloud.off_platform_transport")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_off_platform_unreachable_transport_is_deferred(
+        self,
+        mock_list: MagicMock,
+        mock_transport: MagicMock,
+        _no_off_platform: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # off_platform_transport raises RuntimeError when no zone is persisted (the
+        # volume was never applied); that is deferred like any other box failure.
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        mock_transport.side_effect = RuntimeError("no persisted zone")
+        mock_list.return_value = []
+        _no_off_platform.return_value = [
+            OffPlatformVm(
+                name="vergil-lmf-cloud",
+                provider="gcp",
+                state_dir=Path("/x/gcp"),
+                identity="lmf",
+                org="lmf",
+                repo="cloud",
+                status="RUNNING",
+            )
+        ]
+        result = main(["update", "--all", "--config", str(config_file)])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "failed to update off-platform box 'lmf/cloud [lmf]': no persisted zone" in err
+
+
+class TestOffPlatformFallback:
+    def _config(self) -> IdentityConfig:
+        return IdentityConfig(
+            identities={
+                "lmf": Identity(vm_instance="lmf-agent", projects_dir="/p", vergil="v3.0"),
+            },
+            default_identity="lmf",
+            vergil="v2.0",
+        )
+
+    def _vm(self, identity: str | None) -> OffPlatformVm:
+        return OffPlatformVm(
+            name="vergil-lmf-cloud",
+            provider="gcp",
+            state_dir=Path("/x/gcp"),
+            identity=identity,
+            org="lmf",
+            repo="cloud",
+            status="RUNNING",
+        )
+
+    def test_resolves_from_configured_identity(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _off_platform_fallback
+
+        # The box's labeled identity is still configured -> use its vergil version.
+        assert _off_platform_fallback(self._config(), self._vm("lmf")) == "v3.0"
+
+    def test_falls_back_to_config_default_for_unconfigured_identity(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _off_platform_fallback
+
+        # The labeled identity is gone from config -> config-level vergil version.
+        assert _off_platform_fallback(self._config(), self._vm("ghost")) == "v2.0"
+
+    def test_raises_when_no_vergil_version_configured(self) -> None:
+        from vergil_tooling.bin.vrg_vm import _off_platform_fallback
+
+        config = IdentityConfig(identities={}, default_identity=None, vergil="")
+        with pytest.raises(SystemExit):
+            _off_platform_fallback(config, self._vm("ghost"))
 
 
 class TestSessionStaleness:
@@ -3445,15 +3615,39 @@ class TestCloudSession:
 
 
 class TestCloudUpdate:
-    def test_cloud_update_delegates_to_rebuild(self, _cloud_repo: Path, tmp_path: Path) -> None:
-        with _CloudPatches(tmp_path / "state") as m:
-            result = main(
-                ["update", "lmf/cloud", "--config", str(_cloud_repo), "--output-format", "plain"]
-            )
+    def test_cloud_update_in_place_over_iap(self, _cloud_repo: Path, tmp_path: Path) -> None:
+        # #1812: a running off-platform box updates IN PLACE over its IAP transport —
+        # tooling + plugins refreshed, no destroy/re-apply (the corrected #1803 path).
+        transport = MagicMock()
+        with (
+            _CloudPatches(tmp_path / "state", status="Running") as m,
+            patch("vergil_tooling.bin.vrg_vm.update_tooling") as mock_update,
+            patch("vergil_tooling.bin.vrg_vm.update_plugins") as mock_plugins,
+            patch("vergil_tooling.bin.vrg_vm.get_tooling_version", return_value=None),
+        ):
+            m["transport"].return_value = transport
+            result = main(["update", "lmf/cloud", "--config", str(_cloud_repo)])
         assert result == 0
-        # update -> rebuild -> destroy_vm + re-apply
-        m["destroy_vm"].assert_called_once()
-        m["apply_vm"].assert_called_once()
+        mock_update.assert_called_once()
+        assert mock_update.call_args.args[0] is transport
+        mock_plugins.assert_called_once_with(transport)
+        # No rebuild: the disposable VM is never destroyed or re-applied.
+        m["destroy_vm"].assert_not_called()
+        m["apply_vm"].assert_not_called()
+
+    def test_cloud_update_refuses_when_not_running(
+        self, _cloud_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # In-place update needs IAP reachability, so a non-running box is refused with
+        # an identity-qualified start hint (two identities can share one org/repo).
+        with _CloudPatches(tmp_path / "state", status="") as m:
+            result = main(["update", "lmf/cloud", "--config", str(_cloud_repo)])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "is not running" in err
+        assert "vrg-vm start lmf/cloud --identity vergil-user" in err
+        m["destroy_vm"].assert_not_called()
+        m["apply_vm"].assert_not_called()
 
 
 class TestCloudStopStartUnsupported:
@@ -3625,15 +3819,17 @@ class TestCloudList:
         assert vm.provider == "gcp"
         assert (vm.identity, vm.org, vm.repo) == ("lmf", "lmf", "cloud")
         assert vm.scope == "lmf/cloud"
-        assert vm.update_ref == "lmf/cloud"
+        # Identity-qualified label and ref keep two boxes for one org/repo distinct (#1812).
+        assert vm.label == "lmf/cloud [lmf]"
+        assert vm.update_ref == "lmf/cloud --identity lmf"
         assert vm.status == ""
         assert vm.is_running is False
 
     def test_off_platform_vm_unlabeled_falls_back_to_resource_name(self) -> None:
         from vergil_tooling.bin.vrg_vm import OffPlatformVm
 
-        # A never-applied / unlabeled state has no identity or org/repo, so both the
-        # display scope and the targeted ref fall back to the resource name.
+        # A never-applied / unlabeled state has no identity or org/repo, so the
+        # display scope, label, and targeted ref all fall back to the resource name.
         vm = OffPlatformVm(
             name="vergil-orphan",
             provider="gcp",
@@ -3644,7 +3840,44 @@ class TestCloudList:
             status="",
         )
         assert vm.scope == "vergil-orphan"
+        assert vm.label == "vergil-orphan"
         assert vm.update_ref == "vergil-orphan"
+
+    def test_off_platform_vm_unlabeled_with_identity_uses_identity_ref(self) -> None:
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        # Identity recovered but no org/repo (partially labeled): the box is reached
+        # by --identity alone, and the label carries the identity for distinctness.
+        vm = OffPlatformVm(
+            name="vergil-orphan",
+            provider="gcp",
+            state_dir=Path("/x/gcp"),
+            identity="lmf",
+            org=None,
+            repo=None,
+            status="",
+        )
+        assert vm.scope == "vergil-orphan"
+        assert vm.label == "vergil-orphan [lmf]"
+        assert vm.update_ref == "--identity lmf"
+
+    def test_off_platform_vm_labeled_without_identity_uses_org_repo_ref(self) -> None:
+        from vergil_tooling.bin.vrg_vm import OffPlatformVm
+
+        # org/repo labeled but no identity recovered: ref is the bare org/repo, and
+        # the label has no identity suffix to add.
+        vm = OffPlatformVm(
+            name="vergil-lmf-cloud",
+            provider="gcp",
+            state_dir=Path("/x/gcp"),
+            identity=None,
+            org="lmf",
+            repo="cloud",
+            status="",
+        )
+        assert vm.scope == "lmf/cloud"
+        assert vm.label == "lmf/cloud"
+        assert vm.update_ref == "lmf/cloud"
 
     def test_off_platform_active_sessions_queries_over_transport(self) -> None:
         from vergil_tooling.bin.vrg_vm import OffPlatformVm, _off_platform_active_sessions


### PR DESCRIPTION
# Pull Request

## Summary

- Off-platform 'vrg-vm update' now refreshes vergil-tooling and Claude plugins in place over the box's IAP transport (and 'update --all' updates running off-platform boxes in place), correcting #1803's premise that off-platform update meant an ~8-minute rebuild that destroyed the live session.

## Issue Linkage

- Ref #1812

## Notes

- Three coordinated changes: (1) update_plugins moved lima.py -> vm_guest.py and made transport-generic so the plugin refresh runs over IAP; (2) 'update <off-platform>' and 'update --all' update a running box in place (non-running boxes are refused/skipped with an identity-qualified hint, never silently bulk-rebuilt); (3) off-platform labels, the update ref, and 'list' rows now carry identity so two boxes sharing an org/repo (one per identity) stay distinct. The now-dead '--verbose' flag was removed from the update parser. Validation green (lint/typecheck/100% coverage/tests). Reviewer focus: the fail-deferred exception handling in the new off-platform loop in _cmd_update_all, and _off_platform_fallback's marker-then-identity-then-config resolution order.