### PR TITLE
feat(off-platform): fall back across nested-virt machine families on a reattach stockout (#1836)

### DIFF
--- a/docs/specs/2026-06-23-off-platform-instance-family-fallback-design.md
+++ b/docs/specs/2026-06-23-off-platform-instance-family-fallback-design.md
@@ -1,0 +1,188 @@
+# Off-platform: instance-family fallback on reattach
+
+- **Issue:** vergil-tooling#1836
+- **Status:** Design (approved)
+- **Related:** #1797 (explicit zone knob), #1804 (orphan-firewall rollback), #1813 (zone fallback on fresh create)
+
+## Problem
+
+An off-platform VM apply that **reattaches an existing data disk** is pinned to
+that disk's zone — a zonal `pd-ssd` can only attach to a VM in the same zone.
+When the pinned zone is out of capacity for the requested machine type, the apply
+fails with a transient capacity stockout:
+
+```
+Error waiting for instance to create: The zone '…' does not have enough
+resources available to fulfill the request.  (ZONE_RESOURCE_POOL_EXHAUSTED)
+```
+
+`apply_vm_with_zone_fallback` already recovers from this on the **fresh-volume
+create** path by sweeping zones (#1813). But on the **reattach** path it passes
+`fallback_zones=[]` on purpose — a zonal disk cannot move zones without losing
+its data — so a reattach has no recovery at all and hard-fails.
+
+In practice a *different machine family* in the **same** zone very often has
+capacity when the requested family does not (a stockout is specific to a
+`(zone, family)` pair). The tool never tries one. An operator whose data disk
+already exists is therefore stuck until the exact pinned `(zone, family)` combo
+frees up — which can be an open-ended wait.
+
+## Goal
+
+On a reattach capacity stockout, sweep a curated set of machine **families** in
+the **same pinned zone** before giving up. Preserve the data disk untouched.
+Do not introduce a spec-drift rebuild loop. Keep the change minimal and
+reattach-only for v1.
+
+## Non-goals (v1)
+
+- Changing the fresh-create path (it keeps the existing zone fallback, #1813).
+- Snapshot/restore-based zone migration of a disk that already holds data.
+- Regional persistent disks.
+- A runtime nested-virtualization guard (the curated static ladder is the
+  control; see "Alternatives considered").
+- Dynamically querying GCP for capacity or supported machine types.
+- `highmem` / other shapes beyond those actually in use.
+
+## Constraint that shapes everything: nested virtualization
+
+Nested KVM is the entire point of these VMs — `templates/provision/70-nested-virt.sh`
+**fails the provision loudly** if `/dev/kvm` never appears, and the GCP VM module
+sets `enable_nested_virtualization`. Therefore the fallback ladder may contain
+**only machine families that support GCP nested virtualization.** `e2` and the
+Tau families (`t2d`/`t2a`) do not, so a fallback onto them would produce a VM
+with no `/dev/kvm` and a failed provision — strictly worse than the stockout.
+
+## Design
+
+### 1. The ladder — one family list, size preserved
+
+The family and the size are independent axes; the fallback moves only along the
+**family** axis and carries the requested **size** unchanged. So a single
+ordered family list, not a per-shape table:
+
+```python
+# Ordered nested-virt-capable families, by preference. Size-independent —
+# a fallback swaps the family and keeps the requested shape untouched.
+# MUST match GCP's nested-virtualization supported-machine-types doc.
+NESTED_VIRT_FAMILIES = ["n2", "n2d", "c2", "c2d"]
+
+# Shapes verified to exist across the whole ladder and actually run off-platform.
+# Family-fallback engages only for these; adding a size later is one line.
+FALLBACK_SHAPES = {"standard-8", "standard-16"}
+```
+
+**Candidate derivation.** Split the requested instance into `(family, shape)`,
+e.g. `n2-standard-8 → ("n2", "standard-8")`. If `shape ∈ FALLBACK_SHAPES`, the
+candidate list is the requested family first, then the remaining
+`NESTED_VIRT_FAMILIES`, each combined with that same shape:
+
+```
+n2-standard-8  →  [n2-standard-8, n2d-standard-8, c2-standard-8, c2d-standard-8]
+```
+
+**Why gate on `FALLBACK_SHAPES` instead of blind family-swapping.** Not every
+family offers every shape (e.g. `c2` only exists in fixed shapes). Restricting
+fallback to shapes we have verified exist for *every* family in the ladder
+guarantees we never synthesize an invalid machine type that we'd then have to
+silently skip — which would violate the no-silent-failures rule. If the
+requested shape is not in the set, we log that fallback is unavailable for it and
+re-raise the original capacity error: explicit, not silent. Resizing the
+supported envelope (shrink to `standard-4`, grow past `standard-16` once quota
+lands) is editing one set and never touches the ladder.
+
+### 2. Hook point — reattach only
+
+In the reattach call path (where `fallback_zones=[]` today), add a family sweep:
+
+1. Attempt `apply_vm` with the requested instance in the pinned zone.
+2. On failure, if it is **not** `is_zone_capacity_error(exc)`, re-raise (real
+   config/quota error must abort). `is_zone_capacity_error` already matches the
+   family-stockout message — a family stockout produces the same
+   `ZONE_RESOURCE_POOL_EXHAUSTED` — so it needs no change.
+3. Otherwise iterate the remaining ladder candidates, re-running `apply_vm` with
+   the candidate as the tofu `instance_type`, **same pinned zone, same
+   `volume_id`**. `apply_vm`'s existing partial-state rollback (the orphan
+   `google_compute_firewall.ssh`) runs between attempts so each retry starts
+   clean. The **volume is never touched** (no `destroy_volume`, unlike the
+   zone-fallback path).
+4. On exhaustion, raise a `RuntimeError` naming the families tried and the zone,
+   pointing the operator at waiting, a larger quota, or a different region.
+
+The fresh-create path is unchanged: it still uses `apply_vm_with_zone_fallback`
+with real `fallback_zones`.
+
+### 3. Ladder-aware conformance — no rebuild loop
+
+`spec_fingerprint` includes `instance={spec.instance}` on the off-platform path
+(`vm_spec.py`), and the guest-stamped fingerprint is compared against the
+composed spec by the drift check at `vrg_vm.py:357`, which on mismatch reports
+**"VM no longer meets spec — rebuild it."** A naive fallback that lands `n2d`
+while the spec says `n2` would trip this and steer the operator straight back
+into the stockout.
+
+The fingerprint is, by its own docstring, a hash **over the declaration, not the
+realized resource.** A family fallback does not change the declaration — the
+operator still asked for `n2-standard-8`. So:
+
+> **The fallback overrides only the tofu `instance_type` variable passed to the
+> apply. It does NOT mutate `spec.instance`.**
+
+Consequently `spec_fingerprint(spec)` still hashes the *declared* instance, the
+declared hash is what gets stamped in the guest, and the drift check compares
+declared-vs-declared → it passes. No spurious `NEEDS-REBUILD`, and **no
+fingerprint-format change** (so no existing VM's fingerprint flips on upgrade,
+consistent with the established "don't flip fingerprints on upgrade" pattern).
+
+The **actually landed family** is operational state, recorded separately in the
+per-instance meta sidecar via `write_instance_meta`, and surfaced in
+`vrg-vm list` / `vrg-vm volumes` for transparency and inventory.
+
+### 4. Transparency — no silent fallback
+
+Every attempt and the outcome are logged loudly to stderr, e.g.:
+
+```
+  zone us-central1-f: n2-standard-8 out of capacity — trying n2d-standard-8...
+  landed on n2d-standard-8
+```
+
+The landed family is persisted to the meta sidecar (point 3) so a later
+`list`/`volumes` reflects reality rather than only the declared type.
+
+## Testing
+
+- **Candidate derivation:** requested-family-first ordering; dedup when the
+  requested family is in the ladder; only the requested shape is used; a shape
+  outside `FALLBACK_SHAPES` yields no candidates (fallback disabled).
+- **Ladder validity:** the `FALLBACK_SHAPES × NESTED_VIRT_FAMILIES` cross-product
+  is all valid machine types, and the ladder matches the documented
+  nested-virt-supported set (a pinned list the test asserts against).
+- **Fallback loop:** tries families in order, stops on first success; a
+  non-capacity error aborts immediately; ladder exhaustion raises the helpful
+  error naming families tried; the volume is never destroyed on this path.
+- **Conformance:** after a fallback, the stamped fingerprint equals the
+  *declared* spec's fingerprint (not the landed family's), and the meta sidecar
+  records the landed family.
+
+## Verify before shipping
+
+The ladder's membership and order **must** be checked against GCP's current
+"nested virtualization — supported machine types" documentation. Confident:
+N1/N2/N2D/C2 support nested virtualization; E2 and the Tau families do not.
+**To confirm against the doc before inclusion: C2D (AMD) nested-virtualization
+support.** If C2D is not supported, drop it from `NESTED_VIRT_FAMILIES`; the
+ladder-validity test encodes whatever the doc says.
+
+## Alternatives considered
+
+- **Config-driven ladder per spec** (`fallback_instances` in `vergil.toml`):
+  rejected for v1 — every repo must opt in and get it right, and a wrong entry
+  could silently break nested virt.
+- **Dynamically derived from GCP:** rejected for v1 — adds API calls, a live
+  metadata dependency, and complexity for a list that changes rarely.
+- **Static ladder + runtime nested-virt guard** (belt-and-suspenders): the
+  curated static ladder plus the ladder-validity unit test is judged sufficient;
+  a runtime guard can be added later if the ladder ever grows risky to edit.
+- **Both create and reattach** / **family-first on create:** deferred — the
+  reattach gap is the live pain; fresh-create can already escape via zone sweep.

--- a/docs/specs/2026-06-23-off-platform-instance-family-fallback-design.md
+++ b/docs/specs/2026-06-23-off-platform-instance-family-fallback-design.md
@@ -65,8 +65,9 @@ ordered family list, not a per-shape table:
 ```python
 # Ordered nested-virt-capable families, by preference. Size-independent —
 # a fallback swaps the family and keeps the requested shape untouched.
-# MUST match GCP's nested-virtualization supported-machine-types doc.
-NESTED_VIRT_FAMILIES = ["n2", "n2d", "c2", "c2d"]
+# Intel-only: GCE nested virt excludes AMD/Arm, so n2d/c2d are NOT eligible
+# (verified against GCP docs — see "Verify before shipping").
+NESTED_VIRT_FAMILIES = ["n2", "c2"]
 
 # Shapes verified to exist across the whole ladder and actually run off-platform.
 # Family-fallback engages only for these; adding a size later is one line.
@@ -79,7 +80,7 @@ candidate list is the requested family first, then the remaining
 `NESTED_VIRT_FAMILIES`, each combined with that same shape:
 
 ```
-n2-standard-8  →  [n2-standard-8, n2d-standard-8, c2-standard-8, c2d-standard-8]
+n2-standard-8  →  [n2-standard-8, c2-standard-8]
 ```
 
 **Edge case — requested family not in the ladder.** If the requested instance's
@@ -234,14 +235,21 @@ diffs in separate regions and rebase whichever lands second.
 ## Verify before shipping
 
 This is a **manual, human-performed gate** — the unit test (a change-detector)
-cannot do it. Before merge, the ladder's membership and order **must** be checked
-against GCP's current "nested virtualization — supported machine types"
-documentation, and the verification (doc URL + date) recorded in the PR.
-Confident: N1/N2/N2D/C2 support nested virtualization; E2 and the Tau families do
-not. **To confirm against the doc before inclusion: C2D (AMD) nested-virtualization
-support, and that every `FALLBACK_SHAPES × NESTED_VIRT_FAMILIES` machine type
-actually exists.** If C2D is not supported, drop it from `NESTED_VIRT_FAMILIES`
-and update the change-detector test to match.
+cannot do it.
+
+**Verified 2026-06-24.** GCE nested virtualization requires an Intel (VT-x)
+processor; the docs list **AMD and Arm processors, E2, memory-optimized, and H4D**
+as unsupported. So the AMD families **n2d and c2d are NOT eligible** and were
+dropped — the original draft ladder (`n2/n2d/c2/c2d`) would have booted VMs with no
+`/dev/kvm`. The shipped ladder is Intel-only: **`["n2", "c2"]`**, and both offer
+`standard-8` and `standard-16`. Sources:
+- nested-virt overview — `docs.cloud.google.com/compute/docs/instances/nested-virtualization/overview`
+  ("L1 VMs cannot use ... AMD and Arm processors").
+- general-purpose machine docs — corroborating "N2D VMs don't support ... nested
+  virtualization".
+
+Re-run this manual check (and update the change-detector test) whenever
+`NESTED_VIRT_FAMILIES` or `FALLBACK_SHAPES` changes.
 
 ## Alternatives considered
 

--- a/docs/specs/2026-06-23-off-platform-instance-family-fallback-design.md
+++ b/docs/specs/2026-06-23-off-platform-instance-family-fallback-design.md
@@ -1,8 +1,9 @@
 # Off-platform: instance-family fallback on reattach
 
 - **Issue:** vergil-tooling#1836
-- **Status:** Design (approved)
-- **Related:** #1797 (explicit zone knob), #1804 (orphan-firewall rollback), #1813 (zone fallback on fresh create)
+- **Status:** Design (approved, pushback-reviewed)
+- **Related:** #1797 / PR #1799 (explicit zone knob), #1804 / PR #1807 (orphan-firewall rollback), #1813 / PR #1816 (zone fallback on fresh create)
+- **Coordination:** #1831 (named instances) — in flight, reshaping the meta sidecar; see Design §4.
 
 ## Problem
 
@@ -81,6 +82,13 @@ candidate list is the requested family first, then the remaining
 n2-standard-8  →  [n2-standard-8, n2d-standard-8, c2-standard-8, c2d-standard-8]
 ```
 
+**Edge case — requested family not in the ladder.** If the requested instance's
+family is absent from `NESTED_VIRT_FAMILIES` (e.g. a misconfigured
+`e2-standard-8` with `nested=true`), derive candidates as *requested-instance
+first, then the full ladder, deduped*. The original is still attempted first
+(respecting the operator's declaration), and fallback still reaches the
+nested-virt-safe families rather than dead-ending.
+
 **Why gate on `FALLBACK_SHAPES` instead of blind family-swapping.** Not every
 family offers every shape (e.g. `c2` only exists in fixed shapes). Restricting
 fallback to shapes we have verified exist for *every* family in the ladder
@@ -93,24 +101,43 @@ lands) is editing one set and never touches the ladder.
 
 ### 2. Hook point — reattach only
 
-In the reattach call path (where `fallback_zones=[]` today), add a family sweep:
+There is no separate reattach code path: `_cs_tofu_vm` serves both create and
+reattach, distinguished only by whether `volume.tfstate` exists. `_cs_tofu_volume`
+already encodes that distinction — it populates `state.fallback_zones` **only when
+`volume.tfstate` does not exist** (fresh create). Family-fallback mirrors this
+with a new field, gated on the opposite condition:
+
+- Add `fallback_instances: list[str]` to `_CloudState` (alongside
+  `fallback_zones`). In `_cs_tofu_volume`, populate it **only when
+  `volume.tfstate` exists** (reattach) — the candidate list from §1 minus the
+  requested instance. On fresh create it stays `[]`, so the create path is
+  unchanged and keeps its zone sweep. This symmetric gate is what makes the
+  feature reattach-only; widening to create later is a one-line change to the
+  condition.
+- Add an `instance_override: str | None = None` parameter to
+  `OffPlatformBackend.vm_vars` (see §3 for why this — not spec mutation — is
+  load-bearing). `_cs_tofu_vm` passes `state.fallback_instances` into the apply
+  engine.
+
+The sweep itself (in `apply_vm_with_zone_fallback`, or a sibling it delegates to):
 
 1. Attempt `apply_vm` with the requested instance in the pinned zone.
-2. On failure, if it is **not** `is_zone_capacity_error(exc)`, re-raise (real
+2. On failure, if it is **not** `is_zone_capacity_error(exc)`, re-raise (a real
    config/quota error must abort). `is_zone_capacity_error` already matches the
    family-stockout message — a family stockout produces the same
    `ZONE_RESOURCE_POOL_EXHAUSTED` — so it needs no change.
-3. Otherwise iterate the remaining ladder candidates, re-running `apply_vm` with
-   the candidate as the tofu `instance_type`, **same pinned zone, same
-   `volume_id`**. `apply_vm`'s existing partial-state rollback (the orphan
-   `google_compute_firewall.ssh`) runs between attempts so each retry starts
-   clean. The **volume is never touched** (no `destroy_volume`, unlike the
-   zone-fallback path).
+3. Otherwise iterate `fallback_instances`, re-running `apply_vm` with
+   `vm_vars(zone=…, volume_id=…, instance_override=candidate)` — **same pinned
+   zone, same `volume_id`**. `apply_vm`'s existing partial-state rollback (the
+   orphan `google_compute_firewall.ssh`) runs between attempts so each retry
+   starts clean. The **volume is never touched** (no `destroy_volume`, unlike the
+   zone-fallback path — that loop destroys the *empty* disk to relocate it; here
+   the disk holds data and stays put).
 4. On exhaustion, raise a `RuntimeError` naming the families tried and the zone,
    pointing the operator at waiting, a larger quota, or a different region.
 
