### PR TITLE
fix(retry): retry transient GitHub HTTP 401 Bad credentials errors

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -1,8 +1,8 @@
 """GitHub CLI (``gh``) subprocess wrappers.
 
 All functions that use ``check=True`` retry transparently on transient
-GitHub API errors (HTTP 502, 503, 504, 429 and network-level timeouts)
-with exponential backoff.
+GitHub API errors (HTTP 401, 502, 503, 504, 429 and network-level
+timeouts) with exponential backoff.
 """
 
 from __future__ import annotations
@@ -459,7 +459,7 @@ def wait_for_checks(
     --watch`` which blocks until every check completes.  Resilient to
     the head moving mid-wait (see ``_poll_and_watch_checks``).
 
-    Transient GitHub API errors (502/503/504/429) are retried
+    Transient GitHub API errors (401/502/503/504/429) are retried
     automatically via the library-level retry wrapper.
     """
     _poll_and_watch_checks(

--- a/src/vergil_tooling/lib/retry.py
+++ b/src/vergil_tooling/lib/retry.py
@@ -1,7 +1,14 @@
 """Retry logic for transient GitHub API errors.
 
 Shared by ``github.py`` (library wrappers) and ``vrg_gh.py`` (CLI wrapper)
-so both paths handle HTTP 502/503/504/429 and network timeouts identically.
+so both paths handle HTTP 401/502/503/504/429 and network timeouts
+identically.
+
+HTTP 401 "Bad credentials" is treated as transient: GitHub's API
+(notably the GraphQL endpoint behind ``gh pr checks --watch``)
+intermittently rejects a valid token, with the immediately following
+call succeeding. Retrying is safe even for write operations because a
+401 is rejected at authentication, before any mutation occurs.
 """
 
 from __future__ import annotations
@@ -18,6 +25,8 @@ MAX_RETRIES = 4
 BASE_DELAY_SECS = 2.0
 MAX_DELAY_SECS = 60.0
 _RETRYABLE_PATTERNS = (
+    "http 401",
+    "bad credentials",
     "http 502",
     "http 503",
     "http 504",

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -40,6 +40,23 @@ class TestStreamWithRetry:
             release_subprocess._stream_with_retry(("gh", "run", "watch"))
         assert m_progress.run.call_count == 2
 
+    def test_retries_transient_401_then_succeeds(self) -> None:
+        """A transient 'HTTP 401: Bad credentials' is retried, not propagated (#1819)."""
+        transient = subprocess.CalledProcessError(
+            1,
+            ("gh",),
+            output="",
+            stderr="HTTP 401: Bad credentials (https://api.github.com/graphql)",
+        )
+        with (
+            patch(_MOD + ".progress") as m_progress,
+            patch(_MOD + "._gh_env", return_value=None),
+            patch(_MOD + ".time"),
+        ):
+            m_progress.run.side_effect = [transient, None]
+            release_subprocess._stream_with_retry(("gh", "pr", "checks", "PR", "--watch"))
+        assert m_progress.run.call_count == 2
+
     def test_propagates_non_transient(self) -> None:
         fatal = subprocess.CalledProcessError(1, ("gh",), output="", stderr="not found")
         with (

--- a/tests/vergil_tooling/test_retry.py
+++ b/tests/vergil_tooling/test_retry.py
@@ -33,6 +33,8 @@ class TestIsRetryable:
             "HTTP 503 Service Unavailable",
             "HTTP 504 Gateway Timeout",
             "HTTP 429 rate limit exceeded",
+            "HTTP 401: Bad credentials (https://api.github.com/graphql)",
+            "Bad credentials",
             "request timed out",
             "connection reset by peer",
         ],


### PR DESCRIPTION
# Pull Request

## Summary

- Treat HTTP 401 "Bad credentials" as a transient, retryable GitHub API error. GitHub's API — notably the GraphQL endpoint behind `gh pr checks --watch` — intermittently rejects a valid token with 401 while the immediately following call succeeds; this false positive burned a release `merge` step (PR #1815).

## Issue Linkage

- Ref #1819

## Notes

- Retries are centralized in `retry.is_retryable()`, and every GitHub call path funnels through it: both `gh pr checks --watch` runners (`github.py` library + `release/subprocess.py` streaming), the JSON check-query calls, and the `vrg-gh` CLI wrapper. Adding `http 401` and `bad credentials` to `_RETRYABLE_PATTERNS` covers all of them with one change. Retrying a 401 is safe even for writes: the request is rejected at authentication, before any mutation occurs. Tests: 401 cases added to `is_retryable` plus an explicit streaming-path regression test using the real error string; docstrings updated; full `vrg-validate` passes.