### PR TITLE
feat(off-platform): auto-fall back across a region's zones on a capacity stockout

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -6,12 +6,13 @@ import argparse
 import datetime
 import json
 import os
+import random
 import shlex
 import shutil
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -683,6 +684,9 @@ class _CloudState:
     volume_id: str = ""
     host: str = ""
     transport: Transport | None = None
+    # Remaining zones to try if the VM apply hits a capacity stockout (#1813). Populated
+    # by tofu-volume on a fresh create; empty on a reattach (a zonal disk cannot move).
+    fallback_zones: list[str] = field(default_factory=list)
 
 
 def _require_modules(state: _CloudState) -> Path:
@@ -706,6 +710,19 @@ def _cs_fetch_modules(state: _CloudState) -> None:
     state.modules_root = vm_cloud.fetch_modules(state.tag)
 
 
+def _candidate_zones(backend: OffPlatformBackend) -> list[str]:
+    """Zone order to try for a fresh create: an explicit ``zone`` first (operator
+    preference), otherwise the region's zones shuffled to spread load. (#1813)
+    """
+    zones = vm_cloud.region_zones(backend.spec.region)
+    configured = backend.spec.zone
+    if configured:
+        return [configured, *(z for z in zones if z != configured)]
+    shuffled = list(zones)
+    random.shuffle(shuffled)
+    return shuffled
+
+
 def _cs_tofu_volume(state: _CloudState) -> None:
     modules_root = _require_modules(state)
     print("Applying persistent volume...")
@@ -713,6 +730,13 @@ def _cs_tofu_volume(state: _CloudState) -> None:
     # signatures are precisely typed. The dict is the backend's own contract, so the
     # spread is the right call shape — cast to Any to bridge the object→typed kwargs gap.
     volume_vars = cast("dict[str, Any]", state.backend.volume_vars())
+    # Fresh create -> sweep zones on a capacity stockout. A reattach (existing volume
+    # state) is pinned to its zone — a zonal disk holds data and cannot move (#1813).
+    if not (state.state_dir / "volume.tfstate").exists():
+        candidates = _candidate_zones(state.backend)
+        if candidates:
+            volume_vars["zone"] = candidates[0]
+            state.fallback_zones = candidates[1:]
     volume_id, zone = vm_cloud.apply_volume(modules_root, state.state_dir, **volume_vars)
     state.volume_id = volume_id
     state.zone = zone
@@ -721,9 +745,16 @@ def _cs_tofu_volume(state: _CloudState) -> None:
 def _cs_tofu_vm(state: _CloudState) -> None:
     modules_root = _require_modules(state)
     print("Applying VM...")
-    raw_vm_vars = state.backend.vm_vars(zone=state.zone, volume_id=state.volume_id)
-    vm_vars = cast("dict[str, Any]", raw_vm_vars)
-    out = vm_cloud.apply_vm(modules_root, state.state_dir, **vm_vars)
+    volume_id, zone, out = vm_cloud.apply_vm_with_zone_fallback(
+        modules_root,
+        state.state_dir,
+        state.backend,
+        zone=state.zone,
+        volume_id=state.volume_id,
+        fallback_zones=state.fallback_zones,
+    )
+    state.volume_id = volume_id
+    state.zone = zone
     state.host = out["host"]
     state.transport = state.backend.transport()
 

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -19,7 +19,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from vergil_tooling.lib import progress
 from vergil_tooling.lib.vm_spec import spec_fingerprint
@@ -711,6 +711,91 @@ def read_zone(state_dir: Path) -> str:
         msg = f"no persisted zone at {zone_file} — apply the volume first"
         raise RuntimeError(msg)
     return zone_file.read_text(encoding="utf-8").strip()