-The fresh-create path is unchanged: it still uses `apply_vm_with_zone_fallback`
-with real `fallback_zones`.
+The fresh-create path is unchanged: `fallback_instances` stays `[]` and it still
+sweeps `fallback_zones` as today.
 
 ### 3. Ladder-aware conformance — no rebuild loop
 
@@ -134,9 +161,28 @@ declared-vs-declared → it passes. No spurious `NEEDS-REBUILD`, and **no
 fingerprint-format change** (so no existing VM's fingerprint flips on upgrade,
 consistent with the established "don't flip fingerprints on upgrade" pattern).
 
-The **actually landed family** is operational state, recorded separately in the
-per-instance meta sidecar via `write_instance_meta`, and surfaced in
-`vrg-vm list` / `vrg-vm volumes` for transparency and inventory.
+**The mechanism is load-bearing and must be implemented exactly.** `vm_vars`
+derives *both* the tofu `instance_type` *and* the stamped `SPEC_FINGERPRINT`
+(via `render_provision_env(provision_params(..., fingerprint=spec_fingerprint(self.spec)))`)
+from `self.spec`. The two are independent computations off the same object — so:
+
+- The fallback passes the candidate family through the new `instance_override`
+  parameter; `vm_vars` returns `"instance_type": instance_override or self.spec.instance`.
+- `vm_vars` keeps computing `fingerprint=spec_fingerprint(self.spec)` from the
+  **unmutated** declared spec.
+
+The natural-looking shortcut — mutating `self.spec.instance` before the apply —
+would flip the stamped fingerprint along with the machine type, reintroducing the
+exact drift-rebuild loop this section exists to prevent. **Do not mutate the
+spec.** A test asserts that after a fallback the stamped fingerprint equals the
+*declared* spec's fingerprint, not the landed family's.
+
+The **actually landed family** is read from the realized resource, not recorded
+by hand: `vm.tfstate`'s `google_compute_instance.vm` carries `machine_type`.
+`vrg-vm list` / `volumes` surface it by parsing `vm.tfstate` exactly as `volumes`
+already parses `volume.tfstate` (the `VolumeState` precedent). This is the single
+source of truth — it can't drift from reality — and it deliberately avoids the
+per-instance meta sidecar, which #1831 is concurrently reshaping (see §4).
 
 ### 4. Transparency — no silent fallback
 
