### PR TITLE
fix(git): inject auth for git remote prune and never hang on prompts

### DIFF
--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 from vergil_tooling.lib import github, progress
 
-_REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote"}
+# Subcommands that may contact the remote and therefore need the installation
+# token. "remote" is included because `git remote prune`/`update` ls-remote the
+# origin to compute stale refs — a network op — even though most `git remote`
+# subcommands are local (#1830).
+_REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote", "remote"}
 
 
 def _git_auth_env(token: str) -> dict[str, str]:
@@ -18,30 +22,40 @@ def _git_auth_env(token: str) -> dict[str, str]:
     credentials = base64.b64encode(f"x-access-token:{token}".encode()).decode()
     return {
         **os.environ,
+        # Fail fast on a credential miss instead of blocking on an interactive
+        # prompt no automated caller can answer (#1830).
+        "GIT_TERMINAL_PROMPT": "0",
         "GIT_CONFIG_COUNT": "1",
         "GIT_CONFIG_KEY_0": "http.https://github.com/.extraHeader",
         "GIT_CONFIG_VALUE_0": f"Authorization: Basic {credentials}",
     }
 
 
-def _remote_env(args: tuple[str, ...]) -> dict[str, str] | None:
-    """Return auth env if *args* begins with a remote-capable subcommand."""
+def _git_env(args: tuple[str, ...]) -> dict[str, str]:
+    """Build the env for a git invocation.
+
+    GIT_TERMINAL_PROMPT=0 is set unconditionally (#1830): a network op missing
+    credentials we did not supply must fail fast, never hang forever on an
+    unanswerable interactive prompt (the bug that wedged `git remote prune` in
+    vrg-finalize-pr). For remote-capable subcommands the GitHub installation
+    token is layered on when available.
+    """
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
     if args and args[0] in _REMOTE_SUBCOMMANDS:
         token = github.get_installation_token()
         if token is not None:
-            return _git_auth_env(token)
-    return None
+            env = _git_auth_env(token)
+    return env
 
 
 def run(*args: str) -> None:
     """Run a git command, streaming output, and raise on failure."""
-    env = _remote_env(args)
-    progress.run(("git", *args), env=env)
+    progress.run(("git", *args), env=_git_env(args))
 
 
 def read_output(*args: str) -> str:
     """Run a git command and return stripped stdout."""