+
+
+# A GCP zone-capacity stockout ("the zone does not have enough resources" /
+# ZONE_RESOURCE_POOL_EXHAUSTED) is transient and zone-specific, so it is worth retrying in
+# another zone — unlike a real config/quota error, which must abort. (#1813)
+_ZONE_CAPACITY_RE = re.compile(
+    r"does not have enough resources available|ZONE_RESOURCE_POOL_EXHAUSTED",
+    re.IGNORECASE,
+)
+
+
+def is_zone_capacity_error(exc: subprocess.CalledProcessError) -> bool:
+    """True when a tofu apply failed purely because the zone is out of capacity."""
+    blob = f"{exc.stderr or ''}{exc.stdout or ''}"
+    return bool(_ZONE_CAPACITY_RE.search(blob))
+
+
+def region_zones(region: str) -> list[str]:
+    """The UP zones of a GCP region, sorted (e.g. us-central1 -> -a/-b/-c/-f).
+
+    Used to sweep zones for capacity when an instance create is stocked out.
+    """
+    result = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "gcloud",
+            "compute",
+            "zones",
+            "list",
+            f"--filter=name~^{region}- AND status=UP",
+            "--format=value(name)",
+            f"--project={_resolve_project()}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return sorted(result.stdout.split())
+
+
+def apply_vm_with_zone_fallback(
+    modules_root: Path,
+    state_dir: Path,
+    backend: OffPlatformBackend,
+    *,
+    zone: str,
+    volume_id: str,
+    fallback_zones: list[str],
+) -> tuple[str, str, dict[str, str]]:
+    """Apply the VM in ``zone``; on a capacity stockout, recreate the (empty) volume + VM
+    in each ``fallback_zones`` entry until one lands. Returns ``(volume_id, zone, outputs)``.
+
+    Only the fresh-volume create path supplies fallback zones — a reattach (existing volume
+    with data) passes ``[]``, since a zonal disk cannot move zones without losing its data.
+    ``apply_vm`` already rolls back its own partial state (the firewall) on failure; between
+    fallback zones we additionally destroy the just-created *empty* volume. (#1813)
+    """
+    tried = [zone]
+    vm_vars = cast("dict[str, Any]", backend.vm_vars(zone=zone, volume_id=volume_id))
+    try:
+        return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
+    except subprocess.CalledProcessError as exc:
+        if not (fallback_zones and is_zone_capacity_error(exc)):
+            raise
+        print(f"  zone {zone}: no capacity — trying another...", file=sys.stderr)
+
+    for next_zone in fallback_zones:
+        destroy_volume(modules_root, state_dir)  # the empty disk; rmtrees the state dir
+        state_dir.mkdir(parents=True, exist_ok=True)
+        volume_vars = cast("dict[str, Any]", {**backend.volume_vars(), "zone": next_zone})
+        volume_id, zone = apply_volume(modules_root, state_dir, **volume_vars)
+        tried.append(zone)
+        vm_vars = cast("dict[str, Any]", backend.vm_vars(zone=zone, volume_id=volume_id))
+        try:
+            return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
+        except subprocess.CalledProcessError as exc:
+            if not is_zone_capacity_error(exc):
+                raise
+            print(f"  zone {zone}: no capacity — trying another...", file=sys.stderr)
+
+    msg = (
+        f"no zone in {backend.spec.region} has capacity for {backend.spec.instance} "
+        f"(tried: {', '.join(tried)}). Try a different instance family (e.g. n2d-*), "
+        "another region, or wait for capacity."
+    )
+    raise RuntimeError(msg)
 
 
 # --- Volume state parsing ----------------------------------------------------

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -13,6 +13,7 @@ from vergil_tooling.lib import vm_cloud
 from vergil_tooling.lib.vm_cloud import (
     OffPlatformBackend,
     apply_vm,
+    apply_vm_with_zone_fallback,
     apply_volume,
     await_readiness,
     bootstrap_volume,
@@ -21,12 +22,14 @@ from vergil_tooling.lib.vm_cloud import (
     destroy_vm,
     destroy_volume,
     fetch_modules,
+    is_zone_capacity_error,
     link_cloud_claude_dirs,
     off_platform_transport,
     parse_volume_state,
     preflight,
     provision_params,
     read_zone,
+    region_zones,
     render_provision_env,
     tofu_state_dir,
     zone_to_region,
@@ -940,6 +943,160 @@ class TestReadZone:
     def test_missing_zone_raises(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="no persisted zone"):
             read_zone(tmp_path)
+
+
+def _capacity_exc() -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(
+        1, ["tofu", "apply"], stderr="Error: the zone does not have enough resources available"
+    )
+
+
+class TestZoneCapacity:
+    def test_detects_capacity_phrasings(self) -> None:
+        assert is_zone_capacity_error(_capacity_exc()) is True
+        pool = subprocess.CalledProcessError(1, [], stderr="ZONE_RESOURCE_POOL_EXHAUSTED")
+        assert is_zone_capacity_error(pool) is True
+
+    def test_other_errors_are_not_capacity(self) -> None:
+        other = subprocess.CalledProcessError(1, [], stderr="Error: quota 'CPUS' exceeded")
+        assert is_zone_capacity_error(other) is False
+
+    def test_region_zones_sorted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sub = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                [], 0, stdout="us-central1-c\nus-central1-a\nus-central1-b\n"
+            )
+        )
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.subprocess.run", sub)
+        assert region_zones("us-central1") == [
+            "us-central1-a",
+            "us-central1-b",
+            "us-central1-c",
+        ]
+
+
+class TestZoneFallback:
+    @staticmethod
+    def _backend() -> MagicMock:
+        backend = MagicMock()
+        backend.vm_vars.return_value = {}
+        backend.volume_vars.return_value = {}
+        backend.spec.region = "us-central1"
+        backend.spec.instance = "n2-standard-16"
+        return backend
+
+    def test_first_zone_succeeds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        av = MagicMock(return_value={"host": "h"})
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.apply_vm", av)
+        result = apply_vm_with_zone_fallback(
+            tmp_path / "m",
+            tmp_path / "s",
+            self._backend(),
+            zone="us-central1-a",
+            volume_id="v1",
+            fallback_zones=["us-central1-b"],
+        )
+        assert result == ("v1", "us-central1-a", {"host": "h"})
+        av.assert_called_once()
+
+    def test_falls_back_across_zones_until_one_lands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # zone a (initial) stocked, zone b (fallback) stocked, zone c lands.
+        av = MagicMock(side_effect=[_capacity_exc(), _capacity_exc(), {"host": "h"}])
+        avol = MagicMock(side_effect=[("v2", "us-central1-b"), ("v3", "us-central1-c")])
+        dv = MagicMock()
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.apply_vm", av)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.apply_volume", avol)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.destroy_volume", dv)
+        result = apply_vm_with_zone_fallback(
+            tmp_path / "m",
+            tmp_path / "s",
+            self._backend(),
+            zone="us-central1-a",
+            volume_id="v1",
+            fallback_zones=["us-central1-b", "us-central1-c"],
+        )
+        assert result == ("v3", "us-central1-c", {"host": "h"})
+        assert dv.call_count == 2  # the empty disk is torn down before each retry
+        assert avol.call_count == 2  # recreated in each fallback zone
+        assert av.call_count == 3
+
+    def test_all_zones_stocked_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=_capacity_exc())
+        )
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_volume",
+            MagicMock(return_value=("v2", "us-central1-b")),
+        )
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.destroy_volume", MagicMock())
+        with pytest.raises(RuntimeError, match="no zone in us-central1 has capacity"):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-a",
+                volume_id="v1",
+                fallback_zones=["us-central1-b", "us-central1-c"],
+            )
+
+    def test_non_capacity_error_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        boom = subprocess.CalledProcessError(1, [], stderr="Error: bad config")
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=boom))
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-a",
+                volume_id="v1",
+                fallback_zones=["us-central1-b"],
+            )
+
+    def test_non_capacity_error_during_fallback_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # zone a stocked -> fall back to zone b, which fails with a real (non-capacity) error.
+        boom = subprocess.CalledProcessError(1, [], stderr="Error: bad config")
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=[_capacity_exc(), boom])
+        )
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_volume",
+            MagicMock(return_value=("v2", "us-central1-b")),
+        )
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.destroy_volume", MagicMock())
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-a",
+                volume_id="v1",
+                fallback_zones=["us-central1-b", "us-central1-c"],
+            )
+
+    def test_capacity_with_no_fallback_reraises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reattach (no fallback zones): a capacity error is fatal, not retried.
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=_capacity_exc())
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-a",
+                volume_id="v1",
+                fallback_zones=[],
+            )
 
 
 class TestOffPlatformTransport:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -17,6 +17,7 @@ from vergil_tooling.bin.vrg_vm import (
     DedicatedRow,
     OffPlatformVm,
     Target,
+    _candidate_zones,
     _cloud_backend,
     _CloudState,
     _create_from_target,
@@ -3463,6 +3464,10 @@ class _CloudPatches:
             "vergil_tooling.bin.vrg_vm.vm_cloud.apply_vm",
             return_value={"host": "cloud-host"},
         )