@@ -147,42 +193,66 @@ Every attempt and the outcome are logged loudly to stderr, e.g.:
   landed on n2d-standard-8
 ```
 
-The landed family is persisted to the meta sidecar (point 3) so a later
-`list`/`volumes` reflects reality rather than only the declared type.
+Durable visibility comes from `vm.tfstate` (§3), not a hand-written record: a
+later `list`/`volumes` reads the actual `machine_type` so it reflects reality
+rather than the declared type.
+
+**Coordination with #1831 (named instances).** That in-flight work reshapes the
+per-instance meta sidecar (`write_instance_meta`/`read_instance_meta`). This
+design deliberately records nothing there — landed family comes from `vm.tfstate`
+— so the two features touch disjoint surfaces and won't collide on the meta
+schema. The only shared file is `bin/vrg_vm.py` (#1831 edits instance
+resolution/meta; this edits the `_cs_*` stages and `_CloudState`); keep the
+diffs in separate regions and rebase whichever lands second.
 
 ## Testing
 
 - **Candidate derivation:** requested-family-first ordering; dedup when the
-  requested family is in the ladder; only the requested shape is used; a shape
+  requested family is in the ladder; the requested-family-not-in-ladder edge case
+  (original first, then full ladder); only the requested shape is used; a shape
   outside `FALLBACK_SHAPES` yields no candidates (fallback disabled).
-- **Ladder validity:** the `FALLBACK_SHAPES × NESTED_VIRT_FAMILIES` cross-product
-  is all valid machine types, and the ladder matches the documented
-  nested-virt-supported set (a pinned list the test asserts against).
+- **Ladder change-detector (NOT a validity proof):** a unit test pins
+  `NESTED_VIRT_FAMILIES` and `FALLBACK_SHAPES` to their expected values so the
+  ladder cannot be edited *accidentally* — any change forces a deliberate test
+  update. This asserts intent, **not** GCP reality; it would happily pass on a
+  family that doesn't actually support nested virt. Real validity is the manual
+  gate in "Verify before shipping," optionally reinforced by the per-family e2e
+  below.
 - **Fallback loop:** tries families in order, stops on first success; a
   non-capacity error aborts immediately; ladder exhaustion raises the helpful
   error naming families tried; the volume is never destroyed on this path.
 - **Conformance:** after a fallback, the stamped fingerprint equals the
-  *declared* spec's fingerprint (not the landed family's), and the meta sidecar
-  records the landed family.
+  *declared* spec's fingerprint, **not** the landed family's — and `self.spec` is
+  unmutated after `vm_vars(instance_override=…)`.
+- **Landed-family surfacing:** `vm.tfstate` parsing returns the realized
+  `machine_type`, and `list`/`volumes` report the landed family (not the declared
+  one) after a fallback.
+- **(Optional, not a CI gate) per-family e2e:** boot each ladder family and assert
+  `/dev/kvm` is present — the only test that proves nested virt for real. Run
+  on-demand, not per-PR (real GCP spend; subject to the very stockouts at issue).
 
 ## Verify before shipping
 
-The ladder's membership and order **must** be checked against GCP's current
-"nested virtualization — supported machine types" documentation. Confident:
-N1/N2/N2D/C2 support nested virtualization; E2 and the Tau families do not.
-**To confirm against the doc before inclusion: C2D (AMD) nested-virtualization
-support.** If C2D is not supported, drop it from `NESTED_VIRT_FAMILIES`; the
-ladder-validity test encodes whatever the doc says.
+This is a **manual, human-performed gate** — the unit test (a change-detector)
+cannot do it. Before merge, the ladder's membership and order **must** be checked
+against GCP's current "nested virtualization — supported machine types"
+documentation, and the verification (doc URL + date) recorded in the PR.
+Confident: N1/N2/N2D/C2 support nested virtualization; E2 and the Tau families do
+not. **To confirm against the doc before inclusion: C2D (AMD) nested-virtualization
+support, and that every `FALLBACK_SHAPES × NESTED_VIRT_FAMILIES` machine type
+actually exists.** If C2D is not supported, drop it from `NESTED_VIRT_FAMILIES`
+and update the change-detector test to match.
 
 ## Alternatives considered
 
-- **Config-driven ladder per spec** (`fallback_instances` in `vergil.toml`):
-  rejected for v1 — every repo must opt in and get it right, and a wrong entry
-  could silently break nested virt.
+- **Config-driven ladder per spec** (e.g. a `fallback_families` key in
+  `vergil.toml`): rejected for v1 — every repo must opt in and get it right, and a
+  wrong entry could silently break nested virt.
 - **Dynamically derived from GCP:** rejected for v1 — adds API calls, a live
   metadata dependency, and complexity for a list that changes rarely.
 - **Static ladder + runtime nested-virt guard** (belt-and-suspenders): the
-  curated static ladder plus the ladder-validity unit test is judged sufficient;
-  a runtime guard can be added later if the ladder ever grows risky to edit.
+  curated static ladder plus the change-detector test and the manual GCP-doc
+  verification gate are judged sufficient; a runtime guard can be added later if
+  the ladder ever grows risky to edit.
 - **Both create and reattach** / **family-first on create:** deferred — the
   reattach gap is the live pain; fresh-create can already escape via zone sweep.

--- a/docs/specs/2026-06-23-off-platform-instance-family-fallback-implementation-plan.md
+++ b/docs/specs/2026-06-23-off-platform-instance-family-fallback-implementation-plan.md
@@ -1,0 +1,853 @@
+# Instance-Family Fallback on Reattach — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On a reattach capacity stockout, recover by sweeping a curated, nested-virt-safe machine-family ladder within the pinned zone — without losing the data disk or tripping a spec-drift rebuild loop.
+
+**Architecture:** A pure ladder function in `vm_cloud.py` derives same-shape family candidates. `OffPlatformBackend.vm_vars` gains an `instance_override` that swaps the tofu machine type *without* touching `self.spec` (so the stamped `SPEC_FINGERPRINT` stays the declared one). `apply_vm_with_zone_fallback` gains a family sweep that runs in the pinned zone before the existing zone sweep. The call site in `vrg_vm.py` populates the family ladder only on reattach (mirroring how `fallback_zones` is populated only on fresh create). The landed family is read back from `vm.tfstate` for `vrg-vm volumes`.
+
+**Tech Stack:** Python 3.12, pytest, OpenTofu (GCP modules), `gcloud`.
+
+## Global Constraints
+
+- **Git/GitHub via wrappers only.** Use `vrg-git` (not `git`), `vrg-gh` (not `gh`), and `vrg-commit` (not `git commit`). Raw `git`/`gh` are denied by the permission model.
+- **Work entirely in the worktree:** `/Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1836-instance-family-fallback/` on branch `feature/1836-instance-family-fallback`.
+- **Conformance invariant (load-bearing):** never mutate `spec.instance`; the stamped fingerprint must always be `spec_fingerprint(self.spec)` of the *declared* spec. Violating this reintroduces the drift-rebuild loop the feature exists to prevent.
+- **No silent failures:** a non-capacity error must abort; every fallback attempt logs to stderr.
+- **Ladder validity is a human gate:** before merge, verify `NESTED_VIRT_FAMILIES` against GCP's current "nested virtualization — supported machine types" doc (confirm C2D/AMD; confirm every `FALLBACK_SHAPES × NESTED_VIRT_FAMILIES` type exists). Record the doc URL + date in the PR. The unit test is only a change-detector.
+- **Scope:** reattach-only. Fresh-create keeps its existing zone sweep untouched.
+
+### Per-task workflow
+
+- **Red/green feedback:** run the single test with `uv run pytest <path>::<TestClass>::<test> -v`.
+- **Gate before every commit:** `vrg-container-run -- vrg-validate` (the repo's only sanctioned validation pipeline — lint, types, full test suite).
+- **Commit** with: `vrg-commit --type <feat|test|docs> --scope off-platform --message "<desc> (#1836)" --body "<body>\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"` after `vrg-git add <files>`.
+
+---
+
+## File Structure
+
+- `src/vergil_tooling/lib/vm_cloud.py` — **modify.** Add the ladder (`NESTED_VIRT_FAMILIES`, `FALLBACK_SHAPES`, `instance_fallback_candidates`), the `instance_override` param on `vm_vars`, the family sweep in `apply_vm_with_zone_fallback`, and `parse_vm_machine_type`.
+- `src/vergil_tooling/bin/vrg_vm.py` — **modify.** Add `_CloudState.fallback_instances`, populate it on reattach in `_cs_tofu_volume`, pass it through `_cs_tofu_vm`, and surface the landed family in `_volume_rows`/`_cmd_volumes`.
+- `tests/vergil_tooling/test_vm_cloud.py` — **modify.** Ladder, `vm_vars` conformance, family-sweep, and `parse_vm_machine_type` tests.
+- `tests/vergil_tooling/test_vrg_vm.py` — **modify.** Reattach-wiring and `_volume_rows` tests.
+
+---
+
+## Task 1: Family-fallback ladder (constants + candidate derivation)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_cloud.py` (add after `region_zones`, near the other capacity helpers)
+- Test: `tests/vergil_tooling/test_vm_cloud.py`
+
+**Interfaces:**
+- Produces: `NESTED_VIRT_FAMILIES: tuple[str, ...]`, `FALLBACK_SHAPES: frozenset[str]`, `instance_fallback_candidates(requested: str) -> list[str]` (requested type first, then same-shape ladder siblings, deduped; `[requested]` only when the shape is unsupported).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vm_cloud.py`. Add `instance_fallback_candidates`, `NESTED_VIRT_FAMILIES`, `FALLBACK_SHAPES` to the existing `from vergil_tooling.lib.vm_cloud import (...)` block first.
+
+```python
+class TestInstanceFallbackLadder:
+    def test_requested_first_then_same_shape_siblings(self) -> None:
+        assert instance_fallback_candidates("n2-standard-8") == [
+            "n2-standard-8",
+            "n2d-standard-8",
+            "c2-standard-8",
+            "c2d-standard-8",
+        ]
+
+    def test_dedups_when_requested_family_in_ladder(self) -> None:
+        # n2d is in the ladder; it must appear once, still requested-first.
+        result = instance_fallback_candidates("n2d-standard-16")
+        assert result[0] == "n2d-standard-16"
+        assert result.count("n2d-standard-16") == 1
+        assert set(result) == {
+            "n2d-standard-16",
+            "n2-standard-16",
+            "c2-standard-16",
+            "c2d-standard-16",
+        }
+
+    def test_unsupported_shape_yields_no_fallback(self) -> None:
+        assert instance_fallback_candidates("n2-highmem-8") == ["n2-highmem-8"]
+        assert instance_fallback_candidates("n2-standard-4") == ["n2-standard-4"]
+
+    def test_requested_family_not_in_ladder_still_leads(self) -> None:
+        # A misconfigured non-nested-virt family: original first, then full ladder.
+        assert instance_fallback_candidates("e2-standard-8") == [
+            "e2-standard-8",
+            "n2-standard-8",
+            "n2d-standard-8",
+            "c2-standard-8",
+            "c2d-standard-8",
+        ]
+
+    def test_ladder_change_detector(self) -> None:
+        # NOT a validity proof — pins the curated values so an edit is deliberate.
+        # Real nested-virt validity is verified by hand against GCP docs (#1836).
+        assert NESTED_VIRT_FAMILIES == ("n2", "n2d", "c2", "c2d")
+        assert FALLBACK_SHAPES == frozenset({"standard-8", "standard-16"})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestInstanceFallbackLadder -v`
+Expected: FAIL — `ImportError` / `cannot import name 'instance_fallback_candidates'`.
+
+- [ ] **Step 3: Implement the ladder**
+
+Add to `src/vergil_tooling/lib/vm_cloud.py` immediately after the `region_zones` function:
+
+```python
+# --- Instance-family fallback ladder (#1836) ---------------------------------
+#
+# A capacity stockout is specific to a (zone, machine-family) pair: a different
+# family in the same zone often has capacity when the requested one does not. On a
+# reattach the zonal data disk pins the zone, so swapping the family is the only
+# recovery (see apply_vm_with_zone_fallback). The ladder may contain ONLY families
+# that support GCP nested virtualization — nested KVM is the point of these VMs, and
+# a family without it (e2, Tau) would boot a box with no /dev/kvm and fail the
+# provision. Membership/order is verified BY HAND against GCP's nested-virt
+# supported-machine-types doc before merge; the unit test is only a change-detector.
+NESTED_VIRT_FAMILIES = ("n2", "n2d", "c2", "c2d")
+
+# Shapes verified to exist for EVERY family in the ladder and actually run
+# off-platform. Family-fallback engages only for these, so we never synthesize an
+# invalid machine type. Adding a size is one line here.
+FALLBACK_SHAPES = frozenset({"standard-8", "standard-16"})
+
+
+def instance_fallback_candidates(requested: str) -> list[str]:
+    """Ordered machine types to try for ``requested``, the requested type first.
+
+    Splits ``requested`` into ``(family, shape)`` (``n2-standard-8`` ->
+    ``("n2", "standard-8")``). When the shape is in ``FALLBACK_SHAPES`` the result is
+    the requested type, then every other ``NESTED_VIRT_FAMILIES`` member at the same
+    shape, deduped. When the shape is unsupported the result is just ``[requested]``
+    (no fallback). If the requested family is not in the ladder (e.g. a misconfigured
+    ``e2`` declared with nested virt) the requested type still leads and the full
+    ladder follows, so fallback still reaches the nested-virt-safe families.
+    """
+    _family, _, shape = requested.partition("-")
+    if not shape or shape not in FALLBACK_SHAPES:
+        return [requested]
+    candidates = [requested]
+    for family in NESTED_VIRT_FAMILIES:
+        candidate = f"{family}-{shape}"
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestInstanceFallbackLadder -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/lib/vm_cloud.py tests/vergil_tooling/test_vm_cloud.py
+vrg-commit --type feat --scope off-platform \
+  --message "add nested-virt-safe instance-family fallback ladder (#1836)" \
+  --body "instance_fallback_candidates derives same-shape family siblings for a requested machine type, gated on FALLBACK_SHAPES so no invalid type is ever synthesized. The change-detector test pins the curated values; real nested-virt validity is a manual GCP-doc gate.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `instance_override` on `vm_vars` (conformance-preserving)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_cloud.py` — `OffPlatformBackend.vm_vars` (currently `def vm_vars(self, *, zone: str, volume_id: str)`)
+- Test: `tests/vergil_tooling/test_vm_cloud.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `OffPlatformBackend.vm_vars(self, *, zone: str, volume_id: str, instance_override: str | None = None) -> dict[str, object]` — sets `"instance_type": instance_override or self.spec.instance`; `provision_env`'s `SPEC_FINGERPRINT` is always `spec_fingerprint(self.spec)` of the unmutated declared spec.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vm_cloud.py`. Ensure `from vergil_tooling.lib.vm_spec import spec_fingerprint` is imported at the top (add if missing); `dataclasses` is already imported.
+
+```python
+class TestVmVarsInstanceOverride:
+    def test_override_swaps_machine_type_but_keeps_declared_fingerprint(self) -> None:
+        spec = _off_spec(instance="n2-standard-8")
+        b = OffPlatformBackend(spec, "vergil-user", "o", "r")
+        declared_fp = spec_fingerprint(spec)
+        would_be_landed_fp = spec_fingerprint(
+            dataclasses.replace(spec, instance="n2d-standard-8")
+        )
+
+        v = b.vm_vars(zone="us-central1-f", volume_id="v1", instance_override="n2d-standard-8")
+
+        # The tofu machine type is the fallback family...
+        assert v["instance_type"] == "n2d-standard-8"
+        # ...but the stamped fingerprint is the DECLARED one, never the landed family's.
+        assert declared_fp in str(v["provision_env"])
+        assert would_be_landed_fp not in str(v["provision_env"])
+        # ...and the spec object is never mutated.
+        assert b.spec.instance == "n2-standard-8"
+
+    def test_default_uses_declared_instance(self) -> None:
+        b = OffPlatformBackend(_off_spec(instance="n2-standard-16"), "vergil-user", "o", "r")
+        v = b.vm_vars(zone="us-central1-b", volume_id="v1")
+        assert v["instance_type"] == "n2-standard-16"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestVmVarsInstanceOverride -v`
+Expected: FAIL — `TypeError: vm_vars() got an unexpected keyword argument 'instance_override'`.
+
+- [ ] **Step 3: Add the parameter**
+
+In `src/vergil_tooling/lib/vm_cloud.py`, change `OffPlatformBackend.vm_vars`. Replace:
+
+```python
+    def vm_vars(self, *, zone: str, volume_id: str) -> dict[str, object]:
+        provision_env = render_provision_env(
+```
+
+with:
+
+```python
+    def vm_vars(
+        self, *, zone: str, volume_id: str, instance_override: str | None = None
+    ) -> dict[str, object]:
+        provision_env = render_provision_env(
+```
+
+Then, in the same method's returned dict, replace:
+
+```python
+            "instance_type": self.spec.instance,
+```
+
+with:
+
+```python
+            # A family fallback swaps the machine type here ONLY; self.spec is never
+            # mutated, so fingerprint=spec_fingerprint(self.spec) above stays the
+            # declared hash and the drift check never reads a fallback as drift. (#1836)
+            "instance_type": instance_override or self.spec.instance,
+```
+
+(Leave the `fingerprint=spec_fingerprint(self.spec)` line above exactly as-is — that is the conformance invariant.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestVmVarsInstanceOverride -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/lib/vm_cloud.py tests/vergil_tooling/test_vm_cloud.py
+vrg-commit --type feat --scope off-platform \
+  --message "let vm_vars override the machine type without changing the fingerprint (#1836)" \
+  --body "instance_override swaps only the tofu instance_type; SPEC_FINGERPRINT stays computed from the unmutated declared spec, so a family fallback is conformant by construction.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Family sweep in `apply_vm_with_zone_fallback`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_cloud.py` — `apply_vm_with_zone_fallback`
+- Test: `tests/vergil_tooling/test_vm_cloud.py`
+
+**Interfaces:**
+- Consumes: `instance_fallback_candidates` (Task 1) is *not* called here — the caller passes the ready list; `vm_vars(..., instance_override=...)` (Task 2).
+- Produces: `apply_vm_with_zone_fallback(..., *, zone, volume_id, fallback_zones, fallback_instances: list[str] | None = None)`. On a capacity error it sweeps `fallback_instances` in the pinned zone (same `volume_id`, no `destroy_volume`), then the existing `fallback_zones` sweep. With neither list it re-raises the original error (unchanged reattach-with-nothing behavior).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vm_cloud.py` (the existing `TestZoneFallback`, `_capacity_exc` helper, and imports are already present):
+
+```python
+class TestFamilyFallback:
+    @staticmethod
+    def _backend() -> MagicMock:
+        backend = MagicMock()
+        backend.vm_vars.return_value = {}
+        backend.spec.region = "us-central1"
+        backend.spec.instance = "n2-standard-8"
+        return backend
+
+    def test_swaps_family_in_same_zone_without_touching_volume(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Requested family stocked, first fallback family lands — same zone, same disk.
+        av = MagicMock(side_effect=[_capacity_exc(), {"host": "h"}])
+        dv = MagicMock()
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.apply_vm", av)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.destroy_volume", dv)
+        backend = self._backend()
+
+        result = apply_vm_with_zone_fallback(
+            tmp_path / "m",
+            tmp_path / "s",
+            backend,
+            zone="us-central1-f",
+            volume_id="v1",
+            fallback_zones=[],
+            fallback_instances=["n2d-standard-8", "c2-standard-8"],
+        )
+
+        assert result == ("v1", "us-central1-f", {"host": "h"})
+        assert av.call_count == 2
+        dv.assert_not_called()  # the data disk is never destroyed on this path
+        backend.vm_vars.assert_any_call(
+            zone="us-central1-f", volume_id="v1", instance_override="n2d-standard-8"
+        )
+
+    def test_all_families_stocked_raises_naming_them(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=_capacity_exc())
+        )
+        with pytest.raises(RuntimeError, match="no nested-virt machine family has capacity"):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-f",
+                volume_id="v1",
+                fallback_zones=[],
+                fallback_instances=["n2d-standard-8", "c2-standard-8"],
+            )
+
+    def test_non_capacity_error_during_family_sweep_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        boom = subprocess.CalledProcessError(1, [], stderr="Error: bad config")
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm",
+            MagicMock(side_effect=[_capacity_exc(), boom]),
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-f",
+                volume_id="v1",
+                fallback_zones=[],
+                fallback_instances=["n2d-standard-8", "c2-standard-8"],
+            )
+
+    def test_capacity_with_no_fallbacks_at_all_reraises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reattach of an unsupported shape: no families, no zones -> original error.
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=_capacity_exc())
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-f",
+                volume_id="v1",
+                fallback_zones=[],
+                fallback_instances=[],
+            )
+```
+
+- [ ] **Step 2: Run the new tests AND the existing ones to confirm they fail/still pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestFamilyFallback -v`
+Expected: FAIL — `TypeError: apply_vm_with_zone_fallback() got an unexpected keyword argument 'fallback_instances'`.
+
+- [ ] **Step 3: Add the family sweep**
+
+In `src/vergil_tooling/lib/vm_cloud.py`, replace the entire body of `apply_vm_with_zone_fallback` (from its `def` through its final `raise RuntimeError(msg)`) with:
+
+```python
+def apply_vm_with_zone_fallback(
+    modules_root: Path,
+    state_dir: Path,
+    backend: OffPlatformBackend,
+    *,
+    zone: str,
+    volume_id: str,
+    fallback_zones: list[str],
+    fallback_instances: list[str] | None = None,
+) -> tuple[str, str, dict[str, str]]:
+    """Apply the VM in ``zone``; on a capacity stockout, recover by either swapping the
+    machine family in the SAME zone (reattach — the zonal data disk pins the zone) or,
+    on a fresh create, recreating the empty volume in each ``fallback_zones`` entry.
+
+    ``fallback_instances`` (the ladder minus the requested type, from
+    ``instance_fallback_candidates``) is supplied on a reattach; ``fallback_zones`` on a
+    fresh create. The two are mutually exclusive today. Family fallback keeps
+    ``volume_id`` untouched — the disk holds data and never moves — whereas the zone
+    sweep destroys the *empty* disk to relocate it. With neither list a capacity error
+    is fatal. (#1813, #1836)
+    """
+    instances = list(fallback_instances or [])
+    tried_zones = [zone]
+    tried_instances = [backend.spec.instance]
+    vm_vars = cast("dict[str, Any]", backend.vm_vars(zone=zone, volume_id=volume_id))
+    try:
+        return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
+    except subprocess.CalledProcessError as exc:
+        if not is_zone_capacity_error(exc):
+            raise
+        if not instances and not fallback_zones:
+            raise  # reattach with no ladder (unsupported shape) — original behavior
+
+    # Family fallback — same zone, same volume (a zonal disk with data cannot move).
+    for instance in instances:
+        print(
+            f"  zone {zone}: {tried_instances[-1]} out of capacity — trying {instance}...",
+            file=sys.stderr,
+        )
+        tried_instances.append(instance)
+        vm_vars = cast(
+            "dict[str, Any]",
+            backend.vm_vars(zone=zone, volume_id=volume_id, instance_override=instance),
+        )
+        try:
+            return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
+        except subprocess.CalledProcessError as exc:
+            if not is_zone_capacity_error(exc):
+                raise
+
+    # Zone fallback — fresh create only; recreate the empty disk in each next zone.
+    for next_zone in fallback_zones:
+        print(f"  zone {zone}: no capacity — trying {next_zone}...", file=sys.stderr)
+        destroy_volume(modules_root, state_dir)  # the empty disk; rmtrees the state dir
+        state_dir.mkdir(parents=True, exist_ok=True)
+        volume_vars = cast("dict[str, Any]", {**backend.volume_vars(), "zone": next_zone})
+        volume_id, zone = apply_volume(modules_root, state_dir, **volume_vars)
+        tried_zones.append(zone)
+        vm_vars = cast("dict[str, Any]", backend.vm_vars(zone=zone, volume_id=volume_id))
+        try:
+            return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
+        except subprocess.CalledProcessError as exc:
+            if not is_zone_capacity_error(exc):
+                raise
+
+    if len(tried_instances) > 1:
+        msg = (
+            f"no nested-virt machine family has capacity in {zone} "
+            f"(tried: {', '.join(tried_instances)}). Wait for capacity, raise quota, "
+            "or try another region."
+        )
+    else:
+        msg = (
+            f"no zone in {backend.spec.region} has capacity for {backend.spec.instance} "
+            f"(tried: {', '.join(tried_zones)}). Try a different instance family "
+            "(e.g. n2d-*), another region, or wait for capacity."
+        )
+    raise RuntimeError(msg)
+```
+
+- [ ] **Step 4: Run the new and existing fallback tests to verify all pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestFamilyFallback tests/vergil_tooling/test_vm_cloud.py::TestZoneFallback -v`
+Expected: PASS — all `TestFamilyFallback` (4) and all pre-existing `TestZoneFallback` tests (the zone message and `test_capacity_with_no_fallback_reraises` behavior are preserved).
+
+- [ ] **Step 5: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/lib/vm_cloud.py tests/vergil_tooling/test_vm_cloud.py
+vrg-commit --type feat --scope off-platform \
+  --message "sweep nested-virt machine families in the pinned zone on a reattach stockout (#1836)" \
+  --body "apply_vm_with_zone_fallback tries each fallback_instances candidate in the same zone with the same volume before the existing zone sweep. The data disk is never destroyed on this path; a non-capacity error still aborts; with no ladder and no zones the original error re-raises.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire the ladder at the call site (reattach-only)
+
+**Files:**
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` — `_CloudState` dataclass, `_cs_tofu_volume`, `_cs_tofu_vm`
+- Test: `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Consumes: `vm_cloud.instance_fallback_candidates` (Task 1); `apply_vm_with_zone_fallback(..., fallback_instances=...)` (Task 3).
+- Produces: `_CloudState.fallback_instances: list[str]`, populated only when `volume.tfstate` exists (reattach).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`, inside the existing `TestCloudStageGuards` class (it already has `_state`, and `_cs_tofu_volume` is imported):
+
+```python
+    def test_tofu_volume_reattach_populates_family_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reattach: zone is pinned, so the recovery is a machine-family sweep (#1836).
+        state = self._state(tmp_path)
+        state.modules_root = tmp_path / "modules"
+        state.state_dir.mkdir(parents=True, exist_ok=True)
+        (state.state_dir / "volume.tfstate").write_text("{}")
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.apply_volume",
+            MagicMock(return_value=("vol-1", "us-central1-b")),
+        )
+        _cs_tofu_volume(state)
+        expected = vm_cloud.instance_fallback_candidates(state.backend.spec.instance)[1:]
+        assert state.fallback_instances == expected
+        assert state.fallback_zones == []
+
+    def test_tofu_volume_fresh_create_leaves_family_fallback_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fresh create keeps the zone sweep and never engages family fallback.
+        state = self._state(tmp_path)
+        state.modules_root = tmp_path / "modules"
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.apply_volume",
+            MagicMock(return_value=("vol-1", "us-central1-b")),
+        )
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.region_zones",
+            MagicMock(return_value=["us-central1-a", "us-central1-b"]),
+        )
+        _cs_tofu_volume(state)
+        assert state.fallback_instances == []
+```
+
+Confirm `vm_cloud` is imported in the test module (it is used elsewhere); if not, add `from vergil_tooling.lib import vm_cloud`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestCloudStageGuards::test_tofu_volume_reattach_populates_family_fallback tests/vergil_tooling/test_vrg_vm.py::TestCloudStageGuards::test_tofu_volume_fresh_create_leaves_family_fallback_empty -v`
+Expected: FAIL — `AttributeError: '_CloudState' object has no attribute 'fallback_instances'`.
+
+- [ ] **Step 3a: Add the `_CloudState` field**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, in the `_CloudState` dataclass, immediately after the `fallback_zones` field, add:
+
+```python
+    # Machine families to try (same pinned zone) if a reattach VM apply hits a capacity
+    # stockout — the ladder minus the requested type. Populated only on a reattach; empty
+    # on a fresh create, which sweeps fallback_zones instead. (#1836)
+    fallback_instances: list[str] = field(default_factory=list)
+```
+
+- [ ] **Step 3b: Populate it on reattach**
+
+In `_cs_tofu_volume`, the current fresh-create block reads:
+
+```python
+    if not (state.state_dir / "volume.tfstate").exists():
+        candidates = _candidate_zones(state.backend)
+        if candidates:
+            volume_vars["zone"] = candidates[0]
+            state.fallback_zones = candidates[1:]
+    volume_id, zone = vm_cloud.apply_volume(modules_root, state.state_dir, **volume_vars)
+```
+
+Replace it with:
+
+```python
+    if not (state.state_dir / "volume.tfstate").exists():
+        candidates = _candidate_zones(state.backend)
+        if candidates:
+            volume_vars["zone"] = candidates[0]
+            state.fallback_zones = candidates[1:]
+    else:
+        # Reattach: the zonal disk pins the zone, so recovery is a machine-family
+        # sweep in that zone rather than a zone sweep. (#1836)
+        state.fallback_instances = vm_cloud.instance_fallback_candidates(
+            state.backend.spec.instance
+        )[1:]
+    volume_id, zone = vm_cloud.apply_volume(modules_root, state.state_dir, **volume_vars)
+```
+
+- [ ] **Step 3c: Pass it through `_cs_tofu_vm`**
+
+In `_cs_tofu_vm`, the call currently reads:
+
+```python
+    volume_id, zone, out = vm_cloud.apply_vm_with_zone_fallback(
+        modules_root,
+        state.state_dir,
+        state.backend,
+        zone=state.zone,
+        volume_id=state.volume_id,
+        fallback_zones=state.fallback_zones,
+    )
+```
+
+Add the `fallback_instances` argument:
+
+```python
+    volume_id, zone, out = vm_cloud.apply_vm_with_zone_fallback(
+        modules_root,
+        state.state_dir,
+        state.backend,
+        zone=state.zone,
+        volume_id=state.volume_id,
+        fallback_zones=state.fallback_zones,
+        fallback_instances=state.fallback_instances,
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestCloudStageGuards -v`
+Expected: PASS — the two new tests plus the pre-existing stage-guard tests.
+
+- [ ] **Step 5: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope off-platform \
+  --message "engage instance-family fallback on reattach VM applies (#1836)" \
+  --body "_CloudState gains fallback_instances, populated only when volume.tfstate exists (reattach) and threaded into apply_vm_with_zone_fallback. Fresh create is unchanged and keeps its zone sweep.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Surface the landed family from `vm.tfstate` in `vrg-vm volumes`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_cloud.py` — add `parse_vm_machine_type`
+- Modify: `src/vergil_tooling/bin/vrg_vm.py` — `_volume_rows`, `_cmd_volumes`
+- Test: `tests/vergil_tooling/test_vm_cloud.py`, `tests/vergil_tooling/test_vrg_vm.py`
+
+**Interfaces:**
+- Produces: `parse_vm_machine_type(state_file: Path) -> str | None` — the bare machine type from a `vm.tfstate`'s `google_compute_instance.vm`, or `None`. `_volume_rows` rows gain a `"vm_type"` key.
+
+- [ ] **Step 1a: Write the failing parser test**
+
+Add to `tests/vergil_tooling/test_vm_cloud.py` (add `parse_vm_machine_type` to the import block):
+
+```python
+class TestParseVmMachineType:
+    def _state(self, machine_type: str) -> str:
+        return json.dumps(
+            {
+                "resources": [
+                    {
+                        "type": "google_compute_instance",
+                        "instances": [{"attributes": {"machine_type": machine_type}}],
+                    }
+                ]
+            }
+        )
+
+    def test_returns_bare_type_from_selflink(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(self._state("projects/p/zones/us-central1-f/machineTypes/n2d-standard-8"))
+        assert parse_vm_machine_type(f) == "n2d-standard-8"
+
+    def test_returns_bare_type_when_already_bare(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(self._state("n2-standard-8"))
+        assert parse_vm_machine_type(f) == "n2-standard-8"
+
+    def test_none_when_absent_or_empty(self, tmp_path: Path) -> None:
+        assert parse_vm_machine_type(tmp_path / "missing.tfstate") is None
+        empty = tmp_path / "vm.tfstate"
+        empty.write_text("{}")
+        assert parse_vm_machine_type(empty) is None
+```
+
+`json` is already imported in `test_vm_cloud.py` (used elsewhere); confirm and add if missing.
+
+- [ ] **Step 1b: Run it to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestParseVmMachineType -v`
+Expected: FAIL — `cannot import name 'parse_vm_machine_type'`.
+
+- [ ] **Step 2: Implement the parser**
+
+Add to `src/vergil_tooling/lib/vm_cloud.py`, immediately after `parse_volume_state`:
+
+```python
+def parse_vm_machine_type(state_file: Path) -> str | None:
+    """Return the bare machine type from a ``vm.tfstate``'s instance, or ``None``.
+
+    Mirrors ``parse_volume_state``: ``None`` when the file is absent, unreadable,
+    malformed, or carries no applied ``google_compute_instance``. ``machine_type`` may
+    be a bare type or a full selfLink — normalize to the bare name. This is the single
+    source of truth for the family a reattach fallback actually landed on. (#1836)
+    """
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    for resource in data.get("resources", []):
+        if not isinstance(resource, dict) or resource.get("type") != "google_compute_instance":
+            continue
+        instances = resource.get("instances") or []
+        if not instances or not isinstance(instances[0], dict):
+            continue
+        attrs = instances[0].get("attributes")
+        if not isinstance(attrs, dict):
+            continue
+        machine_type = attrs.get("machine_type")
+        if not machine_type:
+            return None
+        return str(machine_type).rsplit("/", 1)[-1]
+    return None
+```
+
+- [ ] **Step 3: Run the parser test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestParseVmMachineType -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 4: Write the failing `_volume_rows` test**
+
+Add to `tests/vergil_tooling/test_vrg_vm.py`, inside the existing `TestListRows` class (or near `_volume_rows` tests). It writes a `volume.tfstate` and a sibling `vm.tfstate` and asserts the row carries the realized machine type:
+
+```python
+    def test_volume_rows_include_landed_machine_type(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        provider = tmp_path / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        provider.mkdir(parents=True)
+        (provider / "volume.tfstate").write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "type": "google_compute_disk",
+                            "instances": [
+                                {"attributes": {"name": "vergil-lmf-cloud-data", "size": 300,
+                                                "zone": "us-central1-f", "labels": {}}}
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+        (provider / "vm.tfstate").write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "type": "google_compute_instance",
+                            "instances": [{"attributes": {"machine_type": "n2d-standard-8"}}],
+                        }
+                    ]
+                }
+            )
+        )
+        rows = _volume_rows()
+        assert rows
+        assert rows[0]["vm_type"] == "n2d-standard-8"
+```
+
+Confirm `_volume_rows` and `json` are imported in `test_vrg_vm.py`; add `from vergil_tooling.bin.vrg_vm import _volume_rows` / `import json` if missing.
+
+- [ ] **Step 5: Run it to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestListRows::test_volume_rows_include_landed_machine_type -v`
+Expected: FAIL — `KeyError: 'vm_type'`.
+
+- [ ] **Step 6: Wire `vm_type` into `_volume_rows`**
+
+In `src/vergil_tooling/bin/vrg_vm.py`, in `_volume_rows`, inside the `for volume_state in sorted(...)` loop, after `provider = provider_dir.name`, add:
+
+```python
+        vm_type = vm_cloud.parse_vm_machine_type(provider_dir / "vm.tfstate") or "—"
+```
+
+Then add `"vm_type": vm_type,` to **both** dicts appended to `rows` (the `parsed is None` placeholder dict and the populated dict).
+
+- [ ] **Step 7: Run the `_volume_rows` test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_vrg_vm.py::TestListRows::test_volume_rows_include_landed_machine_type -v`
+Expected: PASS.
+
+- [ ] **Step 8: Add the display column**
+
+In `_cmd_volumes`, update the header and line to add a `VM TYPE` column. Replace:
+
+```python
+    header = (
+        f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'DISK NAME':<{name_w}} "
+        f"{'SIZE':<8} {'ZONE':<16} {'REGION':<14}"
+    )
+```
+
+with:
+
+```python
+    header = (
+        f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'DISK NAME':<{name_w}} "
+        f"{'SIZE':<8} {'ZONE':<16} {'REGION':<14} {'VM TYPE':<16}"
+    )
+```
+
+and replace:
+
+```python
+        line = (
+            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} {r['name']!s:<{name_w}} "
+            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14}"
+        )
+```
+
+with:
+
+```python
+        line = (
+            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} {r['name']!s:<{name_w}} "
+            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14} {r['vm_type']!s:<16}"
+        )
+```
+
+- [ ] **Step 9: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/lib/vm_cloud.py src/vergil_tooling/bin/vrg_vm.py tests/vergil_tooling/test_vm_cloud.py tests/vergil_tooling/test_vrg_vm.py
+vrg-commit --type feat --scope off-platform \
+  --message "surface the landed machine family in 'vrg-vm volumes' from vm.tfstate (#1836)" \
+  --body "parse_vm_machine_type reads the realized machine type from vm.tfstate; vrg-vm volumes shows it in a VM TYPE column so a reattach that fell back to another family is visible. Single source of truth, no sidecar, no drift.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final: ladder verification + PR
+
+- [ ] **Manual GCP-doc verification (the real ladder gate).** Open GCP's current "nested virtualization — supported machine types" doc. Confirm each of `n2`, `n2d`, `c2`, `c2d` supports nested virtualization, and that `n2-/n2d-/c2-/c2d-standard-8` and `-standard-16` all exist. If `c2d` (AMD) is not supported, remove it from `NESTED_VIRT_FAMILIES` and update the `test_ladder_change_detector` expectation. Record the doc URL + date in the PR description.
+- [ ] **Open the PR** via the repo's submission workflow (e.g. `vrg-submit-pr`), referencing `#1836`, linking the design spec, and noting the manual verification result.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Ladder (one family list + `FALLBACK_SHAPES`, candidate derivation, edge case) → Task 1.
+- `FALLBACK_SHAPES` gate against invalid types → Task 1 (`test_unsupported_shape_yields_no_fallback`).
+- Ladder-aware conformance / no rebuild loop (instance_override; fingerprint from declared spec; no spec mutation) → Task 2.
+- Reattach-only hook via `_CloudState.fallback_instances` gated on `volume.tfstate` existing → Task 4.
+- Family sweep in pinned zone, volume never destroyed, helpful exhaustion error, non-capacity aborts → Task 3.
+- No silent fallback / loud logging → Task 3 (stderr prints).
+- Landed family surfaced from `vm.tfstate` (no meta sidecar; avoids #1831 collision) → Task 5.
+- Change-detector test + manual GCP-doc gate (not a tautological validity test) → Task 1 + Final.
+- Fresh-create path unchanged → Task 3 (backward-compat tests) + Task 4 (`test_tofu_volume_fresh_create_leaves_family_fallback_empty`).
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code; the only deferred item is the *intentional* manual GCP-doc verification, called out as a human gate.
+
+**3. Type consistency:** `instance_fallback_candidates(requested: str) -> list[str]` produced in Task 1, consumed in Task 4. `vm_vars(..., instance_override=...)` produced in Task 2, consumed in Task 3. `apply_vm_with_zone_fallback(..., fallback_instances=...)` produced in Task 3, consumed in Task 4. `_CloudState.fallback_instances: list[str]` defined in Task 4. `parse_vm_machine_type` produced in Task 5, consumed in `_volume_rows` same task. Names and signatures match across tasks.

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1919,6 +1919,7 @@ def _volume_rows() -> list[dict[str, object]]:
         provider_dir = volume_state.parent
         provider = provider_dir.name
         state_key = provider_dir.parent.name
+        vm_type = vm_cloud.parse_vm_machine_type(provider_dir / "vm.tfstate") or "—"
         parsed = vm_cloud.parse_volume_state(volume_state)
         if parsed is None:
             rows.append(
@@ -1931,6 +1932,7 @@ def _volume_rows() -> list[dict[str, object]]:
                     "zone": "—",
                     "region": "—",
                     "provider": provider,
+                    "vm_type": vm_type,
                 }
             )
             continue
