### PR TITLE
fix(off-platform): copy host Claude config onto cloud VMs so bypass is reachable

### DIFF
--- a/docs/site/docs/guides/permission-model.md
+++ b/docs/site/docs/guides/permission-model.md
@@ -14,19 +14,37 @@ credentials are selected per-operation, see
 
 ## Base Permission Mode
 
-**`acceptEdits`** is the target mode. The agent freely reads and
-modifies code files — that is its primary job. The real risk
-surface is shell commands, not file edits.
+**`bypassPermissions`** is the standard mode — but only because the
+agent runs inside a sandboxed, ephemeral VM (see
+[The VM Sandbox Boundary](#the-vm-sandbox-boundary)). Inside that
+sandbox the agent reads, edits, and runs shell commands without
+per-action prompts, which is what makes it usable for real work.
 
-`acceptEdits` auto-approves:
+### Why not `acceptEdits`
 
-- File reads (Read tool)
-- File edits (Edit tool)
-- File writes (Write tool)
+`acceptEdits` was the original target: auto-approve file edits, prompt
+on any shell command not in the allowlist. It proved impractical for
+the work VERGIL actually does. An agent doing infrastructure work runs
+a constant stream of shell commands — container builds, cloud CLIs,
+system inspection, ad-hoc scripts — and under `acceptEdits` every
+non-allowlisted one stops for human approval. The prompts never end,
+and autonomous work becomes impossible. Chasing an ever-growing bash
+allowlist was a losing race.
 
-Shell commands not in the allowlist prompt the human. This is the
-escalation mechanism: the agent encounters something it cannot do,
-explains the situation, and the human approves or denies.
+So VERGIL moved the boundary outward instead of inward: rather than
+constrain *which commands* the agent may run, **sandbox the whole agent
+in a disposable VM** and let it run in `bypassPermissions` there. The
+blast radius is the VM, which is ephemeral and reproducible.
+
+### Bypass is not "no enforcement"
+
+`bypassPermissions` removes the *prompts*, not the *guardrails*. The
+`vrg-*` wrappers, the deny rules, and the hook guard all still apply —
+a hook hard-block (exit code 2) overrides even bypass mode — and the
+server-side GitHub App permission shapes remain the ultimate boundary
+(see [The Actual Security Boundary](#the-actual-security-boundary)).
+Bypass changes the agent's *experience inside the sandbox*; it does not
+widen what the agent can do to the outside world.
 
 ## `vrg-git` Wrapper
 
@@ -206,14 +224,16 @@ per-developer setup needed.
 ```json
 {
   "permissions": {
-    "defaultMode": "acceptEdits"
+    "defaultMode": "bypassPermissions"
   }
 }
 ```
 
-Switching `defaultMode` to `acceptEdits` makes unknown commands
-prompt the human instead of auto-approving. This is independent
-of the deny rules — raw `git`/`gh` are blocked regardless of mode.
+This is the operator's per-host setting. `vrg-vm` copies it into every
+identity VM — Lima and off-platform alike — via `copy_claude_config`,
+so the agent boots straight into bypass inside the sandbox. The mode is
+independent of the deny rules: raw `git`/`gh` are blocked regardless,
+because the hook guard hard-blocks them even under bypass.
 
 ### Local Settings (`.claude/settings.local.json`)
 
@@ -255,8 +275,8 @@ are found (Explore subagent, native Read tool, future
 | `vrg-git status` | No prompt (project allow) |
 | `grep -r "foo" src/` | No prompt (local allow) |
 | `git push` | Blocked (hook guard) |
-| `curl https://...` | Prompts the human |
-| `rm -rf .` | Prompts the human |
+| `curl https://...` | Runs (bypass; contained to the sandbox VM) |
+| `rm -rf .` | Runs (bypass; the disposable VM is the containment) |
 | `vrg-gh pr merge` | No Claude Code prompt, but wrapper rejects it |
 
 ## Defense-in-Depth
@@ -265,7 +285,7 @@ are found (Explore subagent, native Read tool, future
 
 Every client-side enforcement layer in this model assumes the agent
 is cooperative — that it is operating as Vergil, not Mimir. An
-agent with file write access (which `acceptEdits` grants) can
+agent with file write access (which `bypassPermissions` grants) can
 dismantle the entire client-side stack:
 
 1. Delete or edit `.claude/settings.json` — Layer 1 gone
@@ -284,11 +304,40 @@ boundaries.** They keep a well-intentioned agent on the rails.
 They prevent mistakes, enforce consistency, and provide an audit
 trail. They do not stop an adversary.
 
+The two boundaries an agent **cannot** edit its way out of are not
+client-side: the **VM sandbox** that contains it locally, and the
+**server-side** GitHub App permission shape that bounds what reaches
+GitHub.
+
+### The VM Sandbox Boundary
+
+Agents run inside a per-identity Vergil VM — never on the host. This is
+what makes `bypassPermissions` acceptable: the agent has full rein
+*inside* the VM, but the VM is the wall.
+
+- **Containment.** The agent reaches only what the VM can reach. The
+  host filesystem, other identities' VMs, and the operator's wider
+  environment are outside the sandbox.
+- **Disposability.** The VM is ephemeral and reproducible from its
+  declared profile, so a bad outcome inside it (an `rm -rf`, a wedged
+  toolchain) is recovered by a rebuild, not a forensic cleanup. On the
+  off-platform backend, irreplaceable state lives on a separate
+  persistent volume; injected credentials stay on the ephemeral boot
+  disk and die with the VM.
+- **Credential bounding.** Even with full local control, the agent can
+  only reach GitHub through its injected App token — which the
+  server-side boundary below constrains regardless of what happens in
+  the sandbox.
+
+The sandbox is why VERGIL runs `bypassPermissions` rather than chasing
+a per-command allowlist: move the boundary to the edge of a disposable
+VM, and the prompts inside it stop being the thing that protects you.
+
 ### The Actual Security Boundary
 
-The only enforcement an agent cannot edit its way out of is
-**server-side**: the GitHub App's installation permission shape and
-branch protection rulesets.
+At the GitHub layer, the enforcement an agent cannot edit its way out
+of is **server-side**: the GitHub App's installation permission shape
+and branch protection rulesets.
 
 - Each agent is a GitHub App whose installation token is bounded by
   its declared permission shape. The user App holds
@@ -304,7 +353,8 @@ branch protection rulesets.
 - An App can only act on accounts it is installed on and repos that
   installation covers.
 
-This is the real security model. Everything else is convenience.
+This and the VM sandbox are the real security model. Everything else
+is convenience.
 
 ### Why Client-Side Layers Still Matter
 
@@ -373,29 +423,34 @@ through normal operation.
 
 The rightmost column is the only one that holds against Mimir.
 
-## Phasing
+## History: the `acceptEdits` direction, and why it was dropped
 
-### Phase 1 (current target)
+The original plan phased *toward* a tight `acceptEdits` + allowlist
+model — `acceptEdits` as the default mode, then progressively shrinking
+the bash allowlist until `Bash(vrg *)` was the only allowed pattern and
+everything else required human approval.
 
-- `acceptEdits` as default mode
-- `vrg-git` and `vrg-gh` wrappers with subcommand validation
-- Project-level deny rules for raw `git` and `gh`
-- Temporary read-only bash exceptions in local settings
-- Hooks retained as backstop
+**That direction was not adopted.** In practice, prompting on every
+non-allowlisted shell command made the agent unusable for the
+infrastructure work VERGIL actually does, where running many varied
+commands *is* the job. The allowlist could never keep up, and the
+operator spent sessions approving commands instead of getting work
+done.
 
-### Phase 2 (future)
+VERGIL resolved this by changing *where* the boundary sits rather than
+*how tight* the allowlist is: the agent runs in `bypassPermissions`
+inside a disposable, sandboxed VM (see
+[Base Permission Mode](#base-permission-mode) and
+[The VM Sandbox Boundary](#the-vm-sandbox-boundary)). The `vrg-*`
+wrappers, deny rules, and hooks remain — as consistency and
+mistake-prevention guardrails, and as hard blocks on raw `git`/`gh`
+that hold even under bypass — but they are no longer what makes
+autonomy *safe*. The VM sandbox and the server-side App permissions
+are.
 
-- Evaluate replacing read-only bash exceptions with dedicated
-  tools or subagent patterns
-- Tighten the allowlist as more operations are mechanized
-- Each frequent prompt is a signal to build a new VRG tool
-
-### Phase 3 (future)
-
-- Ideal end state: `Bash(vrg *)` is the only allowlisted pattern
-- All operations flow through one command with validated
-  subcommands
-- No raw shell access without human approval
+The earlier `acceptEdits` design spec
+(`docs/specs/2026-05-14-permission-model-design.md`) is retained as
+historical context; it does not describe the model in use.
 
 ## Related
 

--- a/docs/specs/2026-05-14-permission-model-design.md
+++ b/docs/specs/2026-05-14-permission-model-design.md
@@ -2,7 +2,20 @@
 
 **Issue:** #754
 **Date:** 2026-05-14
-**Status:** Draft
+**Status:** Superseded (historical)
+
+> **Superseded (#1825).** This spec's direction — migrate from
+> `bypassPermissions` to `acceptEdits` plus a shrinking command
+> allowlist — was **not adopted**. In practice the per-command
+> prompting made the agent unusable for infrastructure work. VERGIL
+> instead made `bypassPermissions` the standard mode *inside a
+> disposable, sandboxed VM*, moving the security boundary to the edge
+> of the VM (and the server-side GitHub App permissions) rather than to
+> a client-side allowlist. The `vrg-*` wrappers, deny rules, and hooks
+> described below survive as guardrails, not as the safety mechanism.
+> The current model is documented in
+> [`docs/site/docs/guides/permission-model.md`](../site/docs/guides/permission-model.md).
+> This document is kept for historical context only.
 
 ## Problem
 

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -784,7 +784,16 @@ def _cs_bootstrap_volume(state: _CloudState) -> None:
 
 
 def _cs_link_claude(state: _CloudState) -> None:
-    vm_cloud.link_cloud_claude_dirs(_require_transport(state))
+    # Parity with the Lima path's _st_copy_config (#1825): seed the host's
+    # ~/.claude config (CLAUDE.md + settings.json) onto the cloud VM, THEN link
+    # the durable history subdirs onto the persistent volume. settings.json
+    # carries the operator's permissions.defaultMode; without this copy an
+    # off-platform VM never receives it, so bypassPermissions is unreachable
+    # (it is a launch-time/default mode, not a Shift+Tab cycle). The VM sandbox
+    # is the security boundary that makes bypass-in-guest the standard.
+    transport = _require_transport(state)
+    copy_claude_config(transport, Path.home() / ".claude")
+    vm_cloud.link_cloud_claude_dirs(transport)
 
 
 def _cloud_create_stages() -> list[Stage]:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -22,6 +22,7 @@ from vergil_tooling.bin.vrg_vm import (
     _CloudState,
     _create_from_target,
     _cs_credentials,
+    _cs_link_claude,
     _cs_tofu_volume,
     _list_rows,
     _log_root,
@@ -3471,6 +3472,7 @@ class _CloudPatches:
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.await_readiness")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.bootstrap_volume")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.link_cloud_claude_dirs")
+        _patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.preflight")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.destroy_vm")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.destroy_volume")
@@ -3575,6 +3577,37 @@ class TestCloudStageGuards:
     def test_require_transport_raises(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="tofu-vm did not run"):
             _cs_credentials(self._state(tmp_path))
+
+
+class TestCloudLinkClaudeCopiesConfig:
+    """The cloud link-claude stage must copy host ~/.claude config (parity with
+    the Lima path's _st_copy_config) so the operator's permissions.defaultMode
+    reaches the off-platform VM and bypassPermissions is reachable (#1825)."""
+
+    def _state(self, tmp_path: Path) -> _CloudState:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "cloud", _OFF_PLATFORM_VM)
+        cfg = _identities(tmp_path, projects)
+        target = _resolve_target(_args(cfg, "lmf/cloud"))
+        state = _CloudState(
+            target=target,
+            backend=_cloud_backend(target),
+            state_dir=tmp_path / "state",
+        )
+        state.transport = MagicMock()
+        return state
+
+    @patch("vergil_tooling.bin.vrg_vm.vm_cloud.link_cloud_claude_dirs")
+    @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
+    def test_link_stage_copies_host_config_then_links(
+        self, mock_copy: MagicMock, mock_link: MagicMock, tmp_path: Path
+    ) -> None:
+        state = self._state(tmp_path)
+        _cs_link_claude(state)
+        # copies host ~/.claude (settings.json carries permissions.defaultMode)...
+        mock_copy.assert_called_once_with(state.transport, Path.home() / ".claude")
+        # ...and still links the durable history subdirs onto the volume
+        mock_link.assert_called_once_with(state.transport)
 
 
 class TestCloudCreate:


### PR DESCRIPTION
# Pull Request

## Summary

- Bring the off-platform create path to parity with Lima by copying host ~/.claude config (carrying the operator's permissions.defaultMode) onto the cloud VM in _cs_link_claude before linking history dirs, so off-platform VMs boot into bypassPermissions instead of being stuck unable to reach it; also realign the permission-model docs to the de facto bypass-in-VM-sandbox model and mark the 2026-05-14 acceptEdits design spec superseded.

## Issue Linkage

- Ref #1825

## Notes

- Root cause: the host->VM copy_claude_config ran only on the Lima path (_st_copy_config); the cloud _cs_link_claude only symlinked history subdirs, so the operator's settings.json (with defaultMode) never reached the volume. Fix mirrors Lima exactly. Tests: new direct _cs_link_claude parity test + copy_claude_config added to the cloud-create _CloudPatches bundle. Docs: guide now documents bypassPermissions-in-sandbox as standard, why acceptEdits was retired, and adds an explicit VM Sandbox Boundary section; design spec marked Superseded. vrg-validate green.