-    env = _remote_env(args)
+    env = _git_env(args)
     try:
         result = subprocess.run(  # noqa: S603
             ("git", *args),  # noqa: S607

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -102,18 +102,22 @@ def current_branch() -> str:
 
 def has_staged_changes() -> bool:
     """Return True if there are staged changes."""
+    args = ("diff", "--cached", "--quiet")
     result = subprocess.run(  # noqa: S603
-        ("git", "diff", "--cached", "--quiet"),  # noqa: S607
+        ("git", *args),  # noqa: S607
         check=False,
+        env=_git_env(args),
     )
     return result.returncode != 0
 
 
 def ref_exists(ref: str) -> bool:
     """Return True if a git ref exists."""
+    args = ("rev-parse", "--verify", "--quiet", ref)
     result = subprocess.run(  # noqa: S603
-        ("git", "rev-parse", "--verify", "--quiet", ref),  # noqa: S607
+        ("git", *args),  # noqa: S607
         check=False,
+        env=_git_env(args),
     )
     return result.returncode == 0
 

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -18,7 +18,12 @@ def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedPro
 def test_run_delegates_to_progress_run() -> None:
     with patch("vergil_tooling.lib.git.progress") as m_progress:
         git.run("status")
-    m_progress.run.assert_called_once_with(("git", "status"), env=None)
+    _args, kwargs = m_progress.run.call_args
+    assert _args[0] == ("git", "status")
+    # Local commands carry no auth header but still disable the prompt (#1830).
+    env = kwargs["env"]
+    assert "GIT_CONFIG_KEY_0" not in env
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
 
 
 def test_run_commit_no_env_var_gate() -> None:
@@ -28,7 +33,7 @@ def test_run_commit_no_env_var_gate() -> None:
     with patch("vergil_tooling.lib.git.progress") as m_progress:
         git.run("commit", "-m", "msg")
     _args, kwargs = m_progress.run.call_args
-    assert kwargs.get("env") is None
+    assert "GIT_CONFIG_KEY_0" not in kwargs["env"]
 
 
 def test_run_raises_on_failure() -> None:
@@ -72,9 +77,13 @@ def test_read_output_returns_stripped_stdout() -> None:
     with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed(stdout="  hello world  \n")
         assert git.read_output("log") == "hello world"
-    mock_run.assert_called_once_with(
-        ("git", "log"), check=True, text=True, capture_output=True, env=None
-    )
+    _args, kwargs = mock_run.call_args
+    assert _args[0] == ("git", "log")
+    assert kwargs["check"] is True
+    assert kwargs["text"] is True
+    assert kwargs["capture_output"] is True
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert "GIT_CONFIG_KEY_0" not in kwargs["env"]
 
 
 def test_repo_root_returns_path() -> None:
@@ -181,7 +190,9 @@ def test_working_tree_status_returns_empty_when_clean() -> None:
 class TestRunRemoteCredentialInjection:
     """git.run() injects credentials for remote-capable subcommands."""
 
-    @pytest.mark.parametrize("subcmd", ["push", "pull", "fetch", "ls-remote"])
+    # "remote" is included (#1830): `git remote prune` ls-remotes the origin,
+    # so it must be token-injected just like fetch/pull.
+    @pytest.mark.parametrize("subcmd", ["push", "pull", "fetch", "ls-remote", "remote"])
     def test_injects_token_for_remote_commands(self, subcmd: str) -> None:
         with (
             patch(
@@ -197,6 +208,7 @@ class TestRunRemoteCredentialInjection:
         assert env["GIT_CONFIG_COUNT"] == "1"
         assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraHeader"
         assert "Authorization: Basic" in env["GIT_CONFIG_VALUE_0"]
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
 
     @pytest.mark.parametrize("subcmd", ["status", "log", "diff", "add", "branch", "commit"])
     def test_no_injection_for_local_commands(self, subcmd: str) -> None:
@@ -209,7 +221,10 @@ class TestRunRemoteCredentialInjection:
         ):
             git.run(subcmd)
         _, kwargs = mock_progress.run.call_args
-        assert "env" not in kwargs or kwargs.get("env") is None
+        env = kwargs["env"]
+        # No auth header for local commands, but the prompt is still disabled.
+        assert "GIT_CONFIG_KEY_0" not in env
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
 
     def test_no_injection_when_no_token(self) -> None:
         with (
@@ -221,7 +236,11 @@ class TestRunRemoteCredentialInjection:
         ):
             git.run("push", "origin", "main")
         _, kwargs = mock_progress.run.call_args
-        assert "env" not in kwargs or kwargs.get("env") is None
+        env = kwargs["env"]
+        # Without a token the remote op carries no auth header — but the prompt
+        # stays disabled so it fails fast instead of hanging (#1830).
+        assert "GIT_CONFIG_KEY_0" not in env
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
 
     def test_token_encodes_as_basic_auth(self) -> None:
         import base64
@@ -271,7 +290,9 @@ class TestReadOutputRemoteCredentialInjection:
             mock_run.return_value = _completed(stdout="output\n")
             git.read_output(subcmd)
         _, kwargs = mock_run.call_args
-        assert "env" not in kwargs or kwargs.get("env") is None
+        env = kwargs["env"]
+        assert "GIT_CONFIG_KEY_0" not in env
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
 
 
 def test_commits_ahead_parses_rev_list_count() -> None:

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -134,6 +134,9 @@ def test_has_staged_changes_true() -> None:
     with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed(returncode=1)
         assert git.has_staged_changes() is True
+    # Even this local op disables the prompt so it can never hang (#1830).
+    _, kwargs = mock_run.call_args
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
 
 
 def test_has_staged_changes_false() -> None:
@@ -146,6 +149,9 @@ def test_ref_exists_true() -> None:
     with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
         mock_run.return_value = _completed(returncode=0)
         assert git.ref_exists("main") is True
+    # Even this local op disables the prompt so it can never hang (#1830).
+    _, kwargs = mock_run.call_args
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
 
 
 def test_ref_exists_false() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add "remote" to the token-injected subcommand set so git remote prune authenticates against private origins, and set GIT_TERMINAL_PROMPT=0 on every git invocation so any unanticipated network op fails fast instead of hanging on an unanswerable credential prompt.

## Issue Linkage

- Ref #1830

## Notes

- Fixes vrg-finalize-pr wedging at 'Pruning stale remote-tracking references' on no-TTY private-repo VMs. Two changes in lib/git.py: (1) 'remote' joins _REMOTE_SUBCOMMANDS — git remote prune internally ls-remotes the origin; (2) the env builder always sets GIT_TERMINAL_PROMPT=0, and has_staged_changes()/ref_exists() were routed through it too so the no-hang guard is universal across every git call, not just the wrapped ones. Tests cover the new 'remote' injection, the prompt-disable on local commands, and the two direct subprocess paths; full suite green at 100% coverage.