@@ -1948,6 +1950,7 @@ def _volume_rows() -> list[dict[str, object]]:
                 "zone": parsed.zone or "—",
                 "region": region or "—",
                 "provider": provider,
+                "vm_type": vm_type,
             }
         )
     return rows
@@ -2010,7 +2013,7 @@ def _cmd_volumes(args: argparse.Namespace) -> int:
     inst_w = max([10, *(len(str(r.get("instance", "—"))) for r in rows)])
     header = (
         f"{'IDENTITY':<14} {'ORG/REPO':<{scope_w}} {'INSTANCE':<{inst_w}} "
-        f"{'DISK NAME':<{name_w}} {'SIZE':<8} {'ZONE':<16} {'REGION':<14}"
+        f"{'DISK NAME':<{name_w}} {'SIZE':<8} {'ZONE':<16} {'REGION':<14} {'VM TYPE':<16}"
     )
     if live:
         header += f" {'LIVE':<22}"
@@ -2020,7 +2023,7 @@ def _cmd_volumes(args: argparse.Namespace) -> int:
         line = (
             f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} "
             f"{r.get('instance', '—')!s:<{inst_w}} {r['name']!s:<{name_w}} "
-            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14}"
+            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14} {r['vm_type']!s:<16}"
         )
         if live:
             line += f" {r['live']!s:<22}"

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2023,7 +2023,7 @@ def _cmd_volumes(args: argparse.Namespace) -> int:
         line = (
             f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} "
             f"{r.get('instance', '—')!s:<{inst_w}} {r['name']!s:<{name_w}} "
