### PR TITLE
feat(vm): multiple VM instances per repo (named instances)

### DIFF
--- a/docs/specs/2026-06-23-vrg-vm-named-instances-implementation-plan.md
+++ b/docs/specs/2026-06-23-vrg-vm-named-instances-implementation-plan.md
@@ -21,6 +21,7 @@
 - **No silent failures:** invalid instance names, repo names containing `--`, and `--name X` against a missing instance must raise loudly. Never default or fall back silently.
 - **Instance name grammar:** `[a-z0-9]+(?:-[a-z0-9]+)*` (lowercase alnum, single internal hyphens, no `--`, no leading/trailing hyphen).
 - **Cloud name budget:** the hashed `vrg-<12 hex>` is 16 chars; the GCP `var.name` ≤ 58 guard lives in vergil-vm and is out of scope here.
+- **Reserved, not built:** the per-name tier-6 host-override slot `[<identity>.<org>.<repo>.<name>]` is intentionally NOT parsed or consumed. Tier-6 stays keyed on `(org, repo)` exactly as today; a name-level override table is left unread (non-breaking to add later, per the spec). Do not implement it.
 
 ---
 
@@ -176,7 +177,13 @@ In `parse_vm_stanza`, reject the all-identity tier. Replace the `elif isinstance
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_config.py -k "instances" -v`
 Expected: PASS (all three new tests).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Refactor**
