### PR TITLE
fix(off-platform): handle volume-only boxes and report empty destroy-volume honestly

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1373,10 +1373,22 @@ def _cmd_destroy_volume(args: argparse.Namespace) -> int:
     modules_root = vm_cloud.fetch_modules(tag)
     try:
         print(f"Destroying the persistent volume for {ref} (state: {backend.state_dir()})...")
-        vm_cloud.destroy_volume(modules_root, backend.state_dir())
+        destroyed = vm_cloud.destroy_volume(modules_root, backend.state_dir())
     finally:
         shutil.rmtree(modules_root.parent, ignore_errors=True)
-    print(f"Persistent volume for {ref} destroyed (local tofu state removed).")
+    if destroyed:
+        print(f"Persistent volume for {ref} destroyed (local tofu state removed).")
+    else:
+        # The state held no disk — tofu destroyed nothing. Say so loudly rather than
+        # report a phantom success: a cloud disk created under a different/legacy
+        # state dir may still exist (and keep pinning quota). (#1846)
+        print(
+            f"WARNING: no disk was present in the tofu state for {ref} — nothing was "
+            f"destroyed. The local state has been cleared, but a cloud disk under a "
+            f"different/legacy state may still exist; check `vrg-vm volumes` and your "
+            f"provider console.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -693,14 +693,34 @@ def apply_vm(
 
 
 def destroy_vm(modules_root: Path, state_dir: Path) -> None:
-    """Destroy the disposable VM, reusing the stored tfvars; the volume is untouched."""
-    _run_tofu(modules_root / "gcp" / "vm", state_dir / "vm.tfstate", "destroy", {})
+    """Destroy the disposable VM, reusing the stored tfvars; the volume is untouched.
+
+    A no-op when there is no ``vm.tfstate`` (a volume-only box, the steady state
+    after a prior destroy preserved the volume): there is nothing to tear down, so
+    skip rather than letting ``_run_tofu`` raise on the absent tfvars. When the
+    state *does* exist but its tfvars are gone, ``_run_tofu`` still fails loudly —
+    that is a genuinely under-specified destroy, not an empty one. (#1845)
+    """
+    vm_state = state_dir / "vm.tfstate"
+    if not vm_state.exists():
+        return
+    _run_tofu(modules_root / "gcp" / "vm", vm_state, "destroy", {})
 
 
-def destroy_volume(modules_root: Path, state_dir: Path) -> None:
-    """Destroy the persistent volume, then remove the whole state dir for a clean rebuild."""
+def destroy_volume(modules_root: Path, state_dir: Path) -> bool:
+    """Destroy the persistent volume, then remove the whole state dir for a clean rebuild.
+
+    Returns whether the state actually managed a disk: ``True`` when a
+    ``google_compute_disk`` was present (a real teardown), ``False`` when it held
+    none (an empty/placeholder state, or one already drifted out of band — tofu
+    destroys nothing). The caller reports the no-op honestly rather than claiming a
+    disk was destroyed, which would mask a cloud disk orphaned under another state
+    dir. (#1846)
+    """
+    had_disk = parse_volume_state(state_dir / "volume.tfstate") is not None
     _run_tofu(modules_root / "gcp" / "volume", state_dir / "volume.tfstate", "destroy", {})
     shutil.rmtree(state_dir)
+    return had_disk
 
 
 def read_zone(state_dir: Path) -> str:

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -890,6 +890,8 @@ class TestRunTofu:
         monkeypatch.setenv("HOME", str(tmp_path))
         modules = tmp_path / "modules"
         state_dir = tofu_state_dir("k", "gcp")
+        # A real reuse scenario has both the VM state and its stored tfvars.
+        (state_dir / "vm.tfstate").write_text("{}")
         (state_dir / "vm.tfstate.tfvars.json").write_text('{"name": "vm-x"}')
         run = MagicMock(return_value=0)
         monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
@@ -918,16 +920,32 @@ class TestRunTofu:
         assert "plan" in plan_args
         assert "-auto-approve" not in plan_args
 
-    def test_destroy_without_vars_or_file_raises(
+    def test_destroy_vm_raises_when_state_present_but_tfvars_missing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # A VM state exists but its tfvars were lost: destroy must still fail
+        # loudly rather than run an under-specified destroy (the original guard).
+        monkeypatch.setenv("HOME", str(tmp_path))
+        modules = tmp_path / "modules"
+        state_dir = tofu_state_dir("k", "gcp")
+        (state_dir / "vm.tfstate").write_text("{}")
+        run = MagicMock(return_value=0)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
+        with pytest.raises(RuntimeError, match="no tofu vars supplied"):
+            destroy_vm(modules, state_dir)
+
+    def test_destroy_vm_noop_when_no_vm_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A volume-only box has no vm.tfstate: nothing to destroy, so destroy_vm
+        # is a clean no-op — it must not reach tofu or raise. (#1845)
         monkeypatch.setenv("HOME", str(tmp_path))
         modules = tmp_path / "modules"
         state_dir = tofu_state_dir("k", "gcp")
         run = MagicMock(return_value=0)
         monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
-        with pytest.raises(RuntimeError, match="no tofu vars supplied"):
-            destroy_vm(modules, state_dir)
+        destroy_vm(modules, state_dir)
+        run.assert_not_called()
 
     def test_destroy_volume_cleans_state_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -940,6 +958,56 @@ class TestRunTofu:
         run = MagicMock(return_value=0)
         monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
         destroy_volume(modules, state_dir)
+        assert not state_dir.exists()
+
+    def test_destroy_volume_reports_no_disk_when_state_has_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An empty/placeholder volume.tfstate (no google_compute_disk resource):
+        # tofu destroys nothing, so destroy_volume reports False so the caller can
+        # warn instead of claiming a disk was destroyed. (#1846)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        modules = tmp_path / "modules"
+        state_dir = tofu_state_dir("k", "gcp")
+        (state_dir / "volume.tfstate").write_text(json.dumps({"resources": []}))
+        (state_dir / "volume.tfstate.tfvars.json").write_text('{"name": "vol-x"}')
+        run = MagicMock(return_value=0)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
+        assert destroy_volume(modules, state_dir) is False
+        assert not state_dir.exists()
+
+    def test_destroy_volume_reports_disk_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A volume.tfstate carrying a google_compute_disk: a real teardown, so
+        # destroy_volume reports True. (#1846)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        modules = tmp_path / "modules"
+        state_dir = tofu_state_dir("k", "gcp")
+        (state_dir / "volume.tfstate").write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "type": "google_compute_disk",
+                            "instances": [
+                                {
+                                    "attributes": {
+                                        "name": "vol-x",
+                                        "size": 200,
+                                        "zone": "us-central1-f",
+                                    }
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+        (state_dir / "volume.tfstate.tfvars.json").write_text('{"name": "vol-x"}')
+        run = MagicMock(return_value=0)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", run)
+        assert destroy_volume(modules, state_dir) is True
         assert not state_dir.exists()
 
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3933,6 +3933,19 @@ class TestDestroyVolume:
         assert result == 0
         m["destroy_volume"].assert_called_once()
 
+    def test_warns_when_nothing_destroyed(
+        self, _cloud_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # destroy_volume reports False (state held no disk): the command must warn
+        # that nothing was destroyed rather than claim success. (#1846)
+        with _CloudPatches(tmp_path / "state") as m:
+            m["destroy_volume"].return_value = False
+            result = main(["destroy-volume", "lmf/cloud", "--config", str(_cloud_repo), "--yes"])
+        captured = capsys.readouterr()
+        assert "nothing was destroyed" in captured.err.lower()
+        assert "destroyed (local tofu state removed)" not in captured.out
+        assert result == 0
+
 
 class TestCloudList:
     def test_backend_column_present(self, config_file: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Fix the destroy/rebuild crash on volume-only boxes and stop destroy-volume from reporting a phantom success.

## Issue Linkage

- Ref #1845

## Notes

- Two related bugs in the off-platform teardown path, surfaced while reclaiming GCP SSD quota.

#1845 — vrg-vm destroy and rebuild --destroy-first crashed on a box with a persistent volume but no VM (the steady state after a prior destroy preserved the volume). With no vm.tfstate, the stored tfvars are absent and _run_tofu raised 'no tofu vars supplied'. destroy_vm is now a no-op when there is no vm.tfstate; the loud-failure guard still fires when the state exists but its tfvars are missing (a genuinely under-specified destroy).

#1846 — destroy-volume printed 'Persistent volume destroyed' even when tofu destroyed zero resources, masking a cloud disk orphaned under a different/legacy state dir. destroy_volume now returns whether the state actually managed a disk, and the command warns instead of claiming success.

Tests: added no-op and preserved-guard tests for destroy_vm, disk-present/absent return tests for destroy_volume, and a command-level warning test for destroy-volume. Full vrg-validate green (3557 passed).

Refs #1845 and #1846.