-            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14} {r['vm_type']!s:<16}"
+            f"{r['size']!s:<8} {r['zone']!s:<16} {r['region']!s:<14} {r.get('vm_type', '—')!s:<16}"
         )
         if live:
             line += f" {r['live']!s:<22}"

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -713,6 +713,10 @@ class _CloudState:
     # Remaining zones to try if the VM apply hits a capacity stockout (#1813). Populated
     # by tofu-volume on a fresh create; empty on a reattach (a zonal disk cannot move).
     fallback_zones: list[str] = field(default_factory=list)
+    # Machine families to try (same pinned zone) if a reattach VM apply hits a capacity
+    # stockout — the ladder minus the requested type. Populated only on a reattach; empty
+    # on a fresh create, which sweeps fallback_zones instead. (#1836)
+    fallback_instances: list[str] = field(default_factory=list)
 
 
 def _require_modules(state: _CloudState) -> Path:
@@ -763,6 +767,12 @@ def _cs_tofu_volume(state: _CloudState) -> None:
         if candidates:
             volume_vars["zone"] = candidates[0]
             state.fallback_zones = candidates[1:]
+    else:
+        # Reattach: the zonal disk pins the zone, so recovery is a machine-family
+        # sweep in that zone rather than a zone sweep. (#1836)
+        state.fallback_instances = vm_cloud.instance_fallback_candidates(
+            state.backend.spec.instance
+        )[1:]
     volume_id, zone = vm_cloud.apply_volume(modules_root, state.state_dir, **volume_vars)
     state.volume_id = volume_id
     state.zone = zone