+
+Look for:
+- Duplicated RoleOverlay construction between the top-level role parse and the instance-overlay parse — both build a `RoleOverlay` from the same scalar/list set. Confirm the recursive `_parse_role_overlay(..., allow_instances=False)` reuse is the only construction path (don't fork a second builder).
+- Naming: the `instances={}` default on `RoleOverlay` must not break existing positional constructions in tests — grep `RoleOverlay(` in tests and confirm.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -277,11 +284,33 @@ def test_compose_missing_named_instance_errors_with_available():
         compose_vm_spec(
             identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="nope"
         )
+
+
+def test_fingerprint_excludes_instance_name():
+    # The name is the handle, not fingerprint content: a named instance and the
+    # default that resolve to the SAME effective footprint share a fingerprint, so
+    # adding/renaming an instance never trips drift on the others.
+    role = RoleOverlay(
+        packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        instances={"rdqm-rhel": RoleOverlay(
+            packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
+            apt_repos=[], vagrant_plugins=[], port_forwards=[])},
+    )
+    stanza = VmStanza(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={"vergil-user": role},
+    )
+    default = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+    named = compose_vm_spec(
+        identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="rdqm-rhel"
+    )
+    assert spec_fingerprint(default) == spec_fingerprint(named)
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "validate_instance or validate_repo or named_instance or default_instance" -v`
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "validate_instance or validate_repo or named_instance or default_instance or fingerprint_excludes" -v`
 Expected: FAIL — `ImportError` for `validate_instance_name` / `compose_vm_spec` got unexpected keyword `instance`.
 
 - [ ] **Step 3: Add the validators**
@@ -359,10 +388,16 @@ Replace the tier-3/4 block (lines 200-205) with tier-3/4/5:
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
-Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "validate_instance or validate_repo or named_instance or default_instance or missing_named" -v`
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "validate_instance or validate_repo or named_instance or default_instance or missing_named or fingerprint_excludes" -v`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Refactor**
+
+Look for:
+- The tier-5 block accesses `role.instances` twice (available list + overlay lookup); bind it once to a local.
+- `validate_instance_name`/`validate_repo_segment` error messages should match the existing `SpecError` message style in this module (identity-prefixed where relevant).
+
+- [ ] **Step 7: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -371,7 +406,7 @@ vrg-commit --type feat --scope vm --message "compose tier-5 named-instance overl
   --body "Add validate_instance_name / validate_repo_segment and an 'instance' parameter to compose_vm_spec that applies the [vm.<identity>.instances.<name>] overlay, erroring with available names when the instance is missing. Ref #1831"
 ```
 
-- [ ] **Step 7: Phase 1 full validation**
+- [ ] **Step 8: Phase 1 full validation**
 
 Run: `vrg-container-run -- vrg-validate`
 Expected: PASS (whole suite green; default path unchanged).
@@ -470,7 +505,13 @@ def instance_name(
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "instance_name" -v`
 Expected: PASS (new tests plus existing `instance_name` tests).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Refactor**
+
+Look for:
+- `segments` is built once and reused for both `full` (the readable join) and `digest_src` (the hash input) — confirm there's no second place that re-joins identity/org/repo/name.
+- Naming: the new `name` parameter should not shadow the module-level `name` usages; confirm the function body reads clearly.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -661,7 +702,14 @@ def select_backend(
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_cloud.py tests/vergil_tooling/test_vm_spec.py::test_state_slug_forms -v`
 Expected: PASS. If existing `test_vm_cloud.py` tests call `cloud_resource_name(identity, org, repo)` or `cloud_labels(identity, org, repo)` positionally, update those call sites to the new signatures (the cloud name is now a hash of the slug; assertions on the old dashed name must change to `state_slug(...)` for the state key and `cloud_resource_name(state_slug(...))` for the resource name).
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 8: Refactor**
+
+Look for:
+- Remove the now-unused `_MAX_NAME`/`_HASH_LEN` constants (grep first to confirm no other reference).
+- `OffPlatformBackend` should obtain its slug via `state_slug(...)` (done) rather than re-joining segments — confirm no duplicate slug-building remains in `vm_cloud.py`.
+- Update every `cloud_resource_name(...)`/`cloud_labels(...)` caller to the new signatures (grep both names across `src/` and `tests/`).
+
+- [ ] **Step 9: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -834,7 +882,14 @@ class DedicatedRow:
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "recover_handle" -v`
 Expected: PASS. Then run the full `test_vrg_vm.py` to catch any remaining `recover_triple` references: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -q` and fix any `recover_triple` import in the tests by renaming to `recover_handle` (adjusting expected tuples to four elements).
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 7: Refactor**
+
+Look for:
+- Extract the name-normalization (`str(meta.get("name") or "") or None`) if it reads awkwardly inline.
+- Grep `recover_triple` across `src/` and `tests/` to confirm zero remaining references after the rename to `recover_handle`.
+- Confirm `read_instance_meta`'s schema-1 back-compat (`setdefault("name", "")`) is exercised by a test or note it.
+
+- [ ] **Step 8: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -843,7 +898,7 @@ vrg-commit --type feat --scope vm --message "make handle reversal name-aware (re
   --body "Sidecar payload bumps to schema 2 with a name field; recover_triple becomes recover_handle returning the four-part handle, threaded through discover_dedicated and update --all. Ref #1831"
 ```
 
-- [ ] **Step 8: Phase 2 full validation**
+- [ ] **Step 9: Phase 2 full validation**
 
 Run: `vrg-container-run -- vrg-validate`
 Expected: PASS.
@@ -878,9 +933,28 @@ def test_resolve_target_named_instance(monkeypatch, named_instance_config):
     assert target.instance == "vergil-user.lmf.mq.cloud-x86"
     assert target.spec.off_platform
     assert target.backend.slug == "vergil-user--lmf--mq--cloud-x86"
+
+
+def test_destroy_volume_named_targets_instance_volume(named_instance_config):
+    # destroy-volume --name must resolve the NAMED instance's volume state, not the
+    # default's — it is irreversible and billable.
+    args = _make_args(
+        command="destroy-volume", workspace="lmf/mq", name="cloud-x86", identity="vergil-user"
+    )
+    target = _resolve_target(args)
+    assert target.backend.state_key == "vergil-user--lmf--mq--cloud-x86"
+
+
+def test_update_named_resolves_instance_lima_name(named_instance_local_config):
+    # update (single) routes through _resolve_instance, which must honor --name.
+    args = _make_args(
+        command="update", workspace="lmf/mq", name="rdqm-rhel", identity="vergil-user"
+    )
+    _name, _identity, _config, instance = _resolve_instance(args)
+    assert instance == "vergil-user.lmf.mq.rdqm-rhel"
 ```
 
-If `test_vrg_vm_resolve.py` has no reusable fixture/`_make_args`, add a minimal `argparse.Namespace`-based helper and a config fixture following the patterns already in that file (read the file's existing resolve tests first and match them). The behavioral assertions above are the contract.
+If `test_vrg_vm_resolve.py` has no reusable fixture/`_make_args`, add a minimal `argparse.Namespace`-based helper and config fixtures following the patterns already in that file (read the file's existing resolve tests first and match them). `_make_args` must accept a `command` kwarg. The behavioral assertions above are the contract.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1016,10 +1090,17 @@ Confirm the create-time write (Task 5 Step 5a) passes `target.instance_name_arg`
 
 - [ ] **Step 7: Run the tests to verify they pass**
 
-Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm_resolve.py -k "named_instance" -v`
-Expected: PASS.
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm_resolve.py -k "named" -v`
+Expected: PASS (resolve + destroy-volume + update named tests).
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 8: Refactor**
+
+Look for:
+- The repeated `getattr(args, "name", None)` across `_resolve_target`/`_resolve_instance` — consider a tiny `_requested_name(args)` accessor.
+- `validate_repo_segment` is now called in two resolvers; ensure consistent placement (right after `org`/`repo` are known).
+- `_add_name_arg` is attached to many parsers — confirm one helper, not copy-pasted `add_argument` calls (session is the one intentional exception).
+
+- [ ] **Step 9: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -1028,7 +1109,7 @@ vrg-commit --type feat --scope vm --message "add --name flag across lifecycle ve
   --body "Target carries instance_name_arg; --name is wired into create/session/rebuild/destroy/stop/start/restart/update/destroy-volume and threaded through _resolve_target/_resolve_instance into composition, the Lima name, and the backend. Ref #1831"
 ```
 
-- [ ] **Step 9: Phase 3 full validation**
+- [ ] **Step 10: Phase 3 full validation**
 
 Run: `vrg-container-run -- vrg-validate`
 Expected: PASS. Confirm a bare verb (no `--name`) still resolves the default instance unchanged.
@@ -1135,7 +1216,13 @@ def _recorded_state_for_handle(
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "recorded_state" -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Refactor**
+
+Look for:
+- The `volume.tfstate`/`vm.tfstate` existence check now appears here and in `_off_platform_vms`; if it becomes a third site in Task 8/10, extract a small `_has_tofu_state(provider_dir)` helper.
+- Naming: confirm `RecordedState` fields (`lima_instance`, `tofu_dirs`) read clearly at the call sites in Tasks 8/9.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -1306,7 +1393,14 @@ In `main()`, after the `p_destroy` `--tag` argument (2213-2217), add:
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "destroy_refuses or destroy_yes or destroy_nothing" -v`
 Expected: PASS. Then run the existing destroy tests: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k destroy -v` and reconcile any that assumed the old single-target behavior (they should now expect the recorded-state path; update them to the new contract — this is the intended behavior change).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Refactor**
+
+Look for:
+- `_destroy_recorded`'s fetch-modules / `shutil.rmtree(modules_root.parent)` pattern now mirrors `_cmd_destroy_volume` (and the deleted `_cloud_destroy`); if it is repeated, extract a `_with_fetched_modules(tag)` context manager.
+- Confirm the dead `_cloud_destroy` is removed (grep to verify no remaining caller).
+- The confirmation listing + prompt could be a single `_confirm_destroy(rs, args)` helper if it clutters `_cmd_destroy`.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -1374,7 +1468,13 @@ Expected: the stop test may already PASS (Task 6 made `_resolve_instance` name-a
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "stop or start or restart" -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Refactor**
+
+Look for:
+- This is a test-only task — no production refactor expected. Reuse the existing `_FakeTarget`/`_FakeIdentity` fixtures rather than re-declaring them; grep the test module first.
+- If a production change was needed (a verb dropping `--name`), recheck it routes through the shared resolvers rather than re-deriving the instance.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -1383,7 +1483,7 @@ vrg-commit --type test --scope vm --message "lock stop/start/restart to the hand
   --body "Regression tests proving stop/start/restart address the handle's Lima instance via --name and continue to reject off-platform (no cloud stop/start). Ref #1831"
 ```
 
-- [ ] **Step 6: Phase 4 full validation**
+- [ ] **Step 7: Phase 4 full validation**
 
 Run: `vrg-container-run -- vrg-validate`
 Expected: PASS.
@@ -1535,7 +1635,13 @@ In `_list_rows` (the local-row builder — find it with `grep -n "def _list_rows
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "instance_column or list" -v`
 Expected: PASS. Reconcile any existing `list` tests that assert the old header/column count — update them to include INSTANCE (intended change).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Refactor**
+
+Look for:
+- The per-row format string with the INSTANCE column is now duplicated between the local-row and cloud-row loops in `_cmd_list` (and again in `volumes`, Task 12). Extract a single row-formatting helper / shared width constants.
+- `OffPlatformVm`'s new fields (`instance`, `volume_size`, `vm_present`) need defaults so existing constructions stay valid — grep `OffPlatformVm(` and confirm.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -1546,7 +1652,206 @@ vrg-commit --type feat --scope vm --message "add INSTANCE column and no-vm volum
 
 ---
 
-### Task 11: `volumes` INSTANCE column
+### Task 11: `list` off-platform orphan classification (SPEC column for cloud rows)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_spec.py` (add `split_state_slug` near `state_slug`)
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (add `_classify_off_platform`; thread it into `_cloud_list_rows` 1657-1677 and `_cmd_list` 1711-1715)
+- Test: `tests/vergil_tooling/test_vm_spec.py`, `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Consumes: `_off_platform_vms` (now carrying `instance`/`vm_present` from Task 10), `read_config`, `compose_vm_spec`, `_base_footprint`, `config.identities`.
+- Produces:
+  - `vm_spec.split_state_slug(slug) -> tuple[str, str|None, str|None, str|None]` — exact reverse of `state_slug` via `split('--')` (1 segment = base, 3 = default dedicated, 4 = named); unambiguous because identity/org/repo contain no `--`.
+  - `vrg_vm._classify_off_platform(vm, config) -> str` — `"ok"` / `"orphaned"`: recovers the exact handle from `vm.name` (the readable slug), composes the repo's current profile for that handle, and returns `"orphaned"` when the repo dropped the stanza, no longer declares the instance, or no longer composes that `(off-platform, provider)`.
+  - `_cloud_list_rows(config)` now emits a real `spec` field; `_cmd_list` prints it for cloud rows instead of `—`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vm_spec.py`:
+
+```python
+from vergil_tooling.lib.vm_spec import split_state_slug
+
+
+def test_split_state_slug_roundtrips():
+    assert split_state_slug("vergil-user") == ("vergil-user", None, None, None)
+    assert split_state_slug("vergil-user--lmf--mq") == ("vergil-user", "lmf", "mq", None)
+    assert split_state_slug("vergil-user--lmf--mq--cloud-x86") == (
+        "vergil-user", "lmf", "mq", "cloud-x86",
+    )
+```
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_classify_off_platform_orphaned_when_provider_switched(monkeypatch, tmp_path):
+    from vergil_tooling.bin import vrg_vm
+
+    # The repo's current profile composes off-platform/azure, but the recorded box is gcp.
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86", provider="gcp", state_dir=tmp_path,
+        identity="vergil-user", org="lmf", repo="mq", instance="cloud-x86",
+        status="Running", volume_size=None, vm_present=True,
+    )
+    config = _config_with_azure_instance("vergil-user", "lmf", "mq", "cloud-x86")
+    assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
+
+
+def test_classify_off_platform_orphaned_when_stanza_dropped(monkeypatch, tmp_path):
+    from vergil_tooling.bin import vrg_vm
+
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86", provider="gcp", state_dir=tmp_path,
+        identity="vergil-user", org="lmf", repo="mq", instance="cloud-x86",
+        status="Running", volume_size=None, vm_present=True,
+    )
+    config = _config_no_repo_vm("vergil-user", "lmf", "mq")  # vergil.toml gone / no [vm]
+    assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
+
+
+def test_classify_off_platform_ok_when_matches(monkeypatch, tmp_path):
+    from vergil_tooling.bin import vrg_vm
+
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86", provider="gcp", state_dir=tmp_path,
+        identity="vergil-user", org="lmf", repo="mq", instance="cloud-x86",
+        status="Running", volume_size=None, vm_present=True,
+    )
+    config = _config_with_gcp_instance("vergil-user", "lmf", "mq", "cloud-x86")
+    assert vrg_vm._classify_off_platform(vm, config) == "ok"
+```
+
+Add the `_config_with_azure_instance` / `_config_with_gcp_instance` / `_config_no_repo_vm` helpers following the config fixtures already in `test_vrg_vm.py` (they build an `IdentityConfig` whose identity has a `projects_dir` containing a `vergil.toml` with the named instance overlay; read the existing config fixtures first and match them).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k split_state_slug tests/vergil_tooling/test_vrg_vm.py -k classify_off_platform -v`
+Expected: FAIL — `split_state_slug` import error; `_classify_off_platform` undefined.
+
+- [ ] **Step 3: Add `split_state_slug`**
+
+In `src/vergil_tooling/lib/vm_spec.py`, after `state_slug`, add:
+
+```python
+def split_state_slug(slug: str) -> tuple[str, str | None, str | None, str | None]:
+    """Reverse state_slug. 1 segment = base; 3 = default dedicated; 4 = named instance.
+
+    Unambiguous because identity/org/repo never contain '--' (repo names with '--'
+    are rejected at parse time), so this is the exact inverse — no labels needed.
+    """
+    parts = slug.split(_SLUG_SEP)
+    if len(parts) == 1:
+        return parts[0], None, None, None
+    if len(parts) == 3:  # noqa: PLR2004
+        return parts[0], parts[1], parts[2], None
+    if len(parts) == 4:  # noqa: PLR2004
+        return parts[0], parts[1], parts[2], parts[3]
+    msg = f"unparseable state slug: {slug!r}"
+    raise ValueError(msg)
+```
+
+- [ ] **Step 4: Implement `_classify_off_platform`**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, near `_cloud_list_rows`, add (ensure `split_state_slug`, `compose_vm_spec`, `read_config`, `ConfigError`, `SpecError`, `_base_footprint` are imported/in scope):
+
+```python
+def _classify_off_platform(vm: OffPlatformVm, config: IdentityConfig) -> str:
+    """Classify a recorded off-platform box against the repo's current profile.
+
+    'orphaned' when the repo dropped its [vm], no longer declares this instance, or
+    no longer composes this (off-platform, provider); 'ok' when it still matches.
+    The handle is recovered exactly from the readable slug — no lossy label round-trip.
+    """
+    identity_name, org, repo, inst_name = split_state_slug(vm.name)
+    if org is None or repo is None:
+        return "ok"  # a base box carries no per-repo spec
+    identity = config.identities.get(identity_name)
+    if identity is None:
+        return "orphaned"
+    repo_dir = Path(identity.projects_dir) / org / repo
+    if not (repo_dir / "vergil.toml").exists():
+        return "orphaned"
+    try:
+        stanza = read_config(repo_dir).vm
+        spec = compose_vm_spec(
+            identity=identity_name,
+            base=_base_footprint(identity),
+            stanza=stanza,
+            override=identity.overrides.get((org, repo)),
+            instance=inst_name,
+        )
+    except (ConfigError, SpecError):
+        return "orphaned"
+    if not spec.off_platform or spec.provider != vm.provider:
+        return "orphaned"
+    return "ok"
+```
+
+- [ ] **Step 5: Thread the SPEC into the cloud list rows**
+
+Change `_cloud_list_rows` to accept `config` and emit `spec`. Update its signature and the row dict (building on Task 10's version):
+
+```python
+def _cloud_list_rows(config: IdentityConfig) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for vm in _off_platform_vms():
+        if not vm.vm_present:
+            status = "no-vm"
+            disk = vm.volume_size or "—"
+            spec = _classify_off_platform(vm, config)
+        else:
+            status = vm.status or f"unknown (no {vm.provider} creds)"
+            disk = "—"
+            spec = _classify_off_platform(vm, config)
+        rows.append(
+            {
+                "identity": vm.identity or "—",
+                "scope": vm.scope,
+                "instance": vm.instance or "—",
+                "backend": vm.provider,
+                "status": status,
+                "disk": disk,
+                "spec": spec,
+            }
+        )
+    return rows
+```
+
+In `_cmd_list`, pass `config` and print `spec` for cloud rows. Replace the cloud-row loop:
+
+```python
+    for r in _cloud_list_rows(config):
+        print(
+            f"{r['identity']!s:<14} {r['scope']!s:<40} {r['instance']!s:<11} "
+            f"{r['backend']!s:<13} {r['status']!s:<11} "
+            f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {r['spec']!s:<22}"
+        )
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k split_state_slug tests/vergil_tooling/test_vrg_vm.py -k "classify_off_platform or instance_column" -v`
+Expected: PASS.
+
+- [ ] **Step 7: Refactor**
+
+Look for:
+- `_classify_off_platform` and the local `_classify_instance` both answer "does the repo still compose this handle?"; if the compose+compare logic overlaps cleanly, extract a shared helper (but keep the off-platform provider comparison distinct).
+- Note the deliberate symmetry between `split_state_slug` (`--`) and `parse_instance_name` (`.`) — document it, but do NOT merge them; the delimiters and segment rules differ.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/lib/vm_spec.py src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vm_spec.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm --message "classify off-platform orphans in list SPEC column" \
+  --body "Add split_state_slug (exact handle reversal from the readable slug) and _classify_off_platform: a recorded cloud box whose repo dropped the stanza or switched (backend, provider) now reads 'orphaned' in list, removable via destroy --name X. Closes acceptance #4/#6 for the cloud path. Ref #1831"
+```
+
+---
+
+### Task 12: `volumes` INSTANCE column
 
 **Files:**
 - Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_volume_rows`; `_cmd_volumes` 1807-1843)
@@ -1622,7 +1927,13 @@ In `_cmd_volumes` (1807-1843), add the column to the header and rows. Replace th
 Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "volumes" -v`
 Expected: PASS. Reconcile existing `volumes` tests that assert the old header (intended change).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Refactor**
+
+Look for:
+- The INSTANCE column width/format here duplicates Task 10's `list` rendering; consolidate into the shared column helper introduced in Task 10 (or introduce it now and back-apply).
+- `_volume_rows`' `instance` field should source the `vergil-instance` label the same way `_off_platform_vms` does — avoid a second, divergent label lookup.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 cd .worktrees/issue-1831-named-instances
@@ -1631,7 +1942,7 @@ vrg-commit --type feat --scope vm --message "add INSTANCE column to volumes" \
   --body "vrg-vm volumes shows an INSTANCE column (from the vergil-instance label) so two volumes for one repo are distinguishable. Ref #1831"
 ```
 
-- [ ] **Step 7: Phase 5 full validation + final sweep**
+- [ ] **Step 8: Phase 5 full validation + final sweep**
 
 Run: `vrg-container-run -- vrg-validate`
 Expected: PASS (whole suite green).
@@ -1643,14 +1954,14 @@ Run: `vrg-container-run -- uv run vrg-vm list` and `... vrg-vm volumes` to confi
 
 ## Final acceptance check (map to the spec's acceptance criteria)
 
-After Task 11, confirm each spec acceptance criterion has coverage:
+After Task 12, confirm each spec acceptance criterion has coverage:
 
 1. `--name X` lifecycle independence → Tasks 6, 8, 9.
 2. Two instances co-exist → Tasks 3, 4 (distinct Lima names, slugs, hashed cloud names, volumes).
 3. Bare verb = default unchanged → Tasks 2, 6 (default composition + no-`--name` path); regression suite.
-4. In-place backend/provider edit + `destroy --name X` tears down all recorded state; dropped stanza → `orphaned` → Tasks 7, 8, 10.
+4. In-place backend/provider edit + `destroy --name X` tears down all recorded state; dropped stanza → `orphaned` → Tasks 7, 8, 10, 11.
 5. Invalid instance name / repo `--` rejected at parse time → Tasks 1, 2, 6.
-6. `list` INSTANCE + `no-vm` rows, O(instances) → Task 10.
+6. `list` INSTANCE + `no-vm` rows + per-instance orphan classification, O(instances) → Tasks 10, 11.
 7. `--name X` against a missing instance errors with available names → Task 2.
 8. Deterministic `vrg-<hash>` cloud name + identity labels → Task 4.
 9. Full existing suite green → every phase's `vrg-validate`.

--- a/docs/specs/2026-06-23-vrg-vm-named-instances-implementation-plan.md
+++ b/docs/specs/2026-06-23-vrg-vm-named-instances-implementation-plan.md
@@ -1,0 +1,1671 @@
+# vrg-vm Named Instances Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one `(identity, org/repo)` own several named VM instances via a `--name` flag, each with its own composed profile, backend, recorded state, and volume — fully backward compatible when no name is given.
+
+**Architecture:** A four-part handle `(identity, org, repo, name)` derives three deterministic names — the Lima instance name (`.`-joined, reversed via the sidecar), the readable tofu state slug (`--`-joined), and the hashed cloud resource name (`vrg-<sha256(slug)[:12]>`, with identity in labels). Composition gains a tier-5 per-name overlay; `destroy` resolves from recorded state (all backends) while `stop`/`start`/`restart` stay Lima-only; `list`/`volumes` gain an INSTANCE column.
+
+**Tech Stack:** Python 3.12+, `argparse`, `tomllib`, `pytest`, OpenTofu/GCP modules (owned by vergil-vm), Lima (`limactl`).
+
+**Authoritative spec:** `docs/specs/2026-06-23-vrg-vm-named-instances-tooling-design.md` (this repo) and vergil-vm #242's `docs/specs/2026-06-23-multiple-vm-instances-per-repo-design.md`.
+
+## Global Constraints
+
+- **Working environment:** All work happens in the worktree `.worktrees/issue-1831-named-instances/` on branch `feature/1831-named-instances`. Use absolute worktree paths for Read/Edit/Write; `cd` into the worktree for Bash.
+- **Git/GitHub wrappers only:** `vrg-git` not `git`; `vrg-commit` not `git commit`; `vrg-gh` not `gh`. Raw `git`/`gh` are denied by the hook guard.
+- **Commit format:** `vrg-commit --type <type> --scope vm --message "<desc>" [--body "<body>"]`. Each task's final step commits with `Ref #1831` in the body.
+- **Per-step tests:** run a single test with `vrg-container-run -- uv run pytest <path>::<test> -v` (this repo dogfoods unreleased code via the `[validation]` override, so `uv run` is required).
+- **Full validation (end of each phase):** `vrg-container-run -- vrg-validate` — the only validation command; it runs lint, typecheck, the full test suite, and audits.
+- **Backward compatibility is a hard requirement:** a repo that declares no `instances` and every call without `--name` must behave byte-for-byte as today. The existing `tests/` suite must stay green at every commit.
+- **No silent failures:** invalid instance names, repo names containing `--`, and `--name X` against a missing instance must raise loudly. Never default or fall back silently.
+- **Instance name grammar:** `[a-z0-9]+(?:-[a-z0-9]+)*` (lowercase alnum, single internal hyphens, no `--`, no leading/trailing hyphen).
+- **Cloud name budget:** the hashed `vrg-<12 hex>` is 16 chars; the GCP `var.name` ≤ 58 guard lives in vergil-vm and is out of scope here.
+
+---
+
+## Phase 1 — Config parsing & composition (pure logic)
+
+### Task 1: Parse the per-identity `instances` namespace
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/config.py` (`RoleOverlay` dataclass ~110-129; `_parse_role_overlay` 218-237; `parse_vm_stanza` 240-280)
+- Test: `tests/vergil_tooling/test_config.py`
+
+**Interfaces:**
+- Consumes: existing `RoleOverlay`, `VmStanza`, `_parse_role_overlay`, `parse_vm_stanza`, `ConfigError`.
+- Produces: `RoleOverlay.instances: dict[str, RoleOverlay]` (default `{}`), populated from `[vm.<identity>.instances.<name>]`. A role named `instances` directly under `[vm]` raises `ConfigError` (no all-identity tier). Invalid instance names raise `ConfigError` at parse time.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_config.py`:
+
+```python
+def test_parse_vm_stanza_named_instances():
+    raw = {
+        "vm": {
+            "vergil-user": {
+                "cpus": 12,
+                "instances": {
+                    "cloud-x86": {
+                        "backend": "off-platform",
+                        "provider": "gcp",
+                        "region": "us-central1",
+                        "instance": "n2-standard-16",
+                        "volume": "300GiB",
+                    }
+                },
+            }
+        }
+    }
+    stanza = parse_vm_stanza(raw)
+    role = stanza.roles["vergil-user"]
+    assert role.cpus == 12
+    assert set(role.instances) == {"cloud-x86"}
+    inst = role.instances["cloud-x86"]
+    assert inst.backend == "off-platform"
+    assert inst.instance == "n2-standard-16"
+    assert inst.instances == {}  # no nested instances
+
+
+def test_parse_vm_stanza_rejects_all_identity_instances_tier():
+    raw = {"vm": {"instances": {"cloud-x86": {"cpus": 4}}}}
+    with pytest.raises(ConfigError, match="no all-identity .*instances"):
+        parse_vm_stanza(raw)
+
+
+def test_parse_vm_stanza_rejects_invalid_instance_name():
+    raw = {"vm": {"vergil-user": {"instances": {"bad--name": {"cpus": 4}}}}}
+    with pytest.raises(ConfigError, match="instance name"):
+        parse_vm_stanza(raw)
+```
+
+Ensure `pytest` and `ConfigError`/`parse_vm_stanza` are imported at the top of the test module (they already are for existing tests).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_config.py::test_parse_vm_stanza_named_instances -v`
+Expected: FAIL — `RoleOverlay.__init__` got an unexpected keyword `instances` (or AttributeError on `.instances`).
+
+- [ ] **Step 3: Add the `instances` field to `RoleOverlay`**
+
+In `src/vergil_tooling/lib/config.py`, add to the `RoleOverlay` dataclass (after `nested: bool | None = None`, keeping defaulted fields last):
+
+```python
+    # Named-instance overlays (vergil-tooling #1831). Each value is itself a
+    # RoleOverlay parsed from [vm.<identity>.instances.<name>]; an instance overlay
+    # never carries its own nested instances. Empty for the common (unnamed) case.
+    instances: dict[str, "RoleOverlay"] = field(default_factory=dict)
+```
+
+Ensure `from dataclasses import dataclass, field` at the top of `config.py` (add `field` if missing).
+
+- [ ] **Step 4: Add the instance-name validator import and parse logic**
+
+At the top of `config.py`, add the runtime import (no import cycle — `vm_spec` imports `config` only under `TYPE_CHECKING`):
+
+```python
+from vergil_tooling.lib.vm_spec import validate_instance_name
+```
+
+(`validate_instance_name` is created in Task 2 Step 3 — if you implement Task 1 first, add a temporary stub `def validate_instance_name(name: str) -> None: ...` in `vm_spec.py` and replace it in Task 2. Subagent-driven execution runs tasks in order, so Task 2's validator will already exist.)
+
+Rewrite `_parse_role_overlay` to parse a nested `instances` table:
+
+```python
+def _parse_role_overlay(
+    name: str, raw: dict[str, Any], source: str = CONFIG_FILE, *, allow_instances: bool = True
+) -> RoleOverlay:
+    if _SHARED_FROM_KEY in raw:
+        msg = f"{source}: shared_from is not allowed in a role overlay [vm.{name}]"
+        raise ConfigError(msg)
+    for key in raw:
+        if key == "instances" and allow_instances:
+            continue
+        if key not in _VM_KEYS:
+            print(f"{source}: unrecognized key '{key}' in [vm.{name}]", file=sys.stderr)
+    scalars = {k: _vm_str_scalar(raw, k, f"[vm.{name}]", source) for k in _VM_STR_SCALARS}
+    instances: dict[str, RoleOverlay] = {}
+    if allow_instances:
+        raw_instances = raw.get("instances", {})
+        if not isinstance(raw_instances, dict):
+            msg = f"{source}: [vm.{name}].instances must be a table"
+            raise ConfigError(msg)
+        for iname, itable in raw_instances.items():
+            try:
+                validate_instance_name(iname)
+            except ValueError as exc:
+                msg = f"{source}: [vm.{name}.instances.{iname}]: {exc}"
+                raise ConfigError(msg) from exc
+            if not isinstance(itable, dict):
+                msg = f"{source}: [vm.{name}.instances.{iname}] must be a table"
+                raise ConfigError(msg)
+            instances[iname] = _parse_role_overlay(
+                iname, itable, source, allow_instances=False
+            )
+    return RoleOverlay(
+        packages=list(raw.get("packages", [])),
+        cpus=raw.get("cpus"),
+        memory=raw.get("memory"),
+        disk=raw.get("disk"),
+        stale_days=raw.get("stale_days"),
+        apt_repos=list(raw.get("apt_repos", [])),
+        vagrant_plugins=list(raw.get("vagrant_plugins", [])),
+        port_forwards=list(raw.get("port_forwards", [])),
+        nested=raw.get("nested"),
+        instances=instances,
+        **scalars,
+    )
+```
+
+In `parse_vm_stanza`, reject the all-identity tier. Replace the `elif isinstance(value, dict):` branch:
+
+```python
+        elif isinstance(value, dict):
+            if key == "instances":
+                msg = (
+                    f"{source}: no all-identity [vm.instances] tier — declare named "
+                    f"instances under [vm.<identity>.instances.<name>]"
+                )
+                raise ConfigError(msg)
+            roles[key] = _parse_role_overlay(key, value, source)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_config.py -k "instances" -v`
+Expected: PASS (all three new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/lib/config.py tests/vergil_tooling/test_config.py
+vrg-commit --type feat --scope vm --message "parse [vm.<identity>.instances.<name>] namespace" \
+  --body "Add RoleOverlay.instances parsed from per-identity instance overlays; reject the all-identity [vm.instances] tier and invalid instance names at parse time. Ref #1831"
+```
+
+---
+
+### Task 2: Naming validators + tier-5 composition
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_spec.py` (add validators near 282-303; extend `compose_vm_spec` 169-251)
+- Test: `tests/vergil_tooling/test_vm_spec.py`
+
+**Interfaces:**
+- Consumes: `_apply_overlay`, `_Acc`, `ComposedSpec`, `SpecError`, `RoleOverlay`.
+- Produces:
+  - `validate_instance_name(name: str) -> None` — raises `ValueError` unless `name` matches `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+  - `validate_repo_segment(repo: str) -> None` — raises `ValueError` if `repo` contains `--`.
+  - `compose_vm_spec(*, identity, base, stanza, override, instance: str | None = None) -> ComposedSpec` — applies the tier-5 named overlay; `--name X` with no such instance raises `SpecError` listing available names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vm_spec.py`:
+
+```python
+from vergil_tooling.lib.vm_spec import validate_instance_name, validate_repo_segment
+
+
+@pytest.mark.parametrize("name", ["cloud-x86", "rdqm-rhel", "a", "x1"])
+def test_validate_instance_name_accepts(name):
+    validate_instance_name(name)  # no raise
+
+
+@pytest.mark.parametrize("name", ["bad--name", "-lead", "trail-", "Up", "a_b", ""])
+def test_validate_instance_name_rejects(name):
+    with pytest.raises(ValueError, match="instance name"):
+        validate_instance_name(name)
+
+
+def test_validate_repo_segment_rejects_double_dash():
+    with pytest.raises(ValueError, match="--"):
+        validate_repo_segment("my--repo")
+    validate_repo_segment("my-repo")  # single dash ok
+
+
+def test_compose_named_instance_overlays_tier5():
+    role = RoleOverlay(
+        packages=[], cpus=12, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        instances={
+            "rdqm-rhel": RoleOverlay(
+                packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
+                apt_repos=[], vagrant_plugins=[], port_forwards=[],
+                backend="off-platform", provider="gcp", region="us-central1",
+                instance="n2-standard-8", volume="200GiB",
+            )
+        },
+    )
+    stanza = VmStanza(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        roles={"vergil-user": role},
+    )
+    spec = compose_vm_spec(
+        identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="rdqm-rhel"
+    )
+    assert spec.cpus == 8  # tier-5 overrides tier-4's 12
+    assert spec.memory == "32GiB"
+    assert spec.off_platform
+    assert spec.instance == "n2-standard-8"
+
+
+def test_compose_default_instance_unchanged_when_none():
+    stanza = VmStanza(
+        packages=[], cpus=12, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={},
+    )
+    spec = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+    assert spec.cpus == 12  # tiers 1-4 only, today's behavior
+
+
+def test_compose_missing_named_instance_errors_with_available():
+    role = RoleOverlay(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        instances={"cloud-x86": RoleOverlay(
+            packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+            apt_repos=[], vagrant_plugins=[], port_forwards=[])},
+    )
+    stanza = VmStanza(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={"vergil-user": role},
+    )
+    with pytest.raises(SpecError, match="cloud-x86"):
+        compose_vm_spec(
+            identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="nope"
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "validate_instance or validate_repo or named_instance or default_instance" -v`
+Expected: FAIL — `ImportError` for `validate_instance_name` / `compose_vm_spec` got unexpected keyword `instance`.
+
+- [ ] **Step 3: Add the validators**
+
+In `src/vergil_tooling/lib/vm_spec.py`, after the `_TIER_SEP = "."` block (around line 289), add:
+
+```python
+_INSTANCE_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def validate_instance_name(name: str) -> None:
+    """Reject an instance name that is not [a-z0-9]+ with single internal hyphens.
+
+    A double dash would break the readable ``--``-joined state slug; an empty or
+    upper-cased name is also rejected. Raises loudly (no-silent-failures).
+    """
+    if not _INSTANCE_NAME_RE.fullmatch(name):
+        msg = (
+            f"instance name {name!r} must be lowercase [a-z0-9-] with single internal "
+            f"hyphens (no '--', no leading/trailing hyphen)"
+        )
+        raise ValueError(msg)
+
+
+def validate_repo_segment(repo: str) -> None:
+    """Reject a repo name containing '--', which would make the state slug ambiguous."""
+    if "--" in repo:
+        msg = (
+            f"repo name {repo!r} must not contain '--' (it would make the "
+            f"'--'-joined instance handle ambiguous)"
+        )
+        raise ValueError(msg)
+```
+
+- [ ] **Step 4: Extend `compose_vm_spec` with the `instance` parameter**
+
+Change the signature (line 169-175) to add `instance`:
+
+```python
+def compose_vm_spec(
+    *,
+    identity: str,
+    base: Mapping[str, object],
+    stanza: VmStanza | None,
+    override: Mapping[str, object] | None,
+    instance: str | None = None,
+) -> ComposedSpec:
+    """Overlay the precedence tiers into the effective spec for one (identity, repo[, name])."""
+```
+
+Replace the tier-3/4 block (lines 200-205) with tier-3/4/5:
+
+```python
+    # Tiers 3 + 4: repo [vm] (all-identity), then [vm.<identity>] role overlay.
+    role = None
+    if stanza is not None:
+        _apply_overlay(acc, stanza)
+        role = stanza.roles.get(identity)
+        if role is not None:
+            _apply_overlay(acc, role)
+
+    # Tier 5: the named-instance overlay, if a name was requested.
+    if instance is not None:
+        available = sorted(role.instances) if role is not None else []
+        overlay = role.instances.get(instance) if role is not None else None
+        if overlay is None:
+            avail = ", ".join(available) if available else "(none)"
+            msg = (
+                f"identity {identity!r}: no instance {instance!r} for this repo; "
+                f"available: {avail}"
+            )
+            raise SpecError(msg)
+        _apply_overlay(acc, overlay)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "validate_instance or validate_repo or named_instance or default_instance or missing_named" -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/lib/vm_spec.py tests/vergil_tooling/test_vm_spec.py
+vrg-commit --type feat --scope vm --message "compose tier-5 named-instance overlay" \
+  --body "Add validate_instance_name / validate_repo_segment and an 'instance' parameter to compose_vm_spec that applies the [vm.<identity>.instances.<name>] overlay, erroring with available names when the instance is missing. Ref #1831"
+```
+
+- [ ] **Step 7: Phase 1 full validation**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS (whole suite green; default path unchanged).
+
+---
+
+## Phase 2 — Handle & naming derivations
+
+### Task 3: Lima instance name gains the fourth segment
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_spec.py` (`instance_name` 305-333)
+- Test: `tests/vergil_tooling/test_vm_spec.py`
+
+**Interfaces:**
+- Produces: `instance_name(identity, org, repo, name=None, *, home=None) -> str` — appends `.name` for a named instance; the truncation+hash digest input includes `name` so distinct instances hash distinctly.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vm_spec.py`:
+
+```python
+def test_instance_name_named_appends_segment():
+    assert (
+        instance_name("vergil-user", "lmf", "mq", name="cloud-x86")
+        == "vergil-user.lmf.mq.cloud-x86"
+    )
+
+
+def test_instance_name_default_unchanged():
+    assert instance_name("vergil-user", "lmf", "mq") == "vergil-user.lmf.mq"
+    assert instance_name("vergil-user", None, None) == "vergil-user"
+
+
+def test_instance_name_named_hash_differs_from_default(monkeypatch):
+    # Force the over-budget path with a tiny budget so both names are hashed.
+    monkeypatch.setattr("vergil_tooling.lib.vm_spec.lima_name_budget", lambda home=None: 20)
+    default = instance_name("vergil-user", "logical-minds-foundry", "mq-cluster-tooling")
+    named = instance_name(
+        "vergil-user", "logical-minds-foundry", "mq-cluster-tooling", name="cloud-x86"
+    )
+    assert default != named
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "instance_name_named or instance_name_default" -v`
+Expected: FAIL — `instance_name() got an unexpected keyword argument 'name'`.
+
+- [ ] **Step 3: Implement the fourth segment**
+
+Replace `instance_name` (lines 305-333) with:
+
+```python
+def instance_name(
+    identity: str,
+    org: str | None,
+    repo: str | None,
+    name: str | None = None,
+    *,
+    home: str | None = None,
+) -> str:
+    """Derive the Lima instance name. Bare identity = base; ``.``-joined = dedicated.
+
+    A named instance appends ``.<name>`` as a fourth segment. Over budget, the name
+    is truncated and hashed (the digest input includes ``name`` so distinct instances
+    differ); ``recover_handle`` (vrg_vm) reverses a mangled name via the sidecar.
+    """
+    if org is None or repo is None:
+        return identity
+    for tier, value in (("identity", identity), ("org", org)):
+        if _TIER_SEP in value:
+            msg = f"{tier} name {value!r} must not contain '{_TIER_SEP}'"
+            raise ValueError(msg)
+    segments = [identity, org, repo]
+    if name:
+        segments.append(name)
+    full = _TIER_SEP.join(segments)
+    budget = lima_name_budget(home)
+    if len(full) <= budget:
+        return full
+    if budget < len(identity) + 7:  # 6 hash chars + 1 separator
+        msg = (
+            f"home directory too long to fit a bounded VM name for identity "
+            f"{identity!r}: budget {budget} < {len(identity) + 7}"
+        )
+        raise SpecError(msg)
+    digest_src = "/".join(segments)
+    digest = hashlib.sha256(digest_src.encode()).hexdigest()[:6]
+    keep = budget - 7
+    return f"{full[:keep].rstrip('._-')}-{digest}"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py -k "instance_name" -v`
+Expected: PASS (new tests plus existing `instance_name` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/lib/vm_spec.py tests/vergil_tooling/test_vm_spec.py
+vrg-commit --type feat --scope vm --message "append named-instance segment to Lima instance name" \
+  --body "instance_name takes an optional name appended as a fourth '.'-segment; the over-budget hash digest input includes name so instances differ. Ref #1831"
+```
+
+---
+
+### Task 4: Readable state slug, hashed cloud name, instance label
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_spec.py` (add `state_slug`)
+- Modify: `src/vergil_tooling/lib/vm_cloud.py` (`cloud_resource_name` 42-51; `cloud_labels` 54-60; `OffPlatformBackend.__init__` 920-931)
+- Modify: `src/vergil_tooling/lib/vm_backend.py` (`select_backend` 26-43)
+- Test: `tests/vergil_tooling/test_vm_spec.py`, `tests/vergil_tooling/test_vm_cloud.py`
+
+**Interfaces:**
+- Produces:
+  - `vm_spec.state_slug(identity, org=None, repo=None, name=None) -> str` — `identity` / `identity--org--repo` / `identity--org--repo--name`.
+  - `vm_cloud.cloud_resource_name(slug: str) -> str` — `vrg-<sha256(slug)[:12]>` (signature changed from `(identity, org, repo)`).
+  - `vm_cloud.cloud_labels(identity, org, repo, name=None) -> dict[str,str]` — adds `vergil-instance` when `name` is set.
+  - `OffPlatformBackend(spec, identity, org, repo, name=None)`; `.slug` (readable), `.name` (hashed), `.state_key == .slug`.
+  - `vm_backend.select_backend(spec, *, identity=None, org=None, repo=None, name=None)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vm_spec.py`:
+
+```python
+from vergil_tooling.lib.vm_spec import state_slug
+
+
+def test_state_slug_forms():
+    assert state_slug("vergil-user") == "vergil-user"
+    assert state_slug("vergil-user", "lmf", "mq") == "vergil-user--lmf--mq"
+    assert (
+        state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+        == "vergil-user--lmf--mq--cloud-x86"
+    )
+```
+
+Add to `tests/vergil_tooling/test_vm_cloud.py`:
+
+```python
+from vergil_tooling.lib.vm_cloud import cloud_labels, cloud_resource_name
+
+
+def test_cloud_resource_name_is_hashed_and_deterministic():
+    slug = "vergil-user--logical-minds-foundry--mq-cluster-tooling--cloud-x86"
+    name = cloud_resource_name(slug)
+    assert name.startswith("vrg-")
+    assert len(name) == 16  # "vrg-" + 12 hex
+    assert name == cloud_resource_name(slug)  # deterministic
+    assert cloud_resource_name(slug + "-other") != name
+
+
+def test_cloud_labels_includes_instance_when_named():
+    labels = cloud_labels("vergil-user", "lmf", "mq", "cloud-x86")
+    assert labels["vergil-instance"] == "cloud-x86"
+    assert "vergil-instance" not in cloud_labels("vergil-user", "lmf", "mq")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_spec.py::test_state_slug_forms tests/vergil_tooling/test_vm_cloud.py -k "hashed or instance_when_named" -v`
+Expected: FAIL — `state_slug` import error; `cloud_resource_name` takes 3 args not 1.
+
+- [ ] **Step 3: Add `state_slug` to vm_spec**
+
+In `src/vergil_tooling/lib/vm_spec.py`, after `parse_instance_name` (line 344), add:
+
+```python
+_SLUG_SEP = "--"
+
+
+def state_slug(
+    identity: str, org: str | None = None, repo: str | None = None, name: str | None = None
+) -> str:
+    """The readable '--'-joined handle: state-path key and cloud-name hash input.
+
+    ``identity`` (base) / ``identity--org--repo`` (default dedicated) /
+    ``identity--org--repo--name`` (named). Reversal is via labels (cloud) and the
+    sidecar (Lima), not by splitting — but '--' keeps the path human-readable.
+    """
+    if org is None or repo is None:
+        return identity
+    segments = [identity, org, repo]
+    if name:
+        segments.append(name)
+    return _SLUG_SEP.join(segments)
+```
+
+- [ ] **Step 4: Rewrite `cloud_resource_name` and `cloud_labels`**
+
+In `src/vergil_tooling/lib/vm_cloud.py`, replace `cloud_resource_name` (42-51) and `cloud_labels` (54-60):
+
+```python
+def cloud_resource_name(slug: str) -> str:
+    """Deterministic short RFC1035 name 'vrg-<first 12 hex of sha256(slug)>' (16 chars).
+
+    The four-segment slug overflows GCP's 63-char limit, so the readable slug keys
+    the state path / labels while cloud resources take this opaque hash. Identity is
+    carried in labels (which `list` and `tofu import` read), never in the name.
+    """
+    digest = hashlib.sha256(slug.encode()).hexdigest()[:12]
+    return f"vrg-{digest}"
+
+
+def cloud_labels(
+    identity: str, org: str, repo: str, name: str | None = None
+) -> dict[str, str]:
+    """Structured labels for label-based recovery (independent of the hashed name)."""
+    labels = {
+        "vergil-identity": _slug(identity),
+        "vergil-org": _slug(org),
+        "vergil-repo": _slug(repo),
+    }
+    if name:
+        labels["vergil-instance"] = _slug(name)
+    return labels
+```
+
+The constants `_MAX_NAME`/`_HASH_LEN` (lines 33-34) are no longer used by `cloud_resource_name`. Leave them only if still referenced elsewhere; otherwise delete them (run `grep -n "_MAX_NAME\|_HASH_LEN" src/vergil_tooling/lib/vm_cloud.py` and remove if unused to keep lint clean).
+
+- [ ] **Step 5: Update `OffPlatformBackend.__init__`**
+
+In `src/vergil_tooling/lib/vm_cloud.py`, add the import at the top (with the other `vm_spec` import on line 25):
+
+```python
+from vergil_tooling.lib.vm_spec import spec_fingerprint, state_slug
+```
+
+Replace `OffPlatformBackend.__init__` (920-931):
+
+```python
+    def __init__(
+        self,
+        spec: ComposedSpec,
+        identity: str,
+        org: str,
+        repo: str,
+        name: str | None = None,
+    ) -> None:
+        self.spec = spec
+        self.identity = identity
+        self.org = org
+        self.repo = repo
+        self.instance_name = name
+        # Readable slug keys the state path; the cloud resource name is its hash.
+        self.slug = state_slug(identity, org, repo, name)
+        self.name = cloud_resource_name(self.slug)
+        self.labels = cloud_labels(identity, org, repo, name)
+        self.state_key = self.slug
+        self.ssh_user = _effective_ssh_user()
+        self.provider_label = spec.provider
+```
+
+- [ ] **Step 6: Update `select_backend`**
+
+In `src/vergil_tooling/lib/vm_backend.py`, replace `select_backend` (26-43):
+
+```python
+def select_backend(
+    spec: ComposedSpec,
+    *,
+    identity: str | None = None,
+    org: str | None = None,
+    repo: str | None = None,
+    name: str | None = None,
+) -> Backend:
+    """Return the backend for a composed spec — the one dispatch decision point.
+
+    Off-platform specs require ``identity``/``org``/``repo`` to derive the cloud
+    resource name and labels; ``name`` selects a named instance (None = default).
+    """
+    if spec.off_platform:
+        if identity is None or org is None or repo is None:
+            msg = "off-platform backend requires identity, org, and repo"
+            raise ValueError(msg)
+        return OffPlatformBackend(spec, identity, org, repo, name)
+    return LimaBackend()
+```
+
+- [ ] **Step 7: Run the new tests and the existing cloud suite**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vm_cloud.py tests/vergil_tooling/test_vm_spec.py::test_state_slug_forms -v`
+Expected: PASS. If existing `test_vm_cloud.py` tests call `cloud_resource_name(identity, org, repo)` or `cloud_labels(identity, org, repo)` positionally, update those call sites to the new signatures (the cloud name is now a hash of the slug; assertions on the old dashed name must change to `state_slug(...)` for the state key and `cloud_resource_name(state_slug(...))` for the resource name).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/lib/vm_spec.py src/vergil_tooling/lib/vm_cloud.py src/vergil_tooling/lib/vm_backend.py tests/vergil_tooling/test_vm_spec.py tests/vergil_tooling/test_vm_cloud.py
+vrg-commit --type feat --scope vm --message "derive readable state slug, hashed cloud name, instance label" \
+  --body "state_slug joins the handle with '--' for the state path; cloud_resource_name becomes vrg-<sha256(slug)[:12]>; cloud_labels gains vergil-instance; OffPlatformBackend and select_backend thread the instance name. Ref #1831"
+```
+
+---
+
+### Task 5: Sidecar carries `name`; `recover_handle`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/lima.py` (`write_instance_meta` 284-293; `read_instance_meta` 296-309)
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`recover_triple` 288-300 → `recover_handle`; create-time write 614; `discover_dedicated` 1396-1404; `update --all` site 1116)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Produces:
+  - `lima.write_instance_meta(instance, identity, org, repo, name=None)` — payload `{"schema": 2, "identity", "org", "repo", "name"}` (`name` is `""` when absent).
+  - `vrg_vm.recover_handle(instance) -> tuple[str, str|None, str|None, str|None]` — `(identity, org, repo, name)`; legacy/parse fallback yields `name=None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_recover_handle_roundtrips_named_instance(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.lib.lima import write_instance_meta
+    from vergil_tooling.bin.vrg_vm import recover_handle
+
+    inst = "vergil-user.lmf.mq.cloud-x86"
+    write_instance_meta(inst, "vergil-user", "lmf", "mq", "cloud-x86")
+    assert recover_handle(inst) == ("vergil-user", "lmf", "mq", "cloud-x86")
+
+
+def test_recover_handle_default_instance_name_none(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.lib.lima import write_instance_meta
+    from vergil_tooling.bin.vrg_vm import recover_handle
+
+    inst = "vergil-user.lmf.mq"
+    write_instance_meta(inst, "vergil-user", "lmf", "mq")
+    assert recover_handle(inst) == ("vergil-user", "lmf", "mq", None)
+
+
+def test_recover_handle_parse_fallback_no_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin.vrg_vm import recover_handle
+
+    assert recover_handle("vergil-user.lmf.mq") == ("vergil-user", "lmf", "mq", None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "recover_handle" -v`
+Expected: FAIL — `cannot import name 'recover_handle'`; `write_instance_meta` takes 4 args.
+
+- [ ] **Step 3: Update the sidecar**
+
+In `src/vergil_tooling/lib/lima.py`, replace `write_instance_meta` (284-293) and `read_instance_meta` (296-309):
+
+```python
+def write_instance_meta(
+    instance: str, identity: str, org: str, repo: str, name: str | None = None
+) -> None:
+    """Record the handle beside the instance so a mangled name stays reversible.
+
+    Lives in ``~/.lima/<instance>/``, removed when ``limactl delete --force`` deletes
+    that dir. ``name`` is the optional fourth handle segment (empty for the default).
+    """
+    meta_dir = _serial_dir(instance)
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": 2,
+        "identity": identity,
+        "org": org,
+        "repo": repo,
+        "name": name or "",
+    }
+    (meta_dir / _META_FILE).write_text(json.dumps(payload))
+
+
+def read_instance_meta(instance: str) -> dict[str, object] | None:
+    """Return the instance's recorded metadata, or None if no sidecar exists.
+
+    Carries an int ``schema``, string ``identity``/``org``/``repo``, and (schema 2+)
+    a string ``name``. Raises on a malformed sidecar rather than silently falling
+    back. Schema-1 sidecars (no ``name``) are read as the default instance.
+    """
+    path = _serial_dir(instance) / _META_FILE
+    if not path.exists():
+        return None
+    data: dict[str, object] = json.loads(path.read_text())
+    _ = (data["identity"], data["org"], data["repo"])  # fail loudly on a garbled file
+    data.setdefault("name", "")
+    return data
+```
+
+- [ ] **Step 4: Rename `recover_triple` → `recover_handle`**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, replace `recover_triple` (288-300):
+
+```python
+def recover_handle(instance: str) -> tuple[str, str | None, str | None, str | None]:
+    """Reverse an instance name into the four-part handle (identity, org, repo, name).
+
+    Prefers the per-instance sidecar (reliable once a long name is truncated+hashed);
+    falls back to parsing for legacy short names and base boxes that predate the
+    sidecar, where ``name`` is None.
+    """
+    meta = read_instance_meta(instance)
+    if meta is not None:
+        name = str(meta.get("name") or "") or None
+        return str(meta["identity"]), str(meta["org"]), str(meta["repo"]), name
+    ident, org, repo = parse_instance_name(instance)
+    return ident, org, repo, None
+```
+
+- [ ] **Step 5: Update the three call sites**
+
+(a) Create-time write (line 614) — pass the handle name. In Task 6 the Target gains an `instance_name_arg`; for now keep the default-instance behavior. Replace line 614:
+
+```python
+        write_instance_meta(
+            target.instance, target.identity_name, target.org, target.repo, target.instance_name_arg
+        )
+```
+
+If Task 6 has not yet added `Target.instance_name_arg`, temporarily pass `None`; Task 6 wires the field. (Subagent-driven execution does Task 6 after this; if you prefer, pass `None` here and revisit in Task 6 Step 6.)
+
+(b) `discover_dedicated` (1396-1404) — unpack four and carry the name. Replace the loop body:
+
+```python
+    rows: list[DedicatedRow] = []
+    for name in instances:
+        try:
+            ident, org, repo, inst_name = recover_handle(name)
+        except ValueError:
+            continue
+        if ident != identity_name or org is None or repo is None:
+            continue
+        state, stanza = _classify_instance(projects_dir, org, repo, name)
+        rows.append(DedicatedRow(org, repo, name, state, stanza, inst_name))
+    return rows
+```
+
+Add the `instance_name` field to `DedicatedRow` (1343-1349):
+
+```python
+@dataclass
+class DedicatedRow:
+    org: str
+    repo: str
+    instance: str
+    state: str  # "present" | "orphaned"
+    stanza: VmStanza | None = None
+    instance_name: str | None = None
+```
+
+(c) `update --all` site (line 1116) — replace:
+
+```python
+                ident, org, repo, _inst_name = recover_handle(inst)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "recover_handle" -v`
+Expected: PASS. Then run the full `test_vrg_vm.py` to catch any remaining `recover_triple` references: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -q` and fix any `recover_triple` import in the tests by renaming to `recover_handle` (adjusting expected tuples to four elements).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/lib/lima.py src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm --message "make handle reversal name-aware (recover_handle, sidecar name)" \
+  --body "Sidecar payload bumps to schema 2 with a name field; recover_triple becomes recover_handle returning the four-part handle, threaded through discover_dedicated and update --all. Ref #1831"
+```
+
+- [ ] **Step 8: Phase 2 full validation**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS.
+
+---
+
+## Phase 3 — CLI `--name` wiring
+
+### Task 6: Add `--name` to verbs and thread it through resolution
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`Target` 104-112; `_add_workspace_arg` 2134-2140 or a new `_add_name_arg`; verb parsers 2151-2255; `_resolve_target` 212-259; `_resolve_instance` 262-278)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`, `tests/vergil_tooling/test_vrg_vm_resolve.py`
+
+**Interfaces:**
+- Produces:
+  - `Target.instance_name_arg: str | None` — the requested instance name (the handle's fourth segment).
+  - `--name` flag on `create`/`session`/`rebuild`/`destroy`/`stop`/`start`/`restart`/`update`/`destroy-volume`.
+  - `_resolve_target`/`_resolve_instance` read `args.name`, validate the repo segment, compose with `instance=`, and derive the named Lima instance + named backend.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vrg_vm_resolve.py` (mirror the existing resolve-test fixtures there; this asserts the resolver honors `--name`):
+
+```python
+def test_resolve_target_named_instance(monkeypatch, named_instance_config):
+    # named_instance_config: a fixture building an identities/repo config where
+    # vergil-user/lmf/mq declares an off-platform instance "cloud-x86".
+    args = _make_args(workspace="lmf/mq", name="cloud-x86", identity="vergil-user")
+    target = _resolve_target(args)
+    assert target.instance_name_arg == "cloud-x86"
+    assert target.instance == "vergil-user.lmf.mq.cloud-x86"
+    assert target.spec.off_platform
+    assert target.backend.slug == "vergil-user--lmf--mq--cloud-x86"
+```
+
+If `test_vrg_vm_resolve.py` has no reusable fixture/`_make_args`, add a minimal `argparse.Namespace`-based helper and a config fixture following the patterns already in that file (read the file's existing resolve tests first and match them). The behavioral assertions above are the contract.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm_resolve.py -k "named_instance" -v`
+Expected: FAIL — `Target` has no `instance_name_arg`; `_resolve_target` ignores `name`.
+
+- [ ] **Step 3: Add the `Target` field**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, add to `Target` (104-112), as the last field with a default to avoid reordering:
+
+```python
+@dataclass
+class Target:
+    identity_name: str
+    identity: Identity
+    config: IdentityConfig
+    org: str | None
+    repo: str | None
+    spec: ComposedSpec
+    instance: str
+    fingerprint: str
+    backend: Backend
+    instance_name_arg: str | None = None
+```
+
+- [ ] **Step 4: Add the `--name` argument helper and attach it to the verbs**
+
+Add near `_add_workspace_arg` (2134):
+
+```python
+def _add_name_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--name",
+        default=None,
+        help=(
+            "Named VM instance for this repo (default: the unnamed default instance). "
+            "Must be declared under [vm.<identity>.instances.<name>]."
+        ),
+    )
+```
+
+Call `_add_name_arg(p_*)` for each of: `p_create`, `p_start`, `p_stop`, `p_restart`, `p_update`, `p_destroy`, `p_destroy_volume`, `p_rebuild`, and add `--name` to `p_session` (it builds its own parser without `_add_workspace_arg`; add `p_session.add_argument("--name", default=None, help=...)` alongside its other options). Do **not** add it to `p_list` / `p_volumes` (global enumerators).
+
+- [ ] **Step 5: Thread `--name` through `_resolve_target`**
+
+In `_resolve_target` (212-259), read and validate the name, then compose and derive with it. Replace the body from line 221 onward:
+
+```python
+    name, identity, config = _resolve(args)
+    workspace = getattr(args, "workspace", None)
+    inst_name = getattr(args, "name", None)
+    base = _base_footprint(identity)
+    org, repo = _workspace_org_repo(workspace)
+
+    if org is None or repo is None:
+        if inst_name is not None:
+            msg = "--name requires an <org>/<repo> workspace (named instances are per-repo)"
+            raise SpecError(msg)
+        spec = compose_vm_spec(identity=name, base=base, stanza=None, override=None)
+        backend = select_backend(spec, identity=name, org=None, repo=None)
+        return Target(
+            name, identity, config, None, None, spec, identity.vm_instance, "", backend
+        )
+
+    validate_repo_segment(repo)
+
+    requested_vm = _read_repo_vm(identity, org, repo)
+    borrow = resolve_borrow(identity, org, repo, requested_vm)
+    eff_vm: VmStanza | None
+    if borrow is not None:
+        if not borrow_allowed:
+            raise BorrowError(_borrow_block_msg(args.command, org, repo, borrow.org, borrow.repo))
+        eff_org, eff_repo, eff_vm = borrow.org, borrow.repo, borrow.stanza
+    else:
+        eff_org, eff_repo, eff_vm = org, repo, requested_vm
+
+    override = identity.overrides.get((eff_org, eff_repo))
+    spec = compose_vm_spec(
+        identity=name, base=base, stanza=eff_vm, override=override, instance=inst_name
+    )
+    backend = select_backend(
+        spec, identity=name, org=eff_org, repo=eff_repo, name=inst_name
+    )
+
+    if not spec.dedicated:
+        return Target(
+            name, identity, config, org, repo, spec, identity.vm_instance, "", backend
+        )
+
+    inst = instance_name(name, eff_org, eff_repo, inst_name)
+    return Target(
+        name,
+        identity,
+        config,
+        eff_org,
+        eff_repo,
+        spec,
+        inst,
+        spec_fingerprint(spec),
+        backend,
+        inst_name,
+    )
+```
+
+Add `validate_repo_segment` and `state_slug` (if needed later) to the `vm_spec` import block at the top of `vrg_vm.py` (it already imports `compose_vm_spec`, `instance_name`, `spec_fingerprint`, `parse_instance_name`). Add `validate_repo_segment`.
+
+- [ ] **Step 6: Thread `--name` through `_resolve_instance` and the create-time write**
+
+Replace `_resolve_instance` (262-278):
+
+```python
+def _resolve_instance(
+    args: argparse.Namespace,
+) -> tuple[str, Identity, IdentityConfig, str]:
+    """Resolve the Lima instance NAME for lifecycle commands (stop/restart).
+
+    Maps an ``org/repo`` (or its absence) plus an optional ``--name`` to a Lima
+    instance name. A repo with no readable ``vergil.toml`` still resolves to its own
+    instance name so an orphaned dedicated VM stays reachable.
+    """
+    name, identity, config = _resolve(args)
+    org, repo = _workspace_org_repo(getattr(args, "workspace", None))
+    inst_name = getattr(args, "name", None)
+    if org is not None and repo is not None:
+        validate_repo_segment(repo)
+        instance = instance_name(name, org, repo, inst_name)
+    else:
+        instance = identity.vm_instance
+    return name, identity, config, instance
+```
+
+Confirm the create-time write (Task 5 Step 5a) passes `target.instance_name_arg` — it now exists.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm_resolve.py -k "named_instance" -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm_resolve.py
+vrg-commit --type feat --scope vm --message "add --name flag across lifecycle verbs" \
+  --body "Target carries instance_name_arg; --name is wired into create/session/rebuild/destroy/stop/start/restart/update/destroy-volume and threaded through _resolve_target/_resolve_instance into composition, the Lima name, and the backend. Ref #1831"
+```
+
+- [ ] **Step 9: Phase 3 full validation**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS. Confirm a bare verb (no `--name`) still resolves the default instance unchanged.
+
+---
+
+## Phase 4 — Recorded-state lifecycle dispatch (highest-risk; most tests)
+
+> Per the spec's sequencing callout, this phase carries the bulk of the lifecycle test surface. Test each branch.
+
+### Task 7: Recorded-state enumerator for a handle
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (add `_recorded_state_for_handle` near `_off_platform_vms` 1623)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Produces: `_recorded_state_for_handle(identity, org, repo, name) -> RecordedState`, a dataclass with:
+  - `lima_instance: str | None` — the derived Lima name if that instance exists.
+  - `tofu_dirs: list[tuple[str, Path]]` — `(provider, provider_state_dir)` for every `~/.config/vergil/tofu/<slug>/<provider>/` carrying `volume.tfstate` or `vm.tfstate`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_recorded_state_enumerates_lima_and_tofu(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle, RecordedState
+    from vergil_tooling.lib.vm_spec import state_slug
+
+    slug = state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+    for provider in ("gcp", "azure"):
+        d = tmp_path / ".config" / "vergil" / "tofu" / slug / provider
+        d.mkdir(parents=True)
+        (d / "vm.tfstate").write_text("{}")
+    # Lima instance presence is mocked via list_vms
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.list_vms",
+        lambda: [{"name": "vergil-user.lmf.mq.cloud-x86", "status": "Running"}],
+    )
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert rs.lima_instance == "vergil-user.lmf.mq.cloud-x86"
+    assert {p for p, _ in rs.tofu_dirs} == {"gcp", "azure"}
+
+
+def test_recorded_state_no_lima_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert rs.lima_instance is None
+    assert rs.tofu_dirs == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "recorded_state" -v`
+Expected: FAIL — `cannot import name '_recorded_state_for_handle'`.
+
+- [ ] **Step 3: Implement the enumerator**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, near `_off_platform_vms` (before line 1623), add (ensure `state_slug` is imported from `vm_spec` at the top, and `instance_name`, `list_vms`, `Path` are in scope — they are):
+
+```python
+@dataclass
+class RecordedState:
+    """Everything actually built under one handle, discovered from disk + Lima."""
+
+    lima_instance: str | None
+    tofu_dirs: list[tuple[str, Path]]  # (provider, provider_state_dir)
+
+
+def _recorded_state_for_handle(
+    identity: str, org: str, repo: str, name: str | None
+) -> RecordedState:
+    """Enumerate the Lima box and every tofu provider state recorded for a handle.
+
+    Acts on reality, not the live profile: the Lima instance named for the handle
+    (if it exists) plus every ``~/.config/vergil/tofu/<slug>/<provider>/`` directory
+    carrying recorded state. The slug is deterministic, so this is a direct glob of
+    the handle's own subtree.
+    """
+    lima = instance_name(identity, org, repo, name)
+    existing = {vm["name"] for vm in list_vms()}
+    lima_instance = lima if lima in existing else None
+
+    slug = state_slug(identity, org, repo, name)
+    handle_root = Path.home() / ".config" / "vergil" / "tofu" / slug
+    tofu_dirs: list[tuple[str, Path]] = []
+    if handle_root.is_dir():
+        for provider_dir in sorted(p for p in handle_root.iterdir() if p.is_dir()):
+            if (provider_dir / "volume.tfstate").exists() or (
+                provider_dir / "vm.tfstate"
+            ).exists():
+                tofu_dirs.append((provider_dir.name, provider_dir))
+    return RecordedState(lima_instance, tofu_dirs)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "recorded_state" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm --message "enumerate all recorded state for a handle" \
+  --body "Add _recorded_state_for_handle: the handle's Lima box (if present) plus every <slug>/<provider>/ tofu state dir, discovered from disk and limactl rather than the live profile. Ref #1831"
+```
+
+---
+
+### Task 8: `destroy` tears down all recorded backends with a confirmation contract
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_cmd_destroy` 1249-1268; `_cloud_destroy` 1235-1246; `p_destroy` parser 2210-2217)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Consumes: `_recorded_state_for_handle`, `_resolve`, `vm_cloud.fetch_modules`/`destroy_vm`, `delete_vm`, `resolve_vm_tag`.
+- Produces: `_cmd_destroy` enumerates recorded state for the handle and tears down the Lima box and every provider's `vm.tfstate`; prints the listing first; prompts on a TTY; `--yes` proceeds; non-interactive without `--yes` refuses. `--name` and a new `--yes` flag on `p_destroy`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_destroy_refuses_non_interactive_without_yes(monkeypatch, capsys):
+    from vergil_tooling.bin import vrg_vm
+
+    rs = vrg_vm.RecordedState(
+        lima_instance="vergil-user.lmf.mq.cloud-x86", tofu_dirs=[]
+    )
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig()))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=False)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 1
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_destroy_yes_tears_down_lima_and_all_providers(monkeypatch, capsys):
+    from vergil_tooling.bin import vrg_vm
+    from pathlib import Path
+
+    rs = vrg_vm.RecordedState(
+        lima_instance="vergil-user.lmf.mq.cloud-x86",
+        tofu_dirs=[("gcp", Path("/x/gcp")), ("azure", Path("/x/azure"))],
+    )
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig()))
+    deleted = []
+    destroyed = []
+    monkeypatch.setattr(vrg_vm, "delete_vm", lambda i: deleted.append(i))
+    monkeypatch.setattr(vrg_vm.vm_cloud, "fetch_modules", lambda tag: Path("/m/modules"))
+    monkeypatch.setattr(vrg_vm.vm_cloud, "destroy_vm", lambda root, d: destroyed.append(d))
+    monkeypatch.setattr(vrg_vm.shutil, "rmtree", lambda *a, **k: None)
+    monkeypatch.setattr(vrg_vm, "resolve_vm_tag", lambda c, i: "v1")
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=True)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 0
+    assert deleted == ["vergil-user.lmf.mq.cloud-x86"]
+    assert destroyed == [Path("/x/gcp"), Path("/x/azure")]
+
+
+def test_destroy_nothing_recorded_returns_one(monkeypatch, capsys):
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm, "_recorded_state_for_handle",
+        lambda *a: vrg_vm.RecordedState(lima_instance=None, tofu_dirs=[]),
+    )
+    monkeypatch.setattr(vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig()))
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=True)
+    assert vrg_vm._cmd_destroy(args) == 1
+    assert "no recorded" in capsys.readouterr().err.lower()
+```
+
+Add the small helpers `_destroy_args(...)`, `_FakeIdentity`, `_FakeConfig` at the top of the test module if not already present, following the existing test fixtures in `test_vrg_vm.py` (read them first; `_destroy_args` builds an `argparse.Namespace(command="destroy", workspace=..., name=..., yes=..., tag="", identity="vergil-user", config=None)`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "destroy_refuses or destroy_yes or destroy_nothing" -v`
+Expected: FAIL — current `_cmd_destroy` resolves a single target, ignores recorded state and `--yes`.
+
+- [ ] **Step 3: Rewrite `_cmd_destroy`**
+
+Replace `_cmd_destroy` (1249-1268) and add a teardown helper:
+
+```python
+def _destroy_recorded(rs: RecordedState, args: argparse.Namespace, config, identity) -> int:
+    """Tear down the Lima box and every recorded provider state for a handle."""
+    if rs.lima_instance is not None:
+        print(f"Destroying Lima VM '{rs.lima_instance}'...")
+        delete_vm(rs.lima_instance)
+    if rs.tofu_dirs:
+        tag = args.tag if getattr(args, "tag", "") else resolve_vm_tag(config, identity)
+        modules_root = vm_cloud.fetch_modules(tag)
+        try:
+            for provider, state_dir in rs.tofu_dirs:
+                print(f"Destroying cloud VM under {provider} (volume preserved): {state_dir}")
+                vm_cloud.destroy_vm(modules_root, state_dir)
+        finally:
+            shutil.rmtree(modules_root.parent, ignore_errors=True)
+    print("Destroyed (persistent volumes preserved — use destroy-volume to remove them).")
+    return 0
+
+
+def _cmd_destroy(args: argparse.Namespace) -> int:
+    name, identity, config = _resolve(args)
+    org, repo = _workspace_org_repo(getattr(args, "workspace", None))
+    inst_name = getattr(args, "name", None)
+    if org is None or repo is None:
+        rs = RecordedState(
+            lima_instance=(identity.vm_instance if identity.vm_instance in
+                           {vm["name"] for vm in list_vms()} else None),
+            tofu_dirs=[],
+        )
+    else:
+        validate_repo_segment(repo)
+        rs = _recorded_state_for_handle(name, org, repo, inst_name)
+
+    if rs.lima_instance is None and not rs.tofu_dirs:
+        print("No recorded state to destroy for this handle.", file=sys.stderr)
+        return 1
+
+    # Confirmation contract.
+    print("Will destroy the following recorded boxes:")
+    if rs.lima_instance:
+        print(f"  - Lima: {rs.lima_instance}")
+    for provider, state_dir in rs.tofu_dirs:
+        print(f"  - {provider}: {state_dir}")
+    if not getattr(args, "yes", False):
+        if not sys.stdin.isatty():
+            print(
+                "Refusing to destroy multiple recorded boxes non-interactively — "
+                "re-run with --yes to confirm.",
+                file=sys.stderr,
+            )
+            return 1
+        answer = input("Proceed? [y/N] ").strip().lower()
+        if answer not in {"y", "yes"}:
+            print("Aborted.", file=sys.stderr)
+            return 1
+
+    return _destroy_recorded(rs, args, config, identity)
+```
+
+`_cloud_destroy` (1235-1246) is now unused by `destroy`; leave it only if `rebuild` still calls it (it does not — rebuild uses `_cloud_create(..., destroy_first=True)`). Run `grep -n "_cloud_destroy" src/vergil_tooling/bin/vrg_vm.py`; if `_cmd_destroy` was its only caller, delete `_cloud_destroy` to keep lint clean.
+
+- [ ] **Step 4: Add `--yes` to the destroy parser**
+
+In `main()`, after the `p_destroy` `--tag` argument (2213-2217), add:
+
+```python
+    p_destroy.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt (required for a non-interactive multi-box destroy)",
+    )
+```
+
+(`--name` was added in Task 6 Step 4.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "destroy_refuses or destroy_yes or destroy_nothing" -v`
+Expected: PASS. Then run the existing destroy tests: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k destroy -v` and reconcile any that assumed the old single-target behavior (they should now expect the recorded-state path; update them to the new contract — this is the intended behavior change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm --message "destroy tears down all recorded backends for a handle" \
+  --body "_cmd_destroy enumerates recorded state and removes the Lima box plus every recorded provider's VM (volumes preserved), printing the teardown listing and honoring a confirmation contract: prompt on TTY, --yes to proceed, refuse non-interactively without --yes. Dissolves the backend-switch orphan. Ref #1831"
+```
+
+---
+
+### Task 9: `stop`/`start`/`restart` resolve by handle, Lima-only
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_cmd_stop` 978-987; `_cmd_start` 922-957 already uses `_resolve_target`; `_cmd_restart` 990+)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- `stop`/`start`/`restart` keep rejecting off-platform (`_reject_if_off_platform` / `_EPHEMERAL_MSG`) and now address the handle's Lima instance via `--name`. No new enumeration — the `--name` threading from Task 6 already makes `_resolve_instance`/`_resolve_target` handle-aware; this task adds the regression test that confirms the Lima-only contract holds under a named instance.
+
+- [ ] **Step 1: Write the failing/contract test**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_stop_named_instance_targets_handle_lima(monkeypatch, capsys):
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(vrg_vm, "_reject_if_off_platform", lambda args: False)
+    monkeypatch.setattr(
+        vrg_vm, "_resolve_instance",
+        lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig(), "vergil-user.lmf.mq.cloud-x86"),
+    )
+    stopped = []
+    monkeypatch.setattr(vrg_vm, "stop_vm", lambda i: stopped.append(i))
+    args = _stop_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_stop(args) == 0
+    assert stopped == ["vergil-user.lmf.mq.cloud-x86"]
+
+
+def test_start_named_off_platform_still_rejected(monkeypatch, capsys):
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm, "_resolve_target",
+        lambda args, **k: _FakeTarget(off_platform=True),
+    )
+    args = _start_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_start(args) == 1
+    assert "ephemeral" in capsys.readouterr().err.lower()
+```
+
+Add `_stop_args`/`_start_args`/`_FakeTarget` helpers matching the module's existing fixtures (a `_FakeTarget` exposing `.spec.off_platform`).
+
+- [ ] **Step 2: Run tests to verify behavior**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "stop_named or start_named_off_platform" -v`
+Expected: the stop test may already PASS (Task 6 made `_resolve_instance` name-aware); the off-platform rejection test should PASS unchanged. If the stop test fails because `_cmd_stop`'s message text differs, that is fine — adjust the test to the actual message, not the code. The point is the contract: stop targets the handle's Lima instance, start/restart reject off-platform.
+
+- [ ] **Step 3: Confirm no code change is needed (or make the minimal one)**
+
+`_cmd_stop` already calls `_resolve_instance(args)`, which is now handle-aware. `_cmd_start`/`_cmd_restart` already call `_resolve_target`, now handle-aware, and reject off-platform. If all three behave correctly, no production change is required — this task is the regression lock. If a verb still drops `--name`, ensure its handler reads through the updated resolvers (it should, after Task 6).
+
+- [ ] **Step 4: Run the broader stop/start/restart suite**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "stop or start or restart" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type test --scope vm --message "lock stop/start/restart to the handle's Lima box" \
+  --body "Regression tests proving stop/start/restart address the handle's Lima instance via --name and continue to reject off-platform (no cloud stop/start). Ref #1831"
+```
+
+- [ ] **Step 6: Phase 4 full validation**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS.
+
+---
+
+## Phase 5 — `list` and `volumes` surfaces
+
+### Task 10: `list` INSTANCE column + `no-vm` volume rows
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_cmd_list` 1680-1717; `_list_rows`; `_cloud_list_rows` 1657-1677; `OffPlatformVm` ~1580; `_off_platform_vms` 1623-1654)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- `OffPlatformVm` gains `instance: str | None` (from the `vergil-instance` label).
+- `_cloud_list_rows` emits an `instance` field and a `no-vm` STATUS row carrying the volume size when the volume state exists but the VM is gone.
+- `_cmd_list` prints an INSTANCE column between SCOPE and BACKEND; local rows pass the dedicated row's `instance_name` (from Task 5's `DedicatedRow.instance_name`), `—` for the default.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_list_shows_instance_column_and_no_vm_row(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin import vrg_vm
+
+    # Off-platform: a volume exists, VM is gone -> no-vm row with size.
+    monkeypatch.setattr(
+        vrg_vm, "_off_platform_vms",
+        lambda: [
+            vrg_vm.OffPlatformVm(
+                name="vergil-user--lmf--mq--native-ha", provider="gcp",
+                state_dir=tmp_path, identity="vergil-user", org="lmf", repo="mq",
+                instance="native-ha", status="", volume_size="200GiB", vm_present=False,
+            )
+        ],
+    )
+    monkeypatch.setattr(vrg_vm, "list_vms", lambda: [])
+    monkeypatch.setattr(vrg_vm, "load_config", lambda p: _empty_config())
+    args = _list_args()
+    assert vrg_vm._cmd_list(args) == 0
+    out = capsys.readouterr().out
+    assert "INSTANCE" in out
+    assert "native-ha" in out
+    assert "no-vm" in out
+    assert "200GiB" in out
+```
+
+(The exact `OffPlatformVm` constructor fields are finalized in Step 3 — keep the test in sync.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "instance_column" -v`
+Expected: FAIL — no INSTANCE column; `OffPlatformVm` has no `instance`/`volume_size`/`vm_present`.
+
+- [ ] **Step 3: Extend `OffPlatformVm` and `_off_platform_vms`**
+
+Read the `OffPlatformVm` dataclass (just above `_off_platform_vms`, ~line 1580) and add fields: `instance: str | None = None`, `volume_size: str | None = None`, `vm_present: bool = True`. Update its `scope` property (which currently uses identity/org/repo) to leave instance to a separate column.
+
+In `_off_platform_vms` (1623-1654), populate the new fields from the parsed volume state and a VM-presence check:
+
+```python
+    for volume_state in sorted(tofu_root.glob("*/*/volume.tfstate")):
+        provider_dir = volume_state.parent
+        provider = provider_dir.name
+        state_key = provider_dir.parent.name
+        parsed = vm_cloud.parse_volume_state(volume_state)
+        labels = parsed.labels if parsed else {}
+        size = f"{parsed.size_gib}GiB" if parsed and parsed.size_gib else None
+        vm_present = (provider_dir / "vm.tfstate").exists()
+        status = _cloud_status(provider_dir, state_key) if vm_present else ""
+        vms.append(
+            OffPlatformVm(
+                name=state_key,
+                provider=provider,
+                state_dir=provider_dir,
+                identity=labels.get("vergil-identity"),
+                org=labels.get("vergil-org"),
+                repo=labels.get("vergil-repo"),
+                instance=labels.get("vergil-instance"),
+                status=status,
+                volume_size=size,
+                vm_present=vm_present,
+            )
+        )
+```
+
+- [ ] **Step 4: Emit the INSTANCE column and `no-vm` rows in the list renderers**
+
+Update `_cloud_list_rows` (1657-1677) to carry instance, size, and the no-vm status:
+
+```python
+    rows: list[dict[str, object]] = []
+    for vm in _off_platform_vms():
+        if not vm.vm_present:
+            status = "no-vm"
+            disk = vm.volume_size or "—"
+        else:
+            status = vm.status or f"unknown (no {vm.provider} creds)"
+            disk = "—"
+        rows.append(
+            {
+                "identity": vm.identity or "—",
+                "scope": vm.scope,
+                "instance": vm.instance or "—",
+                "backend": vm.provider,
+                "status": status,
+                "disk": disk,
+            }
+        )
+    return rows
+```
+
+In `_cmd_list` (1680-1717), add INSTANCE to the header and both row loops. Replace the header and loops:
+
+```python
+    header = (
+        f"{'IDENTITY':<14} {'SCOPE':<40} {'INSTANCE':<11} {'BACKEND':<13} {'STATUS':<11} "
+        f"{'CPUS':<5} {'MEM':<7} {'DISK':<7} {'AGENTS':<7} {'HUMANS':<7} {'SPEC':<22}"
+    )
+    print(header)
+    print("─" * len(header))
+
+    for id_name, identity in config.identities.items():
+        for r in _list_rows(id_name, identity, discovered[id_name], status, probes):
+            print(
+                f"{id_name:<14} {r['scope']!s:<40} {r.get('instance', '—')!s:<11} "
+                f"{r['backend']!s:<13} {r['status']!s:<11} "
+                f"{r['cpus']!s:<5} {r['memory']!s:<7} {r['disk']!s:<7} "
+                f"{r['agents']!s:<7} {r['humans']!s:<7} {r['spec']!s:<22}"
+            )
+
+    for r in _cloud_list_rows():
+        print(
+            f"{r['identity']!s:<14} {r['scope']!s:<40} {r['instance']!s:<11} "
+            f"{r['backend']!s:<13} {r['status']!s:<11} "
+            f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {'—':<22}"
+        )
+
+    return 0
+```
+
+In `_list_rows` (the local-row builder — find it with `grep -n "def _list_rows"`), set each row's `instance` from the `DedicatedRow.instance_name` (`—` for base/default). Locate where it builds the per-`DedicatedRow` dict and add `"instance": row.instance_name or "—"`; base rows set `"instance": "—"`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "instance_column or list" -v`
+Expected: PASS. Reconcile any existing `list` tests that assert the old header/column count — update them to include INSTANCE (intended change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm --message "add INSTANCE column and no-vm volume rows to list" \
+  --body "list gains an INSTANCE column (from DedicatedRow.instance_name and the vergil-instance label) and enumerates from volume state: a surviving volume with no VM shows a no-vm row carrying its size, one row per recorded (slug, provider). Ref #1831"
+```
+
+---
+
+### Task 11: `volumes` INSTANCE column
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` (`_volume_rows`; `_cmd_volumes` 1807-1843)
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- `_volume_rows` emits an `instance` field (from the `vergil-instance` label); `_cmd_volumes` prints an INSTANCE column so sibling instances of one repo are distinguishable.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`:
+
+```python
+def test_volumes_shows_instance_column(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm, "_volume_rows",
+        lambda: [
+            {
+                "identity": "vergil-user", "scope": "lmf/mq", "instance": "cloud-x86",
+                "name": "vrg-abc123", "size": "300GiB", "zone": "us-central1-b",
+                "region": "us-central1", "provider": "gcp",
+            }
+        ],
+    )
+    args = vrg_vm.argparse.Namespace(live=False)
+    assert vrg_vm._cmd_volumes(args) == 0
+    out = capsys.readouterr().out
+    assert "INSTANCE" in out
+    assert "cloud-x86" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "volumes_shows_instance" -v`
+Expected: FAIL — no INSTANCE column in `volumes` output.
+
+- [ ] **Step 3: Add `instance` to `_volume_rows`**
+
+Find `_volume_rows` (`grep -n "def _volume_rows"`). It builds rows from `_off_platform_vms()` or directly from volume state labels. Add `"instance": <vergil-instance label or "—">` to each row dict (the label is now populated on `OffPlatformVm.instance` from Task 10, or read directly from `parsed.labels.get("vergil-instance")`).
+
+- [ ] **Step 4: Render the INSTANCE column in `_cmd_volumes`**
+
+In `_cmd_volumes` (1807-1843), add the column to the header and rows. Replace the header/width block and the per-row print:
+
+```python
+    scope_w = max([24, *(len(str(r["scope"])) for r in rows)])
+    name_w = max([20, *(len(str(r["name"])) for r in rows)])
+    inst_w = max([10, *(len(str(r.get("instance", "—"))) for r in rows)])
+    header = (
+        f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'INSTANCE':<{inst_w}} "
+        f"{'DISK NAME':<{name_w}} {'SIZE':<8} {'ZONE':<16} {'REGION':<14}"
+    )
+    if live:
+        header += f" {'LIVE':<22}"
+    print(header)
+    print("─" * len(header))
+    for r in rows:
+        line = (
+            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} "
+            f"{r.get('instance', '—')!s:<{inst_w}} {r['name']!s:<{name_w}} "
+            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14}"
+        )
+        if live:
+            line += f" {r['live']!s:<22}"
+        print(line)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `vrg-container-run -- uv run pytest tests/vergil_tooling/test_vrg_vm.py -k "volumes" -v`
+Expected: PASS. Reconcile existing `volumes` tests that assert the old header (intended change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope vm --message "add INSTANCE column to volumes" \
+  --body "vrg-vm volumes shows an INSTANCE column (from the vergil-instance label) so two volumes for one repo are distinguishable. Ref #1831"
+```
+
+- [ ] **Step 7: Phase 5 full validation + final sweep**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: PASS (whole suite green).
+
+Then do a manual smoke check of backward compatibility:
+Run: `vrg-container-run -- uv run vrg-vm list` and `... vrg-vm volumes` to confirm headers render and existing (unnamed) rows are unaffected.
+
+---
+
+## Final acceptance check (map to the spec's acceptance criteria)
+
+After Task 11, confirm each spec acceptance criterion has coverage:
+
+1. `--name X` lifecycle independence → Tasks 6, 8, 9.
+2. Two instances co-exist → Tasks 3, 4 (distinct Lima names, slugs, hashed cloud names, volumes).
+3. Bare verb = default unchanged → Tasks 2, 6 (default composition + no-`--name` path); regression suite.
+4. In-place backend/provider edit + `destroy --name X` tears down all recorded state; dropped stanza → `orphaned` → Tasks 7, 8, 10.
+5. Invalid instance name / repo `--` rejected at parse time → Tasks 1, 2, 6.
+6. `list` INSTANCE + `no-vm` rows, O(instances) → Task 10.
+7. `--name X` against a missing instance errors with available names → Task 2.
+8. Deterministic `vrg-<hash>` cloud name + identity labels → Task 4.
+9. Full existing suite green → every phase's `vrg-validate`.
+
+## PR handoff
+
+After all tasks land and `vrg-validate` is green, record PR metadata via the oracle (agents do **not** run `vrg-submit-pr`):
+
+```bash
+cd .worktrees/issue-1831-named-instances
+vrg-pr-workflow report-ready \
+  --title "feat(vm): multiple VM instances per repo (named instances)" \
+  --summary "<paraphrased summary of the change>" \
+  --notes "<test evidence + reconciliations>" \
+  --linkage Ref
+```
+
+Then hand off to the human to run `vrg-submit-pr`.

--- a/docs/specs/2026-06-23-vrg-vm-named-instances-tooling-design.md
+++ b/docs/specs/2026-06-23-vrg-vm-named-instances-tooling-design.md
@@ -1,0 +1,381 @@
+# `vrg-vm` Named Instances — Tooling-Side Design
+
+**Issue:** [vergil-tooling #1831 — feat: multiple VM instances per repo (tooling
+side)](https://github.com/vergil-project/vergil-tooling/issues/1831)
+
+**Date:** 2026-06-23
+
+**Status:** Design (from brainstorming, 2026-06-23). Tooling companion to the
+authoritative cross-repo design.
+
+## Relationship to the authoritative design
+
+The authoritative design for multiple VM instances per repo lives in **vergil-vm**
+at `docs/specs/2026-06-23-multiple-vm-instances-per-repo-design.md`
+([vergil-vm #242](https://github.com/vergil-project/vergil-vm/issues/242)). That
+document is authoritative for the cross-repo contract and the `vergil-vm`-owned
+module guard (the `var.name` validation + tests). This document is the
+**tooling-side implementation design** for [#1831](https://github.com/vergil-project/vergil-tooling/issues/1831):
+it grounds the authoritative model in the actual `vrg-vm` code and records the
+design decisions that grounding surfaced.
+
+The split mirrors the prior cross-repo features — per-repo profiles
+(vergil-vm #99 / vergil-tooling #1412) and the off-platform backend
+(vergil-vm #199 / vergil-tooling #1706).
+
+**Where this document diverges from the authoritative spec it says so explicitly**
+(see [Reconciliations](#reconciliations-deltas-from-the-authoritative-spec)). The
+divergences are naming/representation details that the authoritative spec described
+at an idealized level; the observable behavior (named instances, `--name`,
+recorded-state lifecycle, the `list` surface, the cloud length guard) is unchanged.
+
+## Goal
+
+Let one `(identity, org/repo)` own several **named instances**, each with its own
+composed profile, backend, lifecycle, recorded state, and persistent volume. An
+absent name is the default instance — exactly today's behavior, fully backward
+compatible. Dissolve the backend-switch destroy-orphan edge (Problem 1) by making
+the destructive lifecycle verbs act on recorded state rather than the live profile.
+
+## Scope boundary
+
+- **vergil-vm** owns the GCP modules' defense-in-depth `var.name` validation
+  (RFC1035 charset + length ≤ 58) and its tests. The modules are otherwise
+  instance-agnostic (`name`/`labels` are opaque; `interface.json` unchanged).
+- **This issue (vergil-tooling)** owns everything below: profile parsing &
+  composition, the handle and its derived names, `--name` across every verb,
+  recorded-state lifecycle dispatch, the cloud-name hash derivation + labels, and
+  the `list` surface.
+
+## Design decisions (from brainstorming)
+
+Three keystone decisions, settled before this design was written, shape the rest:
+
+1. **Keep the existing per-target delimiters; add the fourth segment to each.**
+   The authoritative spec describes a single `--`-delimited slug that doubles as
+   the Lima instance name and is reversed with `split('--')`. That is not
+   implementable as written: Lima's instance-name regex
+   (`^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$`) rejects consecutive dashes, which is
+   precisely why the #99 implementation already uses `.` for Lima names and a
+   separate `-`/hashed scheme for cloud names, reversing via a sidecar file (Lima)
+   and resource labels (cloud) rather than by splitting. We extend each existing
+   scheme with the fourth segment and keep the proven reversal machinery. The
+   `--` slug survives as the **readable handle** used for the tofu state path and
+   in documentation, not as the literal Lima name.
+
+2. **Decouple the tofu state-path key from the cloud resource name; key the state
+   path on the readable `--` slug.** Today `state_key == cloud_resource_name`.
+   Once the cloud resource name becomes an opaque hash (decision forced by the
+   63-char limit, below), the state directory is keyed on the readable
+   `identity--org--repo--name` slug instead, matching the authoritative spec's
+   "readable slug for the state path" intent and keeping
+   `~/.config/vergil/tofu/` human-debuggable.
+
+3. **Greenfield — no migration path.** There are no live off-platform deployments
+   whose cloud resources or state directories must be preserved across the naming
+   change. The new scheme applies to newly created instances. Existing **local**
+   dedicated VMs are default instances (three-segment `.` Lima names, unchanged),
+   so the Lima side is backward compatible without migration; the cloud-side scheme
+   change affects nothing that exists.
+
+## The handle and its derived names
+
+The authoritative key is the four-part handle `(identity, org, repo, name)`, where
+an absent `name` selects the default instance. From the handle, three deterministic
+names are derived, each with its own delimiter:
+
+| Derived name | Form | Used for | Reversal |
+|---|---|---|---|
+| **Lima instance name** | `identity.org.repo.name` (dots; bare `identity` for base, three-segment for default dedicated) | the `limactl` instance | sidecar metadata (`write_instance_meta` / `recover_triple`), extended to carry `name` |
+| **State slug** (readable) | `identity--org--repo--name` (`--`-joined; three-segment for default dedicated, bare `identity` for base) | tofu state dir `~/.config/vergil/tofu/<slug>/<provider>/`; the SHA-256 input for the cloud name | resource labels (and human-readable in the path) |
+| **Cloud resource name** | `vrg-<first 12 hex of sha256(state-slug)>` (≤ 16 chars, RFC1035: leading letter, lowercase alnum + hyphen) | GCP instance/disk/firewall name | never reversed from the name — `list` and `tofu import` read the labels |
+
+### Why the cloud name is hashed
+
+GCP resource names are capped at 63 chars (RFC1035); the derived `<name>-data`
+disk and `<name>-ssh` firewall add suffixes. The four-segment slug for the
+motivating repo
+(`vergil-user--logical-minds-foundry--mq-cluster-tooling--cloud-x86`, 65 chars)
+already overflows. So the readable slug and the cloud resource name are split: the
+dispatcher passes the GCP modules the short deterministic `vrg-<hash>` name and the
+identity labels. The hash is deterministic (same slug → same name, so `create` is
+idempotent and re-import is stable) and collision-free at fleet-of-one scale.
+
+**The hash is applied uniformly to all off-platform instances** (three- and
+four-segment), not only when the slug would overflow. This is deterministic and
+uniform, and greenfield makes it free. (The prior behavior — derive a readable
+dashed name and hash only on overflow — is dropped; nothing deployed depends on
+it.)
+
+### Identity lives in labels
+
+`vergil-identity` / `vergil-org` / `vergil-repo`, plus the new **`vergil-instance`**
+label, carry the human-readable handle on every cloud resource. `vergil-instance`
+is a value inside the existing opaque `labels` map — **no module variable or
+`interface.json` change**. `vrg-vm list` and `tofu import` read the labels, never
+the opaque resource name.
+
+### Validation (loud, at parse time)
+
+- An instance name must match `[a-z0-9-]+` and must not contain `--`. A single
+  dash inside a name is fine; a double dash would break the readable slug.
+- A **repo name containing `--` is rejected**, keeping the readable `--` state
+  slug unambiguous. (Identities are a closed vergil-prefixed set and GitHub
+  org/user logins cannot contain consecutive hyphens, so only the repo segment
+  needs the guard.)
+
+Both checks fail loudly before any name is constructed — no malformed slug is ever
+produced (no-silent-failures).
+
+## Configuration parsing & composition (`lib/vm_spec.py`)
+
+### The `instances` namespace
+
+A named instance is declared under an explicit `instances` table inside the role
+overlay (**per-identity by design — there is no all-identity
+`[vm.instances.<name>]` tier**):
+
+```toml
+[vm.vergil-user]                         # the default (unnamed) instance
+cpus   = 12
+memory = "64GiB"
+
+[vm.vergil-user.instances.cloud-x86]     # named: "cloud-x86"
+backend  = "off-platform"
+provider = "gcp"
+region   = "us-central1"
+instance = "n2-standard-16"
+volume   = "300GiB"
+```
+
+The parser reads `[vm.<identity>.instances.<name>]` into a new
+`instances: Mapping[str, RoleOverlay]` field on the per-identity overlay. The
+explicit namespace avoids any clash with array-of-table keys (`port_forwards`,
+`apt_repos`).
+
+### The composition cascade
+
+`compose_vm_spec` gains an optional `instance: str | None` parameter and composes:
+
+1. Built-in base footprint.
+2. `identities.toml [<identity>]` — credentials + base footprint.
+3. Repo `[vm]` — all-identity requirements.
+4. Repo `[vm.<identity>]` — role overlay. **Defines the default instance.**
+5. Repo `[vm.<identity>.instances.<name>]` — named-instance overlay (only when
+   `instance` is given).
+6. `identities.toml [<identity>.<org>.<repo>]` — host override, wins. The per-name
+   slot `[<identity>.<org>.<repo>.<name>]` is **reserved** (parsed-but-unused),
+   non-breaking to activate later.
+
+- **Default instance** composes tiers 1–4 (+6) — today's path, byte-for-byte
+  unchanged when no `instances` are declared.
+- **Named instance** composes tiers 1–5 (+6): inherits the role overlay (tier 4),
+  then the named overlay (tier 5).
+
+Merge rules are unchanged (`_apply_overlay`): `packages` accumulate (union),
+scalars are last-wins, credentials come solely from tier 2. The off-platform
+required-key contract (`_validate_backend`: `off-platform` requires
+`provider`/`region`/`instance`/`volume`) runs per composed instance.
+
+`--name X` against an identity that declares no instance `X` raises a `SpecError`
+listing that identity's available instance names — **no silent fallback to the
+default**.
+
+### Fingerprint
+
+`spec_fingerprint` inputs are unchanged. The **name is part of the handle, not
+fingerprint content**, so adding or renaming an instance never trips drift on its
+siblings. The preflight gate (`session`/`start`) is the #99 gate, now keyed on the
+four-part handle.
+
+## CLI (`bin/vrg_vm.py`)
+
+- Add a `--name <name>` flag to
+  `create`/`session`/`rebuild`/`destroy`/`stop`/`start`/`update`/`destroy-volume`,
+  threaded through `_resolve_target` and `_resolve_instance` into the handle.
+- Absent `--name` resolves the **default instance**, exactly as today. There is
+  **no error path** when only named instances exist — "bare verb hits the default
+  box" is the consistent #99 rule (a "forbid the bare default" mode is a deferred
+  non-goal).
+
+## Recorded-state lifecycle dispatch (the Problem-1 fix)
+
+Resolution is split by verb intent:
+
+- **`create` / `rebuild` / `session`-preflight** resolve from the **composed
+  profile + fingerprint** — you are asserting intent. Unchanged shape.
+- **`destroy` / `stop` / `start`** resolve from **recorded state for the handle**,
+  not the live profile. A new enumerator takes `(identity, org, repo, name)` and
+  finds every recorded box under the handle:
+  - the Lima instance `identity.org.repo.name`, if it exists; and
+  - every `~/.config/vergil/tofu/<state-slug>/<provider>/` directory carrying
+    recorded state.
+
+  Because the state slug is now readable and deterministic, this is a direct glob
+  of the handle's own subtree — no scan of unrelated handles.
+
+A bare `destroy --name X` tears down **every** recorded backend/provider under the
+handle (a Lima box *and* a `gcp` box, or `gcp` *and* `azure` state side by side,
+left by an in-place `backend`/`provider` edit) — after printing a confirmation
+listing of exactly what it will remove. `stop`/`start` act on each recorded running
+box. This replaces `_resolve_instance`'s spec-derivation for these three verbs.
+
+**How this dissolves Problem 1.** A profile edit can no longer aim `destroy` at a
+box that was never built, nor leave a sibling-backend box behind: nothing built
+under a handle survives a `destroy` of that handle. The orphan-prone in-place
+backend flip is also no longer the natural operation — "move the lab to GCP"
+becomes "declare a `cloud-x86` instance, destroy `local` by name when ready," two
+independent handles. Any leftover whose composed spec no longer backs it surfaces
+as `orphaned` in `list` and is removable by `destroy --name X`.
+
+## `vrg-vm list`
+
+- Add an **INSTANCE** column (between SCOPE and BACKEND); `—` for the default
+  instance.
+- Enumerate from **VM/instance state and volume state**: the Lima `<identity>.*`
+  prefix scan (now including four-segment slugs, reversed via the sidecar) plus the
+  tofu state dirs (reversed via labels, now including `vergil-instance`). One row
+  per recorded `(slug, provider)`, so a handle carrying more than one recorded
+  backend/provider (from an in-place edit) is never hidden; the stale sibling reads
+  `orphaned` against the current composed spec.
+- A handle whose `volume.tfstate` exists but whose VM has been destroyed shows a
+  `STATUS = no-vm` row carrying the **persistent volume size in the DISK column**,
+  so every paid volume stays visible with its VM down. No reaper, no billing math —
+  just no hidden paid volume. `destroy-volume --name X` removes one.
+- CPUS/MEM/DISK, AGENTS/HUMANS (process-tree classification), BACKEND, and SPEC
+  (`ok` / `NEEDS-REBUILD` / `orphaned` / `under`) semantics are unchanged, reported
+  per instance. Enumeration stays **O(instances)**. `list` degrades visibly without
+  cloud creds (`unknown (no <provider> creds)`), per instance.
+
+## State paths, labels, and volumes
+
+```
+~/.config/vergil/tofu/<identity>--<org>--<repo>--<name>/<provider>/
+  volume.tfstate   # precious; re-importable from labels
+  vm.tfstate       # ephemeral
+```
+
+Each named instance owns its **own** persistent volume, keyed by the four-part
+handle, disk-named `<cloud-name>-data` (per vergil-vm #221). The mapping stays
+1:1 instance→volume, preserving #199's no-concurrent-attach property (no
+multi-attach, no shared FS). The bootstrap-vs-reattach logic, the fixed-path mount,
+the format-only-if-blank guard, and the guarded `destroy-volume --name <name>` verb
+all behave per #199, per instance. With `prevent_destroy` no longer set on the
+modules (#212), the guarded explicit `destroy-volume` is the only path that removes
+a volume.
+
+## Backward compatibility
+
+Fully backward compatible:
+
+- A repo that declares no `instances` resolves exactly as today (default instance =
+  tiers 1–4, base box if empty).
+- Existing local dedicated VMs are default instances with unchanged three-segment
+  `.` Lima names.
+- `--name` is optional on every verb; omitting it preserves current behavior.
+- No migration of existing VMs or `identities.toml` / `vergil.toml` config is
+  required (greenfield on the cloud side; see decision 3).
+
+## Security boundaries
+
+The #99 repo-code-runs-as-root-in-a-credentialed-VM boundary applies **per
+instance** — each instance composes its own profile and provisions independently,
+so a permissive config on one does not widen another. The off-platform access model
+(IAP + private VM, Cloud NAT egress; vergil-vm #207/#211/#228) is per instance and
+unchanged: each instance is its own IAP target. Letting a named collaborator into a
+specific instance is an out-of-band IAM grant
+(`roles/iap.tunnelResourceAccessor` + OS Login), **not** a `vergil.toml` knob — the
+named-instance model contributes the dedicated, independently-disposable box, not
+the access grant. No new security-register entry is required; vergil-tooling #1369
+covers the seams at instance granularity.
+
+## Testing
+
+- **Composition / handle.** A named instance composes tiers 1–5 and the default
+  composes 1–4; a repo with an empty `instances` namespace behaves identically to
+  today; `--name X` against an identity declaring no instance `X` errors with the
+  available names; the four-part handle round-trips through the sidecar (Lima) and
+  labels (cloud), including four-segment slugs; an invalid instance name (`--` or
+  illegal chars) **and a repo name containing `--`** are rejected loudly at parse
+  time.
+- **Cloud naming.** The dispatcher derives the deterministic `vrg-<hash>` name
+  (≤ 63) and composes the `vergil-identity`/`vergil-org`/`vergil-repo`/
+  `vergil-instance` labels; `list` and re-import read the labels, not the name.
+- **Lifecycle / Problem 1.** `destroy` enumerates and reconciles all recorded
+  state, not the live profile: build a local instance, edit its overlay `backend`
+  to off-platform, `destroy --name X` removes the **local** box (no orphan); build
+  under `gcp`, edit `provider` to `azure` and rebuild, assert `destroy --name X`
+  tears down **both** the `gcp` and `azure` recorded states (no sibling orphan); a
+  leftover from a dropped stanza shows `orphaned` in `list` and `destroy --name X`
+  removes it.
+- **Volume visibility.** A handle whose VM is destroyed but whose volume state
+  remains shows a `no-vm` row in `list` carrying the volume size.
+- **Regression.** The full existing `tests/` suite stays green — the Lima
+  default path is unchanged.
+- **Gated real two-instance cloud e2e — deferred.** `tests/e2e-off-platform.sh`
+  does not yet exist (#199 left the paid cloud e2e unbuilt); standing it up is a
+  separate follow-up.
+
+## Acceptance criteria (tooling subset)
+
+1. `create/session/destroy/stop/start/rebuild <repo> --name X` operate on the named
+   instance `X` independently of the default and of other named instances.
+2. Two named instances for one `(identity, repo)` co-exist and run simultaneously,
+   each with its own volume, state, and fingerprint.
+3. A bare verb resolves to the default instance exactly as today; a repo that names
+   nothing is behaviorally identical to pre-change.
+4. Editing a built instance's `backend`/`provider` in place and running
+   `destroy --name X` tears down **every recorded backend/provider** under the
+   handle — never orphaning a sibling — and a dropped stanza surfaces as `orphaned`
+   in `list`, removable by `destroy --name X`.
+5. An invalid instance name **or a repo name containing `--`** is rejected at parse
+   time with a clear error; no malformed slug is produced.
+6. `vrg-vm list` shows the INSTANCE column with correct per-instance
+   STATUS/footprint/AGENTS/HUMANS/BACKEND/SPEC; a surviving volume with a destroyed
+   VM shows a `no-vm` row carrying the volume size; enumeration stays O(instances).
+7. `--name X` against an identity that declares no instance `X` errors loudly with
+   that identity's available named instances — no silent fallback.
+8. The dispatcher derives the deterministic `vrg-<hash>` cloud name and composes
+   the identity labels (`list`/import read the labels, not the name).
+9. The full existing `tests/` suite is green.
+
+## Reconciliations (deltas from the authoritative spec)
+
+Recorded so the divergence from the authoritative `vergil-vm` document is explicit
+and auditable:
+
+1. **Lima name stays `.`-delimited; reversal is not `split('--')`.** The
+   authoritative spec presents one `--` slug that is also the Lima instance name,
+   reversed by splitting. Lima rejects `--`, so the Lima name keeps the existing
+   `.` delimiter (fourth segment appended) and is reversed via the existing sidecar
+   metadata. The `--` slug remains the readable handle for the state path and docs.
+   The repo-name-`--` rejection and instance-name validation are still implemented
+   (they keep the readable state slug unambiguous), satisfying the spec's
+   acceptance criteria.
+2. **`state_key` decoupled from `cloud_resource_name`.** The state directory is
+   keyed on the readable `--` slug; the cloud resource name is the `vrg-<hash>`.
+   (Today they are equal.)
+3. **The cloud hash is applied uniformly** to all off-platform instances, not only
+   when the slug would overflow 63 chars. Deterministic and uniform; greenfield
+   makes it free.
+
+## Implementation touch-points
+
+- `lib/vm_spec.py` — parse `[vm.<identity>.instances.<name>]`; `compose_vm_spec`
+  gains `instance`; tier-5 composition; instance-name + repo-`--` validation;
+  derive the three names from the handle; reserve the tier-6 per-name slot.
+- `lib/vm_cloud.py` — `cloud_resource_name` → `vrg-<hash>`; decouple `state_key`
+  (readable slug) from the cloud name; add `vergil-instance` to `cloud_labels`.
+- `lib/lima.py` — extend the sidecar (`write_instance_meta`/`recover_triple`) to
+  carry `name`.
+- `bin/vrg_vm.py` — `--name` across the verbs; the recorded-state enumerator for
+  `destroy`/`stop`/`start`; `list` INSTANCE column + `no-vm` rows + per-`(slug,
+  provider)` rows.
+
+## Related
+
+- **Authoritative design:** vergil-vm #242 +
+  `docs/specs/2026-06-23-multiple-vm-instances-per-repo-design.md`.
+- **Parent models:** vergil-vm #99 / vergil-tooling #1412 (per-repo profiles);
+  vergil-vm #199 / vergil-tooling #1706 (off-platform backend).
+- **Security register:** vergil-tooling #1369.

--- a/docs/specs/2026-06-23-vrg-vm-named-instances-tooling-design.md
+++ b/docs/specs/2026-06-23-vrg-vm-named-instances-tooling-design.md
@@ -86,9 +86,17 @@ names are derived, each with its own delimiter:
 
 | Derived name | Form | Used for | Reversal |
 |---|---|---|---|
-| **Lima instance name** | `identity.org.repo.name` (dots; bare `identity` for base, three-segment for default dedicated) | the `limactl` instance | sidecar metadata (`write_instance_meta` / `recover_triple`), extended to carry `name` |
+| **Lima instance name** | `identity.org.repo.name` (dots; bare `identity` for base, three-segment for default dedicated) | the `limactl` instance | sidecar metadata (`write_instance_meta` / `recover_handle`), extended to carry `name` |
 | **State slug** (readable) | `identity--org--repo--name` (`--`-joined; three-segment for default dedicated, bare `identity` for base) | tofu state dir `~/.config/vergil/tofu/<slug>/<provider>/`; the SHA-256 input for the cloud name | resource labels (and human-readable in the path) |
 | **Cloud resource name** | `vrg-<first 12 hex of sha256(state-slug)>` (≤ 16 chars, RFC1035: leading letter, lowercase alnum + hyphen) | GCP instance/disk/firewall name | never reversed from the name — `list` and `tofu import` read the labels |
+
+**The Lima name follows the existing budget rule.** The dotted
+`identity.org.repo.name` form is what you get when it fits within
+`lima_name_budget(home)`; when it overflows (more common now that a fourth segment
+is appended), `instance_name()` produces a deterministic truncated+hashed
+`…-<hash>` form, exactly as today. Either way the **sidecar is the reversal
+source** — the dotted-name parse is only a legacy fallback for pre-sidecar short
+names and must not be relied on for named instances.
 
 ### Why the cloud name is hashed
 
@@ -106,6 +114,24 @@ four-segment), not only when the slug would overflow. This is deterministic and
 uniform, and greenfield makes it free. (The prior behavior — derive a readable
 dashed name and hash only on overflow — is dropped; nothing deployed depends on
 it.)
+
+### Reversal is handle-aware end-to-end
+
+The fourth segment ripples through the whole reversal path, not just the sidecar
+write:
+
+- `write_instance_meta` gains a `name` parameter and records it in the sidecar.
+- `recover_triple` becomes `recover_handle`, returning
+  `(identity, org, repo, name | None)` (a four-part handle; `name` is `None` for
+  base and default-dedicated boxes).
+- Its consumers thread the name as part of the match/identity key:
+  `discover_dedicated` (the `list` builder) and `update --all` (which enumerates
+  every Lima + off-platform box and matches each to a configured identity). Without
+  this, `update --all` would be blind to four-segment named instances — silently
+  dropping the name or skipping the box.
+
+Cloud reversal (labels) and Lima reversal (sidecar) stay symmetric: both carry the
+full handle.
 
 ### Identity lives in labels
 
@@ -200,25 +226,50 @@ four-part handle.
 
 ## Recorded-state lifecycle dispatch (the Problem-1 fix)
 
-Resolution is split by verb intent:
+Resolution is split by verb intent. Note that `stop`/`start`/`restart` operate on
+**Lima boxes only** — they reject off-platform today (`_reject_if_off_platform`),
+and cloud VMs have no stop/start lifecycle through `vrg-vm` (they are create/destroy
+only, per #199). That rejection is preserved; only `destroy` spans backends.
 
 - **`create` / `rebuild` / `session`-preflight** resolve from the **composed
   profile + fingerprint** — you are asserting intent. Unchanged shape.
-- **`destroy` / `stop` / `start`** resolve from **recorded state for the handle**,
-  not the live profile. A new enumerator takes `(identity, org, repo, name)` and
-  finds every recorded box under the handle:
+- **`destroy`** resolves from **all recorded state for the handle**, not the live
+  profile. A new enumerator takes `(identity, org, repo, name)` and finds every
+  recorded box under the handle:
   - the Lima instance `identity.org.repo.name`, if it exists; and
   - every `~/.config/vergil/tofu/<state-slug>/<provider>/` directory carrying
     recorded state.
 
   Because the state slug is now readable and deterministic, this is a direct glob
-  of the handle's own subtree — no scan of unrelated handles.
+  of the handle's own subtree — no scan of unrelated handles. A bare
+  `destroy --name X` tears down **every** recorded backend/provider under the handle
+  (a Lima box *and* a `gcp` box, or `gcp` *and* `azure` state side by side, left by
+  an in-place `backend`/`provider` edit) — after printing a confirmation listing of
+  exactly what it will remove.
 
-A bare `destroy --name X` tears down **every** recorded backend/provider under the
-handle (a Lima box *and* a `gcp` box, or `gcp` *and* `azure` state side by side,
-left by an in-place `backend`/`provider` edit) — after printing a confirmation
-listing of exactly what it will remove. `stop`/`start` act on each recorded running
-box. This replaces `_resolve_instance`'s spec-derivation for these three verbs.
+  **Confirmation contract (interactive and agent paths).** `destroy` always prints
+  the listing of boxes it will remove first. It then:
+  - **Interactive (stdin is a TTY):** prompts for confirmation before proceeding.
+  - **`--yes`/`-y` given:** proceeds without prompting (after printing the listing).
+  - **No TTY and no `--yes`:** **refuses** with a clear message instructing the
+    caller to re-run with `--yes`. This is the safe default for a verb that now
+    tears down *multiple* boxes at once, and is the path agent sessions take
+    deliberately (no silent multi-box teardown). The `--yes` flag is added to
+    `destroy` (and mirrors the existing `destroy-volume` confirmation).
+- **`stop` / `start` / `restart`** resolve from **Lima recorded state only** for
+  the handle (the derived Lima instance name), continuing to reject off-platform.
+  They act on the handle's Lima box; there is no cloud stop/start.
+
+This replaces `_resolve_instance`'s spec-derivation for these verbs.
+
+**Implementation sequencing.** This recorded-state dispatch is the highest-risk
+unit of the whole change — it is the Problem-1 fix, it rewrites target resolution
+for the destructive verbs, and it carries the bulk of the lifecycle test surface
+(the multi-provider teardown and orphan-reconciliation cases). The rest of the work
+(namespace parsing, composition, the `--name` flag, the `list`/`volumes` columns) is
+largely additive. The implementation plan should land the parsing/composition/naming
+groundwork first, then treat this dispatch as its own phase with disproportionate
+test coverage — not as one task among equals.
 
 **How this dissolves Problem 1.** A profile edit can no longer aim `destroy` at a
 box that was never built, nor leave a sibling-backend box behind: nothing built
@@ -246,6 +297,16 @@ as `orphaned` in `list` and is removable by `destroy --name X`.
   (`ok` / `NEEDS-REBUILD` / `orphaned` / `under`) semantics are unchanged, reported
   per instance. Enumeration stays **O(instances)**. `list` degrades visibly without
   cloud creds (`unknown (no <provider> creds)`), per instance.
+
+**Relationship to `vrg-vm volumes`.** The existing `volumes` command (#1798) stays
+as the focused, billing-oriented view of off-platform persistent volumes (DISK
+NAME / SIZE / ZONE / REGION, with `--live`), while `list`'s `no-vm` row is the
+unified per-handle lifecycle view. They serve different audiences and both remain.
+Under named instances, `volumes` gains an **INSTANCE column** (read from the
+`vergil-instance` label) so two volumes for one repo (e.g. `cloud-x86` and
+`rdqm-rhel`) are distinguishable; without it, sibling instances' volumes would be
+indistinguishable in its SCOPE-only output. `volumes` is a global enumerator (no
+`--name`), like `list`.
 
 ## State paths, labels, and volumes
 
@@ -366,11 +427,13 @@ and auditable:
   derive the three names from the handle; reserve the tier-6 per-name slot.
 - `lib/vm_cloud.py` — `cloud_resource_name` → `vrg-<hash>`; decouple `state_key`
   (readable slug) from the cloud name; add `vergil-instance` to `cloud_labels`.
-- `lib/lima.py` — extend the sidecar (`write_instance_meta`/`recover_triple`) to
-  carry `name`.
-- `bin/vrg_vm.py` — `--name` across the verbs; the recorded-state enumerator for
-  `destroy`/`stop`/`start`; `list` INSTANCE column + `no-vm` rows + per-`(slug,
-  provider)` rows.
+- `lib/lima.py` — extend the sidecar: `write_instance_meta` gains a `name`
+  parameter and records it.
+- `bin/vrg_vm.py` — `recover_triple` → `recover_handle` (returns the four-part
+  handle), threaded through `discover_dedicated` and `update --all`; `--name` across
+  the verbs; the recorded-state enumerator for `destroy` (all backends) and
+  `stop`/`start`/`restart` (Lima only); `list` INSTANCE column + `no-vm` rows +
+  per-`(slug, provider)` rows; `volumes` INSTANCE column.
 
 ## Related
 

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -285,19 +285,19 @@ def _target_ref(target: Target) -> str:
     return f"--identity {target.identity_name}"
 
 
-def recover_triple(instance: str) -> tuple[str, str | None, str | None]:
-    """Reverse an instance name into (identity, org, repo).
+def recover_handle(instance: str) -> tuple[str, str | None, str | None, str | None]:
+    """Reverse an instance name into the four-part handle (identity, org, repo, name).
 
-    Prefers the per-instance sidecar (the only reliable source once a long name
-    has been truncated+hashed); falls back to parsing the name for legacy short
-    names and base boxes that predate the sidecar.
+    Prefers the per-instance sidecar (reliable once a long name is truncated+hashed);
+    falls back to parsing for legacy short names and base boxes that predate the
+    sidecar, where ``name`` is None.
     """
     meta = read_instance_meta(instance)
     if meta is not None:
-        # Sidecar fields are always strings on disk; the mapping is typed
-        # ``dict[str, object]`` only because it also carries an int schema.
-        return str(meta["identity"]), str(meta["org"]), str(meta["repo"])
-    return parse_instance_name(instance)
+        name = str(meta.get("name") or "") or None
+        return str(meta["identity"]), str(meta["org"]), str(meta["repo"]), name
+    ident, org, repo = parse_instance_name(instance)
+    return ident, org, repo, None
 
 
 def _warn_under(target: Target) -> None:
@@ -607,11 +607,13 @@ def _create_from_target(target: Target, template: Path) -> None:
             fingerprint=target.fingerprint,
             nested=target.spec.nested,
         )
-        # Persist (identity, org, repo) so recover_triple can reverse the name
+        # Persist (identity, org, repo) so recover_handle can reverse the name
         # even after it has been truncated+hashed to fit UNIX_PATH_MAX.
         # org/repo are guaranteed non-None for dedicated targets.
         assert target.org is not None and target.repo is not None  # noqa: S101
-        write_instance_meta(target.instance, target.identity_name, target.org, target.repo)
+        write_instance_meta(
+            target.instance, target.identity_name, target.org, target.repo, None
+        )  # Task 6 wires the instance name here
     else:
         create_vm(
             target.instance,
@@ -1113,7 +1115,7 @@ def _all_update_targets(
             targets.append((id_name, identity, identity.vm_instance))
         for inst in sorted(status):
             try:
-                ident, org, repo = recover_triple(inst)
+                ident, org, repo, _inst_name = recover_handle(inst)
             except ValueError:
                 continue
             if ident == id_name and org is not None and repo is not None:
@@ -1347,6 +1349,7 @@ class DedicatedRow:
     instance: str
     state: str  # "present" | "orphaned"
     stanza: VmStanza | None = None
+    instance_name: str | None = None
 
 
 def _classify_instance(
@@ -1395,13 +1398,13 @@ def discover_dedicated(
     rows: list[DedicatedRow] = []
     for name in instances:
         try:
-            ident, org, repo = recover_triple(name)
+            ident, org, repo, inst_name = recover_handle(name)
         except ValueError:
             continue
         if ident != identity_name or org is None or repo is None:
             continue
         state, stanza = _classify_instance(projects_dir, org, repo, name)
-        rows.append(DedicatedRow(org, repo, name, state, stanza))
+        rows.append(DedicatedRow(org, repo, name, state, stanza, inst_name))
     return rows
 
 

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1767,6 +1767,11 @@ def _classify_off_platform(vm: OffPlatformVm, config: IdentityConfig) -> str:
     'orphaned' when the repo dropped its [vm], no longer declares this instance, or
     no longer composes this (off-platform, provider); 'ok' when it still matches.
     The handle is recovered exactly from the readable slug — no lossy label round-trip.
+
+    A repo whose vergil.toml fails to parse is classified 'ok' conservatively —
+    flagging it orphaned would invite destroying a VM whose spec may still be
+    declared — and the failure is warned loudly with the config path (mirrors the
+    Lima-path ``_classify_instance`` treatment of ConfigError).
     """
     identity_name, org, repo, inst_name = split_state_slug(vm.name)
     if org is None or repo is None:
@@ -1775,7 +1780,8 @@ def _classify_off_platform(vm: OffPlatformVm, config: IdentityConfig) -> str:
     if identity is None:
         return "orphaned"
     repo_dir = Path(identity.projects_dir) / org / repo
-    if not (repo_dir / "vergil.toml").exists():
+    config_path = repo_dir / "vergil.toml"
+    if not config_path.exists():
         return "orphaned"
     try:
         stanza = read_config(repo_dir).vm
@@ -1786,7 +1792,14 @@ def _classify_off_platform(vm: OffPlatformVm, config: IdentityConfig) -> str:
             override=identity.overrides.get((org, repo)),
             instance=inst_name,
         )
-    except (ConfigError, SpecError):
+    except ConfigError as exc:
+        print(
+            f"WARNING: cannot parse {config_path}: {exc} — "
+            f"listing '{vm.name}' as present (unverified)",
+            file=sys.stderr,
+        )
+        return "ok"
+    except SpecError:
         return "orphaned"
     if not spec.off_platform or spec.provider != vm.provider:
         return "orphaned"
@@ -1804,14 +1817,13 @@ def _cloud_list_rows(config: IdentityConfig) -> list[dict[str, object]]:
     """
     rows: list[dict[str, object]] = []
     for vm in _off_platform_vms():
+        spec = _classify_off_platform(vm, config)
         if not vm.vm_present:
             status = "no-vm"
             disk = vm.volume_size or "—"
-            spec = _classify_off_platform(vm, config)
         else:
             status = vm.status or f"unknown (no {vm.provider} creds)"
             disk = "—"
-            spec = _classify_off_platform(vm, config)
         rows.append(
             {
                 "identity": vm.identity or "—",

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -80,6 +80,7 @@ from vergil_tooling.lib.vm_spec import (
     instance_name,
     parse_instance_name,
     spec_fingerprint,
+    state_slug,
     validate_repo_segment,
 )
 from vergil_tooling.lib.vm_transport import LimaTransport
@@ -1642,6 +1643,41 @@ class OffPlatformVm:
         if self.identity:
             return f"--identity {self.identity}"
         return self.name
+
+
+@dataclass
+class RecordedState:
+    """Everything actually built under one handle, discovered from disk + Lima."""
+
+    lima_instance: str | None
+    tofu_dirs: list[tuple[str, Path]]  # (provider, provider_state_dir)
+
+
+def _recorded_state_for_handle(
+    identity: str, org: str, repo: str, name: str | None
+) -> RecordedState:
+    """Enumerate the Lima box and every tofu provider state recorded for a handle.
+
+    Acts on reality, not the live profile: the Lima instance named for the handle
+    (if it exists) plus every ``~/.config/vergil/tofu/<slug>/<provider>/`` directory
+    carrying recorded state. The slug is deterministic, so this is a direct glob of
+    the handle's own subtree.
+    """
+    lima = instance_name(identity, org, repo, name)
+    existing = {vm["name"] for vm in list_vms()}
+    lima_instance = lima if lima in existing else None
+
+    slug = state_slug(identity, org, repo, name)
+    handle_root = Path.home() / ".config" / "vergil" / "tofu" / slug
+    tofu_dirs: list[tuple[str, Path]] = []
+    if handle_root.is_dir():
+        for provider_dir in sorted(p for p in handle_root.iterdir() if p.is_dir()):
+            has_state = (provider_dir / "volume.tfstate").exists() or (
+                provider_dir / "vm.tfstate"
+            ).exists()
+            if has_state:
+                tofu_dirs.append((provider_dir.name, provider_dir))
+    return RecordedState(lima_instance, tofu_dirs)
 
 
 def _off_platform_vms() -> list[OffPlatformVm]:

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -82,6 +82,7 @@ from vergil_tooling.lib.vm_spec import (
     spec_fingerprint,
     split_state_slug,
     state_slug,
+    validate_instance_name,
     validate_repo_segment,
 )
 from vergil_tooling.lib.vm_transport import LimaTransport
@@ -1295,6 +1296,12 @@ def _cmd_destroy(args: argparse.Namespace) -> int:
         )
     else:
         validate_repo_segment(repo)
+        if inst_name is not None:
+            try:
+                validate_instance_name(inst_name)
+            except ValueError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 1
         requested_vm = _read_repo_vm(identity, org, repo)
         borrow = resolve_borrow(identity, org, repo, requested_vm)
         if borrow is not None:
@@ -1306,7 +1313,9 @@ def _cmd_destroy(args: argparse.Namespace) -> int:
         return 1
 
     # Confirmation contract.
-    print("Will destroy the following recorded boxes:")
+    box_count = (1 if rs.lima_instance else 0) + len(rs.tofu_dirs)
+    box_word = "box" if box_count == 1 else "boxes"
+    print(f"Will destroy the following recorded {box_word}:")
     if rs.lima_instance:
         print(f"  - Lima: {rs.lima_instance}")
     for provider, state_dir in rs.tofu_dirs:
@@ -1314,7 +1323,7 @@ def _cmd_destroy(args: argparse.Namespace) -> int:
     if not getattr(args, "yes", False):
         if not sys.stdin.isatty():
             print(
-                "Refusing to destroy multiple recorded boxes non-interactively"
+                f"Refusing to destroy {box_count} recorded {box_word} non-interactively"
                 " — re-run with --yes to confirm.",
                 file=sys.stderr,
             )

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1534,6 +1534,7 @@ def _list_rows(
     rows.append(
         {
             "scope": "base",
+            "instance": "—",
             "backend": "local",
             "status": status.get(identity.vm_instance, "Not Created"),
             "cpus": cast("int", base["cpus"]),
@@ -1553,6 +1554,7 @@ def _list_rows(
             rows.append(
                 {
                     "scope": scope,
+                    "instance": d.instance_name or "—",
                     "backend": "local",
                     "status": st,
                     "cpus": "—",
@@ -1571,6 +1573,7 @@ def _list_rows(
         rows.append(
             {
                 "scope": scope,
+                "instance": d.instance_name or "—",
                 "backend": "local",
                 "status": st,
                 "cpus": spec.cpus,
@@ -1636,6 +1639,9 @@ class OffPlatformVm:
     org: str | None
     repo: str | None
     status: str
+    instance: str | None = None
+    volume_size: str | None = None
+    vm_present: bool = True
 
     @property
     def is_running(self) -> bool:
@@ -1734,6 +1740,9 @@ def _off_platform_vms() -> list[OffPlatformVm]:
         state_key = provider_dir.parent.name
         parsed = vm_cloud.parse_volume_state(volume_state)
         labels = parsed.labels if parsed else {}
+        size = f"{parsed.size_gib}GiB" if parsed and parsed.size_gib else None
+        vm_present = (provider_dir / "vm.tfstate").exists()
+        status = _cloud_status(provider_dir, state_key) if vm_present else ""
         vms.append(
             OffPlatformVm(
                 name=state_key,
@@ -1742,7 +1751,10 @@ def _off_platform_vms() -> list[OffPlatformVm]:
                 identity=labels.get("vergil-identity"),
                 org=labels.get("vergil-org"),
                 repo=labels.get("vergil-repo"),
-                status=_cloud_status(provider_dir, state_key),
+                instance=labels.get("vergil-instance"),
+                status=status,
+                volume_size=size,
+                vm_present=vm_present,
             )
         )
     return vms
@@ -1759,13 +1771,20 @@ def _cloud_list_rows() -> list[dict[str, object]]:
     """
     rows: list[dict[str, object]] = []
     for vm in _off_platform_vms():
-        status = vm.status or f"unknown (no {vm.provider} creds)"
+        if not vm.vm_present:
+            status = "no-vm"
+            disk = vm.volume_size or "—"
+        else:
+            status = vm.status or f"unknown (no {vm.provider} creds)"
+            disk = "—"
         rows.append(
             {
                 "identity": vm.identity or "—",
                 "scope": vm.scope,
+                "instance": vm.instance or "—",
                 "backend": vm.provider,
                 "status": status,
+                "disk": disk,
             }
         )
     return rows
@@ -1788,8 +1807,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
     probes = _probe_running(config.identities, discovered, status)
 
     header = (
-        f"{'IDENTITY':<14} {'SCOPE':<40} {'BACKEND':<13} {'STATUS':<11} {'CPUS':<5} "
-        f"{'MEM':<7} {'DISK':<7} {'AGENTS':<7} {'HUMANS':<7} {'SPEC':<22}"
+        f"{'IDENTITY':<14} {'SCOPE':<40} {'INSTANCE':<11} {'BACKEND':<13} {'STATUS':<11} "
+        f"{'CPUS':<5} {'MEM':<7} {'DISK':<7} {'AGENTS':<7} {'HUMANS':<7} {'SPEC':<22}"
     )
     print(header)
     print("─" * len(header))
@@ -1797,15 +1816,17 @@ def _cmd_list(args: argparse.Namespace) -> int:
     for id_name, identity in config.identities.items():
         for r in _list_rows(id_name, identity, discovered[id_name], status, probes):
             print(
-                f"{id_name:<14} {r['scope']!s:<40} {r['backend']!s:<13} {r['status']!s:<11} "
+                f"{id_name:<14} {r['scope']!s:<40} {r.get('instance', '—')!s:<11} "
+                f"{r['backend']!s:<13} {r['status']!s:<11} "
                 f"{r['cpus']!s:<5} {r['memory']!s:<7} {r['disk']!s:<7} "
                 f"{r['agents']!s:<7} {r['humans']!s:<7} {r['spec']!s:<22}"
             )
 
     for r in _cloud_list_rows():
         print(
-            f"{r['identity']!s:<14} {r['scope']!s:<40} {r['backend']!s:<13} {r['status']!s:<11} "
-            f"{'—':<5} {'—':<7} {'—':<7} {'—':<7} {'—':<7} {'—':<22}"
+            f"{r['identity']!s:<14} {r['scope']!s:<40} {r['instance']!s:<11} "
+            f"{r['backend']!s:<13} {r['status']!s:<11} "
+            f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {'—':<22}"
         )
 
     return 0

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1905,6 +1905,7 @@ def _volume_rows() -> list[dict[str, object]]:
                 {
                     "identity": "—",
                     "scope": state_key,
+                    "instance": "—",
                     "name": "—",
                     "size": "—",
                     "zone": "—",
@@ -1921,6 +1922,7 @@ def _volume_rows() -> list[dict[str, object]]:
             {
                 "identity": parsed.labels.get("vergil-identity") or "—",
                 "scope": scope,
+                "instance": parsed.labels.get("vergil-instance") or "—",
                 "name": parsed.name or "—",
                 "size": f"{parsed.size_gib}GiB" if parsed.size_gib is not None else "—",
                 "zone": parsed.zone or "—",
@@ -1985,9 +1987,10 @@ def _cmd_volumes(args: argparse.Namespace) -> int:
 
     scope_w = max([24, *(len(str(r["scope"])) for r in rows)])
     name_w = max([20, *(len(str(r["name"])) for r in rows)])
+    inst_w = max([10, *(len(str(r.get("instance", "—"))) for r in rows)])
     header = (
-        f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'DISK NAME':<{name_w}} "
-        f"{'SIZE':<8} {'ZONE':<16} {'REGION':<14}"
+        f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'INSTANCE':<{inst_w}} "
+        f"{'DISK NAME':<{name_w}} {'SIZE':<8} {'ZONE':<16} {'REGION':<14}"
     )
     if live:
         header += f" {'LIVE':<22}"
@@ -1995,7 +1998,8 @@ def _cmd_volumes(args: argparse.Namespace) -> int:
     print("─" * len(header))
     for r in rows:
         line = (
-            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} {r['name']!s:<{name_w}} "
+            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} "
+            f"{r.get('instance', '—')!s:<{inst_w}} {r['name']!s:<{name_w}} "
             f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14}"
         )
         if live:

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1256,40 +1256,74 @@ def _cmd_update_all(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cloud_destroy(target: Target, args: argparse.Namespace) -> int:
-    """Destroy the disposable cloud VM, leaving the persistent volume intact."""
-    backend = _cloud_backend(target)
-    tag = args.tag if getattr(args, "tag", "") else resolve_vm_tag(target.config, target.identity)
-    modules_root = vm_cloud.fetch_modules(tag)
-    try:
-        print(f"Destroying cloud VM '{backend.name}' (volume preserved)...")
-        vm_cloud.destroy_vm(modules_root, backend.state_dir())
-    finally:
-        shutil.rmtree(modules_root.parent, ignore_errors=True)
-    print(f"Cloud VM '{backend.name}' destroyed (persistent volume preserved).")
+def _destroy_recorded(
+    rs: RecordedState,
+    args: argparse.Namespace,
+    config: IdentityConfig,
+    identity: Identity,
+) -> int:
+    """Tear down the Lima box and every recorded provider state for a handle."""
+    if rs.lima_instance is not None:
+        print(f"Destroying Lima VM '{rs.lima_instance}'...")
+        delete_vm(rs.lima_instance)
+    if rs.tofu_dirs:
+        tag = args.tag if getattr(args, "tag", "") else resolve_vm_tag(config, identity)
+        modules_root = vm_cloud.fetch_modules(tag)
+        try:
+            for provider, state_dir in rs.tofu_dirs:
+                print(f"Destroying cloud VM under {provider} (volume preserved): {state_dir}")
+                vm_cloud.destroy_vm(modules_root, state_dir)
+        finally:
+            shutil.rmtree(modules_root.parent, ignore_errors=True)
+    print("Destroyed (persistent volumes preserved — use destroy-volume to remove them).")
     return 0
 
 
 def _cmd_destroy(args: argparse.Namespace) -> int:
-    target = _resolve_target(args)
-    if target.spec.off_platform:
-        return _cloud_destroy(target, args)
-
-    name, _identity, _config, instance = _resolve_instance(args)
-
-    status = vm_status(instance)
-    if not status:
-        print(
-            f"VM '{instance}' does not exist.",
-            file=sys.stderr,
+    name, identity, config = _resolve(args)
+    org, repo = _workspace_org_repo(getattr(args, "workspace", None))
+    inst_name = getattr(args, "name", None)
+    if org is None or repo is None:
+        rs = RecordedState(
+            lima_instance=(
+                identity.vm_instance
+                if identity.vm_instance in {vm["name"] for vm in list_vms()}
+                else None
+            ),
+            tofu_dirs=[],
         )
+    else:
+        validate_repo_segment(repo)
+        requested_vm = _read_repo_vm(identity, org, repo)
+        borrow = resolve_borrow(identity, org, repo, requested_vm)
+        if borrow is not None:
+            raise BorrowError(_borrow_block_msg(args.command, org, repo, borrow.org, borrow.repo))
+        rs = _recorded_state_for_handle(name, org, repo, inst_name)
+
+    if rs.lima_instance is None and not rs.tofu_dirs:
+        print("No recorded state to destroy for this handle.", file=sys.stderr)
         return 1
 
-    print(f"Destroying VM '{instance}' (identity: {name})...")
-    delete_vm(instance)
+    # Confirmation contract.
+    print("Will destroy the following recorded boxes:")
+    if rs.lima_instance:
+        print(f"  - Lima: {rs.lima_instance}")
+    for provider, state_dir in rs.tofu_dirs:
+        print(f"  - {provider}: {state_dir}")
+    if not getattr(args, "yes", False):
+        if not sys.stdin.isatty():
+            print(
+                "Refusing to destroy multiple recorded boxes non-interactively"
+                " — re-run with --yes to confirm.",
+                file=sys.stderr,
+            )
+            return 1
+        answer = input("Proceed? [y/N] ").strip().lower()
+        if answer not in {"y", "yes"}:
+            print("Aborted.", file=sys.stderr)
+            return 1
 
-    print(f"VM '{instance}' destroyed.")
-    return 0
+    return _destroy_recorded(rs, args, config, identity)
 
 
 def _cmd_destroy_volume(args: argparse.Namespace) -> int:
@@ -2291,6 +2325,12 @@ def main(argv: list[str] | None = None) -> int:
         "--tag",
         default="",
         help="OpenTofu module version tag for off-platform destroy (default: from config)",
+    )
+    p_destroy.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip the confirmation prompt (required for non-interactive destroy)",
     )
 
     p_destroy_volume = sub.add_parser(

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -80,6 +80,7 @@ from vergil_tooling.lib.vm_spec import (
     instance_name,
     parse_instance_name,
     spec_fingerprint,
+    split_state_slug,
     state_slug,
     validate_repo_segment,
 )
@@ -1760,7 +1761,39 @@ def _off_platform_vms() -> list[OffPlatformVm]:
     return vms
 
 
-def _cloud_list_rows() -> list[dict[str, object]]:
+def _classify_off_platform(vm: OffPlatformVm, config: IdentityConfig) -> str:
+    """Classify a recorded off-platform box against the repo's current profile.
+
+    'orphaned' when the repo dropped its [vm], no longer declares this instance, or
+    no longer composes this (off-platform, provider); 'ok' when it still matches.
+    The handle is recovered exactly from the readable slug — no lossy label round-trip.
+    """
+    identity_name, org, repo, inst_name = split_state_slug(vm.name)
+    if org is None or repo is None:
+        return "ok"  # a base box carries no per-repo spec
+    identity = config.identities.get(identity_name)
+    if identity is None:
+        return "orphaned"
+    repo_dir = Path(identity.projects_dir) / org / repo
+    if not (repo_dir / "vergil.toml").exists():
+        return "orphaned"
+    try:
+        stanza = read_config(repo_dir).vm
+        spec = compose_vm_spec(
+            identity=identity_name,
+            base=_base_footprint(identity),
+            stanza=stanza,
+            override=identity.overrides.get((org, repo)),
+            instance=inst_name,
+        )
+    except (ConfigError, SpecError):
+        return "orphaned"
+    if not spec.off_platform or spec.provider != vm.provider:
+        return "orphaned"
+    return "ok"
+
+
+def _cloud_list_rows(config: IdentityConfig) -> list[dict[str, object]]:
     """Display rows for off-platform VMs (the cloud half of ``vrg-vm list``).
 
     Reuses the shared ``_off_platform_vms()`` enumeration; an unauthed/unreachable
@@ -1774,9 +1807,11 @@ def _cloud_list_rows() -> list[dict[str, object]]:
         if not vm.vm_present:
             status = "no-vm"
             disk = vm.volume_size or "—"
+            spec = _classify_off_platform(vm, config)
         else:
             status = vm.status or f"unknown (no {vm.provider} creds)"
             disk = "—"
+            spec = _classify_off_platform(vm, config)
         rows.append(
             {
                 "identity": vm.identity or "—",
@@ -1785,6 +1820,7 @@ def _cloud_list_rows() -> list[dict[str, object]]:
                 "backend": vm.provider,
                 "status": status,
                 "disk": disk,
+                "spec": spec,
             }
         )
     return rows
@@ -1822,11 +1858,11 @@ def _cmd_list(args: argparse.Namespace) -> int:
                 f"{r['agents']!s:<7} {r['humans']!s:<7} {r['spec']!s:<22}"
             )
 
-    for r in _cloud_list_rows():
+    for r in _cloud_list_rows(config):
         print(
             f"{r['identity']!s:<14} {r['scope']!s:<40} {r['instance']!s:<11} "
             f"{r['backend']!s:<13} {r['status']!s:<11} "
-            f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {'—':<22}"
+            f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {r['spec']!s:<22}"
         )
 
     return 0

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -80,6 +80,7 @@ from vergil_tooling.lib.vm_spec import (
     instance_name,
     parse_instance_name,
     spec_fingerprint,
+    validate_repo_segment,
 )
 from vergil_tooling.lib.vm_transport import LimaTransport
 
@@ -111,6 +112,7 @@ class Target:
     instance: str
     fingerprint: str
     backend: Backend
+    instance_name_arg: str | None = None
 
 
 class BorrowError(Exception):
@@ -192,6 +194,11 @@ def _base_footprint(identity: Identity) -> dict[str, object]:
     }
 
 
+def _requested_name(args: argparse.Namespace) -> str | None:
+    """Return the --name value from args, or None if the flag is absent."""
+    return getattr(args, "name", None)
+
+
 def _workspace_org_repo(workspace: str | None) -> tuple[str | None, str | None]:
     """Derive (org, repo) for VM selection.
 
@@ -220,13 +227,19 @@ def _resolve_target(args: argparse.Namespace, *, borrow_allowed: bool = False) -
     """
     name, identity, config = _resolve(args)
     workspace = getattr(args, "workspace", None)
+    inst_name = _requested_name(args)
     base = _base_footprint(identity)
     org, repo = _workspace_org_repo(workspace)
 
     if org is None or repo is None:
+        if inst_name is not None:
+            msg = "--name requires an <org>/<repo> workspace (named instances are per-repo)"
+            raise SpecError(msg)
         spec = compose_vm_spec(identity=name, base=base, stanza=None, override=None)
         backend = select_backend(spec, identity=name, org=None, repo=None)
         return Target(name, identity, config, None, None, spec, identity.vm_instance, "", backend)
+
+    validate_repo_segment(repo)
 
     requested_vm = _read_repo_vm(identity, org, repo)
     borrow = resolve_borrow(identity, org, repo, requested_vm)
@@ -239,13 +252,15 @@ def _resolve_target(args: argparse.Namespace, *, borrow_allowed: bool = False) -
         eff_org, eff_repo, eff_vm = org, repo, requested_vm
 
     override = identity.overrides.get((eff_org, eff_repo))
-    spec = compose_vm_spec(identity=name, base=base, stanza=eff_vm, override=override)
-    backend = select_backend(spec, identity=name, org=eff_org, repo=eff_repo)
+    spec = compose_vm_spec(
+        identity=name, base=base, stanza=eff_vm, override=override, instance=inst_name
+    )
+    backend = select_backend(spec, identity=name, org=eff_org, repo=eff_repo, name=inst_name)
 
     if not spec.dedicated:
         return Target(name, identity, config, org, repo, spec, identity.vm_instance, "", backend)
 
-    inst = instance_name(name, eff_org, eff_repo)
+    inst = instance_name(name, eff_org, eff_repo, inst_name)
     return Target(
         name,
         identity,
@@ -256,23 +271,25 @@ def _resolve_target(args: argparse.Namespace, *, borrow_allowed: bool = False) -
         inst,
         spec_fingerprint(spec),
         backend,
+        inst_name,
     )
 
 
-def _resolve_instance(args: argparse.Namespace) -> tuple[str, Identity, IdentityConfig, str]:
-    """Resolve just the instance NAME for lifecycle commands (stop/restart/destroy/update).
+def _resolve_instance(
+    args: argparse.Namespace,
+) -> tuple[str, Identity, IdentityConfig, str]:
+    """Resolve the Lima instance NAME for lifecycle commands (stop/restart).
 
-    These are all MANAGE commands. The borrow block (``[vm] shared_from``) and the
-    off-platform/Lima split are owned by the ``_resolve_target`` call each command
-    now runs first, so this helper only maps an ``org/repo`` (or its absence) to an
-    instance name. A repo with no readable ``vergil.toml`` (a true orphan) resolves
-    to its own instance name, so an orphaned dedicated VM (whose repo dropped its
-    `[vm]`) stays reachable; anything else is base.
+    Maps an ``org/repo`` (or its absence) plus an optional ``--name`` to a Lima
+    instance name. A repo with no readable ``vergil.toml`` still resolves to its own
+    instance name so an orphaned dedicated VM stays reachable.
     """
     name, identity, config = _resolve(args)
     org, repo = _workspace_org_repo(getattr(args, "workspace", None))
+    inst_name = _requested_name(args)
     if org is not None and repo is not None:
-        instance = instance_name(name, org, repo)
+        validate_repo_segment(repo)
+        instance = instance_name(name, org, repo, inst_name)
     else:
         instance = identity.vm_instance
     return name, identity, config, instance
@@ -612,8 +629,12 @@ def _create_from_target(target: Target, template: Path) -> None:
         # org/repo are guaranteed non-None for dedicated targets.
         assert target.org is not None and target.repo is not None  # noqa: S101
         write_instance_meta(
-            target.instance, target.identity_name, target.org, target.repo, None
-        )  # Task 6 wires the instance name here
+            target.instance,
+            target.identity_name,
+            target.org,
+            target.repo,
+            target.instance_name_arg,
+        )
     else:
         create_vm(
             target.instance,
@@ -2143,6 +2164,17 @@ def _add_workspace_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_name_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--name",
+        default=None,
+        help=(
+            "Named VM instance for this repo (default: the unnamed default instance). "
+            "Must be declared under [vm.<identity>.instances.<name>]."
+        ),
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="vrg-vm",
@@ -2154,6 +2186,7 @@ def main(argv: list[str] | None = None) -> int:
     p_create = sub.add_parser("create", help="Create and provision a new VM")
     _add_identity_args(p_create)
     _add_workspace_arg(p_create)
+    _add_name_arg(p_create)
     p_create.add_argument(
         "--tag", default="", help="VM template version tag (default: vergil version from config)"
     )
@@ -2170,6 +2203,7 @@ def main(argv: list[str] | None = None) -> int:
     p_start = sub.add_parser("start", help="Start VM and inject credentials")
     _add_identity_args(p_start)
     _add_workspace_arg(p_start)
+    _add_name_arg(p_start)
     p_start.add_argument(
         "--allow-stale-vm",
         action="store_true",
@@ -2185,16 +2219,19 @@ def main(argv: list[str] | None = None) -> int:
     p_stop = sub.add_parser("stop", help="Stop VM")
     _add_identity_args(p_stop)
     _add_workspace_arg(p_stop)
+    _add_name_arg(p_stop)
 
     p_restart = sub.add_parser("restart", help="Restart VM and re-inject credentials")
     _add_identity_args(p_restart)
     _add_workspace_arg(p_restart)
+    _add_name_arg(p_restart)
 
     p_update = sub.add_parser(
         "update", help="Reinstall vergil-tooling and refresh plugins in a running box (in place)"
     )
     _add_identity_args(p_update)
     _add_workspace_arg(p_update)
+    _add_name_arg(p_update)
     p_update.add_argument(
         "--tag", default="", help="Override version tag (default: tag from initial install)"
     )
@@ -2213,6 +2250,7 @@ def main(argv: list[str] | None = None) -> int:
     p_destroy = sub.add_parser("destroy", help="Destroy VM entirely")
     _add_identity_args(p_destroy)
     _add_workspace_arg(p_destroy)
+    _add_name_arg(p_destroy)
     p_destroy.add_argument(
         "--tag",
         default="",
@@ -2225,6 +2263,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     _add_identity_args(p_destroy_volume)
     _add_workspace_arg(p_destroy_volume)
+    _add_name_arg(p_destroy_volume)
     p_destroy_volume.add_argument(
         "--tag",
         default="",
@@ -2239,6 +2278,7 @@ def main(argv: list[str] | None = None) -> int:
     p_rebuild = sub.add_parser("rebuild", help="Destroy and recreate VM (stateless rebuild)")
     _add_identity_args(p_rebuild)
     _add_workspace_arg(p_rebuild)
+    _add_name_arg(p_rebuild)
     p_rebuild.add_argument(
         "--tag", default="", help="VM template version tag (default: vergil version from config)"
     )
@@ -2308,6 +2348,14 @@ def main(argv: list[str] | None = None) -> int:
 
     p_session = sub.add_parser("session", help="Launch a Claude session in a VM")
     _add_identity_args(p_session)
+    p_session.add_argument(
+        "--name",
+        default=None,
+        help=(
+            "Named VM instance for this repo (default: the unnamed default instance). "
+            "Must be declared under [vm.<identity>.instances.<name>]."
+        ),
+    )
     p_session.add_argument(
         "--allow-stale-vm",
         action="store_true",

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -230,6 +230,9 @@ def _parse_role_overlay(
     for key in raw:
         if key == "instances" and allow_instances:
             continue
+        if key == "instances" and not allow_instances:
+            msg = f"{source}: [vm.{name}.instances.{name}] must not contain nested instances"
+            raise ConfigError(msg)
         if key not in _VM_KEYS:
             print(f"{source}: unrecognized key '{key}' in [vm.{name}]", file=sys.stderr)
     scalars = {k: _vm_str_scalar(raw, k, f"[vm.{name}]", source) for k in _VM_STR_SCALARS}

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -251,9 +251,7 @@ def _parse_role_overlay(
             if not isinstance(itable, dict):
                 msg = f"{source}: [vm.{name}.instances.{iname}] must be a table"
                 raise ConfigError(msg)
-            instances[iname] = _parse_role_overlay(
-                iname, itable, source, allow_instances=False
-            )
+            instances[iname] = _parse_role_overlay(iname, itable, source, allow_instances=False)
     return RoleOverlay(
         packages=list(raw.get("packages", [])),
         cpus=raw.get("cpus"),

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -132,7 +132,7 @@ class RoleOverlay:
     # Named-instance overlays (vergil-tooling #1831). Each value is itself a
     # RoleOverlay parsed from [vm.<identity>.instances.<name>]; an instance overlay
     # never carries its own nested instances. Empty for the common (unnamed) case.
-    instances: dict[str, "RoleOverlay"] = field(default_factory=dict)
+    instances: dict[str, RoleOverlay] = field(default_factory=dict)
 
 
 @dataclass
@@ -345,16 +345,16 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
     _warn_unrecognized_keys(raw, source)
     project_raw = raw.get("project", {})
 
-    for field in _REQUIRED_PROJECT_FIELDS:
-        if field not in project_raw or not project_raw[field]:
-            msg = f"{source}: missing or empty required field '{field}'"
+    for required_field in _REQUIRED_PROJECT_FIELDS:
+        if required_field not in project_raw or not project_raw[required_field]:
+            msg = f"{source}: missing or empty required field '{required_field}'"
             raise ConfigError(msg)
 
-    for field in _REQUIRED_PROJECT_FIELDS:
-        value = project_raw[field]
-        if value not in _ENUMS[field]:
-            allowed = ", ".join(sorted(_ENUMS[field]))
-            msg = f"{source}: invalid {field} '{value}' (allowed: {allowed})"
+    for required_field in _REQUIRED_PROJECT_FIELDS:
+        value = project_raw[required_field]
+        if value not in _ENUMS[required_field]:
+            allowed = ", ".join(sorted(_ENUMS[required_field]))
+            msg = f"{source}: invalid {required_field} '{value}' (allowed: {allowed})"
             raise ConfigError(msg)
 
     raw_lang = project_raw.get("primary-language", "")

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import os
 import sys
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+from vergil_tooling.lib.vm_spec import validate_instance_name
 
 CONFIG_FILE = "vergil.toml"
 
@@ -127,6 +129,10 @@ class RoleOverlay:
     instance: str | None = None
     volume: str | None = None
     zone: str | None = None
+    # Named-instance overlays (vergil-tooling #1831). Each value is itself a
+    # RoleOverlay parsed from [vm.<identity>.instances.<name>]; an instance overlay
+    # never carries its own nested instances. Empty for the common (unnamed) case.
+    instances: dict[str, "RoleOverlay"] = field(default_factory=dict)
 
 
 @dataclass
@@ -215,14 +221,36 @@ def _parse_shared_from(value: Any, source: str) -> tuple[str, str]:
     return (parts[0], parts[1])
 
 
-def _parse_role_overlay(name: str, raw: dict[str, Any], source: str = CONFIG_FILE) -> RoleOverlay:
+def _parse_role_overlay(
+    name: str, raw: dict[str, Any], source: str = CONFIG_FILE, *, allow_instances: bool = True
+) -> RoleOverlay:
     if _SHARED_FROM_KEY in raw:
         msg = f"{source}: shared_from is not allowed in a role overlay [vm.{name}]"
         raise ConfigError(msg)
     for key in raw:
+        if key == "instances" and allow_instances:
+            continue
         if key not in _VM_KEYS:
             print(f"{source}: unrecognized key '{key}' in [vm.{name}]", file=sys.stderr)
     scalars = {k: _vm_str_scalar(raw, k, f"[vm.{name}]", source) for k in _VM_STR_SCALARS}
+    instances: dict[str, RoleOverlay] = {}
+    if allow_instances:
+        raw_instances = raw.get("instances", {})
+        if not isinstance(raw_instances, dict):
+            msg = f"{source}: [vm.{name}].instances must be a table"
+            raise ConfigError(msg)
+        for iname, itable in raw_instances.items():
+            try:
+                validate_instance_name(iname)
+            except ValueError as exc:
+                msg = f"{source}: [vm.{name}.instances.{iname}]: {exc}"
+                raise ConfigError(msg) from exc
+            if not isinstance(itable, dict):
+                msg = f"{source}: [vm.{name}.instances.{iname}] must be a table"
+                raise ConfigError(msg)
+            instances[iname] = _parse_role_overlay(
+                iname, itable, source, allow_instances=False
+            )
     return RoleOverlay(
         packages=list(raw.get("packages", [])),
         cpus=raw.get("cpus"),
@@ -233,6 +261,7 @@ def _parse_role_overlay(name: str, raw: dict[str, Any], source: str = CONFIG_FIL
         vagrant_plugins=list(raw.get("vagrant_plugins", [])),
         port_forwards=list(raw.get("port_forwards", [])),
         nested=raw.get("nested"),
+        instances=instances,
         **scalars,
     )
 
@@ -249,6 +278,12 @@ def parse_vm_stanza(raw: dict[str, Any], source: str = CONFIG_FILE) -> VmStanza 
         if key == _SHARED_FROM_KEY:
             shared_from = _parse_shared_from(value, source)
         elif isinstance(value, dict):
+            if key == "instances":
+                msg = (
+                    f"{source}: no all-identity [vm.instances] tier — declare named "
+                    f"instances under [vm.<identity>.instances.<name>]"
+                )
+                raise ConfigError(msg)
             roles[key] = _parse_role_overlay(key, value, source)
         elif key in _VM_KEYS:
             fields[key] = value

--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -281,31 +281,39 @@ def _serial_dir(instance: str) -> Path:
 _META_FILE = "vergil-meta.json"
 
 
-def write_instance_meta(instance: str, identity: str, org: str, repo: str) -> None:
-    """Record (identity, org, repo) beside the instance so a mangled name stays reversible.
+def write_instance_meta(
+    instance: str, identity: str, org: str, repo: str, name: str | None = None
+) -> None:
+    """Record the handle beside the instance so a mangled name stays reversible.
 
-    Lives in the instance's own ``~/.lima/<instance>/`` dir, so it is removed when
-    ``limactl delete --force`` deletes that dir — no separate cleanup, no drift.
+    Lives in ``~/.lima/<instance>/``, removed when ``limactl delete --force`` deletes
+    that dir. ``name`` is the optional fourth handle segment (empty for the default).
     """
     meta_dir = _serial_dir(instance)
     meta_dir.mkdir(parents=True, exist_ok=True)
-    payload = {"schema": 1, "identity": identity, "org": org, "repo": repo}
+    payload = {
+        "schema": 2,
+        "identity": identity,
+        "org": org,
+        "repo": repo,
+        "name": name or "",
+    }
     (meta_dir / _META_FILE).write_text(json.dumps(payload))
 
 
 def read_instance_meta(instance: str) -> dict[str, object] | None:
     """Return the instance's recorded metadata, or None if no sidecar exists.
 
-    The mapping carries an int ``schema`` plus string ``identity``/``org``/``repo``,
-    hence the ``object`` value type. Raises on a malformed sidecar rather than
-    silently falling back — a corrupt file is a real fault, not a missing one.
+    Carries an int ``schema``, string ``identity``/``org``/``repo``, and (schema 2+)
+    a string ``name``. Raises on a malformed sidecar rather than silently falling
+    back. Schema-1 sidecars (no ``name``) are read as the default instance.
     """
     path = _serial_dir(instance) / _META_FILE
     if not path.exists():
         return None
     data: dict[str, object] = json.loads(path.read_text())
-    # Touch the required keys so a truncated/garbled file fails loudly here.
-    _ = (data["identity"], data["org"], data["repo"])
+    _ = (data["identity"], data["org"], data["repo"])  # fail loudly on a garbled file
+    data.setdefault("name", "")
     return data
 
 

--- a/src/vergil_tooling/lib/vm_backend.py
+++ b/src/vergil_tooling/lib/vm_backend.py
@@ -29,15 +29,16 @@ def select_backend(
     identity: str | None = None,
     org: str | None = None,
     repo: str | None = None,
+    name: str | None = None,
 ) -> Backend:
     """Return the backend for a composed spec — the one dispatch decision point.
 
     Off-platform specs require ``identity``/``org``/``repo`` to derive the cloud
-    resource name and labels; a missing one is a programming error and fails loudly.
+    resource name and labels; ``name`` selects a named instance (None = default).
     """
     if spec.off_platform:
         if identity is None or org is None or repo is None:
             msg = "off-platform backend requires identity, org, and repo"
             raise ValueError(msg)
-        return OffPlatformBackend(spec, identity, org, repo)
+        return OffPlatformBackend(spec, identity, org, repo, name)
     return LimaBackend()

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from vergil_tooling.lib.vm_spec import ComposedSpec
     from vergil_tooling.lib.vm_transport import Transport
 
+
 def _slug(value: str) -> str:
     s = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return s or "x"
@@ -46,9 +47,7 @@ def cloud_resource_name(slug: str) -> str:
     return f"vrg-{digest}"
 
 
-def cloud_labels(
-    identity: str, org: str, repo: str, name: str | None = None
-) -> dict[str, str]:
+def cloud_labels(identity: str, org: str, repo: str, name: str | None = None) -> dict[str, str]:
     """Structured labels for label-based recovery (independent of the hashed name)."""
     labels = {
         "vergil-identity": _slug(identity),

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from vergil_tooling.lib import progress
-from vergil_tooling.lib.vm_spec import spec_fingerprint
+from vergil_tooling.lib.vm_spec import spec_fingerprint, state_slug
 from vergil_tooling.lib.vm_transport import IapTransport
 
 if TYPE_CHECKING:
@@ -30,34 +30,34 @@ if TYPE_CHECKING:
     from vergil_tooling.lib.vm_spec import ComposedSpec
     from vergil_tooling.lib.vm_transport import Transport
 
-_MAX_NAME = 58  # GCP names <=63; the volume module appends "-data" (the longest suffix).
-_HASH_LEN = 6
-
-
 def _slug(value: str) -> str:
     s = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return s or "x"
 
 
-def cloud_resource_name(identity: str, org: str, repo: str) -> str:
-    """A deterministic RFC1035 name (<=59 chars) for the GCP instance/disk/firewall."""
-    base = "-".join(_slug(p) for p in (identity, org, repo))
-    if not base[:1].isalpha():
-        base = f"v-{base}"
-    if len(base) <= _MAX_NAME:
-        return base
-    digest = hashlib.sha256(f"{identity}/{org}/{repo}".encode()).hexdigest()[:_HASH_LEN]
-    keep = _MAX_NAME - _HASH_LEN - 1
-    return f"{base[:keep].rstrip('-')}-{digest}"
+def cloud_resource_name(slug: str) -> str:
+    """Deterministic short RFC1035 name 'vrg-<first 12 hex of sha256(slug)>' (16 chars).
+
+    The four-segment slug overflows GCP's 63-char limit, so the readable slug keys
+    the state path / labels while cloud resources take this opaque hash. Identity is
+    carried in labels (which `list` and `tofu import` read), never in the name.
+    """
+    digest = hashlib.sha256(slug.encode()).hexdigest()[:12]
+    return f"vrg-{digest}"
 
 
-def cloud_labels(identity: str, org: str, repo: str) -> dict[str, str]:
-    """Structured labels for label-based recovery (independent of the mangled name)."""
-    return {
+def cloud_labels(
+    identity: str, org: str, repo: str, name: str | None = None
+) -> dict[str, str]:
+    """Structured labels for label-based recovery (independent of the hashed name)."""
+    labels = {
         "vergil-identity": _slug(identity),
         "vergil-org": _slug(org),
         "vergil-repo": _slug(repo),
     }
+    if name:
+        labels["vergil-instance"] = _slug(name)
+    return labels
 
 
 # GitHub auto-generates a source archive for any tag at this URL — a single
@@ -917,14 +917,24 @@ class OffPlatformBackend:
     with ``LimaBackend`` and is ignored.
     """
 
-    def __init__(self, spec: ComposedSpec, identity: str, org: str, repo: str) -> None:
+    def __init__(
+        self,
+        spec: ComposedSpec,
+        identity: str,
+        org: str,
+        repo: str,
+        name: str | None = None,
+    ) -> None:
         self.spec = spec
         self.identity = identity
         self.org = org
         self.repo = repo
-        self.name = cloud_resource_name(identity, org, repo)
-        self.labels = cloud_labels(identity, org, repo)
-        self.state_key = self.name
+        self.instance_name = name
+        # Readable slug keys the state path; the cloud resource name is its hash.
+        self.slug = state_slug(identity, org, repo, name)
+        self.name = cloud_resource_name(self.slug)
+        self.labels = cloud_labels(identity, org, repo, name)
+        self.state_key = self.slug
         self.ssh_user = _effective_ssh_user()
         # Plain attribute (not a property): the Backend protocol declares
         # provider_label as a settable variable, which a read-only property fails.

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -213,8 +213,7 @@ def compose_vm_spec(
         if overlay is None:
             avail = ", ".join(sorted(instances)) if instances else "(none)"
             msg = (
-                f"identity {identity!r}: no instance {instance!r} for this repo; "
-                f"available: {avail}"
+                f"identity {identity!r}: no instance {instance!r} for this repo; available: {avail}"
             )
             raise SpecError(msg)
         _apply_overlay(acc, overlay)

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -383,6 +383,26 @@ def instance_name(
     return f"{full[:keep].rstrip('._-')}-{digest}"
 
 
+_SLUG_SEP = "--"
+
+
+def state_slug(
+    identity: str, org: str | None = None, repo: str | None = None, name: str | None = None
+) -> str:
+    """The readable '--'-joined handle: state-path key and cloud-name hash input.
+
+    ``identity`` (base) / ``identity--org--repo`` (default dedicated) /
+    ``identity--org--repo--name`` (named). Reversal is via labels (cloud) and the
+    sidecar (Lima), not by splitting — but '--' keeps the path human-readable.
+    """
+    if org is None or repo is None:
+        return identity
+    segments = [identity, org, repo]
+    if name:
+        segments.append(name)
+    return _SLUG_SEP.join(segments)
+
+
 def parse_instance_name(name: str) -> tuple[str, str | None, str | None]:
     """Reverse instance_name. Returns (identity, org, repo); org/repo are None for base."""
     parts = name.split(_TIER_SEP, 2)

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -402,6 +402,27 @@ def state_slug(
     return _SLUG_SEP.join(segments)
 
 
+def split_state_slug(slug: str) -> tuple[str, str | None, str | None, str | None]:
+    """Reverse state_slug. 1 segment = base; 3 = default dedicated; 4 = named instance.
+
+    Unambiguous because identity/org/repo never contain '--' (repo names with '--'
+    are rejected at parse time), so this is the exact inverse — no labels needed.
+
+    Deliberate symmetry: ``split_state_slug`` uses ``'--'`` (cloud/state paths);
+    ``parse_instance_name`` uses ``'.'`` (Lima instance names). The delimiters and
+    segment rules differ — do NOT merge them.
+    """
+    parts = slug.split(_SLUG_SEP)
+    if len(parts) == 1:
+        return parts[0], None, None, None
+    if len(parts) == 3:  # noqa: PLR2004
+        return parts[0], parts[1], parts[2], None
+    if len(parts) == 4:  # noqa: PLR2004
+        return parts[0], parts[1], parts[2], parts[3]
+    msg = f"unparseable state slug: {slug!r}"
+    raise ValueError(msg)
+
+
 def parse_instance_name(name: str) -> tuple[str, str | None, str | None]:
     """Reverse instance_name. Returns (identity, org, repo); org/repo are None for base."""
     parts = name.split(_TIER_SEP, 2)

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -345,14 +345,18 @@ def lima_name_budget(home: str | None = None) -> int:
 
 
 def instance_name(
-    identity: str, org: str | None, repo: str | None, *, home: str | None = None
+    identity: str,
+    org: str | None,
+    repo: str | None,
+    name: str | None = None,
+    *,
+    home: str | None = None,
 ) -> str:
-    """Derive the Lima instance name. Bare identity = base box; ``.``-joined = dedicated.
+    """Derive the Lima instance name. Bare identity = base; ``.``-joined = dedicated.
 
-    Dedicated names are returned verbatim when they fit ``lima_name_budget``; over
-    budget they are truncated and hashed (mirroring ``vm_cloud.cloud_resource_name``)
-    so Lima's worst-case socket path stays under UNIX_PATH_MAX. ``recover_triple``
-    (vrg_vm) reverses a mangled name via the per-instance sidecar.
+    A named instance appends ``.<name>`` as a fourth segment. Over budget, the name
+    is truncated and hashed (the digest input includes ``name`` so distinct instances
+    differ); ``recover_handle`` (vrg_vm) reverses a mangled name via the sidecar.
     """
     if org is None or repo is None:
         return identity
@@ -360,7 +364,10 @@ def instance_name(
         if _TIER_SEP in value:
             msg = f"{tier} name {value!r} must not contain '{_TIER_SEP}'"
             raise ValueError(msg)
-    full = _TIER_SEP.join((identity, org, repo))
+    segments = [identity, org, repo]
+    if name:
+        segments.append(name)
+    full = _TIER_SEP.join(segments)
     budget = lima_name_budget(home)
     if len(full) <= budget:
         return full
@@ -370,7 +377,8 @@ def instance_name(
             f"{identity!r}: budget {budget} < {len(identity) + 7}"
         )
         raise SpecError(msg)
-    digest = hashlib.sha256(f"{identity}/{org}/{repo}".encode()).hexdigest()[:6]
+    digest_src = "/".join(segments)
+    digest = hashlib.sha256(digest_src.encode()).hexdigest()[:6]
     keep = budget - 7
     return f"{full[:keep].rstrip('._-')}-{digest}"
 

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -172,8 +172,9 @@ def compose_vm_spec(
     base: Mapping[str, object],
     stanza: VmStanza | None,
     override: Mapping[str, object] | None,
+    instance: str | None = None,
 ) -> ComposedSpec:
-    """Overlay the five precedence tiers into the effective spec for one (identity, repo)."""
+    """Overlay the precedence tiers into the effective spec for one (identity, repo[, name])."""
     # Tier 1+2: built-in/base footprint from the identity.
     acc = _Acc(
         cpus=cast("int", base["cpus"]),
@@ -198,13 +199,27 @@ def compose_vm_spec(
     )
 
     # Tiers 3 + 4: repo [vm] (all-identity), then [vm.<identity>] role overlay.
+    role = None
     if stanza is not None:
         _apply_overlay(acc, stanza)
         role = stanza.roles.get(identity)
         if role is not None:
             _apply_overlay(acc, role)
 
-    # Tier 5: host override (wins). Flag any scalar pushed below the repo-declared floor.
+    # Tier 5: the named-instance overlay, if a name was requested.
+    if instance is not None:
+        instances = role.instances if role is not None else {}
+        overlay = instances.get(instance)
+        if overlay is None:
+            avail = ", ".join(sorted(instances)) if instances else "(none)"
+            msg = (
+                f"identity {identity!r}: no instance {instance!r} for this repo; "
+                f"available: {avail}"
+            )
+            raise SpecError(msg)
+        _apply_overlay(acc, overlay)
+
+    # Host override (wins). Flag any scalar pushed below the repo-declared floor.
     under: list[str] = []
     if override:
         acc.customized = True
@@ -301,6 +316,16 @@ def validate_instance_name(name: str) -> None:
         msg = (
             f"instance name {name!r} must be lowercase [a-z0-9-] with single internal "
             f"hyphens (no '--', no leading/trailing hyphen)"
+        )
+        raise ValueError(msg)
+
+
+def validate_repo_segment(repo: str) -> None:
+    """Reject a repo name containing '--', which would make the state slug ambiguous."""
+    if "--" in repo:
+        msg = (
+            f"repo name {repo!r} must not contain '--' (it would make the "
+            f"'--'-joined instance handle ambiguous)"
         )
         raise ValueError(msg)
 

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -288,6 +288,23 @@ def _validate_backend(identity: str, acc: _Acc) -> None:
 # enforces that loudly rather than silently producing a name that won't decode.
 _TIER_SEP = "."
 
+_INSTANCE_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def validate_instance_name(name: str) -> None:
+    """Reject an instance name that is not [a-z0-9]+ with single internal hyphens.
+
+    A double dash would break the readable ``--``-joined state slug; an empty or
+    upper-cased name is also rejected. Raises loudly (no-silent-failures).
+    """
+    if not _INSTANCE_NAME_RE.fullmatch(name):
+        msg = (
+            f"instance name {name!r} must be lowercase [a-z0-9-] with single internal "
+            f"hyphens (no '--', no leading/trailing hyphen)"
+        )
+        raise ValueError(msg)
+
+
 _UNIX_PATH_MAX = 104
 # Lima validates the longest socket path it might create:
 #   <home>/.lima/<instance>/ssh.sock.<16-char worst-case reservation>

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -958,7 +958,7 @@ def test_project_ghas_is_recognized_key(tmp_path: Path, capsys: pytest.CaptureFi
 # -- named instances (vergil-tooling #1831) ------------------------------------
 
 
-def test_parse_vm_stanza_named_instances():
+def test_parse_vm_stanza_named_instances() -> None:
     raw = {
         "vm": {
             "vergil-user": {
@@ -985,13 +985,25 @@ def test_parse_vm_stanza_named_instances():
     assert inst.instances == {}  # no nested instances
 
 
-def test_parse_vm_stanza_rejects_all_identity_instances_tier():
+def test_parse_vm_stanza_rejects_all_identity_instances_tier() -> None:
     raw = {"vm": {"instances": {"cloud-x86": {"cpus": 4}}}}
     with pytest.raises(ConfigError, match="no all-identity .*instances"):
         parse_vm_stanza(raw)
 
 
-def test_parse_vm_stanza_rejects_invalid_instance_name():
+def test_parse_vm_stanza_rejects_invalid_instance_name() -> None:
     raw = {"vm": {"vergil-user": {"instances": {"bad--name": {"cpus": 4}}}}}
     with pytest.raises(ConfigError, match="instance name"):
+        parse_vm_stanza(raw)
+
+
+def test_parse_vm_stanza_rejects_nested_instances_in_overlay() -> None:
+    raw = {
+        "vm": {
+            "vergil-user": {
+                "instances": {"cloud-x86": {"instances": {"nope": {}}}}
+            }
+        }
+    }
+    with pytest.raises(ConfigError, match="nested instances"):
         parse_vm_stanza(raw)

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -976,6 +976,7 @@ def test_parse_vm_stanza_named_instances() -> None:
         }
     }
     stanza = parse_vm_stanza(raw)
+    assert stanza is not None
     role = stanza.roles["vergil-user"]
     assert role.cpus == 12
     assert set(role.instances) == {"cloud-x86"}
@@ -998,12 +999,18 @@ def test_parse_vm_stanza_rejects_invalid_instance_name() -> None:
 
 
 def test_parse_vm_stanza_rejects_nested_instances_in_overlay() -> None:
-    raw = {
-        "vm": {
-            "vergil-user": {
-                "instances": {"cloud-x86": {"instances": {"nope": {}}}}
-            }
-        }
-    }
+    raw = {"vm": {"vergil-user": {"instances": {"cloud-x86": {"instances": {"nope": {}}}}}}}
     with pytest.raises(ConfigError, match="nested instances"):
+        parse_vm_stanza(raw)
+
+
+def test_parse_vm_stanza_rejects_instances_not_a_table() -> None:
+    raw = {"vm": {"vergil-user": {"instances": "not-a-table"}}}
+    with pytest.raises(ConfigError, match="must be a table"):
+        parse_vm_stanza(raw)
+
+
+def test_parse_vm_stanza_rejects_instance_entry_not_a_table() -> None:
+    raw = {"vm": {"vergil-user": {"instances": {"cloud-x86": "not-a-table"}}}}
+    with pytest.raises(ConfigError, match="must be a table"):
         parse_vm_stanza(raw)

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -953,3 +953,45 @@ def test_project_ghas_is_recognized_key(tmp_path: Path, capsys: pytest.CaptureFi
     (tmp_path / "vergil.toml").write_text(_GHAS_TOML_TEMPLATE.format(ghas_line="ghas = true"))
     read_config(tmp_path)
     assert "unrecognized key 'ghas'" not in capsys.readouterr().err
+
+
+# -- named instances (vergil-tooling #1831) ------------------------------------
+
+
+def test_parse_vm_stanza_named_instances():
+    raw = {
+        "vm": {
+            "vergil-user": {
+                "cpus": 12,
+                "instances": {
+                    "cloud-x86": {
+                        "backend": "off-platform",
+                        "provider": "gcp",
+                        "region": "us-central1",
+                        "instance": "n2-standard-16",
+                        "volume": "300GiB",
+                    }
+                },
+            }
+        }
+    }
+    stanza = parse_vm_stanza(raw)
+    role = stanza.roles["vergil-user"]
+    assert role.cpus == 12
+    assert set(role.instances) == {"cloud-x86"}
+    inst = role.instances["cloud-x86"]
+    assert inst.backend == "off-platform"
+    assert inst.instance == "n2-standard-16"
+    assert inst.instances == {}  # no nested instances
+
+
+def test_parse_vm_stanza_rejects_all_identity_instances_tier():
+    raw = {"vm": {"instances": {"cloud-x86": {"cpus": 4}}}}
+    with pytest.raises(ConfigError, match="no all-identity .*instances"):
+        parse_vm_stanza(raw)
+
+
+def test_parse_vm_stanza_rejects_invalid_instance_name():
+    raw = {"vm": {"vergil-user": {"instances": {"bad--name": {"cpus": 4}}}}}
+    with pytest.raises(ConfigError, match="instance name"):
+        parse_vm_stanza(raw)

--- a/tests/vergil_tooling/test_lima_meta.py
+++ b/tests/vergil_tooling/test_lima_meta.py
@@ -17,10 +17,11 @@ def test_write_then_read_round_trips(tmp_path: Path, monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
     lima.write_instance_meta("u.org.repo", "vergil-user", "org", "repo")
     assert lima.read_instance_meta("u.org.repo") == {
-        "schema": 1,
+        "schema": 2,
         "identity": "vergil-user",
         "org": "org",
         "repo": "repo",
+        "name": "",
     }
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -34,7 +34,7 @@ from vergil_tooling.lib.vm_cloud import (
     tofu_state_dir,
     zone_to_region,
 )
-from vergil_tooling.lib.vm_spec import ComposedSpec
+from vergil_tooling.lib.vm_spec import ComposedSpec, state_slug
 from vergil_tooling.lib.vm_transport import IapTransport
 
 _RFC1035 = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
@@ -67,34 +67,38 @@ class TestResolveProject:
 
 
 class TestCloudName:
-    def test_lowercases_and_replaces_dots(self) -> None:
-        name = cloud_resource_name("vergil-user", "Logical-Minds", "MQ.Cluster")
+    def test_rfc1035_and_fixed_length(self) -> None:
+        slug = state_slug("vergil-user", "Logical-Minds", "MQ.Cluster")
+        name = cloud_resource_name(slug)
         assert _RFC1035.fullmatch(name)
-        assert "." not in name and name == name.lower()
+        assert len(name) == 16  # "vrg-" + 12 hex
 
     def test_deterministic(self) -> None:
-        a = cloud_resource_name("vergil-user", "o", "r")
-        b = cloud_resource_name("vergil-user", "o", "r")
+        slug = state_slug("vergil-user", "o", "r")
+        a = cloud_resource_name(slug)
+        b = cloud_resource_name(slug)
         assert a == b
 
-    def test_truncates_long_names_to_58_with_hash(self) -> None:
-        name = cloud_resource_name("vergil-user", "a" * 40, "b" * 40)
-        # 58 leaves room for the volume module's "-data" suffix within GCP's 63-char cap.
-        assert len(name) <= 58
+    def test_always_fits_gcp_limit(self) -> None:
+        slug = state_slug("vergil-user", "a" * 40, "b" * 40)
+        name = cloud_resource_name(slug)
+        # 16 chars always fits within GCP's 63-char cap (and its "-data" suffix).
+        assert len(name) == 16
         assert _RFC1035.fullmatch(name)
 
-    def test_distinct_inputs_distinct_names_even_when_truncated(self) -> None:
-        n1 = cloud_resource_name("vergil-user", "a" * 40, "b" * 40)
-        n2 = cloud_resource_name("vergil-user", "a" * 40, "c" * 40)
+    def test_distinct_slugs_produce_distinct_names(self) -> None:
+        n1 = cloud_resource_name(state_slug("vergil-user", "a" * 40, "b" * 40))
+        n2 = cloud_resource_name(state_slug("vergil-user", "a" * 40, "c" * 40))
         assert n1 != n2
 
-    def test_prefixes_non_alpha_leading_name(self) -> None:
-        name = cloud_resource_name("9user", "org", "repo")
+    def test_always_starts_with_vrg(self) -> None:
+        # Hash prefix "vrg-" guarantees RFC1035-valid first char regardless of input.
+        name = cloud_resource_name(state_slug("9user", "org", "repo"))
+        assert name.startswith("vrg-")
         assert _RFC1035.fullmatch(name)
-        assert name.startswith("v-")
 
-    def test_empty_components_fall_back_to_placeholder(self) -> None:
-        name = cloud_resource_name("...", "...", "...")
+    def test_any_slug_produces_valid_name(self) -> None:
+        name = cloud_resource_name(state_slug("...", "...", "..."))
         assert _RFC1035.fullmatch(name)
 
 
@@ -1147,8 +1151,10 @@ class TestOffPlatformBackend:
     def test_init_computes_name_labels_and_ssh_user(self) -> None:
         b = OffPlatformBackend(_off_spec(), "vergil-user", "o", "r")
         assert b.provider_label == "gcp"
-        assert b.name == cloud_resource_name("vergil-user", "o", "r")
-        assert b.state_key == b.name
+        expected_slug = state_slug("vergil-user", "o", "r")
+        assert b.slug == expected_slug
+        assert b.name == cloud_resource_name(expected_slug)
+        assert b.state_key == expected_slug  # readable slug, not the hashed name
         assert b.labels == cloud_labels("vergil-user", "o", "r")
         assert b.ssh_user == "ubuntu"
 
@@ -1461,3 +1467,18 @@ class TestParseVolumeState:
             )
         )
         assert parse_volume_state(state) is None
+
+
+def test_cloud_resource_name_is_hashed_and_deterministic() -> None:
+    slug = "vergil-user--logical-minds-foundry--mq-cluster-tooling--cloud-x86"
+    name = cloud_resource_name(slug)
+    assert name.startswith("vrg-")
+    assert len(name) == 16  # "vrg-" + 12 hex
+    assert name == cloud_resource_name(slug)  # deterministic
+    assert cloud_resource_name(slug + "-other") != name
+
+
+def test_cloud_labels_includes_instance_when_named() -> None:
+    labels = cloud_labels("vergil-user", "lmf", "mq", "cloud-x86")
+    assert labels["vergil-instance"] == "cloud-x86"
+    assert "vergil-instance" not in cloud_labels("vergil-user", "lmf", "mq")

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -498,7 +498,9 @@ class TestInstanceName:
         assert instance_name("vergil-user", "lmf", "mq") == "vergil-user.lmf.mq"
         assert instance_name("vergil-user", None, None) == "vergil-user"
 
-    def test_instance_name_named_hash_differs_from_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_instance_name_named_hash_differs_from_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Force the over-budget path with a tiny budget so both names are hashed.
         monkeypatch.setattr("vergil_tooling.lib.vm_spec.lima_name_budget", lambda home=None: 20)
         default = instance_name("vergil-user", "logical-minds-foundry", "mq-cluster-tooling")

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -17,6 +17,8 @@ from vergil_tooling.lib.vm_spec import (
     lima_name_budget,
     parse_instance_name,
     spec_fingerprint,
+    validate_instance_name,
+    validate_repo_segment,
 )
 
 BASE = {"cpus": 4, "memory": "4GiB", "disk": "50GiB"}
@@ -678,3 +680,101 @@ class TestFingerprint:
         )
         expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         assert spec_fingerprint(self._op_spec()) == expected
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Naming validators + tier-5 composition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["cloud-x86", "rdqm-rhel", "a", "x1"])
+def test_validate_instance_name_accepts(name: str) -> None:
+    validate_instance_name(name)  # no raise
+
+
+@pytest.mark.parametrize("name", ["bad--name", "-lead", "trail-", "Up", "a_b", ""])
+def test_validate_instance_name_rejects(name: str) -> None:
+    with pytest.raises(ValueError, match="instance name"):
+        validate_instance_name(name)
+
+
+def test_validate_repo_segment_rejects_double_dash() -> None:
+    with pytest.raises(ValueError, match="--"):
+        validate_repo_segment("my--repo")
+    validate_repo_segment("my-repo")  # single dash ok
+
+
+def test_compose_named_instance_overlays_tier5() -> None:
+    role = RoleOverlay(
+        packages=[], cpus=12, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        instances={
+            "rdqm-rhel": RoleOverlay(
+                packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
+                apt_repos=[], vagrant_plugins=[], port_forwards=[],
+                backend="off-platform", provider="gcp", region="us-central1",
+                instance="n2-standard-8", volume="200GiB",
+            )
+        },
+    )
+    stanza = VmStanza(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        roles={"vergil-user": role},
+    )
+    spec = compose_vm_spec(
+        identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="rdqm-rhel"
+    )
+    assert spec.cpus == 8  # tier-5 overrides tier-4's 12
+    assert spec.memory == "32GiB"
+    assert spec.off_platform
+    assert spec.instance == "n2-standard-8"
+
+
+def test_compose_default_instance_unchanged_when_none() -> None:
+    stanza = VmStanza(
+        packages=[], cpus=12, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={},
+    )
+    spec = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+    assert spec.cpus == 12  # tiers 1-4 only, today's behavior
+
+
+def test_compose_missing_named_instance_errors_with_available() -> None:
+    role = RoleOverlay(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        instances={"cloud-x86": RoleOverlay(
+            packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+            apt_repos=[], vagrant_plugins=[], port_forwards=[])},
+    )
+    stanza = VmStanza(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={"vergil-user": role},
+    )
+    with pytest.raises(SpecError, match="cloud-x86"):
+        compose_vm_spec(
+            identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="nope"
+        )
+
+
+def test_fingerprint_excludes_instance_name() -> None:
+    # The name is the handle, not fingerprint content: a named instance and the
+    # default that resolve to the SAME effective footprint share a fingerprint, so
+    # adding/renaming an instance never trips drift on the others.
+    role = RoleOverlay(
+        packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        instances={"rdqm-rhel": RoleOverlay(
+            packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
+            apt_repos=[], vagrant_plugins=[], port_forwards=[])},
+    )
+    stanza = VmStanza(
+        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
+        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={"vergil-user": role},
+    )
+    default = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
+    named = compose_vm_spec(
+        identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="rdqm-rhel"
+    )
+    assert spec_fingerprint(default) == spec_fingerprint(named)

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib.vm_spec import (
     lima_name_budget,
     parse_instance_name,
     spec_fingerprint,
+    split_state_slug,
     state_slug,
     validate_instance_name,
     validate_repo_segment,
@@ -878,3 +879,19 @@ def test_state_slug_forms() -> None:
     assert state_slug("vergil-user") == "vergil-user"
     assert state_slug("vergil-user", "lmf", "mq") == "vergil-user--lmf--mq"
     assert state_slug("vergil-user", "lmf", "mq", "cloud-x86") == "vergil-user--lmf--mq--cloud-x86"
+
+
+def test_split_state_slug_roundtrips() -> None:
+    assert split_state_slug("vergil-user") == ("vergil-user", None, None, None)
+    assert split_state_slug("vergil-user--lmf--mq") == ("vergil-user", "lmf", "mq", None)
+    assert split_state_slug("vergil-user--lmf--mq--cloud-x86") == (
+        "vergil-user",
+        "lmf",
+        "mq",
+        "cloud-x86",
+    )
+
+
+def test_split_state_slug_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="unparseable"):
+        split_state_slug("a--b")  # 2 segments — not a valid form

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -895,3 +895,7 @@ def test_split_state_slug_roundtrips() -> None:
 def test_split_state_slug_invalid_raises() -> None:
     with pytest.raises(ValueError, match="unparseable"):
         split_state_slug("a--b")  # 2 segments — not a valid form
+    # 5-segment slugs are also invalid. This can only arise from filesystem corruption
+    # because validate_repo_segment prevents '--' in repo names at parse time.
+    with pytest.raises(ValueError, match="unparseable"):
+        split_state_slug("a--b--c--d--e")  # 5 segments — not a valid form

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -728,20 +728,41 @@ def test_validate_repo_segment_rejects_double_dash() -> None:
 
 def test_compose_named_instance_overlays_tier5() -> None:
     role = RoleOverlay(
-        packages=[], cpus=12, memory=None, disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        packages=[],
+        cpus=12,
+        memory=None,
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
         instances={
             "rdqm-rhel": RoleOverlay(
-                packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
-                apt_repos=[], vagrant_plugins=[], port_forwards=[],
-                backend="off-platform", provider="gcp", region="us-central1",
-                instance="n2-standard-8", volume="200GiB",
+                packages=[],
+                cpus=8,
+                memory="32GiB",
+                disk=None,
+                stale_days=None,
+                apt_repos=[],
+                vagrant_plugins=[],
+                port_forwards=[],
+                backend="off-platform",
+                provider="gcp",
+                region="us-central1",
+                instance="n2-standard-8",
+                volume="200GiB",
             )
         },
     )
     stanza = VmStanza(
-        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[],
+        packages=[],
+        cpus=None,
+        memory=None,
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
         roles={"vergil-user": role},
     )
     spec = compose_vm_spec(
@@ -755,8 +776,15 @@ def test_compose_named_instance_overlays_tier5() -> None:
 
 def test_compose_default_instance_unchanged_when_none() -> None:
     stanza = VmStanza(
-        packages=[], cpus=12, memory=None, disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={},
+        packages=[],
+        cpus=12,
+        memory=None,
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
+        roles={},
     )
     spec = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
     assert spec.cpus == 12  # tiers 1-4 only, today's behavior
@@ -764,15 +792,37 @@ def test_compose_default_instance_unchanged_when_none() -> None:
 
 def test_compose_missing_named_instance_errors_with_available() -> None:
     role = RoleOverlay(
-        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[],
-        instances={"cloud-x86": RoleOverlay(
-            packages=[], cpus=None, memory=None, disk=None, stale_days=None,
-            apt_repos=[], vagrant_plugins=[], port_forwards=[])},
+        packages=[],
+        cpus=None,
+        memory=None,
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
+        instances={
+            "cloud-x86": RoleOverlay(
+                packages=[],
+                cpus=None,
+                memory=None,
+                disk=None,
+                stale_days=None,
+                apt_repos=[],
+                vagrant_plugins=[],
+                port_forwards=[],
+            )
+        },
     )
     stanza = VmStanza(
-        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={"vergil-user": role},
+        packages=[],
+        cpus=None,
+        memory=None,
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
+        roles={"vergil-user": role},
     )
     with pytest.raises(SpecError, match="cloud-x86"):
         compose_vm_spec(
@@ -785,15 +835,37 @@ def test_fingerprint_excludes_instance_name() -> None:
     # default that resolve to the SAME effective footprint share a fingerprint, so
     # adding/renaming an instance never trips drift on the others.
     role = RoleOverlay(
-        packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[],
-        instances={"rdqm-rhel": RoleOverlay(
-            packages=[], cpus=8, memory="32GiB", disk=None, stale_days=None,
-            apt_repos=[], vagrant_plugins=[], port_forwards=[])},
+        packages=[],
+        cpus=8,
+        memory="32GiB",
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
+        instances={
+            "rdqm-rhel": RoleOverlay(
+                packages=[],
+                cpus=8,
+                memory="32GiB",
+                disk=None,
+                stale_days=None,
+                apt_repos=[],
+                vagrant_plugins=[],
+                port_forwards=[],
+            )
+        },
     )
     stanza = VmStanza(
-        packages=[], cpus=None, memory=None, disk=None, stale_days=None,
-        apt_repos=[], vagrant_plugins=[], port_forwards=[], roles={"vergil-user": role},
+        packages=[],
+        cpus=None,
+        memory=None,
+        disk=None,
+        stale_days=None,
+        apt_repos=[],
+        vagrant_plugins=[],
+        port_forwards=[],
+        roles={"vergil-user": role},
     )
     default = compose_vm_spec(identity="vergil-user", base=BASE, stanza=stanza, override=None)
     named = compose_vm_spec(
@@ -805,7 +877,4 @@ def test_fingerprint_excludes_instance_name() -> None:
 def test_state_slug_forms() -> None:
     assert state_slug("vergil-user") == "vergil-user"
     assert state_slug("vergil-user", "lmf", "mq") == "vergil-user--lmf--mq"
-    assert (
-        state_slug("vergil-user", "lmf", "mq", "cloud-x86")
-        == "vergil-user--lmf--mq--cloud-x86"
-    )
+    assert state_slug("vergil-user", "lmf", "mq", "cloud-x86") == "vergil-user--lmf--mq--cloud-x86"

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib.vm_spec import (
     lima_name_budget,
     parse_instance_name,
     spec_fingerprint,
+    state_slug,
     validate_instance_name,
     validate_repo_segment,
 )
@@ -799,3 +800,12 @@ def test_fingerprint_excludes_instance_name() -> None:
         identity="vergil-user", base=BASE, stanza=stanza, override=None, instance="rdqm-rhel"
     )
     assert spec_fingerprint(default) == spec_fingerprint(named)
+
+
+def test_state_slug_forms() -> None:
+    assert state_slug("vergil-user") == "vergil-user"
+    assert state_slug("vergil-user", "lmf", "mq") == "vergil-user--lmf--mq"
+    assert (
+        state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+        == "vergil-user--lmf--mq--cloud-x86"
+    )

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -488,6 +488,25 @@ class TestInstanceName:
         with pytest.raises(ValueError, match="unparseable VM instance name"):
             parse_instance_name("a.b")
 
+    def test_instance_name_named_appends_segment(self) -> None:
+        assert (
+            instance_name("vergil-user", "lmf", "mq", name="cloud-x86")
+            == "vergil-user.lmf.mq.cloud-x86"
+        )
+
+    def test_instance_name_default_unchanged(self) -> None:
+        assert instance_name("vergil-user", "lmf", "mq") == "vergil-user.lmf.mq"
+        assert instance_name("vergil-user", None, None) == "vergil-user"
+
+    def test_instance_name_named_hash_differs_from_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force the over-budget path with a tiny budget so both names are hashed.
+        monkeypatch.setattr("vergil_tooling.lib.vm_spec.lima_name_budget", lambda home=None: 20)
+        default = instance_name("vergil-user", "logical-minds-foundry", "mq-cluster-tooling")
+        named = instance_name(
+            "vergil-user", "logical-minds-foundry", "mq-cluster-tooling", name="cloud-x86"
+        )
+        assert default != named
+
 
 class TestFingerprint:
     def _spec(self, **over: Any) -> ComposedSpec:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -36,7 +36,7 @@ from vergil_tooling.bin.vrg_vm import (
     _warn_under,
     discover_dedicated,
     main,
-    recover_triple,
+    recover_handle,
     resolve_borrow,
 )
 from vergil_tooling.lib.identity import Identity, IdentityConfig
@@ -147,26 +147,61 @@ def config_file_top_model(tmp_path: Path) -> Path:
     return p
 
 
-def test_recover_triple_prefers_sidecar(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_recover_handle_prefers_sidecar(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "vergil_tooling.bin.vrg_vm.read_instance_meta",
-        lambda inst: {"schema": 1, "identity": "vergil-user", "org": "o", "repo": "r"},
+        lambda inst: {
+            "schema": 1, "identity": "vergil-user", "org": "o", "repo": "r", "name": ""
+        },
     )
-    assert recover_triple("mangled-abc123") == ("vergil-user", "o", "r")
+    assert recover_handle("mangled-abc123") == ("vergil-user", "o", "r", None)
 
 
-def test_recover_triple_falls_back_to_parse_for_legacy_name(
+def test_recover_handle_falls_back_to_parse_for_legacy_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
-    assert recover_triple("vergil-user.acme.widgets") == ("vergil-user", "acme", "widgets")
+    assert recover_handle("vergil-user.acme.widgets") == ("vergil-user", "acme", "widgets", None)
 
 
-def test_recover_triple_falls_back_to_parse_for_base_box(
+def test_recover_handle_falls_back_to_parse_for_base_box(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.read_instance_meta", lambda inst: None)
-    assert recover_triple("vergil-user") == ("vergil-user", None, None)
+    assert recover_handle("vergil-user") == ("vergil-user", None, None, None)
+
+
+def test_recover_handle_roundtrips_named_instance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin.vrg_vm import recover_handle
+    from vergil_tooling.lib.lima import write_instance_meta
+
+    inst = "vergil-user.lmf.mq.cloud-x86"
+    write_instance_meta(inst, "vergil-user", "lmf", "mq", "cloud-x86")
+    assert recover_handle(inst) == ("vergil-user", "lmf", "mq", "cloud-x86")
+
+
+def test_recover_handle_default_instance_name_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin.vrg_vm import recover_handle
+    from vergil_tooling.lib.lima import write_instance_meta
+
+    inst = "vergil-user.lmf.mq"
+    write_instance_meta(inst, "vergil-user", "lmf", "mq")
+    assert recover_handle(inst) == ("vergil-user", "lmf", "mq", None)
+
+
+def test_recover_handle_parse_fallback_no_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin.vrg_vm import recover_handle
+
+    assert recover_handle("vergil-user.lmf.mq") == ("vergil-user", "lmf", "mq", None)
 
 
 def _stub_target(
@@ -214,7 +249,7 @@ def test_create_from_target_writes_sidecar_for_dedicated(
         instance="vergil-user.acme.widgets",
     )
     _create_from_target(target, tmp_path / "t.yaml")
-    assert calls == [("vergil-user.acme.widgets", "vergil-user", "acme", "widgets")]
+    assert calls == [("vergil-user.acme.widgets", "vergil-user", "acme", "widgets", None)]
 
 
 def test_create_from_target_skips_sidecar_for_base(

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4686,6 +4686,34 @@ class TestVolumesCommand:
         assert "READY" in out
         live.assert_called_once_with("vergil-lmf-cloud-data", "us-central1-a", "gcp")
 
+    def test_volumes_shows_instance_column(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        from vergil_tooling.bin import vrg_vm
+
+        monkeypatch.setattr(
+            vrg_vm,
+            "_volume_rows",
+            lambda: [
+                {
+                    "identity": "vergil-user",
+                    "scope": "lmf/mq",
+                    "instance": "cloud-x86",
+                    "name": "vrg-abc123",
+                    "size": "300GiB",
+                    "zone": "us-central1-b",
+                    "region": "us-central1",
+                    "provider": "gcp",
+                }
+            ],
+        )
+        args = vrg_vm.argparse.Namespace(live=False)
+        assert vrg_vm._cmd_volumes(args) == 0
+        out = capsys.readouterr().out
+        assert "INSTANCE" in out
+        assert "cloud-x86" in out
+
 
 # ---------------------------------------------------------------------------
 # Task 7 — _recorded_state_for_handle / RecordedState

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -697,15 +697,18 @@ class TestRestart:
 
 class TestDestroy:
     @patch("vergil_tooling.bin.vrg_vm.delete_vm")
-    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Running")
-    def test_destroy(self, _status: MagicMock, mock_delete: MagicMock, config_file: Path) -> None:
-        result = main(["destroy", "--config", str(config_file)])
+    @patch(
+        "vergil_tooling.bin.vrg_vm.list_vms",
+        return_value=[{"name": "vergil-agent", "status": "Running"}],
+    )
+    def test_destroy(self, _list: MagicMock, mock_delete: MagicMock, config_file: Path) -> None:
+        result = main(["destroy", "--yes", "--config", str(config_file)])
         assert result == 0
         mock_delete.assert_called_once_with("vergil-agent")
 
-    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="")
-    def test_destroy_nonexistent(self, _status: MagicMock, config_file: Path) -> None:
-        result = main(["destroy", "--config", str(config_file)])
+    @patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[])
+    def test_destroy_nonexistent(self, _list: MagicMock, config_file: Path) -> None:
+        result = main(["destroy", "--yes", "--config", str(config_file)])
         assert result == 1
 
 
@@ -2941,13 +2944,19 @@ class TestDedicatedGateThroughCommands:
 
 class TestLifecyclePositional:
     @patch("vergil_tooling.bin.vrg_vm.delete_vm")
-    @patch("vergil_tooling.bin.vrg_vm.vm_status", return_value="Stopped")
+    @patch(
+        "vergil_tooling.bin.vrg_vm._recorded_state_for_handle",
+        return_value=None,  # will be set in test
+    )
     def test_destroy_targets_dedicated_instance(
-        self, _status: MagicMock, mock_delete: MagicMock, tmp_path: Path
+        self, mock_rs: MagicMock, mock_delete: MagicMock, tmp_path: Path
     ) -> None:
+        from vergil_tooling.bin.vrg_vm import RecordedState
+
         # No repo/spec needed: an orphan (repo dropped [vm]) is still reachable by name.
+        mock_rs.return_value = RecordedState(lima_instance="vergil-user.lmf.mq", tofu_dirs=[])
         cfg = _identities(tmp_path, tmp_path / "projects")
-        assert main(["destroy", "lmf/mq", "--config", str(cfg)]) == 0
+        assert main(["destroy", "--yes", "lmf/mq", "--config", str(cfg)]) == 0
         mock_delete.assert_called_once_with("vergil-user.lmf.mq")
 
     @patch("vergil_tooling.bin.vrg_vm.stop_vm")
@@ -3715,12 +3724,22 @@ class TestCloudDestroy:
     def test_cloud_destroy_calls_destroy_vm(
         self, _cloud_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        with _CloudPatches(tmp_path / "state") as m:
-            result = main(["destroy", "lmf/cloud", "--config", str(_cloud_repo)])
+        from vergil_tooling.bin.vrg_vm import RecordedState
+
+        state_dir = tmp_path / "state" / "gcp"
+        rs = RecordedState(lima_instance=None, tofu_dirs=[("gcp", state_dir)])
+        with (
+            _CloudPatches(tmp_path / "state") as m,
+            patch(
+                "vergil_tooling.bin.vrg_vm._recorded_state_for_handle",
+                return_value=rs,
+            ),
+        ):
+            result = main(["destroy", "--yes", "lmf/cloud", "--config", str(_cloud_repo)])
         assert result == 0
-        m["destroy_vm"].assert_called_once()
+        m["destroy_vm"].assert_called_once_with(ANY, state_dir)
         m["destroy_volume"].assert_not_called()
-        assert "destroyed" in capsys.readouterr().out
+        assert "Destroyed" in capsys.readouterr().out
 
 
 class TestCloudRebuild:
@@ -4431,3 +4450,146 @@ def test_recorded_state_dir_without_tfstate_excluded(
 
     rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
     assert rs.tofu_dirs == []
+
+
+# ---------------------------------------------------------------------------
+# Task 8 --- _cmd_destroy / confirmation contract
+# ---------------------------------------------------------------------------
+
+
+class _FakeIdentity:
+    vm_instance = "vergil-user"
+
+
+class _FakeConfig:
+    pass
+
+
+def _destroy_args(
+    workspace: str | None = None,
+    name: str | None = None,
+    yes: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="destroy",
+        workspace=workspace,
+        name=name,
+        yes=yes,
+        tag="",
+        identity="vergil-user",
+        config=None,
+    )
+
+
+def test_destroy_refuses_non_interactive_without_yes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    rs = vrg_vm.RecordedState(lima_instance="vergil-user.lmf.mq.cloud-x86", tofu_dirs=[])
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=False)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 1
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_destroy_yes_tears_down_lima_and_all_providers(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    rs = vrg_vm.RecordedState(
+        lima_instance="vergil-user.lmf.mq.cloud-x86",
+        tofu_dirs=[("gcp", Path("/x/gcp")), ("azure", Path("/x/azure"))],
+    )
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    deleted: list[str] = []
+    destroyed: list[Path] = []
+    monkeypatch.setattr(vrg_vm, "delete_vm", lambda i: deleted.append(i))
+    monkeypatch.setattr(vrg_vm.vm_cloud, "fetch_modules", lambda tag: Path("/m/modules"))
+    monkeypatch.setattr(vrg_vm.vm_cloud, "destroy_vm", lambda root, d: destroyed.append(d))
+    monkeypatch.setattr(vrg_vm.shutil, "rmtree", lambda *a, **k: None)
+    monkeypatch.setattr(vrg_vm, "resolve_vm_tag", lambda c, i: "v1")
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=True)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 0
+    assert deleted == ["vergil-user.lmf.mq.cloud-x86"]
+    assert destroyed == [Path("/x/gcp"), Path("/x/azure")]
+
+
+def test_destroy_nothing_recorded_returns_one(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm,
+        "_recorded_state_for_handle",
+        lambda *a: vrg_vm.RecordedState(lima_instance=None, tofu_dirs=[]),
+    )
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=True)
+    assert vrg_vm._cmd_destroy(args) == 1
+    assert "no recorded" in capsys.readouterr().err.lower()
+
+
+def test_destroy_interactive_y_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    rs = vrg_vm.RecordedState(lima_instance="vergil-user.lmf.mq.cloud-x86", tofu_dirs=[])
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    deleted: list[str] = []
+    monkeypatch.setattr(vrg_vm, "delete_vm", lambda i: deleted.append(i))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=False)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 0
+    assert deleted == ["vergil-user.lmf.mq.cloud-x86"]
+
+
+def test_destroy_interactive_n_aborts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    rs = vrg_vm.RecordedState(lima_instance="vergil-user.lmf.mq.cloud-x86", tofu_dirs=[])
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=False)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 1
+    assert "aborted" in capsys.readouterr().err.lower()

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import subprocess
+import tempfile
 import textwrap
 import types
 from pathlib import Path
@@ -4313,3 +4314,118 @@ class TestVolumesCommand:
         assert "LIVE" in out
         assert "READY" in out
         live.assert_called_once_with("vergil-lmf-cloud-data", "us-central1-a", "gcp")
+
+
+# ---------------------------------------------------------------------------
+# Task 7 — _recorded_state_for_handle / RecordedState
+# ---------------------------------------------------------------------------
+#
+# instance_name() computes a Lima socket-path budget from the home directory.
+# pytest's tmp_path is typically ≥50 chars, leaving <14 chars of budget — not
+# enough for "vergil-user.lmf.mq.cloud-x86" (30 chars).  We therefore use a
+# short home path created via tempfile.mkdtemp() (~13 chars), which leaves a
+# budget of ≥57 chars — enough for the full unmangled instance name.
+
+
+def _make_short_home(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a short temp directory suitable as a Lima-budget home.
+
+    Uses tempfile.mkdtemp() so the path is unique (~13 chars) — short enough
+    for Lima's socket-path budget, unlike pytest's tmp_path which is ≥50 chars.
+    Cleanup is left to the OS; the directory lives in the system temp area.
+    """
+    short = Path(tempfile.mkdtemp())
+    monkeypatch.setattr("pathlib.Path.home", lambda: short)
+    return short
+
+
+def test_recorded_state_enumerates_lima_and_tofu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = _make_short_home(monkeypatch)
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
+    from vergil_tooling.lib.vm_spec import state_slug
+
+    slug = state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+    for provider in ("gcp", "azure"):
+        d = home / ".config" / "vergil" / "tofu" / slug / provider
+        d.mkdir(parents=True)
+        (d / "vm.tfstate").write_text("{}")
+    # Lima instance presence is mocked via list_vms
+    monkeypatch.setattr(
+        "vergil_tooling.bin.vrg_vm.list_vms",
+        lambda: [{"name": "vergil-user.lmf.mq.cloud-x86", "status": "Running"}],
+    )
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert rs.lima_instance == "vergil-user.lmf.mq.cloud-x86"
+    assert {p for p, _ in rs.tofu_dirs} == {"gcp", "azure"}
+
+
+def test_recorded_state_no_lima_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _make_short_home(monkeypatch)
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert rs.lima_instance is None
+    assert rs.tofu_dirs == []
+
+
+def test_recorded_state_volume_tfstate_included(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """volume.tfstate alone (no vm.tfstate) is still detected as recorded state."""
+    home = _make_short_home(monkeypatch)
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
+    from vergil_tooling.lib.vm_spec import state_slug
+
+    slug = state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+    d = home / ".config" / "vergil" / "tofu" / slug / "gcp"
+    d.mkdir(parents=True)
+    (d / "volume.tfstate").write_text("{}")
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert rs.lima_instance is None
+    assert {p for p, _ in rs.tofu_dirs} == {"gcp"}
+
+
+def test_recorded_state_both_tfstate_files_included(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dir with both volume.tfstate and vm.tfstate appears exactly once."""
+    home = _make_short_home(monkeypatch)
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
+    from vergil_tooling.lib.vm_spec import state_slug
+
+    slug = state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+    d = home / ".config" / "vergil" / "tofu" / slug / "gcp"
+    d.mkdir(parents=True)
+    (d / "volume.tfstate").write_text("{}")
+    (d / "vm.tfstate").write_text("{}")
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert len(rs.tofu_dirs) == 1
+    assert rs.tofu_dirs[0][0] == "gcp"
+
+
+def test_recorded_state_dir_without_tfstate_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider dir with no .tfstate files is not included in tofu_dirs."""
+    home = _make_short_home(monkeypatch)
+    monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
+    from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
+    from vergil_tooling.lib.vm_spec import state_slug
+
+    slug = state_slug("vergil-user", "lmf", "mq", "cloud-x86")
+    d = home / ".config" / "vergil" / "tofu" / slug / "gcp"
+    d.mkdir(parents=True)
+    (d / "other.json").write_text("{}")  # no tfstate file
+
+    rs = _recorded_state_for_handle("vergil-user", "lmf", "mq", "cloud-x86")
+    assert rs.tofu_dirs == []

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4375,6 +4375,46 @@ def test_classify_off_platform_no_vergil_toml_orphaned(tmp_path: Path) -> None:
     assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
 
 
+def test_classify_off_platform_config_error_returns_ok_with_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A malformed vergil.toml triggers a stderr WARNING and conservatively returns 'ok'.
+
+    Mirrors _classify_instance: a broken config must not be treated as orphaned
+    (which could mislead an operator into destroying a live cloud box). The box is
+    listed as 'ok' (unverified) until the config is fixed.
+    """
+    from vergil_tooling.bin import vrg_vm
+
+    projects = tmp_path / "projects"
+    repo_dir = projects / "lmf" / "mq"
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    (repo_dir / "vergil.toml").write_text("[invalid toml")  # malformed -> ConfigError on read
+
+    ident = Identity(vm_instance="vergil-user", projects_dir=str(projects))
+    config = IdentityConfig(identities={"vergil-user": ident}, default_identity="vergil-user")
+
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org="lmf",
+        repo="mq",
+        instance="cloud-x86",
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+
+    result = vrg_vm._classify_off_platform(vm, config)
+    assert result == "ok"
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "vergil-user--lmf--mq--cloud-x86" in captured.err
+    assert "unverified" in captured.err
+
+
 class TestCloudUnderProvision:
     def _cloud_repo_instance(self, tmp_path: Path, instance: str, *, cpus: int) -> Path:
         projects = tmp_path / "projects"

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4593,3 +4593,169 @@ def test_destroy_interactive_n_aborts(
     rc = vrg_vm._cmd_destroy(args)
     assert rc == 1
     assert "aborted" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Task 9 — stop/start/restart resolve by handle, Lima-only
+# ---------------------------------------------------------------------------
+
+
+def _stop_args(
+    workspace: str | None = None,
+    name: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="stop",
+        workspace=workspace,
+        name=name,
+        tag="",
+        identity="vergil-user",
+        config=None,
+    )
+
+
+def _start_args(
+    workspace: str | None = None,
+    name: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="start",
+        workspace=workspace,
+        name=name,
+        tag="",
+        timeout="30m",
+        allow_stale_vm=False,
+        identity="vergil-user",
+        config=None,
+    )
+
+
+def _restart_args(
+    workspace: str | None = None,
+    name: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="restart",
+        workspace=workspace,
+        name=name,
+        tag="",
+        identity="vergil-user",
+        config=None,
+    )
+
+
+class _FakeTarget:
+    """Minimal stand-in for Target with a configurable off_platform flag."""
+
+    def __init__(self, *, off_platform: bool = False) -> None:
+        self.spec = types.SimpleNamespace(off_platform=off_platform)
+        self.identity_name = "vergil-user"
+
+
+def test_stop_named_instance_targets_handle_lima(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stop --name routes stop_vm to the 4-segment Lima instance name."""
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(vrg_vm, "_reject_if_off_platform", lambda args: False)
+    monkeypatch.setattr(
+        vrg_vm,
+        "_resolve_instance",
+        lambda args: (
+            "vergil-user",
+            _FakeIdentity(),
+            _FakeConfig(),
+            "vergil-user.lmf.mq.cloud-x86",
+        ),
+    )
+    stopped: list[str] = []
+    monkeypatch.setattr(vrg_vm, "stop_vm", lambda i: stopped.append(i))
+    args = _stop_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_stop(args) == 0
+    assert stopped == ["vergil-user.lmf.mq.cloud-x86"]
+
+
+def test_stop_named_off_platform_still_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """stop --name rejects off-platform targets before touching the VM."""
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm,
+        "_resolve_target",
+        lambda args, **k: _FakeTarget(off_platform=True),
+    )
+    stopped: list[str] = []
+    monkeypatch.setattr(vrg_vm, "stop_vm", lambda i: stopped.append(i))
+    args = _stop_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_stop(args) == 1
+    assert stopped == []
+    assert "ephemeral" in capsys.readouterr().err.lower()
+
+
+def test_start_named_off_platform_still_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """start --name rejects off-platform targets before touching the VM."""
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm,
+        "_resolve_target",
+        lambda args, **k: _FakeTarget(off_platform=True),
+    )
+    args = _start_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_start(args) == 1
+    assert "ephemeral" in capsys.readouterr().err.lower()
+
+
+def test_restart_named_instance_targets_handle_lima(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """restart --name routes stop_vm/start_vm to the 4-segment Lima instance name."""
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(vrg_vm, "_reject_if_off_platform", lambda args: False)
+    monkeypatch.setattr(
+        vrg_vm,
+        "_resolve_instance",
+        lambda args: (
+            "vergil-user",
+            _FakeIdentity(),
+            _FakeConfig(),
+            "vergil-user.lmf.mq.cloud-x86",
+        ),
+    )
+    stopped: list[str] = []
+    started: list[str] = []
+    monkeypatch.setattr(vrg_vm, "stop_vm", lambda i: stopped.append(i))
+    monkeypatch.setattr(vrg_vm, "start_vm", lambda i: started.append(i))
+    monkeypatch.setattr(vrg_vm, "inject_credentials", lambda transport, identity: None)
+    args = _restart_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_restart(args) == 0
+    assert stopped == ["vergil-user.lmf.mq.cloud-x86"]
+    assert started == ["vergil-user.lmf.mq.cloud-x86"]
+
+
+def test_restart_named_off_platform_still_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """restart --name rejects off-platform targets before touching the VM."""
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm,
+        "_resolve_target",
+        lambda args, **k: _FakeTarget(off_platform=True),
+    )
+    stopped: list[str] = []
+    monkeypatch.setattr(vrg_vm, "stop_vm", lambda i: stopped.append(i))
+    args = _restart_args(workspace="lmf/mq", name="cloud-x86")
+    assert vrg_vm._cmd_restart(args) == 1
+    assert stopped == []
+    assert "ephemeral" in capsys.readouterr().err.lower()

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -150,9 +150,7 @@ def config_file_top_model(tmp_path: Path) -> Path:
 def test_recover_handle_prefers_sidecar(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "vergil_tooling.bin.vrg_vm.read_instance_meta",
-        lambda inst: {
-            "schema": 1, "identity": "vergil-user", "org": "o", "repo": "r", "name": ""
-        },
+        lambda inst: {"schema": 1, "identity": "vergil-user", "org": "o", "repo": "r", "name": ""},
     )
     assert recover_handle("mangled-abc123") == ("vergil-user", "o", "r", None)
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -229,6 +229,7 @@ def _stub_target(
             repo=repo,
             instance=instance,
             fingerprint="fp",
+            instance_name_arg=None,
         ),
     )
 
@@ -236,7 +237,7 @@ def _stub_target(
 def test_create_from_target_writes_sidecar_for_dedicated(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str, ...]] = []
+    calls: list[tuple[object, ...]] = []
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.create_vm", lambda *a, **k: None)
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.write_instance_meta", lambda *a: calls.append(a))
     target = _stub_target(

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4996,6 +4996,61 @@ def test_destroy_interactive_n_aborts(
     assert "aborted" in capsys.readouterr().err.lower()
 
 
+def test_destroy_rejects_malformed_instance_name(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """destroy --name with a grammar-violating name (e.g. 'Bad_Name') must reject loudly
+    before touching recorded state — not silently fall through to 'no recorded state'."""
+    from vergil_tooling.bin import vrg_vm
+
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    # _recorded_state_for_handle must NOT be called — validation fires before it.
+    called: list[object] = []
+
+    def _fake_recorded_state(*a: object) -> vrg_vm.RecordedState:
+        called.append(a)
+        return vrg_vm.RecordedState(lima_instance=None, tofu_dirs=[])
+
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", _fake_recorded_state)
+    args = _destroy_args(workspace="lmf/mq", name="Bad_Name", yes=True)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Bad_Name" in err
+    assert called == [], "recorded-state lookup must not run after a malformed name"
+
+
+def test_destroy_single_box_uses_singular_wording(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When exactly one box will be destroyed the listing header says 'box', not 'boxes',
+    and the non-interactive refusal says '1 recorded box'."""
+    from vergil_tooling.bin import vrg_vm
+
+    rs = vrg_vm.RecordedState(lima_instance="vergil-user.lmf.mq.cloud-x86", tofu_dirs=[])
+    monkeypatch.setattr(vrg_vm, "_recorded_state_for_handle", lambda *a: rs)
+    monkeypatch.setattr(
+        vrg_vm, "_resolve", lambda args: ("vergil-user", _FakeIdentity(), _FakeConfig())
+    )
+    monkeypatch.setattr(vrg_vm, "_read_repo_vm", lambda *a: None)
+    monkeypatch.setattr(vrg_vm, "resolve_borrow", lambda *a: None)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    args = _destroy_args(workspace="lmf/mq", name="cloud-x86", yes=False)
+
+    rc = vrg_vm._cmd_destroy(args)
+    assert rc == 1
+    out = capsys.readouterr()
+    assert "the following recorded box:" in out.out
+    assert "1 recorded box" in out.err
+    assert "boxes" not in out.out
+    assert "boxes" not in out.err
+
+
 # ---------------------------------------------------------------------------
 # Task 9 — stop/start/restart resolve by handle, Lima-only
 # ---------------------------------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3875,14 +3875,40 @@ class TestCloudList:
         assert "BACKEND" in buf.getvalue()
         assert "local" in buf.getvalue()
 
-    def test_cloud_rows_enumerated_with_degraded_status(
+    def test_cloud_rows_enumerated_with_no_vm_status(
         self, config_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Build a fake tofu state tree: ~/.config/vergil/tofu/<key>/<provider>/volume.tfstate
+        # volume.tfstate present, vm.tfstate absent -> no-vm row (volume orphaned from VM).
         fake_home = tmp_path / "home"
         tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
         tofu.mkdir(parents=True)
         (tofu / "volume.tfstate").write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with (
+            patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[]),
+            redirect_stdout(buf),
+        ):
+            result = main(["list", "--config", str(config_file)])
+        assert result == 0
+        out = buf.getvalue()
+        assert "vergil-lmf-cloud" in out
+        assert "gcp" in out
+        assert "no-vm" in out
+
+    def test_cloud_rows_enumerated_with_degraded_status(
+        self, config_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # volume.tfstate + vm.tfstate present, no zone -> degraded placeholder.
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        (tofu / "volume.tfstate").write_text("{}")
+        (tofu / "vm.tfstate").write_text("{}")
         monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
 
         import io
@@ -4062,6 +4088,46 @@ class TestCloudList:
         transport.run.assert_called_once_with("vrg-vm-resolve-session", "--list-json")
         # Only the active row is retained, keyed by session id.
         assert set(rows) == {"c1"}
+
+
+def test_list_shows_instance_column_and_no_vm_row(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin import vrg_vm
+
+    # Off-platform: a volume exists, VM is gone -> no-vm row with size.
+    monkeypatch.setattr(
+        vrg_vm,
+        "_off_platform_vms",
+        lambda: [
+            vrg_vm.OffPlatformVm(
+                name="vergil-user--lmf--mq--native-ha",
+                provider="gcp",
+                state_dir=tmp_path,
+                identity="vergil-user",
+                org="lmf",
+                repo="mq",
+                instance="native-ha",
+                status="",
+                volume_size="200GiB",
+                vm_present=False,
+            )
+        ],
+    )
+    monkeypatch.setattr(vrg_vm, "list_vms", lambda: [])
+    monkeypatch.setattr(
+        vrg_vm,
+        "load_config",
+        lambda p: IdentityConfig(identities={}, default_identity=None),
+    )
+    args = argparse.Namespace(config=None, sessions=False)
+    assert vrg_vm._cmd_list(args) == 0
+    out = capsys.readouterr().out
+    assert "INSTANCE" in out
+    assert "native-ha" in out
+    assert "no-vm" in out
+    assert "200GiB" in out
 
 
 class TestCloudUnderProvision:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4570,6 +4570,27 @@ class TestVolumeRows:
         assert row["zone"] == "us-central1-a"
         assert row["region"] == "us-central1"
         assert row["provider"] == "gcp"
+        assert row["instance"] == "—"  # default labels have no vergil-instance
+
+    def test_builds_row_with_instance_label(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _volume_rows
+
+        home = tmp_path / "home"
+        _write_volume_state(
+            home,
+            "vergil-lmf-cloud",
+            labels={
+                "vergil-identity": "vergil",
+                "vergil-org": "lmf",
+                "vergil-repo": "cloud",
+                "vergil-instance": "cloud-x86",
+            },
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        (row,) = _volume_rows()
+        assert row["instance"] == "cloud-x86"
 
     def test_placeholder_row_for_never_applied_state(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -4584,6 +4605,7 @@ class TestVolumeRows:
         assert row["identity"] == "—"
         assert row["name"] == "—"
         assert row["size"] == "—"
+        assert row["instance"] == "—"
 
     def test_falls_back_to_state_key_when_labels_missing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3957,7 +3957,8 @@ class TestCloudList:
         from vergil_tooling.bin.vrg_vm import _cloud_list_rows
 
         monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path / "empty"))
-        assert _cloud_list_rows() == []
+        config = IdentityConfig(identities={}, default_identity=None)
+        assert _cloud_list_rows(config) == []
 
     def test_off_platform_vms_recovers_identity_from_labels(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -4128,6 +4129,250 @@ def test_list_shows_instance_column_and_no_vm_row(
     assert "native-ha" in out
     assert "no-vm" in out
     assert "200GiB" in out
+
+
+# ---------------------------------------------------------------------------
+# Helpers for _classify_off_platform tests
+# ---------------------------------------------------------------------------
+
+_REPO_TOML_HEAD = """\
+[project]
+repository-type = "tooling"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["3.14"]
+"""
+
+_GCP_NAMED_INSTANCE_VM = """
+[vm]
+backend = "off-platform"
+provider = "gcp"
+region = "us-central1"
+instance = "n2-standard-8"
+volume = "300GiB"
+
+[vm.vergil-user.instances.cloud-x86]
+provider = "gcp"
+region = "us-central1"
+instance = "n2-standard-8"
+volume = "300GiB"
+"""
+
+_AZURE_NAMED_INSTANCE_VM = """
+[vm]
+backend = "off-platform"
+provider = "azure"
+region = "eastus"
+instance = "Standard_D8s_v3"
+volume = "300GiB"
+
+[vm.vergil-user.instances.cloud-x86]
+provider = "azure"
+region = "eastus"
+instance = "Standard_D8s_v3"
+volume = "300GiB"
+"""
+
+_NO_VM_TOML = """
+[project]
+repository-type = "tooling"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["3.14"]
+"""
+
+
+def _make_classify_repo(projects: Path, org: str, repo: str, vm_section: str) -> None:
+    repo_dir = projects / org / repo
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    (repo_dir / "vergil.toml").write_text(_REPO_TOML_HEAD + vm_section)
+
+
+def _config_with_gcp_instance(
+    identity_name: str, org: str, repo: str, inst_name: str, tmp_path: Path
+) -> IdentityConfig:
+    """IdentityConfig whose identity declares a GCP named instance."""
+    projects = tmp_path / "projects"
+    _make_classify_repo(projects, org, repo, _GCP_NAMED_INSTANCE_VM)
+    ident = Identity(
+        vm_instance=identity_name,
+        projects_dir=str(projects),
+    )
+    return IdentityConfig(identities={identity_name: ident}, default_identity=identity_name)
+
+
+def _config_with_azure_instance(
+    identity_name: str, org: str, repo: str, inst_name: str, tmp_path: Path
+) -> IdentityConfig:
+    """IdentityConfig whose identity declares an Azure named instance."""
+    projects = tmp_path / "projects"
+    _make_classify_repo(projects, org, repo, _AZURE_NAMED_INSTANCE_VM)
+    ident = Identity(
+        vm_instance=identity_name,
+        projects_dir=str(projects),
+    )
+    return IdentityConfig(identities={identity_name: ident}, default_identity=identity_name)
+
+
+def _config_no_repo_vm(identity_name: str, org: str, repo: str, tmp_path: Path) -> IdentityConfig:
+    """IdentityConfig whose identity has a repo with no [vm] stanza."""
+    projects = tmp_path / "projects"
+    _make_classify_repo(projects, org, repo, "")
+    ident = Identity(
+        vm_instance=identity_name,
+        projects_dir=str(projects),
+    )
+    return IdentityConfig(identities={identity_name: ident}, default_identity=identity_name)
+
+
+def _config_no_vergil_toml(
+    identity_name: str, org: str, repo: str, tmp_path: Path
+) -> IdentityConfig:
+    """IdentityConfig whose identity has no vergil.toml in the repo dir."""
+    projects = tmp_path / "projects"
+    # Create the repo dir but no vergil.toml
+    repo_dir = projects / org / repo
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    ident = Identity(
+        vm_instance=identity_name,
+        projects_dir=str(projects),
+    )
+    return IdentityConfig(identities={identity_name: ident}, default_identity=identity_name)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _classify_off_platform
+# ---------------------------------------------------------------------------
+
+
+def test_classify_off_platform_orphaned_when_provider_switched(tmp_path: Path) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    # The repo's current profile composes off-platform/azure, but the recorded box is gcp.
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org="lmf",
+        repo="mq",
+        instance="cloud-x86",
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+    config = _config_with_azure_instance("vergil-user", "lmf", "mq", "cloud-x86", tmp_path)
+    assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
+
+
+def test_classify_off_platform_orphaned_when_stanza_dropped(tmp_path: Path) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org="lmf",
+        repo="mq",
+        instance="cloud-x86",
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+    # vergil.toml present but no [vm] stanza -> SpecError -> orphaned
+    config = _config_no_repo_vm("vergil-user", "lmf", "mq", tmp_path)
+    assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
+
+
+def test_classify_off_platform_ok_when_matches(tmp_path: Path) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org="lmf",
+        repo="mq",
+        instance="cloud-x86",
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+    config = _config_with_gcp_instance("vergil-user", "lmf", "mq", "cloud-x86", tmp_path)
+    assert vrg_vm._classify_off_platform(vm, config) == "ok"
+
+
+def test_classify_off_platform_base_slug_returns_ok(tmp_path: Path) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    # A base slug (no org/repo) carries no per-repo spec -> always ok.
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org=None,
+        repo=None,
+        instance=None,
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+    config = IdentityConfig(identities={}, default_identity=None)
+    assert vrg_vm._classify_off_platform(vm, config) == "ok"
+
+
+def test_classify_off_platform_identity_not_in_config_orphaned(tmp_path: Path) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    # The slug decodes a valid identity name, but it's not in this config.
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org="lmf",
+        repo="mq",
+        instance="cloud-x86",
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+    config = IdentityConfig(identities={}, default_identity=None)
+    assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
+
+
+def test_classify_off_platform_no_vergil_toml_orphaned(tmp_path: Path) -> None:
+    from vergil_tooling.bin import vrg_vm
+
+    vm = vrg_vm.OffPlatformVm(
+        name="vergil-user--lmf--mq--cloud-x86",
+        provider="gcp",
+        state_dir=tmp_path,
+        identity="vergil-user",
+        org="lmf",
+        repo="mq",
+        instance="cloud-x86",
+        status="Running",
+        volume_size=None,
+        vm_present=True,
+    )
+    config = _config_no_vergil_toml("vergil-user", "lmf", "mq", tmp_path)
+    assert vrg_vm._classify_off_platform(vm, config) == "orphaned"
 
 
 class TestCloudUnderProvision:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import textwrap
@@ -4327,22 +4328,20 @@ class TestVolumesCommand:
 # budget of ≥57 chars — enough for the full unmangled instance name.
 
 
-def _make_short_home(monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Create a short temp directory suitable as a Lima-budget home.
-
-    Uses tempfile.mkdtemp() so the path is unique (~13 chars) — short enough
-    for Lima's socket-path budget, unlike pytest's tmp_path which is ≥50 chars.
-    Cleanup is left to the OS; the directory lives in the system temp area.
-    """
+@pytest.fixture
+def short_home(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Home dir short enough to fit a Lima socket-path budget; auto-removed after the test."""
     short = Path(tempfile.mkdtemp())
     monkeypatch.setattr("pathlib.Path.home", lambda: short)
-    return short
+    yield short
+    shutil.rmtree(short, ignore_errors=True)
 
 
 def test_recorded_state_enumerates_lima_and_tofu(
     monkeypatch: pytest.MonkeyPatch,
+    short_home: Path,
 ) -> None:
-    home = _make_short_home(monkeypatch)
+    home = short_home
     from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
     from vergil_tooling.lib.vm_spec import state_slug
 
@@ -4364,8 +4363,8 @@ def test_recorded_state_enumerates_lima_and_tofu(
 
 def test_recorded_state_no_lima_when_absent(
     monkeypatch: pytest.MonkeyPatch,
+    short_home: Path,
 ) -> None:
-    _make_short_home(monkeypatch)
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
     from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
 
@@ -4376,9 +4375,10 @@ def test_recorded_state_no_lima_when_absent(
 
 def test_recorded_state_volume_tfstate_included(
     monkeypatch: pytest.MonkeyPatch,
+    short_home: Path,
 ) -> None:
     """volume.tfstate alone (no vm.tfstate) is still detected as recorded state."""
-    home = _make_short_home(monkeypatch)
+    home = short_home
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
     from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
     from vergil_tooling.lib.vm_spec import state_slug
@@ -4395,9 +4395,10 @@ def test_recorded_state_volume_tfstate_included(
 
 def test_recorded_state_both_tfstate_files_included(
     monkeypatch: pytest.MonkeyPatch,
+    short_home: Path,
 ) -> None:
     """A dir with both volume.tfstate and vm.tfstate appears exactly once."""
-    home = _make_short_home(monkeypatch)
+    home = short_home
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
     from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
     from vergil_tooling.lib.vm_spec import state_slug
@@ -4415,9 +4416,10 @@ def test_recorded_state_both_tfstate_files_included(
 
 def test_recorded_state_dir_without_tfstate_excluded(
     monkeypatch: pytest.MonkeyPatch,
+    short_home: Path,
 ) -> None:
     """A provider dir with no .tfstate files is not included in tofu_dirs."""
-    home = _make_short_home(monkeypatch)
+    home = short_home
     monkeypatch.setattr("vergil_tooling.bin.vrg_vm.list_vms", lambda: [])
     from vergil_tooling.bin.vrg_vm import _recorded_state_for_handle
     from vergil_tooling.lib.vm_spec import state_slug

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import argparse
 import datetime
 import json
 import os
+import textwrap
 from typing import TYPE_CHECKING
 
 import pytest
@@ -706,3 +708,157 @@ def test_resolve_resumes_session_under_current_slug(
     monkeypatch.setattr(os, "getcwd", lambda: "/work/tool")
     assert _resolve("id", "tool") == 0
     assert capture_exec == [["claude", "--resume", "good", "-n", "id:01:tool"]]
+
+
+# --- _resolve_target / _resolve_instance named-instance tests (issue #1831) ---
+
+_REPO_TOML_HEAD = """\
+[project]
+repository-type = "tooling"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["3.14"]
+"""
+
+_NAMED_INSTANCE_OFF_PLATFORM_VM = """
+[vm]
+backend = "off-platform"
+provider = "gcp"
+region = "us-central1"
+instance = "n2-standard-8"
+volume = "300GiB"
+
+[vm.vergil-user.instances.cloud-x86]
+provider = "gcp"
+region = "us-central1"
+instance = "n2-standard-8"
+volume = "300GiB"
+"""
+
+_NAMED_INSTANCE_LOCAL_VM = """
+[vm]
+packages = ["qemu-system-x86"]
+
+[vm.vergil-user.instances.rdqm-rhel]
+"""
+
+
+def _make_args(
+    *,
+    workspace: str | None = None,
+    name: str | None = None,
+    identity: str | None = None,
+    command: str = "create",
+    config: Path | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        config=config,
+        identity=identity,
+        workspace=workspace,
+        name=name,
+        command=command,
+    )
+
+
+def _make_identity_config(tmp_path: Path, projects: Path) -> Path:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent(f"""\
+        default_identity = "vergil-user"
+        vergil = "v2.0"
+
+        [identities.vergil-user]
+        vm_instance = "vergil-user"
+        projects_dir = "{projects}"
+    """)
+    )
+    return p
+
+
+def _make_repo(projects: Path, org: str, repo: str, vm_section: str = "") -> None:
+    repo_dir = projects / org / repo
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "vergil.toml").write_text(_REPO_TOML_HEAD + vm_section)
+
+
+@pytest.fixture()
+def named_instance_config(tmp_path: Path) -> Path:
+    """Identity config with lmf/mq declaring an off-platform named instance 'cloud-x86'."""
+    projects = tmp_path / "projects"
+    _make_repo(projects, "lmf", "mq", _NAMED_INSTANCE_OFF_PLATFORM_VM)
+    return _make_identity_config(tmp_path, projects)
+
+
+@pytest.fixture()
+def named_instance_local_config(tmp_path: Path) -> Path:
+    """Identity config with lmf/mq declaring a local named instance 'rdqm-rhel'."""
+    projects = tmp_path / "projects"
+    _make_repo(projects, "lmf", "mq", _NAMED_INSTANCE_LOCAL_VM)
+    return _make_identity_config(tmp_path, projects)
+
+
+def test_resolve_target_named_instance(named_instance_config: Path) -> None:
+    from vergil_tooling.bin.vrg_vm import Target, _resolve_target
+    from vergil_tooling.lib.vm_cloud import OffPlatformBackend
+
+    args = _make_args(
+        workspace="lmf/mq", name="cloud-x86", identity="vergil-user", config=named_instance_config
+    )
+    target = _resolve_target(args)
+    assert isinstance(target, Target)
+    assert target.instance_name_arg == "cloud-x86"
+    assert target.instance == "vergil-user.lmf.mq.cloud-x86"
+    assert target.spec.off_platform
+    assert isinstance(target.backend, OffPlatformBackend)
+    assert target.backend.slug == "vergil-user--lmf--mq--cloud-x86"
+
+
+def test_destroy_volume_named_targets_instance_volume(named_instance_config: Path) -> None:
+    # destroy-volume --name must resolve the NAMED instance's volume state, not the
+    # default's — it is irreversible and billable.
+    from vergil_tooling.bin.vrg_vm import _resolve_target
+    from vergil_tooling.lib.vm_cloud import OffPlatformBackend
+
+    args = _make_args(
+        command="destroy-volume",
+        workspace="lmf/mq",
+        name="cloud-x86",
+        identity="vergil-user",
+        config=named_instance_config,
+    )
+    target = _resolve_target(args)
+    assert isinstance(target.backend, OffPlatformBackend)
+    assert target.backend.state_key == "vergil-user--lmf--mq--cloud-x86"
+
+
+def test_update_named_resolves_instance_lima_name(named_instance_local_config: Path) -> None:
+    # update (single) routes through _resolve_instance, which must honor --name.
+    from vergil_tooling.bin.vrg_vm import _resolve_instance
+
+    args = _make_args(
+        command="update",
+        workspace="lmf/mq",
+        name="rdqm-rhel",
+        identity="vergil-user",
+        config=named_instance_local_config,
+    )
+    _name, _identity, _config, instance = _resolve_instance(args)
+    assert instance == "vergil-user.lmf.mq.rdqm-rhel"
+
+
+def test_resolve_target_name_without_workspace_raises(named_instance_config: Path) -> None:
+    # --name without an org/repo workspace must raise SpecError.
+    from vergil_tooling.bin.vrg_vm import _resolve_target
+    from vergil_tooling.lib.vm_spec import SpecError
+
+    args = _make_args(
+        workspace=None, name="cloud-x86", identity="vergil-user", config=named_instance_config
+    )
+    with pytest.raises(SpecError, match="--name requires"):
+        _resolve_target(args)


### PR DESCRIPTION
# Pull Request

## Summary

- Adds named VM instances to vrg-vm: one (identity, org/repo) can now own several instances via a --name flag, each with its own composed profile, backend, recorded state, and persistent volume. An absent --name resolves the default instance exactly as today, so the change is fully backward compatible. The feature also dissolves the backend-switch destroy-orphan edge (vergil-vm #242 Problem 1) by making destroy reconcile all recorded state for a handle rather than the live profile. Tooling companion to the authoritative vergil-vm #242 design.

## Issue Linkage

- Ref #1831

## Notes

- Implemented across 12 TDD tasks (subagent-driven, per-task spec+quality review plus an opus whole-branch review). Validation: vrg-container-run -- vrg-validate fully green on HEAD e5d8a49b6 (3530 tests passed, 100% branch coverage; ruff check + ruff format, mypy + ty strict, audit all clean).

Design highlights and reconciliations vs the authoritative spec (see docs/specs/2026-06-23-vrg-vm-named-instances-tooling-design.md): the four-part handle (identity, org, repo, name) derives three deterministic names with their own delimiters -- the Lima instance name (dot-joined, reversed via the sidecar), the readable tofu state slug (dash-dash-joined), and a hashed cloud resource name vrg-<sha256(slug)[:12]> with identity carried in labels (adding vergil-instance). The spec's single dash-dash slug was not implementable as the Lima name (limactl rejects consecutive dashes), so existing per-target delimiters were kept and the fourth segment appended to each, reversing via the existing sidecar/label machinery. The tofu state path is keyed on the readable slug (decoupled from the hashed cloud name); greenfield, no migration.

Lifecycle: destroy now enumerates recorded state (the handle's Lima box plus every <slug>/<provider>/ tofu state dir) and tears down all of it, with a confirmation contract (prints the listing; prompts on a TTY; --yes proceeds; refuses non-interactively without --yes -- the no-silent-multi-box-teardown rule approved during pushback). stop/start/restart remain Lima-only. list gains an INSTANCE column and no-vm rows (a surviving volume with a destroyed VM shows its size), plus off-platform orphan classification in the SPEC column; volumes gains an INSTANCE column.

All 9 spec acceptance criteria verified met by the final review. Deferred (optional follow-up polish, none blocking): a few docstring/wording nits, test-organization tidy-ups, and a state_slug partial-None guard note -- captured in the SDD progress ledger.