+        _patch(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.region_zones",
+            return_value=["us-central1-a", "us-central1-b", "us-central1-c"],
+        )
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.await_readiness")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.bootstrap_volume")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.link_cloud_claude_dirs")
@@ -3490,6 +3495,31 @@ class _CloudPatches:
             p.stop()
 
 
+class TestCandidateZones:
+    def test_configured_zone_is_tried_first(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.region_zones",
+            lambda _region: ["us-central1-a", "us-central1-b", "us-central1-c"],
+        )
+        backend = MagicMock()
+        backend.spec.region = "us-central1"
+        backend.spec.zone = "us-central1-c"
+        assert _candidate_zones(backend) == ["us-central1-c", "us-central1-a", "us-central1-b"]
+
+    def test_no_configured_zone_returns_all_region_zones(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.region_zones",
+            lambda _region: ["us-central1-a", "us-central1-b"],
+        )
+        monkeypatch.setattr("vergil_tooling.bin.vrg_vm.random.shuffle", lambda _seq: None)
+        backend = MagicMock()
+        backend.spec.region = "us-central1"
+        backend.spec.zone = ""
+        assert _candidate_zones(backend) == ["us-central1-a", "us-central1-b"]
+
+
 class TestCloudStageGuards:
     def _state(self, tmp_path: Path) -> _CloudState:
         projects = tmp_path / "projects"