@@ -778,6 +788,7 @@ def _cs_tofu_vm(state: _CloudState) -> None:
         zone=state.zone,
         volume_id=state.volume_id,
         fallback_zones=state.fallback_zones,
+        fallback_instances=state.fallback_instances,
     )
     state.volume_id = volume_id
     state.zone = zone

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -797,43 +797,75 @@ def apply_vm_with_zone_fallback(
     zone: str,
     volume_id: str,
     fallback_zones: list[str],
+    fallback_instances: list[str] | None = None,
 ) -> tuple[str, str, dict[str, str]]:
-    """Apply the VM in ``zone``; on a capacity stockout, recreate the (empty) volume + VM
-    in each ``fallback_zones`` entry until one lands. Returns ``(volume_id, zone, outputs)``.
+    """Apply the VM in ``zone``; on a capacity stockout, recover by either swapping the
+    machine family in the SAME zone (reattach — the zonal data disk pins the zone) or,
+    on a fresh create, recreating the empty volume in each ``fallback_zones`` entry.
 
-    Only the fresh-volume create path supplies fallback zones — a reattach (existing volume
-    with data) passes ``[]``, since a zonal disk cannot move zones without losing its data.
-    ``apply_vm`` already rolls back its own partial state (the firewall) on failure; between
-    fallback zones we additionally destroy the just-created *empty* volume. (#1813)
+    ``fallback_instances`` (the ladder minus the requested type, from
+    ``instance_fallback_candidates``) is supplied on a reattach; ``fallback_zones`` on a
+    fresh create. The two are mutually exclusive today. Family fallback keeps
+    ``volume_id`` untouched — the disk holds data and never moves — whereas the zone
+    sweep destroys the *empty* disk to relocate it. With neither list a capacity error
+    is fatal. (#1813, #1836)
     """
-    tried = [zone]
+    instances = list(fallback_instances or [])
+    tried_zones = [zone]
+    tried_instances = [backend.spec.instance]
     vm_vars = cast("dict[str, Any]", backend.vm_vars(zone=zone, volume_id=volume_id))
     try:
         return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
     except subprocess.CalledProcessError as exc:
-        if not (fallback_zones and is_zone_capacity_error(exc)):
+        if not is_zone_capacity_error(exc):
             raise
-        print(f"  zone {zone}: no capacity — trying another...", file=sys.stderr)
+        if not instances and not fallback_zones:
+            raise  # reattach with no ladder (unsupported shape) — original behavior
 
+    # Family fallback — same zone, same volume (a zonal disk with data cannot move).
+    for instance in instances:
+        print(
+            f"  zone {zone}: {tried_instances[-1]} out of capacity — trying {instance}...",
+            file=sys.stderr,
+        )
+        tried_instances.append(instance)
+        vm_vars = cast(
+            "dict[str, Any]",
+            backend.vm_vars(zone=zone, volume_id=volume_id, instance_override=instance),
+        )
+        try:
+            return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
+        except subprocess.CalledProcessError as exc:
+            if not is_zone_capacity_error(exc):
+                raise
+
+    # Zone fallback — fresh create only; recreate the empty disk in each next zone.
     for next_zone in fallback_zones:
+        print(f"  zone {zone}: no capacity — trying {next_zone}...", file=sys.stderr)
         destroy_volume(modules_root, state_dir)  # the empty disk; rmtrees the state dir
         state_dir.mkdir(parents=True, exist_ok=True)
         volume_vars = cast("dict[str, Any]", {**backend.volume_vars(), "zone": next_zone})
         volume_id, zone = apply_volume(modules_root, state_dir, **volume_vars)
-        tried.append(zone)
+        tried_zones.append(zone)
         vm_vars = cast("dict[str, Any]", backend.vm_vars(zone=zone, volume_id=volume_id))
         try:
             return volume_id, zone, apply_vm(modules_root, state_dir, **vm_vars)
         except subprocess.CalledProcessError as exc:
             if not is_zone_capacity_error(exc):
                 raise
-            print(f"  zone {zone}: no capacity — trying another...", file=sys.stderr)
 
-    msg = (
-        f"no zone in {backend.spec.region} has capacity for {backend.spec.instance} "
-        f"(tried: {', '.join(tried)}). Try a different instance family (e.g. n2d-*), "
-        "another region, or wait for capacity."
-    )
+    if len(tried_instances) > 1:
+        msg = (
+            f"no nested-virt machine family has capacity in {zone} "
+            f"(tried: {', '.join(tried_instances)}). Wait for capacity, raise quota, "
+            "or try another region."
+        )
+    else:
+        msg = (
+            f"no zone in {backend.spec.region} has capacity for {backend.spec.instance} "
+            f"(tried: {', '.join(tried_zones)}). Try a different instance family "
+            "(e.g. n2d-*), another region, or wait for capacity."
+        )
     raise RuntimeError(msg)
 
 

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -756,10 +756,15 @@ def region_zones(region: str) -> list[str]:
 # reattach the zonal data disk pins the zone, so swapping the family is the only
 # recovery (see apply_vm_with_zone_fallback). The ladder may contain ONLY families
 # that support GCP nested virtualization — nested KVM is the point of these VMs, and
-# a family without it (e2, Tau) would boot a box with no /dev/kvm and fail the
-# provision. Membership/order is verified BY HAND against GCP's nested-virt
-# supported-machine-types doc before merge; the unit test is only a change-detector.
-NESTED_VIRT_FAMILIES = ("n2", "n2d", "c2", "c2d")
+# a family without it would boot a box with no /dev/kvm and fail the provision.
+# GCE nested virt requires an Intel (VT-x) processor: AMD, Arm, E2, memory-optimized,
+# and H4D VMs are all excluded, so the AMD families (n2d, c2d) are NOT eligible —
+# only the Intel families n2 and c2 are. Verified against GCP's nested-virt overview
+# (docs.cloud.google.com/compute/docs/instances/nested-virtualization/overview, which
+# lists "AMD and Arm processors" among the unsupported), corroborated by the
+# general-purpose machine docs ("N2D VMs don't support ... nested virtualization");
+# checked 2026-06-24. The unit test is only a change-detector — re-verify on edit.
+NESTED_VIRT_FAMILIES = ("n2", "c2")
 
 # Shapes verified to exist for EVERY family in the ladder and actually run
 # off-platform. Family-fallback engages only for these, so we never synthesize an

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -749,6 +749,46 @@ def region_zones(region: str) -> list[str]:
     return sorted(result.stdout.split())
 
 
+# --- Instance-family fallback ladder (#1836) ---------------------------------
+#
+# A capacity stockout is specific to a (zone, machine-family) pair: a different
+# family in the same zone often has capacity when the requested one does not. On a
+# reattach the zonal data disk pins the zone, so swapping the family is the only
+# recovery (see apply_vm_with_zone_fallback). The ladder may contain ONLY families
+# that support GCP nested virtualization — nested KVM is the point of these VMs, and
+# a family without it (e2, Tau) would boot a box with no /dev/kvm and fail the
+# provision. Membership/order is verified BY HAND against GCP's nested-virt
+# supported-machine-types doc before merge; the unit test is only a change-detector.
+NESTED_VIRT_FAMILIES = ("n2", "n2d", "c2", "c2d")
+
+# Shapes verified to exist for EVERY family in the ladder and actually run
+# off-platform. Family-fallback engages only for these, so we never synthesize an
+# invalid machine type. Adding a size is one line here.
+FALLBACK_SHAPES = frozenset({"standard-8", "standard-16"})
+
+
+def instance_fallback_candidates(requested: str) -> list[str]:
+    """Ordered machine types to try for ``requested``, the requested type first.
+
+    Splits ``requested`` into ``(family, shape)`` (``n2-standard-8`` ->
+    ``("n2", "standard-8")``). When the shape is in ``FALLBACK_SHAPES`` the result is
+    the requested type, then every other ``NESTED_VIRT_FAMILIES`` member at the same
+    shape, deduped. When the shape is unsupported the result is just ``[requested]``
+    (no fallback). If the requested family is not in the ladder (e.g. a misconfigured
+    ``e2`` declared with nested virt) the requested type still leads and the full
+    ladder follows, so fallback still reaches the nested-virt-safe families.
+    """
+    _family, _, shape = requested.partition("-")
+    if not shape or shape not in FALLBACK_SHAPES:
+        return [requested]
+    candidates = [requested]
+    for family in NESTED_VIRT_FAMILIES:
+        candidate = f"{family}-{shape}"
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+
+
 def apply_vm_with_zone_fallback(
     modules_root: Path,
     state_dir: Path,

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -955,6 +955,36 @@ def parse_volume_state(state_file: Path) -> VolumeState | None:
     return None
 
 
+def parse_vm_machine_type(state_file: Path) -> str | None:
+    """Return the bare machine type from a ``vm.tfstate``'s instance, or ``None``.
+
+    Mirrors ``parse_volume_state``: ``None`` when the file is absent, unreadable,
+    malformed, or carries no applied ``google_compute_instance``. ``machine_type`` may
+    be a bare type or a full selfLink — normalize to the bare name. This is the single
+    source of truth for the family a reattach fallback actually landed on. (#1836)
+    """
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    for resource in data.get("resources", []):
+        if not isinstance(resource, dict) or resource.get("type") != "google_compute_instance":
+            continue
+        instances = resource.get("instances") or []
+        if not instances or not isinstance(instances[0], dict):
+            continue
+        attrs = instances[0].get("attributes")
+        if not isinstance(attrs, dict):
+            continue
+        machine_type = attrs.get("machine_type")
+        if not machine_type:
+            return None
+        return str(machine_type).rsplit("/", 1)[-1]
+    return None
+
+
 # --- Off-platform backend ----------------------------------------------------
 
 # ASSUMPTION pending real-cloud e2e (vergil-vm gated test): the GCE image's

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -1028,7 +1028,9 @@ class OffPlatformBackend:
             "zone": self.spec.zone,
         }
 
-    def vm_vars(self, *, zone: str, volume_id: str) -> dict[str, object]:
+    def vm_vars(
+        self, *, zone: str, volume_id: str, instance_override: str | None = None
+    ) -> dict[str, object]:
         provision_env = render_provision_env(
             provision_params(
                 packages=list(self.spec.packages),
@@ -1044,7 +1046,10 @@ class OffPlatformBackend:
         return {
             "name": self.name,
             "zone": zone,
-            "instance_type": self.spec.instance,
+            # A family fallback swaps the machine type here ONLY; self.spec is never
+            # mutated, so fingerprint=spec_fingerprint(self.spec) above stays the
+            # declared hash and the drift check never reads a fallback as drift. (#1836)
+            "instance_type": instance_override or self.spec.instance,
             "nested": self.spec.nested,
             "volume_id": volume_id,
             "ssh_user": self.ssh_user,

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -854,6 +854,8 @@ def apply_vm_with_zone_fallback(
             if not is_zone_capacity_error(exc):
                 raise
 
+    # fallback_instances (reattach) and fallback_zones (fresh create) are mutually exclusive
+    # today; if both ever populate, this message names only the families tried.
     if len(tried_instances) > 1:
         msg = (
             f"no nested-virt machine family has capacity in {zone} "
@@ -980,7 +982,7 @@ def parse_vm_machine_type(state_file: Path) -> str | None:
             continue
         machine_type = attrs.get("machine_type")
         if not machine_type:
-            return None
+            continue
         return str(machine_type).rsplit("/", 1)[-1]
     return None
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -11,6 +11,8 @@ import pytest
 
 from vergil_tooling.lib import vm_cloud
 from vergil_tooling.lib.vm_cloud import (
+    FALLBACK_SHAPES,
+    NESTED_VIRT_FAMILIES,
     OffPlatformBackend,
     apply_vm,
     apply_vm_with_zone_fallback,
@@ -22,6 +24,7 @@ from vergil_tooling.lib.vm_cloud import (
     destroy_vm,
     destroy_volume,
     fetch_modules,
+    instance_fallback_candidates,
     is_zone_capacity_error,
     link_cloud_claude_dirs,
     off_platform_transport,
@@ -1482,3 +1485,45 @@ def test_cloud_labels_includes_instance_when_named() -> None:
     labels = cloud_labels("vergil-user", "lmf", "mq", "cloud-x86")
     assert labels["vergil-instance"] == "cloud-x86"
     assert "vergil-instance" not in cloud_labels("vergil-user", "lmf", "mq")
+
+
+class TestInstanceFallbackLadder:
+    def test_requested_first_then_same_shape_siblings(self) -> None:
+        assert instance_fallback_candidates("n2-standard-8") == [
+            "n2-standard-8",
+            "n2d-standard-8",
+            "c2-standard-8",
+            "c2d-standard-8",
+        ]
+
+    def test_dedups_when_requested_family_in_ladder(self) -> None:
+        # n2d is in the ladder; it must appear once, still requested-first.
+        result = instance_fallback_candidates("n2d-standard-16")
+        assert result[0] == "n2d-standard-16"
+        assert result.count("n2d-standard-16") == 1
+        assert set(result) == {
+            "n2d-standard-16",
+            "n2-standard-16",
+            "c2-standard-16",
+            "c2d-standard-16",
+        }
+
+    def test_unsupported_shape_yields_no_fallback(self) -> None:
+        assert instance_fallback_candidates("n2-highmem-8") == ["n2-highmem-8"]
+        assert instance_fallback_candidates("n2-standard-4") == ["n2-standard-4"]
+
+    def test_requested_family_not_in_ladder_still_leads(self) -> None:
+        # A misconfigured non-nested-virt family: original first, then full ladder.
+        assert instance_fallback_candidates("e2-standard-8") == [
+            "e2-standard-8",
+            "n2-standard-8",
+            "n2d-standard-8",
+            "c2-standard-8",
+            "c2d-standard-8",
+        ]
+
+    def test_ladder_change_detector(self) -> None:
+        # NOT a validity proof — pins the curated values so an edit is deliberate.
+        # Real nested-virt validity is verified by hand against GCP docs (#1836).
+        assert NESTED_VIRT_FAMILIES == ("n2", "n2d", "c2", "c2d")
+        assert FALLBACK_SHAPES == frozenset({"standard-8", "standard-16"})  # noqa: SIM300

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -1534,9 +1534,7 @@ class TestVmVarsInstanceOverride:
         spec = _off_spec(instance="n2-standard-8")
         b = OffPlatformBackend(spec, "vergil-user", "o", "r")
         declared_fp = spec_fingerprint(spec)
-        would_be_landed_fp = spec_fingerprint(
-            dataclasses.replace(spec, instance="n2d-standard-8")
-        )
+        would_be_landed_fp = spec_fingerprint(dataclasses.replace(spec, instance="n2d-standard-8"))
 
         v = b.vm_vars(zone="us-central1-f", volume_id="v1", instance_override="n2d-standard-8")
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -1492,21 +1492,17 @@ class TestInstanceFallbackLadder:
     def test_requested_first_then_same_shape_siblings(self) -> None:
         assert instance_fallback_candidates("n2-standard-8") == [
             "n2-standard-8",
-            "n2d-standard-8",
             "c2-standard-8",
-            "c2d-standard-8",
         ]
 
     def test_dedups_when_requested_family_in_ladder(self) -> None:
-        # n2d is in the ladder; it must appear once, still requested-first.
-        result = instance_fallback_candidates("n2d-standard-16")
-        assert result[0] == "n2d-standard-16"
-        assert result.count("n2d-standard-16") == 1
+        # c2 is in the ladder; it must appear once, still requested-first.
+        result = instance_fallback_candidates("c2-standard-16")
+        assert result[0] == "c2-standard-16"
+        assert result.count("c2-standard-16") == 1
         assert set(result) == {
-            "n2d-standard-16",
-            "n2-standard-16",
             "c2-standard-16",
-            "c2d-standard-16",
+            "n2-standard-16",
         }
 
     def test_unsupported_shape_yields_no_fallback(self) -> None:
@@ -1518,15 +1514,14 @@ class TestInstanceFallbackLadder:
         assert instance_fallback_candidates("e2-standard-8") == [
             "e2-standard-8",
             "n2-standard-8",
-            "n2d-standard-8",
             "c2-standard-8",
-            "c2d-standard-8",
         ]
 
     def test_ladder_change_detector(self) -> None:
         # NOT a validity proof — pins the curated values so an edit is deliberate.
-        # Real nested-virt validity is verified by hand against GCP docs (#1836).
-        assert NESTED_VIRT_FAMILIES == ("n2", "n2d", "c2", "c2d")
+        # Real nested-virt validity is verified by hand against GCP docs (#1836):
+        # GCE nested virt is Intel-only, so the AMD families (n2d, c2d) are excluded.
+        assert NESTED_VIRT_FAMILIES == ("n2", "c2")
         assert FALLBACK_SHAPES == frozenset({"standard-8", "standard-16"})  # noqa: SIM300 — variable == literal reads naturally for a change-detector pin
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -1673,3 +1673,42 @@ class TestParseVmMachineType:
         empty = tmp_path / "vm.tfstate"
         empty.write_text("{}")
         assert parse_vm_machine_type(empty) is None
+
+    def test_none_when_json_is_not_an_object(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text("[]")  # valid JSON, but not a dict
+        assert parse_vm_machine_type(f) is None
+
+    def test_skips_non_dict_and_non_instance_resources(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(
+            json.dumps(
+                {"resources": ["not-a-dict", {"type": "google_compute_disk", "instances": []}]}
+            )
+        )
+        assert parse_vm_machine_type(f) is None
+
+    def test_none_when_instance_resource_has_no_usable_instance(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(
+            json.dumps({"resources": [{"type": "google_compute_instance", "instances": ["x"]}]})
+        )
+        assert parse_vm_machine_type(f) is None
+
+    def test_none_when_attributes_not_a_dict(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {"type": "google_compute_instance", "instances": [{"attributes": "nope"}]}
+                    ]
+                }
+            )
+        )
+        assert parse_vm_machine_type(f) is None
+
+    def test_none_when_machine_type_is_empty(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(self._state(""))  # falsy machine_type -> continue -> None
+        assert parse_vm_machine_type(f) is None

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -1527,7 +1527,7 @@ class TestInstanceFallbackLadder:
         # NOT a validity proof — pins the curated values so an edit is deliberate.
         # Real nested-virt validity is verified by hand against GCP docs (#1836).
         assert NESTED_VIRT_FAMILIES == ("n2", "n2d", "c2", "c2d")
-        assert FALLBACK_SHAPES == frozenset({"standard-8", "standard-16"})  # noqa: SIM300
+        assert FALLBACK_SHAPES == frozenset({"standard-8", "standard-16"})  # noqa: SIM300 — variable == literal reads naturally for a change-detector pin
 
 
 class TestVmVarsInstanceOverride:
@@ -1551,6 +1551,7 @@ class TestVmVarsInstanceOverride:
         b = OffPlatformBackend(_off_spec(instance="n2-standard-16"), "vergil-user", "o", "r")
         v = b.vm_vars(zone="us-central1-b", volume_id="v1")
         assert v["instance_type"] == "n2-standard-16"
+        assert spec_fingerprint(_off_spec(instance="n2-standard-16")) in str(v["provision_env"])
 
 
 class TestFamilyFallback:

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -1550,3 +1550,94 @@ class TestVmVarsInstanceOverride:
         b = OffPlatformBackend(_off_spec(instance="n2-standard-16"), "vergil-user", "o", "r")
         v = b.vm_vars(zone="us-central1-b", volume_id="v1")
         assert v["instance_type"] == "n2-standard-16"
+
+
+class TestFamilyFallback:
+    @staticmethod
+    def _backend() -> MagicMock:
+        backend = MagicMock()
+        backend.vm_vars.return_value = {}
+        backend.spec.region = "us-central1"
+        backend.spec.instance = "n2-standard-8"
+        return backend
+
+    def test_swaps_family_in_same_zone_without_touching_volume(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Requested family stocked, first fallback family lands — same zone, same disk.
+        av = MagicMock(side_effect=[_capacity_exc(), {"host": "h"}])
+        dv = MagicMock()
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.apply_vm", av)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.destroy_volume", dv)
+        backend = self._backend()
+
+        result = apply_vm_with_zone_fallback(
+            tmp_path / "m",
+            tmp_path / "s",
+            backend,
+            zone="us-central1-f",
+            volume_id="v1",
+            fallback_zones=[],
+            fallback_instances=["n2d-standard-8", "c2-standard-8"],
+        )
+
+        assert result == ("v1", "us-central1-f", {"host": "h"})
+        assert av.call_count == 2
+        dv.assert_not_called()  # the data disk is never destroyed on this path
+        backend.vm_vars.assert_any_call(
+            zone="us-central1-f", volume_id="v1", instance_override="n2d-standard-8"
+        )
+
+    def test_all_families_stocked_raises_naming_them(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=_capacity_exc())
+        )
+        with pytest.raises(RuntimeError, match="no nested-virt machine family has capacity"):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-f",
+                volume_id="v1",
+                fallback_zones=[],
+                fallback_instances=["n2d-standard-8", "c2-standard-8"],
+            )
+
+    def test_non_capacity_error_during_family_sweep_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        boom = subprocess.CalledProcessError(1, [], stderr="Error: bad config")
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm",
+            MagicMock(side_effect=[_capacity_exc(), boom]),
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-f",
+                volume_id="v1",
+                fallback_zones=[],
+                fallback_instances=["n2d-standard-8", "c2-standard-8"],
+            )
+
+    def test_capacity_with_no_fallbacks_at_all_reraises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reattach of an unsupported shape: no families, no zones -> original error.
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.apply_vm", MagicMock(side_effect=_capacity_exc())
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            apply_vm_with_zone_fallback(
+                tmp_path / "m",
+                tmp_path / "s",
+                self._backend(),
+                zone="us-central1-f",
+                volume_id="v1",
+                fallback_zones=[],
+                fallback_instances=[],
+            )

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -28,6 +28,7 @@ from vergil_tooling.lib.vm_cloud import (
     is_zone_capacity_error,
     link_cloud_claude_dirs,
     off_platform_transport,
+    parse_vm_machine_type,
     parse_volume_state,
     preflight,
     provision_params,
@@ -1641,3 +1642,33 @@ class TestFamilyFallback:
                 fallback_zones=[],
                 fallback_instances=[],
             )
+
+
+class TestParseVmMachineType:
+    def _state(self, machine_type: str) -> str:
+        return json.dumps(
+            {
+                "resources": [
+                    {
+                        "type": "google_compute_instance",
+                        "instances": [{"attributes": {"machine_type": machine_type}}],
+                    }
+                ]
+            }
+        )
+
+    def test_returns_bare_type_from_selflink(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(self._state("projects/p/zones/us-central1-f/machineTypes/n2d-standard-8"))
+        assert parse_vm_machine_type(f) == "n2d-standard-8"
+
+    def test_returns_bare_type_when_already_bare(self, tmp_path: Path) -> None:
+        f = tmp_path / "vm.tfstate"
+        f.write_text(self._state("n2-standard-8"))
+        assert parse_vm_machine_type(f) == "n2-standard-8"
+
+    def test_none_when_absent_or_empty(self, tmp_path: Path) -> None:
+        assert parse_vm_machine_type(tmp_path / "missing.tfstate") is None
+        empty = tmp_path / "vm.tfstate"
+        empty.write_text("{}")
+        assert parse_vm_machine_type(empty) is None

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -37,7 +37,7 @@ from vergil_tooling.lib.vm_cloud import (
     tofu_state_dir,
     zone_to_region,
 )
-from vergil_tooling.lib.vm_spec import ComposedSpec, state_slug
+from vergil_tooling.lib.vm_spec import ComposedSpec, spec_fingerprint, state_slug
 from vergil_tooling.lib.vm_transport import IapTransport
 
 _RFC1035 = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
@@ -1527,3 +1527,28 @@ class TestInstanceFallbackLadder:
         # Real nested-virt validity is verified by hand against GCP docs (#1836).
         assert NESTED_VIRT_FAMILIES == ("n2", "n2d", "c2", "c2d")
         assert FALLBACK_SHAPES == frozenset({"standard-8", "standard-16"})  # noqa: SIM300
+
+
+class TestVmVarsInstanceOverride:
+    def test_override_swaps_machine_type_but_keeps_declared_fingerprint(self) -> None:
+        spec = _off_spec(instance="n2-standard-8")
+        b = OffPlatformBackend(spec, "vergil-user", "o", "r")
+        declared_fp = spec_fingerprint(spec)
+        would_be_landed_fp = spec_fingerprint(
+            dataclasses.replace(spec, instance="n2d-standard-8")
+        )
+
+        v = b.vm_vars(zone="us-central1-f", volume_id="v1", instance_override="n2d-standard-8")
+
+        # The tofu machine type is the fallback family...
+        assert v["instance_type"] == "n2d-standard-8"
+        # ...but the stamped fingerprint is the DECLARED one, never the landed family's.
+        assert declared_fp in str(v["provision_env"])
+        assert would_be_landed_fp not in str(v["provision_env"])
+        # ...and the spec object is never mutated.
+        assert b.spec.instance == "n2-standard-8"
+
+    def test_default_uses_declared_instance(self) -> None:
+        b = OffPlatformBackend(_off_spec(instance="n2-standard-16"), "vergil-user", "o", "r")
+        v = b.vm_vars(zone="us-central1-b", volume_id="v1")
+        assert v["instance_type"] == "n2-standard-16"

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -41,6 +41,7 @@ from vergil_tooling.bin.vrg_vm import (
     recover_handle,
     resolve_borrow,
 )
+from vergil_tooling.lib import vm_cloud
 from vergil_tooling.lib.identity import Identity, IdentityConfig
 from vergil_tooling.lib.vm_backend import select_backend
 from vergil_tooling.lib.vm_spec import ComposedSpec
@@ -3614,6 +3615,40 @@ class TestCloudStageGuards:
         )
         _cs_tofu_volume(state)
         assert state.fallback_zones == []
+
+    def test_tofu_volume_reattach_populates_family_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reattach: zone is pinned, so the recovery is a machine-family sweep (#1836).
+        state = self._state(tmp_path)
+        state.modules_root = tmp_path / "modules"
+        state.state_dir.mkdir(parents=True, exist_ok=True)
+        (state.state_dir / "volume.tfstate").write_text("{}")
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.apply_volume",
+            MagicMock(return_value=("vol-1", "us-central1-b")),
+        )
+        _cs_tofu_volume(state)
+        expected = vm_cloud.instance_fallback_candidates(state.backend.spec.instance)[1:]
+        assert state.fallback_instances == expected
+        assert state.fallback_zones == []
+
+    def test_tofu_volume_fresh_create_leaves_family_fallback_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fresh create keeps the zone sweep and never engages family fallback.
+        state = self._state(tmp_path)
+        state.modules_root = tmp_path / "modules"
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.apply_volume",
+            MagicMock(return_value=("vol-1", "us-central1-b")),
+        )
+        monkeypatch.setattr(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.region_zones",
+            MagicMock(return_value=["us-central1-a", "us-central1-b"]),
+        )
+        _cs_tofu_volume(state)
+        assert state.fallback_instances == []
 
     def test_require_modules_raises(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="fetch-modules did not run"):

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4815,6 +4815,20 @@ class TestVolumesCommand:
         assert "INSTANCE" in out
         assert "cloud-x86" in out
 
+    def test_placeholder_row_renders_vm_type_dash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # When volume.tfstate is malformed (parse_volume_state returns None) and
+        # no vm.tfstate exists, _cmd_volumes must print the VM TYPE header and
+        # render the "—" placeholder without raising.
+        home = tmp_path / "home"
+        _write_volume_state(home, "vergil-lmf-cloud", raw="{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+        assert main(["volumes"]) == 0
+        out = capsys.readouterr().out
+        assert "VM TYPE" in out
+        assert "—" in out
+
 
 # ---------------------------------------------------------------------------
 # Task 7 — _recorded_state_for_handle / RecordedState

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -35,6 +35,7 @@ from vergil_tooling.bin.vrg_vm import (
     _resolve_target,
     _resolve_vm_verbose,
     _target_ref,
+    _volume_rows,
     _warn_under,
     discover_dedicated,
     main,
@@ -3130,6 +3131,49 @@ class TestListRows:
         _make_repo(projects, "lmf", "mq", _MQ_VM_SECTION)
         cfg = _identities(tmp_path, projects)
         assert main(["start", "lmf/mq", "--config", str(cfg)]) == 1
+
+    def test_volume_rows_include_landed_machine_type(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        provider = tmp_path / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        provider.mkdir(parents=True)
+        (provider / "volume.tfstate").write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "type": "google_compute_disk",
+                            "instances": [
+                                {
+                                    "attributes": {
+                                        "name": "vergil-lmf-cloud-data",
+                                        "size": 300,
+                                        "zone": "us-central1-f",
+                                        "labels": {},
+                                    }
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+        (provider / "vm.tfstate").write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "type": "google_compute_instance",
+                            "instances": [{"attributes": {"machine_type": "n2d-standard-8"}}],
+                        }
+                    ]
+                }
+            )
+        )
+        rows = _volume_rows()
+        assert rows
+        assert rows[0]["vm_type"] == "n2d-standard-8"
 
 
 class TestProbeRunning:


### PR DESCRIPTION
# Pull Request

## Summary

- On a reattach VM apply hitting a zone capacity stockout, sweep an Intel-only nested-virt-safe machine-family ladder (n2, c2) in the pinned zone instead of hard-failing, keeping the data disk and without tripping the spec-drift rebuild loop.

## Issue Linkage

- Ref #1836

## Notes

- Design+plan: docs/specs/2026-06-23-off-platform-instance-family-fallback-{design,implementation-plan}.md. Built via 5 TDD tasks (each independently reviewed) + a final whole-branch review.

Key points for review:
- Conformance invariant: vm_vars gains instance_override that swaps only the tofu machine type; SPEC_FINGERPRINT stays computed from the unmutated declared spec, so a fallback is conformant by construction (no NEEDS-REBUILD loop). Test asserts the stamped fp is the declared one, not the landed family's.
- Family sweep lives in apply_vm_with_zone_fallback (same pinned zone, same volume; never destroys the data disk), running before the existing zone sweep. Backward-compat with the zone-fallback path preserved (verified against existing TestZoneFallback).
- Reattach-only: _CloudState.fallback_instances populated only when volume.tfstate exists; fresh create keeps its zone sweep untouched.
- Landed family surfaced in 'vrg-vm volumes' via parse_vm_machine_type reading vm.tfstate (single source of truth; no meta sidecar, so no collision with in-flight #1831).
- LADDER VERIFICATION (the one human gate): GCE nested virt is Intel-only — AMD/Arm unsupported per GCP docs (nested-virtualization overview + general-purpose machine docs, checked 2026-06-24). The original draft n2/n2d/c2/c2d was corrected to n2/c2; n2d/c2d (AMD EPYC) would have booted VMs with no /dev/kvm. Recorded with sources in the design spec.
- Canonical 'vrg-container-run -- vrg-validate' is green (lint, typecheck, tests at 100% coverage, audit).