### PR TITLE
docs(off-platform): Scaleway Elastic Metal design + provider-dispatch Phase 1 plan (#1851)

### DIFF
--- a/docs/specs/2026-06-24-off-platform-provider-dispatch-implementation-plan.md
+++ b/docs/specs/2026-06-24-off-platform-provider-dispatch-implementation-plan.md
@@ -1,0 +1,259 @@
+# Off-platform Provider-Dispatch Abstraction (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the minimal provider-dispatch seam (so `select_backend` routes off-platform specs by `spec.provider`) and a dev-fetch override for OpenTofu modules — the GCP-safe foundation that unblocks the Azure and Scaleway backends.
+
+**Architecture:** Two small, independent changes in vergil-tooling: (1) `select_backend` branches on `spec.provider` within the off-platform path, returning the GCP backend for `"gcp"` and raising a clear error for any not-yet-implemented provider — this is the single file Azure/Scaleway later extend; (2) `fetch_modules` gains `VRG_MODULES_PATH` / `VRG_MODULES_REF` dev overrides so a backend can be developed/e2e-tested against an unreleased module before a vergil-vm v-tag exists. No engine/lifecycle refactor here.
+
+**Tech Stack:** Python 3.12, pytest, OpenTofu (modules fetched from vergil-vm v-tag archives).
+
+## Scope note (from the spec, refined)
+
+The design spec (`docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md`, §2/§9/§10) folds an engine extraction into "Phase 1." This plan **deliberately defers the engine/lifecycle-interface extraction (§9) to Phase 3**, where the Scaleway backend provides the second concrete implementation to validate the abstraction against. Abstracting the lifecycle interface from a single (GCP) example would be speculative (YAGNI) and would touch the shipped GCP engine for no present consumer. Phase 1 ships only the dispatch seam (§2, dispatch half) + the dev-fetch override (§10) — both independently valuable, GCP-behavior-preserving, and sufficient to unblock Azure's collision point (`select_backend`).
+
+## Global Constraints
+
+- **Git/commits via wrappers only:** `vrg-git` (not `git`), `vrg-commit` (not `git commit`), `vrg-gh` (not `gh`). Raw `git`/`gh` are denied by the permission model.
+- **Work entirely in the worktree:** `/Users/pmoore/dev/projects/vergil-project/vergil-tooling/.worktrees/issue-1851-scaleway-elastic-metal/` on branch `feature/1851-scaleway-elastic-metal`.
+- **GCP behavior unchanged:** the existing off-platform (GCP) path must behave identically; the full existing test suite stays green.
+- **No silent failures:** an unknown provider raises; a set-but-invalid `VRG_MODULES_PATH` raises. No fallbacks that hide misconfig.
+- **100% test coverage** is enforced by the gate — every new line/branch must be covered.
+- **Dev-fetch override is dev-only:** with no override env set, `fetch_modules` resolves to the v-tag exactly as today (production path unchanged).
+- **`select_backend` is the shared seam** Azure also edits — keep this diff small and in one clear region.
+
+### Per-task workflow
+
+- **Red/green feedback:** run the single test with `uv run pytest <path>::<TestClass>::<test> -v`.
+- **Gate before every commit:** `vrg-container-run -- vrg-validate` (the canonical pipeline — lint, types, full test suite at 100% coverage, audit; it runs in this environment).
+- **Commit:** `vrg-git add <files>` then `vrg-commit --type <feat|test> --scope off-platform --message "<desc> (#1851)" --body "<body>"` with the body ending in a real newline then `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `src/vergil_tooling/lib/vm_backend.py` — **modify** `select_backend` to branch on `spec.provider`.
+- `src/vergil_tooling/lib/vm_cloud.py` — **modify** `fetch_modules` (+ add `_MODULES_REF_URL`) for the dev-fetch override.
+- `tests/vergil_tooling/test_vm_backend.py` — **modify** (`TestSelectBackend`): unknown-provider raises.
+- `tests/vergil_tooling/test_vm_cloud.py` — **modify** (`TestFetchModules`): path/ref overrides.
+
+---
+
+## Task 1: Provider dispatch in `select_backend`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_backend.py` (the `select_backend` body, currently lines 39–44)
+- Test: `tests/vergil_tooling/test_vm_backend.py` (`TestSelectBackend`)
+
+**Interfaces:**
+- Consumes: `ComposedSpec.off_platform` (bool), `ComposedSpec.provider` (str); `OffPlatformBackend(spec, identity, org, repo, name)`.
+- Produces: `select_backend(...)` raises `ValueError` for an off-platform spec whose `provider` is not a supported off-platform provider; `"gcp"` continues to return `OffPlatformBackend`. The provider branch is where Azure/Scaleway add their cases.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/vergil_tooling/test_vm_backend.py` inside `TestSelectBackend` (the `_spec` helper already exists at module top):
+
+```python
+    def test_off_platform_unsupported_provider_raises(self) -> None:
+        spec = _spec(
+            "off-platform",
+            provider="scaleway",  # not implemented yet in Phase 1
+            region="fr-par-2",
+            instance="EM-B230E-NVMe-128G",
+            volume="0GiB",
+        )
+        with pytest.raises(ValueError, match="unsupported off-platform provider"):
+            select_backend(spec, identity="vergil-user", org="o", repo="r")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_backend.py::TestSelectBackend::test_off_platform_unsupported_provider_raises -v`
+Expected: FAIL — today `select_backend` ignores `provider` and returns an `OffPlatformBackend`, so no `ValueError` is raised.
+
+- [ ] **Step 3: Add the provider branch**
+
+In `src/vergil_tooling/lib/vm_backend.py`, replace the off-platform block in `select_backend`:
+
+```python
+    if spec.off_platform:
+        if identity is None or org is None or repo is None:
+            msg = "off-platform backend requires identity, org, and repo"
+            raise ValueError(msg)
+        return OffPlatformBackend(spec, identity, org, repo, name)
+    return LimaBackend()
+```
+
+with:
+
+```python
+    if spec.off_platform:
+        if identity is None or org is None or repo is None:
+            msg = "off-platform backend requires identity, org, and repo"
+            raise ValueError(msg)
+        # Dispatch by provider. This branch is the seam additional off-platform
+        # providers (azure, scaleway) extend with their own backend. (#1851)
+        if spec.provider == "gcp":
+            return OffPlatformBackend(spec, identity, org, repo, name)
+        msg = f"unsupported off-platform provider {spec.provider!r} (supported: gcp)"
+        raise ValueError(msg)
+    return LimaBackend()
+```
+
+- [ ] **Step 4: Run the new test + the existing dispatch tests to verify all pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_backend.py::TestSelectBackend -v`
+Expected: PASS — the new unsupported-provider test plus the pre-existing `test_off_platform_returns_off_platform_backend` (provider `"gcp"`), `test_local_returns_lima_backend`, and `test_off_platform_requires_identity_org_repo`.
+
+- [ ] **Step 5: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/lib/vm_backend.py tests/vergil_tooling/test_vm_backend.py
+vrg-commit --type feat --scope off-platform \
+  --message "dispatch off-platform backends by spec.provider (#1851)" \
+  --body "select_backend branches on spec.provider: gcp returns the existing backend; any other provider raises a clear error. This is the seam the azure and scaleway backends extend.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Dev-fetch override in `fetch_modules`
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/vm_cloud.py` (`fetch_modules`, currently lines 72–98; add `_MODULES_REF_URL` near `_MODULES_URL` ~line 68)
+- Test: `tests/vergil_tooling/test_vm_cloud.py` (`TestFetchModules`)
+
+**Interfaces:**
+- Consumes: `os.environ` (`VRG_MODULES_PATH`, `VRG_MODULES_REF`); existing `_MODULES_URL`, `_TAG_RE`.
+- Produces: `fetch_modules(tag)` resolves, in order — `VRG_MODULES_PATH` (a local vergil-vm checkout → its `opentofu/modules`), `VRG_MODULES_REF` (a git ref/branch → `archive/{ref}.tar.gz`, tag validation skipped), else the existing v-tag path unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/vergil_tooling/test_vm_cloud.py` inside `TestFetchModules`. Add an autouse fixture first so existing tests stay deterministic if these env vars leak from the shell, then the override tests:
+
+```python
+    @pytest.fixture(autouse=True)
+    def _clear_module_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VRG_MODULES_PATH", raising=False)
+        monkeypatch.delenv("VRG_MODULES_REF", raising=False)
+
+    def test_local_path_override_returns_modules(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        modules = tmp_path / "checkout" / "opentofu" / "modules"
+        modules.mkdir(parents=True)
+        monkeypatch.setenv("VRG_MODULES_PATH", str(tmp_path / "checkout"))
+        # No network: a bogus tag must be ignored when the path override wins.
+        assert fetch_modules("not-a-tag") == modules
+
+    def test_local_path_override_missing_dir_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VRG_MODULES_PATH", str(tmp_path / "checkout"))  # no opentofu/modules
+        with pytest.raises(SystemExit):
+            fetch_modules("v2.1.50")
+
+    @patch("vergil_tooling.lib.vm_cloud.urllib.request.urlopen")
+    def test_ref_override_builds_ref_url_and_skips_tag_check(
+        self, mock_urlopen: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VRG_MODULES_REF", "feature/1851-scaleway-elastic-metal")
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"not-a-tarball"
+        with pytest.raises(SystemExit):  # tar extraction of fake bytes fails loudly
+            fetch_modules("not-a-tag")  # bogus tag proves the ref path skips _TAG_RE
+        url = mock_urlopen.call_args[0][0]
+        assert url == (
+            "https://github.com/vergil-project/vergil-vm/archive/"
+            "feature/1851-scaleway-elastic-metal.tar.gz"
+        )
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestFetchModules -v`
+Expected: FAIL — `test_local_path_override_returns_modules` raises `SystemExit` (bogus tag rejected; override not implemented); the ref test builds the v-tag/`refs/tags` URL, not the `archive/<ref>` URL.
+
+- [ ] **Step 3: Add the `_MODULES_REF_URL` constant**
+
+In `src/vergil_tooling/lib/vm_cloud.py`, immediately after the `_MODULES_URL` definition (~line 68), add:
+
+```python
+# Dev-only override target: an arbitrary git ref (branch/tag/SHA) rather than a release
+# v-tag, so an unreleased module can be fetched during development. GitHub's archive
+# endpoint resolves branches/tags/SHAs here; the */opentofu/modules glob handles the
+# ref-derived root dir name. (#1851)
+_MODULES_REF_URL = "https://github.com/vergil-project/vergil-vm/archive/{ref}.tar.gz"
+```
+
+- [ ] **Step 4: Implement the override in `fetch_modules`**
+
+In `src/vergil_tooling/lib/vm_cloud.py`, replace the start of `fetch_modules` (the docstring stays; replace from the `if not _TAG_RE...` validation down to the `url = _MODULES_URL.format(tag=tag)` line):
+
+```python
+    if not _TAG_RE.fullmatch(tag):
+        print(f"ERROR: invalid module tag '{tag}' (expected vN.N or vN.N.N)", file=sys.stderr)
+        raise SystemExit(1)
+    url = _MODULES_URL.format(tag=tag)
+```
+
+with:
+
+```python
+    # Dev-only overrides (production passes neither and resolves the v-tag below):
+    #   VRG_MODULES_PATH — a local vergil-vm checkout; use its opentofu/modules directly.
+    #   VRG_MODULES_REF  — a git ref/branch; fetch its archive, skipping v-tag validation.
+    # Lets a backend be developed against an unreleased module before a release tag. (#1851)
+    local = os.environ.get("VRG_MODULES_PATH")
+    if local:
+        modules = Path(local) / "opentofu" / "modules"
+        if not modules.is_dir():
+            print(
+                f"ERROR: VRG_MODULES_PATH set but {modules} is not a directory",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        return modules
+    ref = os.environ.get("VRG_MODULES_REF")
+    if ref:
+        url = _MODULES_REF_URL.format(ref=ref)
+    else:
+        if not _TAG_RE.fullmatch(tag):
+            print(f"ERROR: invalid module tag '{tag}' (expected vN.N or vN.N.N)", file=sys.stderr)
+            raise SystemExit(1)
+        url = _MODULES_URL.format(tag=tag)
+```
+
+(`os` and `Path` are already imported in `vm_cloud.py`.)
+
+- [ ] **Step 5: Run the override tests + the existing fetch tests to verify all pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_vm_cloud.py::TestFetchModules -v`
+Expected: PASS — the three new tests plus the pre-existing `test_rejects_bad_tag`, `test_builds_archive_url`, `test_builds_archive_url_two_segment_tag`, `test_returns_modules_path_when_present`, `test_missing_modules_dir_aborts` (no override env → v-tag path unchanged).
+
+- [ ] **Step 6: Gate and commit**
+
+```bash
+vrg-container-run -- vrg-validate
+vrg-git add src/vergil_tooling/lib/vm_cloud.py tests/vergil_tooling/test_vm_cloud.py
+vrg-commit --type feat --scope off-platform \
+  --message "add VRG_MODULES_PATH/VRG_MODULES_REF dev-fetch overrides (#1851)" \
+  --body "fetch_modules can resolve modules from a local checkout or an arbitrary git ref, so a backend is testable against an unreleased module before a vergil-vm release tag exists. Production (no override) resolves the v-tag unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (this phase only):**
+- §2 dispatch half — provider branch in `select_backend` → Task 1.
+- §10 dev-fetch override (`VRG_MODULES_PATH`/`VRG_MODULES_REF`) → Task 2.
+- §9 engine extraction — **explicitly deferred to Phase 3** (scope note), validated there by the Scaleway backend. Azure's collision point (`select_backend`) is covered by Task 1.
+- Provider-neutral phasing (§"Phased implementation", phase 1) — this plan is exactly that phase.
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows the full before/after; commands have expected output.
+
+**3. Type consistency:** `select_backend(spec, *, identity, org, repo, name)` unchanged signature; `OffPlatformBackend(spec, identity, org, repo, name)` call unchanged. `fetch_modules(tag: str) -> Path` signature unchanged; new `_MODULES_REF_URL` formatted with `{ref}`. Env var names `VRG_MODULES_PATH` / `VRG_MODULES_REF` used identically in code and tests. No cross-task type references (the two tasks are independent).

--- a/docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md
+++ b/docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md
@@ -1,7 +1,7 @@
 # Off-platform: Scaleway Elastic Metal backend + provider-dispatch abstraction
 
 - **Issue:** vergil-tooling#1851
-- **Status:** Design (brainstormed)
+- **Status:** Design (brainstormed, pushback-reviewed)
 - **Related:** #1836 / PR #1841 (nested-virt family fallback on GCP reattach)
 - **Coordination:** in-flight **Azure** backend — this spec defines the provider-dispatch seam Azure conforms to (see §2 and §8).
 
@@ -62,9 +62,17 @@ server is released. Since this box runs ~24/7 and its data is reproducible
 
 - **create** → provision one `scaleway_baremetal_server` (offer, zone, OS image, SSH
   key, cloud-init user-data). Provisioning runs `templates/provision/*.sh` unchanged.
-- **rebuild** → **OS reinstall on the same allocated server** (Scaleway supports
-  reinstall/reprovision in place). Keeps the box — **no capacity loss** — wipes the
-  disk. This is the bare-metal analog of GCP's rebuild, minus the disk-survival.
+- **rebuild** → **OS reinstall on the same allocated server**, driven via the Scaleway
+  **install/reinstall API** against the stored server ID — **not** via a Terraform
+  `os`/`user_data` change. The platform supports in-place reinstall (a dedicated
+  Elastic Metal operation that keeps the allocation), but the `scaleway_baremetal_server`
+  Terraform resource's `ForceNew` behavior on `os`/`user_data` is unverified — if those
+  are `ForceNew`, a plain `terraform apply` would destroy+recreate and **lose the box**,
+  reintroducing the GCP capacity-loss failure. Driving reinstall through the API makes the
+  "keep the box, no capacity loss" guarantee independent of provider-version semantics.
+  Terraform owns create/destroy; the server ID is persisted in state so rebuild targets it.
+  Keeps the box, wipes the disk. *(Build task: confirm the TF `ForceNew` flags and, if
+  needed, ensure the resource isn't replaced when the API-driven reinstall changes the OS.)*
 - **destroy** → release the server; capacity returns to Scaleway's pool, all state gone.
 - Native KVM: the `nested` flag and `70-nested-virt.sh` are satisfied with no config.
 
@@ -99,8 +107,13 @@ A single module using the first-class `scaleway` Terraform provider:
   rendered cloud-init).
 - Reuses the existing `templates/provision/*.sh` via the cloud-init `user-data` path
   exactly as the GCP module does — the provisioning scripts are backend-neutral already.
+  **Caveat:** Scaleway accepts **`text/plain` user-data only** ([cloud-init concepts](https://www.scaleway.com/en/docs/elastic-metal/concepts/));
+  the rendered provision document must be a single text/plain payload (cloud-config is
+  normally text/plain, so this is expected to be fine — confirm at build, no multipart MIME).
+- The module itself lives in **vergil-vm**, not this repo, and is fetched by v-tag — see §10.
 - No volume module, no firewall-for-IAP, no `enable_nested_virtualization`.
-- Outputs: the server's tailnet hostname/address for the transport (see §4).
+- Outputs: the server ID (for API-driven reinstall, §1) and the tailnet hostname/address
+  for the transport (see §4).
 
 ### 4. Transport — Tailscale/WireGuard overlay
 
@@ -116,6 +129,25 @@ Scaleway metal has a public IP; we deliberately do **not** expose SSH on it.
   preserving the GCP IAP security posture (no public attack surface, roaming-proof).
 - **Prerequisite:** the operator's machine is on the same tailnet, and an auth key is
   configured (per-identity, alongside the Scaleway token). Documented in setup.
+
+**Readiness probe.** The GCP path polls cloud-init status over IAP; tailnet-only SSH has
+a blind window until `tailscaled` is up and joined. So `await-readiness` for Scaleway
+waits for the node to appear on the tailnet — via the Tailscale API, or by polling
+SSH-over-MagicDNS for the cloud-init readiness/fingerprint marker — on a bounded timeout.
+On timeout it fails **loudly**, pointing at the break-glass below; it does not hang or
+silently pass.
+
+**Lockout / break-glass.** If `tailscaled` never comes up (expired/invalid key, Tailscale
+outage, ACL/tag mistake) the box has no public SSH and is unreachable over the network.
+This is **not** a brick: Scaleway provides hardware-level **out-of-band KVM / serial
+console** access, which is always available. The readiness-timeout error names it as the
+manual recovery path. The tooling does not automate console recovery in v1.
+
+**Auth-key lifecycle & exposure.** Keys are **ephemeral, pre-authorized, tagged, short-TTL,
+and minted per provision** (every create *and* every rebuild/reinstall gets a fresh key).
+The key is injected via cloud-init user-data, which is readable in Scaleway's instance
+metadata/console — a secret surface — so the short TTL + single-use ephemerality keep a
+leaked key near-worthless and self-expiring. User-data is **not** treated as a secret store.
 
 ### 5. Credentials & configuration
 
@@ -135,14 +167,22 @@ Replacing GCP's ADC/project:
 - Validate the offer name and zone against the provider at compose/apply time; a typo
   must fail loudly with the list of valid offers, not a cryptic Terraform error.
 
-### 7. Stock-out handling
+### 7. Stock-out handling — multi-zone stock check at create
 
-Elastic Metal offers can be **out of stock** in a given zone (a real, if rarer,
-analog to GCP's capacity stockout). v1: detect the out-of-stock apply error, surface
-a clear message naming the offer/zone and pointing at the other Scaleway zones
-(`fr-par-1/2`, `nl-ams-1`, `pl-waw-2`). A zone sweep can reuse the #1836 pattern but
-is **deferred** unless stock-outs prove common — bare metal you hold doesn't churn the
-way on-demand VMs do.
+The "assigned box, no churn" reliability win applies to *holding* a server; **acquiring**
+one still has to find available stock, and Elastic Metal offers (especially the cheap AMD
+class) **do go out of stock per zone**. So the create path must handle this, or the
+headline reliability claim is overstated for the first `create` (and any
+`destroy`→`create`).
+
+- **Create-time multi-zone stock check.** Elastic Metal exposes per-zone offer
+  availability (console/API — confirm the exact endpoint at build). The create path checks
+  the target offer across Scaleway zones (`fr-par-1/2`, `nl-ams-1`, `pl-waw-2`), provisions
+  in the first available zone, and if none have stock, fails **loudly**: "offer X out of
+  stock in all zones — try offer Y or wait." This is the create-time analog of the #1836
+  zone/family fallback.
+- Once acquired, the box is held (no churn), so this only gates initial acquisition and
+  full teardown→recreate — not rebuild (which reinstalls the same held server, §1).
 
 ### 8. Coordination with the in-flight Azure backend
 
@@ -163,6 +203,30 @@ fallback. Extract the provider-specific pieces behind the §2 interface so the e
 lifecycle-stage framework (`_cs_*` stages) is provider-neutral and the GCP behavior is
 unchanged. Keep the GCP capacity-fallback logic in the GCP backend, not the shared engine.
 
+### 10. Cross-repo split & module fetch (release-ordered)
+
+The OpenTofu module is **not** local to vergil-tooling. The off-platform engine fetches
+modules from a **vergil-vm v-tag archive**:
+
+```python
+_MODULES_URL = "https://github.com/vergil-project/vergil-vm/archive/refs/tags/{tag}.tar.gz"
+_TAG_RE = re.compile(r"^v\d+\.\d+(\.\d+)?$")   # tags only — no branch/local override today
+```
+
+So the Scaleway module (`opentofu/modules/scaleway/server`) lives in **vergil-vm** and is
+only fetchable once it's in a **released vergil-vm tag**. This makes the feature a
+two-repo, release-ordered change:
+
+- **Sequence:** vergil-vm Scaleway-module PR → vergil-vm release (v-tag) → vergil-tooling
+  backend referencing that tag. The backend cannot be e2e-"done" until the module is tagged.
+- **Dev-fetch override (new, small):** add a `fetch_modules` escape hatch —
+  `VRG_MODULES_REF` (a git ref/branch) and/or `VRG_MODULES_PATH` (a local checkout) — so
+  the backend is developable and e2e-testable against an unreleased module *before* the prod
+  tag exists. Without it, every iteration requires cutting a vergil-vm release. The override
+  is dev-only and useful beyond this feature; production still resolves to the v-tag.
+- **Coordination:** the module PR (vergil-vm) and the backend PR (vergil-tooling) are
+  tracked together under #1851; the module must merge+tag first.
+
 ## Testing
 
 - **Dispatch**: `select_backend` returns the Scaleway backend for `provider="scaleway"`,
@@ -172,19 +236,32 @@ unchanged. Keep the GCP capacity-fallback logic in the GCP backend, not the shar
 - **Module var mapping**: spec → `scaleway_baremetal_server` vars (offer/zone/os/ssh/
   user-data) are correct; cloud-init carries the provision env + Tailscale auth key.
 - **Transport**: `TailscaleTransport` targets the MagicDNS name; no public SSH assumed.
-- **Lifecycle**: rebuild maps to reinstall (same server), destroy to release; single-state
-  (no volume calls).
-- **Stock-out**: the out-of-stock apply error surfaces the clear message, not a raw trace.
+- **Readiness**: the readiness probe waits on the tailnet marker and, on timeout, raises a
+  loud error naming the console break-glass (never hangs, never silently passes).
+- **Lifecycle**: rebuild drives the **reinstall API against the stored server ID** (same
+  server, not a destroy+recreate) and mints a fresh ephemeral key; destroy releases;
+  single-state (no volume calls).
+- **Stock check**: create sweeps zones for offer availability and provisions in the first
+  with stock; all-out-of-stock raises the clear message, not a raw trace.
+- **Module fetch**: `VRG_MODULES_REF` / `VRG_MODULES_PATH` override resolves modules from a
+  branch/local path; absent the override, production resolves to the v-tag (and rejects a
+  non-tag ref).
 - **e2e (gated, costs money)**: real provision on Scaleway, `/dev/kvm` present, reachable
-  over tailnet — mirrors the gated GCP cloud e2e.
+  over tailnet, rebuild keeps the same server ID — mirrors the gated GCP cloud e2e.
 
 ## Phased implementation
 
 1. **Provider-dispatch abstraction** — extract the seam (§2, §9); GCP behavior unchanged,
-   fully green. Independently testable and the foundation Azure also consumes.
-2. **Scaleway backend + module + transport** — §1, §3, §4, §5, §6, §7 on top of phase 1.
+   fully green. Independently testable and the foundation Azure also consumes. Includes the
+   dev-fetch override (§10), which is provider-neutral.
+2. **Scaleway module in vergil-vm** (§3) — the `scaleway/server` OpenTofu module, merged and
+   **tagged** in a vergil-vm release (the prerequisite for phase 3 e2e; see §10).
+3. **Scaleway backend + transport + lifecycle** — §1, §4, §5, §6, §7 on top of phases 1–2
+   (reinstall-via-API rebuild, Tailscale transport + readiness/break-glass, create-time
+   stock check). e2e uses the dev-fetch override until the phase-2 tag lands.
 
-(Likely two implementation plans; this is one cohesive design.)
+(Three implementation plans across two repos; this is one cohesive design. Phase 2 is the
+vergil-vm change and gates phase-3 e2e.)
 
 ## Alternatives considered
 

--- a/docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md
+++ b/docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md
@@ -1,0 +1,202 @@
+# Off-platform: Scaleway Elastic Metal backend + provider-dispatch abstraction
+
+- **Issue:** vergil-tooling#1851
+- **Status:** Design (brainstormed)
+- **Related:** #1836 / PR #1841 (nested-virt family fallback on GCP reattach)
+- **Coordination:** in-flight **Azure** backend — this spec defines the provider-dispatch seam Azure conforms to (see §2 and §8).
+
+## Problem
+
+GCP on-demand capacity for nested-virtualization-capable machines is structurally
+unreliable. Nested virt on GCE is **Intel-only** (n2/c2; AMD excluded — see #1836),
+and those families stock out (`ZONE_RESOURCE_POOL_EXHAUSTED`) in popular zones. #1836
+added family fallback, but it only spreads the bet across a small, contended pool;
+when every Intel family is exhausted there is no recovery, and releasing a box to
+rebuild it routinely loses the slot to another tenant.
+
+We need a **reliable, cheap, IaC-provisioned** alternative that does not compete for
+scarce cloud VM SKUs.
+
+## Goal
+
+Add a Scaleway **Elastic Metal** off-platform backend:
+
+- **Bare metal ⇒ native KVM.** Nested virt is a non-issue — the agent's KVM guests
+  are first-level, no per-SKU policy roulette, `70-nested-virt.sh` passes trivially.
+- **The box is assigned to us.** No capacity loss on rebuild; the GCP "release it and
+  someone grabs it" failure cannot happen.
+- **Cheap and IaC-native.** First-class Terraform provider; ~€150/mo for an
+  EM-B230E (AMD EPYC 8C/16T, 128 GB) — roughly 4× cheaper than a GCP reservation.
+
+Introduce the minimal **provider-dispatch abstraction** required to host a second
+off-platform provider cleanly, and define it so the concurrent Azure backend
+conforms to the same seam rather than inventing a parallel one.
+
+## Non-goals (v1)
+
+- Any change to the GCP backend's behavior (beyond extracting the shared seam).
+- The Azure backend itself (parallel work; it consumes the seam defined here).
+- Detachable / persistent storage on metal (no two-state model — see §3).
+- Other bare-metal providers (Hetzner, Latitude, Vultr) — future, behind the same seam.
+- Multi-box fleets / autoscaling on Scaleway.
+
+## Decisions (from brainstorm)
+
+| Axis | Decision |
+| --- | --- |
+| Integration model | Cloud-IaC (OpenTofu / first-class TF provider), not a hand-managed host. |
+| Provider | Scaleway Elastic Metal (EU; geography-flexible, cost/reliability prioritized). |
+| Footprint | ~16 threads / ≥64 GB, nested-virt, kept ~24/7. EM-B230E (8C/16T, 128 GB). |
+| Lifecycle | **Single-state** — server only; rebuild = OS reinstall on the same box. |
+| Transport | **Tailscale/WireGuard overlay** — no public SSH; survives operator roaming. |
+| Azure coordination | **Define the provider-dispatch seam here; Azure conforms.** |
+
+## Design
+
+### 1. Lifecycle — single-state (not GCP's two-state)
+
+GCP splits a disposable VM from a surviving persistent disk so the VM can be rebuilt
+without data loss. Bare metal cannot: the disk belongs to the server and dies when the
+server is released. Since this box runs ~24/7 and its data is reproducible
+(blow-away-and-recreate), the Scaleway backend uses a **single resource**:
+
+- **create** → provision one `scaleway_baremetal_server` (offer, zone, OS image, SSH
+  key, cloud-init user-data). Provisioning runs `templates/provision/*.sh` unchanged.
+- **rebuild** → **OS reinstall on the same allocated server** (Scaleway supports
+  reinstall/reprovision in place). Keeps the box — **no capacity loss** — wipes the
+  disk. This is the bare-metal analog of GCP's rebuild, minus the disk-survival.
+- **destroy** → release the server; capacity returns to Scaleway's pool, all state gone.
+- Native KVM: the `nested` flag and `70-nested-virt.sh` are satisfied with no config.
+
+### 2. Provider-dispatch abstraction (the seam Azure conforms to)
+
+Today `off-platform` resolves directly to a GCP-specific `OffPlatformBackend`. Introduce:
+
+- `spec.provider` already exists; `select_backend` branches on it when
+  `spec.off_platform` is true: `"gcp"` → the GCP backend, `"scaleway"` → the Scaleway
+  backend. Unknown provider → explicit error.
+- A **provider-neutral backend interface** (extending the existing `Backend` protocol)
+  with the methods the off-platform engine calls. The minimum seam:
+  - `apply(state_dir) -> ApplyResult` (host/address + whatever transport needs),
+  - `destroy(state_dir)`, `rebuild(state_dir)`,
+  - `transport() -> Transport`,
+  - `status() -> str`,
+  - `fingerprint_fields() -> list[str]` (provider-specific declaration inputs).
+- **Fingerprint**: `spec_fingerprint` already includes `provider`; it must include the
+  provider-relevant fields only (Scaleway: provider/region/offer; *not* the GCP-only
+  `zone`/`volume`/`nested`). Each backend declares its fields so a non-applicable knob
+  never trips a spurious rebuild.
+
+This is the **only file both this work and Azure must touch** (`select_backend` +
+the interface). The contract above is the convergence point (see §8).
+
+### 3. OpenTofu module — `opentofu/modules/scaleway/server`
+
+A single module using the first-class `scaleway` Terraform provider:
+
+- `scaleway_baremetal_server` (offer = e.g. `EM-B230E-NVMe-128G`, zone = e.g.
+  `fr-par-2`, os = an image that supports cloud-init, ssh_key_ids, user-data =
+  rendered cloud-init).
+- Reuses the existing `templates/provision/*.sh` via the cloud-init `user-data` path
+  exactly as the GCP module does — the provisioning scripts are backend-neutral already.
+- No volume module, no firewall-for-IAP, no `enable_nested_virtualization`.
+- Outputs: the server's tailnet hostname/address for the transport (see §4).
+
+### 4. Transport — Tailscale/WireGuard overlay
+
+Scaleway metal has a public IP; we deliberately do **not** expose SSH on it.
+
+- At provision, cloud-init installs `tailscaled` and joins the tailnet using an
+  **ephemeral, pre-authorized auth key** (injected as a provision param, like
+  `SPEC_FINGERPRINT`). The node sets its Tailscale hostname to the deterministic
+  cloud resource name, so it has a stable MagicDNS name.
+- Public SSH is firewalled off; SSH is reachable **only over the tailnet**.
+- A new `TailscaleTransport` (sibling of `IapTransport`) SSHes to the MagicDNS name.
+  It needs no IP allow-list and survives operator roaming (identity is the tailnet),
+  preserving the GCP IAP security posture (no public attack surface, roaming-proof).
+- **Prerequisite:** the operator's machine is on the same tailnet, and an auth key is
+  configured (per-identity, alongside the Scaleway token). Documented in setup.
+
+### 5. Credentials & configuration
+
+Replacing GCP's ADC/project:
+
+- **Scaleway**: API access key + secret key, project ID, default zone/region — read
+  from the existing identity/config mechanism (e.g. `~/.config/vergil/…`), env-var
+  overridable, failing loudly if absent (no silent fallback).
+- **SSH key**: registered with Scaleway (or referenced by ID) so the server accepts the
+  operator key for the initial cloud-init bootstrap before tailnet is up.
+- **Tailscale**: an auth key (ephemeral + pre-authorized + tagged) per identity.
+
+### 6. Spec fields & validation
+
+- `provider = "scaleway"`, `region` (Scaleway zone, e.g. `fr-par-2`), `instance` = the
+  Elastic Metal offer name. `zone`/`volume`/`nested` are GCP-only and unused here.
+- Validate the offer name and zone against the provider at compose/apply time; a typo
+  must fail loudly with the list of valid offers, not a cryptic Terraform error.
+
+### 7. Stock-out handling
+
+Elastic Metal offers can be **out of stock** in a given zone (a real, if rarer,
+analog to GCP's capacity stockout). v1: detect the out-of-stock apply error, surface
+a clear message naming the offer/zone and pointing at the other Scaleway zones
+(`fr-par-1/2`, `nl-ams-1`, `pl-waw-2`). A zone sweep can reuse the #1836 pattern but
+is **deferred** unless stock-outs prove common — bare metal you hold doesn't churn the
+way on-demand VMs do.
+
+### 8. Coordination with the in-flight Azure backend
+
+Both Azure and this work introduce provider branching. The convergence contract is §2:
+`select_backend` branches on `spec.provider`, and each provider implements the
+backend interface. Azure is a **cloud-VM** provider (it will likely keep a
+VM+disk shape and a private-networking transport), so it diverges from Scaleway's
+single-state/Tailscale specifics — but both must use the **same dispatch seam and
+interface**. Whichever lands second rebases onto the seam; this spec owns its
+definition. The only expected shared-file edits are `select_backend` and the backend
+interface/protocol module.
+
+### 9. Engine abstraction
+
+`vm_cloud.py` is GCP-coupled: `gcloud` calls (`region_zones`, `_resolve_project`), the
+IAP transport, the two-state `apply_volume`/`apply_vm`, and the #1836 capacity
+fallback. Extract the provider-specific pieces behind the §2 interface so the engine's
+lifecycle-stage framework (`_cs_*` stages) is provider-neutral and the GCP behavior is
+unchanged. Keep the GCP capacity-fallback logic in the GCP backend, not the shared engine.
+
+## Testing
+
+- **Dispatch**: `select_backend` returns the Scaleway backend for `provider="scaleway"`,
+  GCP backend for `"gcp"`, raises on unknown.
+- **Fingerprint**: Scaleway fingerprint includes provider/region/offer and is unaffected
+  by GCP-only fields; the GCP fingerprint is byte-for-byte unchanged (no spurious rebuild).
+- **Module var mapping**: spec → `scaleway_baremetal_server` vars (offer/zone/os/ssh/
+  user-data) are correct; cloud-init carries the provision env + Tailscale auth key.
+- **Transport**: `TailscaleTransport` targets the MagicDNS name; no public SSH assumed.
+- **Lifecycle**: rebuild maps to reinstall (same server), destroy to release; single-state
+  (no volume calls).
+- **Stock-out**: the out-of-stock apply error surfaces the clear message, not a raw trace.
+- **e2e (gated, costs money)**: real provision on Scaleway, `/dev/kvm` present, reachable
+  over tailnet — mirrors the gated GCP cloud e2e.
+
+## Phased implementation
+
+1. **Provider-dispatch abstraction** — extract the seam (§2, §9); GCP behavior unchanged,
+   fully green. Independently testable and the foundation Azure also consumes.
+2. **Scaleway backend + module + transport** — §1, §3, §4, §5, §6, §7 on top of phase 1.
+
+(Likely two implementation plans; this is one cohesive design.)
+
+## Alternatives considered
+
+- **Hetzner dedicated (AX42, ~€46/mo)** — ~3× cheaper, but Robot/`installimage`
+  provisioning and only a community Terraform provider; the roughest IaC fit, against the
+  "cloud-IaC only" decision. Revisit as a future provider if cost dominates.
+- **Oracle OCI (E5.Flex, ~$250/mo)** — clean Terraform cloud VM with confirmed nested
+  virt; pricier and still a capacity-contended cloud VM. A good *cloud-VM* fallback,
+  not the cheapest reliable.
+- **Direct key-only public SSH + firewall** — simplest transport, but public attack
+  surface and IP allow-lists break on operator roaming (the problem IAP solved). Rejected
+  in favor of the overlay.
+- **Two-state (server + network volume)** — Scaleway has block storage, but it adds cost
+  and complexity for data we've declared non-precious; single-state is simpler and matches
+  the 24/7 usage.

--- a/docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md
+++ b/docs/specs/2026-06-24-off-platform-scaleway-elastic-metal-design.md
@@ -1,7 +1,7 @@
 # Off-platform: Scaleway Elastic Metal backend + provider-dispatch abstraction
 
 - **Issue:** vergil-tooling#1851
-- **Status:** Design (brainstormed, pushback-reviewed)
+- **Status:** Design (brainstormed, pushback-reviewed, alignment-checked)
 - **Related:** #1836 / PR #1841 (nested-virt family fallback on GCP reattach)
 - **Coordination:** in-flight **Azure** backend — this spec defines the provider-dispatch seam Azure conforms to (see §2 and §8).
 
@@ -78,25 +78,25 @@ server is released. Since this box runs ~24/7 and its data is reproducible
 
 ### 2. Provider-dispatch abstraction (the seam Azure conforms to)
 
-Today `off-platform` resolves directly to a GCP-specific `OffPlatformBackend`. Introduce:
+Today `off-platform` resolves directly to a GCP-specific `OffPlatformBackend`. The seam
+lands in two steps across phases (don't abstract a lifecycle interface from a single GCP
+example — let the second consumer shape it):
 
-- `spec.provider` already exists; `select_backend` branches on it when
-  `spec.off_platform` is true: `"gcp"` → the GCP backend, `"scaleway"` → the Scaleway
-  backend. Unknown provider → explicit error.
-- A **provider-neutral backend interface** (extending the existing `Backend` protocol)
-  with the methods the off-platform engine calls. The minimum seam:
-  - `apply(state_dir) -> ApplyResult` (host/address + whatever transport needs),
-  - `destroy(state_dir)`, `rebuild(state_dir)`,
-  - `transport() -> Transport`,
-  - `status() -> str`,
-  - `fingerprint_fields() -> list[str]` (provider-specific declaration inputs).
-- **Fingerprint**: `spec_fingerprint` already includes `provider`; it must include the
-  provider-relevant fields only (Scaleway: provider/region/offer; *not* the GCP-only
-  `zone`/`volume`/`nested`). Each backend declares its fields so a non-applicable knob
-  never trips a spurious rebuild.
+- **Phase 1 — dispatch only.** `spec.provider` already exists; `select_backend` branches on
+  it when `spec.off_platform` is true: `"gcp"` → the GCP backend, anything else → an
+  explicit "unsupported provider" error. This branch is the one shared edit; Azure/Scaleway
+  add their own `provider` case here. (No interface change, no engine change — GCP-safe.)
+- **Phase 3 — provider-neutral interface + fingerprint.** When the Scaleway backend lands
+  (the second consumer), extract a provider-neutral interface (extending the existing
+  `Backend` protocol) for the methods the off-platform engine calls — roughly
+  `apply`/`destroy`/`rebuild`/`transport`/`status` plus a `fingerprint_fields()` so each
+  backend declares only its own declaration inputs (Scaleway: provider/region/offer; *not*
+  the GCP-only `zone`/`volume`/`nested`), so a non-applicable knob never trips a spurious
+  rebuild. The exact method set is fixed against two real implementations, not guessed now.
 
-This is the **only file both this work and Azure must touch** (`select_backend` +
-the interface). The contract above is the convergence point (see §8).
+**Phase-1 shared edit:** only `select_backend`'s `provider` branch. That dispatch point — not
+the fuller interface — is Azure's sole hard Phase-1 dependency (see §8). The interface
+extraction is §9, deferred to Phase 3.
 
 ### 3. OpenTofu module — `opentofu/modules/scaleway/server`
 
@@ -186,22 +186,30 @@ headline reliability claim is overstated for the first `create` (and any
 
 ### 8. Coordination with the in-flight Azure backend
 
-Both Azure and this work introduce provider branching. The convergence contract is §2:
-`select_backend` branches on `spec.provider`, and each provider implements the
-backend interface. Azure is a **cloud-VM** provider (it will likely keep a
-VM+disk shape and a private-networking transport), so it diverges from Scaleway's
-single-state/Tailscale specifics — but both must use the **same dispatch seam and
-interface**. Whichever lands second rebases onto the seam; this spec owns its
-definition. The only expected shared-file edits are `select_backend` and the backend
-interface/protocol module.
+Both Azure and this work introduce provider branching. Azure's **only hard Phase-1
+dependency is the `select_backend` `provider` dispatch point** (§2, Phase 1) — that's the
+single shared edit and the actual collision risk; whoever lands first adds the branch and
+the other adds its `provider` case beside it. Azure is a **cloud-VM** provider (it will
+likely keep a VM+disk shape and a private-networking transport), so it diverges from
+Scaleway's single-state/Tailscale specifics. The **provider-neutral interface itself is not
+a Phase-1 artifact** — it's extracted in Phase 3 (§9) once there are two real consumers
+(GCP + Scaleway) to shape it; Azure conforms to that interface when it lands relative to
+Phase 3, not before. So the only Phase-1 shared file is `select_backend`.
 
-### 9. Engine abstraction
+### 9. Engine abstraction — **Phase 3** (not Phase 1)
 
 `vm_cloud.py` is GCP-coupled: `gcloud` calls (`region_zones`, `_resolve_project`), the
 IAP transport, the two-state `apply_volume`/`apply_vm`, and the #1836 capacity
 fallback. Extract the provider-specific pieces behind the §2 interface so the engine's
 lifecycle-stage framework (`_cs_*` stages) is provider-neutral and the GCP behavior is
 unchanged. Keep the GCP capacity-fallback logic in the GCP backend, not the shared engine.
+
+**This is deliberately Phase 3, not Phase 1.** Abstracting the engine before a second
+backend exists would be speculative (the right interface comes from two implementations,
+not one) and would churn the shipped GCP path for no current consumer. Phase 1 ships only
+the `select_backend` dispatch branch (§2) + the dev-fetch override (§10); the engine
+extraction happens here in Phase 3, with the Scaleway backend as the validating second
+consumer and the full GCP test suite as the behavior-preservation guard.
 
 ### 10. Cross-repo split & module fetch (release-ordered)
 
@@ -251,17 +259,22 @@ two-repo, release-ordered change:
 
 ## Phased implementation
 
-1. **Provider-dispatch abstraction** — extract the seam (§2, §9); GCP behavior unchanged,
-   fully green. Independently testable and the foundation Azure also consumes. Includes the
-   dev-fetch override (§10), which is provider-neutral.
+1. **Provider dispatch + dev-fetch override** — the `select_backend` `provider` branch
+   (§2, Phase 1) and the `VRG_MODULES_PATH`/`VRG_MODULES_REF` overrides (§10). GCP behavior
+   unchanged, fully green, independently mergeable. This is the only Phase-1 shared edit and
+   Azure's sole hard Phase-1 dependency. **No interface or engine change here.**
 2. **Scaleway module in vergil-vm** (§3) — the `scaleway/server` OpenTofu module, merged and
    **tagged** in a vergil-vm release (the prerequisite for phase 3 e2e; see §10).
-3. **Scaleway backend + transport + lifecycle** — §1, §4, §5, §6, §7 on top of phases 1–2
-   (reinstall-via-API rebuild, Tailscale transport + readiness/break-glass, create-time
-   stock check). e2e uses the dev-fetch override until the phase-2 tag lands.
+3. **Scaleway backend + provider-neutral abstraction** — the engine/interface extraction
+   (§2 interface + `fingerprint_fields`, §9) *together with* the Scaleway backend that
+   validates it, plus §1, §4, §5, §6, §7 (reinstall-via-API rebuild, Tailscale transport +
+   readiness/break-glass, create-time stock check), on top of phases 1–2. The full GCP test
+   suite is the behavior-preservation guard; e2e uses the dev-fetch override until the
+   phase-2 tag lands.
 
-(Three implementation plans across two repos; this is one cohesive design. Phase 2 is the
-vergil-vm change and gates phase-3 e2e.)
+(Three implementation plans across two repos; this is one cohesive design. The provider-
+neutral interface is extracted in phase 3 — with two real consumers to shape it — not phase
+1. Phase 2 is the vergil-vm change and gates phase-3 e2e.)
 
 ## Alternatives considered
 


### PR DESCRIPTION
# Pull Request

## Summary

- Capture the brainstormed, pushback-reviewed, alignment-checked design for a Scaleway Elastic Metal off-platform backend plus the Phase 1 (provider-dispatch + dev-fetch) implementation plan; implementation is intentionally parked, so this is docs-only.

## Issue Linkage

- Ref #1851

## Notes

- DOCS-ONLY PR — implementation is parked for now (no code changes; only docs/specs/ additions).

Contents:
- 2026-06-24-off-platform-scaleway-elastic-metal-design.md — full design: bare-metal nested-virt (native KVM, no SKU roulette), single-state lifecycle (rebuild = reinstall-via-API on the held box), Tailscale transport (no public SSH) with readiness probe + console break-glass, create-time multi-zone stock check, provider-dispatch seam (Azure conforms), cross-repo module/release ordering + dev-fetch override. Verified externally: Elastic Metal cloud-init support and in-place reinstall.
- 2026-06-24-off-platform-provider-dispatch-implementation-plan.md — Phase 1 plan (provider dispatch + VRG_MODULES_PATH/REF dev override), GCP-safe, two TDD tasks.

Phasing: (1) provider dispatch + dev-fetch [planned], (2) Scaleway module in vergil-vm [future plan], (3) backend + provider-neutral abstraction [future plan]. Coordinates with the in-flight Azure backend on the select_backend dispatch point.

Reviewer focus: this is design intent, not code — sanity-check the approach, the Scaleway provider choice over Hetzner/OCI, and the Tailscale transport decision. No runtime behavior changes.