@@ -3501,6 +3531,42 @@ class TestCloudStageGuards:
             backend=_cloud_backend(target),
             state_dir=tmp_path / "state",
         )
+
+    def test_tofu_volume_reattach_skips_zone_sweep(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An existing volume.tfstate means a reattach: the zonal disk is pinned, so no
+        # zone enumeration/fallback (#1813).
+        state = self._state(tmp_path)
+        state.modules_root = tmp_path / "modules"
+        state.state_dir.mkdir(parents=True, exist_ok=True)
+        (state.state_dir / "volume.tfstate").write_text("{}")
+        region_zones = MagicMock()
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.apply_volume",
+            MagicMock(return_value=("vol-1", "us-central1-b")),
+        )
+        monkeypatch.setattr("vergil_tooling.bin.vrg_vm.vm_cloud.region_zones", region_zones)
+        _cs_tofu_volume(state)
+        region_zones.assert_not_called()
+        assert state.fallback_zones == []
+        assert state.zone == "us-central1-b"
+
+    def test_tofu_volume_fresh_with_no_region_zones(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fresh, but region_zones came back empty -> no zone override, no fallback.
+        state = self._state(tmp_path)
+        state.modules_root = tmp_path / "modules"
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.apply_volume",
+            MagicMock(return_value=("vol-1", "us-central1-b")),
+        )
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.region_zones", MagicMock(return_value=[])
+        )
+        _cs_tofu_volume(state)
+        assert state.fallback_zones == []
 
     def test_require_modules_raises(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="fetch-modules did not run"):


### PR DESCRIPTION
# Pull Request

## Summary

- On a fresh off-platform create, sweep the region's zones (gcloud-enumerated) until the instance lands instead of failing on the first stocked zone. apply_vm_with_zone_fallback tries the chosen zone, and on a capacity stockout (ZONE_RESOURCE_POOL_EXHAUSTED) destroys the empty volume and recreates volume+VM in each fallback zone; a real (non-capacity) error still aborts. An explicit profile 'zone' is tried first, else zones are shuffled. Reattach (existing volume) is pinned — no fallback, since a zonal disk can't move without data loss.

## Issue Linkage

- Ref #1813

## Notes

- Builds on #1797 (zone plumbing); the per-attempt rollback also keeps a failed create retryable (cf #1804 orphan firewall). Hit live: n2-standard-8/16 stocked across us-central1-a/b/c. Region-wide crunches surface honestly (message points at a different family/region/wait). Capacity can't be probed ahead — try-rollback-retry is inherent. Validation green: 3451 tests, 100% coverage.