### PR TITLE
feat(release): defer artifact-publish failures so vrg-release never strands develop

### DIFF
--- a/docs/specs/2026-06-24-vrg-release-deferred-publish-design.md
+++ b/docs/specs/2026-06-24-vrg-release-deferred-publish-design.md
@@ -68,6 +68,15 @@ defers everything else.
 If the `release` job failed, or the tag/Release cannot be cut, the release is
 genuinely broken and must stop immediately — same as today.
 
+The `release` job is the single load-bearing assertion, so it is matched
+**exactly** (the reusable-workflow leaf name `release / release`, via a named
+constant), **not** by the loose substring matching `_find_job` uses elsewhere.
+Exact matching avoids a future `release`-containing job (e.g. `release-notes`)
+binding the hard gate to the wrong job. If the release job is ever renamed
+upstream, the exact lookup returns nothing and confirm-main hard-fails
+"release job not found" — fail-closed, which is the safe direction. The
+substring `_find_job` is retained only for the deferred-job sweep.
+
 ### Deferred jobs (the change)
 
 Every **other** job in the `cd.yml` run that did not conclude `success` —
@@ -82,7 +91,20 @@ Every **other** job in the `cd.yml` run that did not conclude `success` —
   clear summary line naming each failed publish job, and the release tracking
   issue is **left open** with a "republish" to-do rather than closed.
 
-`confirm-develop`'s `docs` check defers the same way, for consistency.
+### `confirm-develop` — unified reporting, not a behavior change
+
+`confirm-develop` is **already** `mode="fail_defer"`, so a `docs` failure there
+already does not abort the pipeline — that behavior needs no change. The only
+change is **reporting**: instead of letting `confirm_develop` raise (which would
+record the generic stage name `"confirm-develop"` into the `_tracked`-owned
+`deferred_failures` and surface a bare stage error), it records the failed
+`docs` job into the **same** `ctx.deferred_publish_failures` list that
+`confirm-main` uses, and does not raise. That way every deferred publish
+failure — docker-on-main, docs-on-main, docs-on-develop — flows through one
+surface: the `publish-status` summary, the open tracking issue, and the same
+remediation message. Without this, a docs-on-develop failure would report
+differently and would not trigger the "leave the issue open + how to republish"
+handling (which keys off `deferred_publish_failures`).
 
 ### Mechanics
 
@@ -99,11 +121,26 @@ Every **other** job in the `cd.yml` run that did not conclude `success` —
    A separate field is used rather than the existing `ctx.deferred_failures`
    because the latter is owned by the `_tracked` wrapper, which appends **stage
    names** on stage exceptions. Mixing job names into it would conflate the two.
-3. **Surface the deferral** via two independent consumers:
+3. **Surface the deferral** via three consumers:
    - `close-finalize` must **not** close the tracking issue when
      `ctx.deferred_publish_failures` is non-empty; instead it posts a comment
-     listing the deferred publish jobs and the remediation (re-run the publish /
-     nightly `no-cache` rebuild) and leaves the issue open.
+     and leaves the issue open. The comment names the **concrete** remediation,
+     because the intuitive next step is a trap: the release is already tagged
+     and `develop` already bumped, so `vrg-release --resume` does **not** apply
+     (it is for a *halted* release, not a *completed-with-deferral* one) and
+     will error on the existing tag. The correct remediation is a **CD-side
+     re-run** of the publish — `gh workflow run cd.yml` / Actions → CD → Run
+     workflow, or the nightly `no-cache` `ops.yml` rebuild — once the blocker
+     (e.g. CVE triage) is cleared. The comment states this explicitly and warns
+     against `--resume`. A first-class `vrg-republish` helper is tracked
+     separately as a follow-up (#1854).
+   - `consumer-refresh` must **guard** on `ctx.deferred_publish_failures`: when
+     it is non-empty, it prints a **hold-warning** ("artifacts pending
+     republish — do not advertise vX.Y.Z to consumers until republished")
+     instead of the normal upgrade guidance. Otherwise the run would print
+     "consumers can upgrade now" immediately before the deferred-failure
+     summary says the artifacts never shipped — contradictory output that
+     invites advertising a stale release.
    - A new terminal stage **`publish-status`** (mode `fail_defer`, last in the
      pipeline) raises a `ReleaseError` iff `ctx.deferred_publish_failures` is
      non-empty. Being `fail_defer`, it does not abort anything (every prior
@@ -122,11 +159,17 @@ added then, against a concrete need.
 
 ## Components touched
 
-- `lib/release/confirm.py` — `confirm_main` (narrow the hard gate, classify and
-  record deferred jobs); `confirm_develop` (defer `docs`); the `_verify_jobs` /
-  `_watch_cd` helpers.
+- `lib/release/confirm.py` — `confirm_main`: watch with `check_status=False`,
+  exact-match the `release` job for the hard gate, classify every other failed
+  job into `ctx.deferred_publish_failures`. `confirm_develop`: record a failed
+  `docs` job into the same list (do not raise). Add an exact-match helper (named
+  constant for `release / release`); keep substring `_find_job` for the sweep.
 - `lib/release/finalize.py` — `close_and_finalize` honors a non-empty
-  `ctx.deferred_failures` (leave the issue open, post a remediation comment).
+  `ctx.deferred_publish_failures`: leave the issue open and post a remediation
+  comment naming the CD re-run and warning against `vrg-release --resume`.
+- `lib/release/handoff.py` — `consumer_refresh` guards on
+  `ctx.deferred_publish_failures`: print a hold-warning instead of upgrade
+  guidance when non-empty.
 - `lib/release/context.py` — add `deferred_publish_failures` (job name,
   conclusion, run URL), separate from the `_tracked`-owned `deferred_failures`.
 - `lib/release/orchestrator.py` — append one terminal `publish-status` stage
@@ -149,8 +192,14 @@ back-merge-bump … promote … (all run normally; develop ⊇ main, vX.Y promot
         ▼
 close-finalize  (fail_defer)
   └─ ctx.deferred_publish_failures non-empty?
-        ├─ yes ─▶ leave tracking issue OPEN + remediation comment
+        ├─ yes ─▶ leave issue OPEN + comment: CD re-run remediation, NOT --resume
         └─ no  ─▶ close tracking issue
+        │
+        ▼
+consumer-refresh  (fail_defer)
+  └─ ctx.deferred_publish_failures non-empty?
+        ├─ yes ─▶ hold-warning ("pending republish; do not advertise vX.Y.Z")
+        └─ no  ─▶ normal upgrade guidance
         │
         ▼
 publish-status  (fail_defer, terminal)
@@ -167,6 +216,12 @@ publish-status  (fail_defer, terminal)
   classification reuses it so a still-settling job is not misread as failed.
 - If the CD run itself never appears or never reaches terminal, that remains a
   hard `confirm-main` failure (we cannot confirm the release at all).
+- `check_status=False` does **not** make the watch return early: `watch_workflow`
+  runs `gh run watch <run_id>`, which blocks until the run is terminal
+  regardless; `check_status` only toggles `--exit-status` (whether a red run
+  *propagates* as a failure). So the per-job classification never races a
+  still-running job, and `_settled_run_jobs` guards the conclusion-settle window
+  on top of that.
 
 ## Testing
 
@@ -175,19 +230,27 @@ publish-status  (fail_defer, terminal)
   `ctx.deferred_publish_failures == ["docker-publish"]`.
 - Unit: `release` = `failure` → raises (fatal), regardless of other jobs.
 - Unit: artifacts missing (`release` success but no tag) → raises (fatal).
-- Unit: `docs` = `failure` on develop → `confirm_develop` defers, no raise.
+- Unit: a job named `release-notes` present alongside `release / release` →
+  the hard gate binds to `release` exactly, not the substring match.
+- Unit: `docs` = `failure` on develop → `confirm_develop` records it into
+  `ctx.deferred_publish_failures` and does not raise.
 - Unit: `close_and_finalize` with non-empty `deferred_publish_failures` → issue
-  left open, remediation comment posted; with empty → issue closed.
+  left open; the comment names the CD re-run and warns against `--resume`; with
+  empty → issue closed.
+- Unit: `consumer_refresh` with non-empty `deferred_publish_failures` → prints
+  the hold-warning, not upgrade guidance; with empty → normal guidance.
 - Unit: `publish-status` stage raises (deferred) when
   `deferred_publish_failures` is non-empty, no-op when empty.
 - Integration: full pipeline with a stubbed CD run where only `docker-publish`
-  failed → all stages run, `develop ⊇ main`, rolling tag promoted, exit 1,
-  tracking issue open.
+  failed → all stages run, `develop ⊇ main`, rolling tag promoted, consumer
+  hold-warning shown, exit 1, tracking issue open with remediation comment.
 
 ## Scope
 
-In scope: `confirm-main` / `confirm-develop` job classification, the
-deferred-failure surfacing, and the `close-finalize` issue-handling change.
+In scope: `confirm-main` / `confirm-develop` job classification; the new
+`deferred_publish_failures` context field and `publish-status` terminal stage;
+the `close-finalize` issue-handling + remediation comment; and the
+`consumer-refresh` hold-warning guard.
 
 Out of scope: the `vergil-docker` Trivy CVE triage itself (a separate,
 recurring `.trivyignore` task); changing what the `cd.yml` jobs do; any

--- a/docs/specs/2026-06-24-vrg-release-deferred-publish-design.md
+++ b/docs/specs/2026-06-24-vrg-release-deferred-publish-design.md
@@ -1,0 +1,202 @@
+# Defer Artifact-Publish Failures in vrg-release
+
+**Issue:** [#1853](https://github.com/vergil-project/vergil-tooling/issues/1853)
+**Date:** 2026-06-24
+
+## Problem
+
+`vrg-release` aborts the entire release pipeline when **any** CD job fails at
+the `confirm-main` gate — including artifact-publish jobs (`docker-publish`,
+`docs`) that have no bearing on the integrity of the release itself.
+
+The `confirm-main` stage runs in `fail_fast` mode and sits **before**
+`back-merge-bump` in the pipeline:
+
+```
+prepare → merge-release → confirm-main (fail_fast) → back-merge-bump → ...
+```
+
+So when a publish job fails, `confirm-main` raises and the run aborts **before**
+`develop` is back-merged and version-bumped. The result is the recurring mess:
+`develop` left behind `main` (no back-merge), no rolling `vX.Y` tag, and the
+release tracking issue left open — each occurrence requiring a manual
+back-merge + bump + tag-promote cleanup.
+
+This bites `vergil-docker` routinely: its `docker-publish` job fails the Trivy
+CRITICAL/HIGH gate whenever the upstream language base images carry un-triaged
+CVEs, which is a near-constant background condition.
+
+### Root cause
+
+`confirm_main` (in `lib/release/confirm.py`) gates on two things:
+
+1. `_watch_cd(ctx, branch="main", check_status=True)` — fails if the
+   **overall run** status is not success. A `docker-publish` failure turns the
+   whole `cd.yml` run red, so this is what trips.
+2. `_verify_jobs(ctx, run_id, _MAIN_EXPECTED_JOBS=("docs", "release"))` — a
+   per-job check that currently treats `docs` as hard-required and does not
+   look at `docker-publish` at all.
+
+The overall-run-status gate (1) is the over-broad veto: it aborts the release
+on *any* job failure, even a re-publishable artifact job.
+
+## Principle
+
+The git tag + GitHub Release is the only **irreversible** commitment in a
+release. Every published artifact — docs, Docker images, packages — is
+**re-publishable** after the fact, without re-cutting the release. Therefore an
+artifact-publish failure must never abort the release bookkeeping (back-merge,
+develop bump, tag promote).
+
+This holds for every repository, so the new behavior is a **fleet-wide
+default** with **no configuration**. We lower the release-integrity bar for no
+one; we simply stop letting retryable downstream work veto it.
+
+## Solution
+
+`confirm-main` hard-fails on exactly one thing — the release itself — and
+defers everything else.
+
+### Hard gate (unchanged severity, narrowed scope)
+
+`confirm-main` raises (fatal, `fail_fast`) only when one of these is true:
+
+- the `release` job did not conclude `success`, or
+- a release artifact is missing: the `vX.Y.Z` tag, the GitHub Release for that
+  tag, or the `develop-vX.Y.Z` boundary tag.
+
+If the `release` job failed, or the tag/Release cannot be cut, the release is
+genuinely broken and must stop immediately — same as today.
+
+### Deferred jobs (the change)
+
+Every **other** job in the `cd.yml` run that did not conclude `success` —
+`docs`, `docker-publish`, and anything added later — is recorded as a
+**deferred failure** rather than raising:
+
+- `confirm-main` does **not** raise for it; the stage completes, so the pipeline
+  proceeds through `back-merge-bump` and the remaining stages. `develop` is
+  back-merged and bumped, the rolling `vX.Y` tag is promoted — the bookkeeping
+  always completes.
+- The deferred failure is surfaced at the end of the run: a non-zero exit, a
+  clear summary line naming each failed publish job, and the release tracking
+  issue is **left open** with a "republish" to-do rather than closed.
+
+`confirm-develop`'s `docs` check defers the same way, for consistency.
+
+### Mechanics
+
+1. **Stop vetoing on overall run status.** `confirm_main` watches the run to a
+   terminal state but no longer treats overall-run failure as fatal
+   (`_watch_cd(..., check_status=False)` for the main-branch confirm). The
+   run-level red is expected when a deferrable job fails.
+2. **Classify per job.** After the run settles, fetch all jobs. Hard-verify the
+   `release` job (`conclusion == "success"`) and the artifacts. For every other
+   job whose `conclusion != "success"`, append a structured entry to a **new**
+   context field `ctx.deferred_publish_failures` (job name + conclusion + run
+   URL) and print a warning. Do not raise.
+
+   A separate field is used rather than the existing `ctx.deferred_failures`
+   because the latter is owned by the `_tracked` wrapper, which appends **stage
+   names** on stage exceptions. Mixing job names into it would conflate the two.
+3. **Surface the deferral** via two independent consumers:
+   - `close-finalize` must **not** close the tracking issue when
+     `ctx.deferred_publish_failures` is non-empty; instead it posts a comment
+     listing the deferred publish jobs and the remediation (re-run the publish /
+     nightly `no-cache` rebuild) and leaves the issue open.
+   - A new terminal stage **`publish-status`** (mode `fail_defer`, last in the
+     pipeline) raises a `ReleaseError` iff `ctx.deferred_publish_failures` is
+     non-empty. Being `fail_defer`, it does not abort anything (every prior
+     stage has already run) but it marks the run failed, so the existing
+     `lib/progress.py` summary renders the deferred `PipelineError … exit 1`
+     naming the unpublished artifacts. When the field is empty the stage is a
+     no-op and the run exits `0`.
+
+### Why not a `vergil.toml` opt-in
+
+An earlier iteration scoped this per-repo via `vergil.toml`. It was dropped:
+the principle (only the release commit is irreversible) is universal, so a
+config knob would only ever be set one way. Per YAGNI, no config is introduced.
+If a future repo genuinely needs a publish to be fatal, a config key can be
+added then, against a concrete need.
+
+## Components touched
+
+- `lib/release/confirm.py` — `confirm_main` (narrow the hard gate, classify and
+  record deferred jobs); `confirm_develop` (defer `docs`); the `_verify_jobs` /
+  `_watch_cd` helpers.
+- `lib/release/finalize.py` — `close_and_finalize` honors a non-empty
+  `ctx.deferred_failures` (leave the issue open, post a remediation comment).
+- `lib/release/context.py` — add `deferred_publish_failures` (job name,
+  conclusion, run URL), separate from the `_tracked`-owned `deferred_failures`.
+- `lib/release/orchestrator.py` — append one terminal `publish-status` stage
+  (mode `fail_defer`) that raises iff `ctx.deferred_publish_failures` is
+  non-empty. `confirm-main` keeps mode `fail_fast` (its *hard gate* is still
+  fatal); the deferral itself is data on the context, surfaced by the new stage.
+
+## Data flow
+
+```
+confirm-main  (fail_fast)
+  ├─ watch cd.yml run on main → terminal (no overall-status veto)
+  ├─ release job success?  ── no ─▶ raise (fatal)
+  ├─ artifacts present?    ── no ─▶ raise (fatal)
+  └─ each other failed job ─▶ ctx.deferred_publish_failures.append(job)  (no raise)
+        │
+        ▼
+back-merge-bump … promote … (all run normally; develop ⊇ main, vX.Y promoted)
+        │
+        ▼
+close-finalize  (fail_defer)
+  └─ ctx.deferred_publish_failures non-empty?
+        ├─ yes ─▶ leave tracking issue OPEN + remediation comment
+        └─ no  ─▶ close tracking issue
+        │
+        ▼
+publish-status  (fail_defer, terminal)
+  └─ ctx.deferred_publish_failures non-empty? ── yes ─▶ raise ─▶ summary exit 1
+                                              └─ no  ─▶ no-op  ─▶ exit 0
+```
+
+## Error handling
+
+- A genuinely-broken release (release job failed, or tag/Release/boundary tag
+  missing) still aborts immediately at `confirm-main`, before any back-merge —
+  unchanged from today.
+- A transient jobs-API lag is already handled by `_settled_run_jobs`; the
+  classification reuses it so a still-settling job is not misread as failed.
+- If the CD run itself never appears or never reaches terminal, that remains a
+  hard `confirm-main` failure (we cannot confirm the release at all).
+
+## Testing
+
+- Unit: `confirm_main` with a jobs fixture where `docker-publish` =
+  `failure`, `release` = `success`, artifacts present → no raise,
+  `ctx.deferred_publish_failures == ["docker-publish"]`.
+- Unit: `release` = `failure` → raises (fatal), regardless of other jobs.
+- Unit: artifacts missing (`release` success but no tag) → raises (fatal).
+- Unit: `docs` = `failure` on develop → `confirm_develop` defers, no raise.
+- Unit: `close_and_finalize` with non-empty `deferred_publish_failures` → issue
+  left open, remediation comment posted; with empty → issue closed.
+- Unit: `publish-status` stage raises (deferred) when
+  `deferred_publish_failures` is non-empty, no-op when empty.
+- Integration: full pipeline with a stubbed CD run where only `docker-publish`
+  failed → all stages run, `develop ⊇ main`, rolling tag promoted, exit 1,
+  tracking issue open.
+
+## Scope
+
+In scope: `confirm-main` / `confirm-develop` job classification, the
+deferred-failure surfacing, and the `close-finalize` issue-handling change.
+
+Out of scope: the `vergil-docker` Trivy CVE triage itself (a separate,
+recurring `.trivyignore` task); changing what the `cd.yml` jobs do; any
+`vergil.toml` configuration.
+
+## Limitations
+
+- Defer-by-default means a future *non-publish* critical job added to CD would
+  also defer unless it is the `release` job. This is acceptable: the deferred
+  failure is still surfaced (exit 1, issue open) — it just no longer strands
+  `develop`. If such a job ever needs hard-fail semantics, it can be added to
+  the hard gate explicitly at that time.

--- a/docs/specs/2026-06-24-vrg-release-deferred-publish-design.md
+++ b/docs/specs/2026-06-24-vrg-release-deferred-publish-design.md
@@ -113,14 +113,20 @@ handling (which keys off `deferred_publish_failures`).
    (`_watch_cd(..., check_status=False)` for the main-branch confirm). The
    run-level red is expected when a deferrable job fails.
 2. **Classify per job.** After the run settles, fetch all jobs. Hard-verify the
-   `release` job (`conclusion == "success"`) and the artifacts. For every other
-   job whose `conclusion != "success"`, append a structured entry to a **new**
-   context field `ctx.deferred_publish_failures` (job name + conclusion + run
-   URL) and print a warning. Do not raise.
+   `release` job and the artifacts. For every other job whose conclusion is
+   neither `success` nor `skipped`, append its **family** to a **new** context
+   field `ctx.deferred_publish_failures: list[str]`, and print a warning. Do not
+   raise. The family is the part of a reusable-workflow leaf name before
+   `" / "` (e.g. `docker-publish / publish: prod-base:latest` → `docker-publish`),
+   so a matrix of failed `docker-publish` leaves collapses to a single
+   `docker-publish` entry; the field holds ordered-unique families. The run URL
+   for the remediation comes from `ctx.cd_run_url` (already set), so no per-job
+   URL or conclusion is stored — `list[str]` is enough.
 
    A separate field is used rather than the existing `ctx.deferred_failures`
    because the latter is owned by the `_tracked` wrapper, which appends **stage
-   names** on stage exceptions. Mixing job names into it would conflate the two.
+   names** on stage exceptions. Mixing job families into it would conflate the
+   two — see the precedence rule under *Surface the deferral*.
 3. **Surface the deferral** via three consumers:
    - `close-finalize` must **not** close the tracking issue when
      `ctx.deferred_publish_failures` is non-empty; instead it posts a comment
@@ -134,6 +140,18 @@ handling (which keys off `deferred_publish_failures`).
      (e.g. CVE triage) is cleared. The comment states this explicitly and warns
      against `--resume`. A first-class `vrg-republish` helper is tracked
      separately as a follow-up (#1854).
+
+     **Precedence (both lists non-empty).** A genuine fail-defer *stage* error
+     (in `ctx.deferred_failures`, e.g. `promote` blew up) and a publish deferral
+     (in `ctx.deferred_publish_failures`) can co-occur. They have *opposite*
+     remediations — a stage error means the release is halted and **resumable**
+     (`--resume`), a publish deferral means it is **complete** (do *not*
+     `--resume`). `deferred_failures` therefore **takes precedence**:
+     `close-finalize` checks it first and short-circuits to the resume path,
+     leaving the issue open without the publish-deferral comment (the publish
+     deferral rides along in the same open issue). Emitting both would produce
+     contradictory `--resume` / don't-`--resume` guidance. This precedence is a
+     rule, not an accident of statement order — do not reorder the checks.
    - `consumer-refresh` must **guard** on `ctx.deferred_publish_failures`: when
      it is non-empty, it prints a **hold-warning** ("artifacts pending
      republish — do not advertise vX.Y.Z to consumers until republished")
@@ -147,7 +165,12 @@ handling (which keys off `deferred_publish_failures`).
      stage has already run) but it marks the run failed, so the existing
      `lib/progress.py` summary renders the deferred `PipelineError … exit 1`
      naming the unpublished artifacts. When the field is empty the stage is a
-     no-op and the run exits `0`.
+     no-op and the run exits `0`. **It is wired as a bare `Stage`, not via the
+     `_tracked` wrapper** (like `teardown-worktree`): `_tracked` appends the
+     stage name to `deferred_failures` and posts a "phase failed" tracking-issue
+     comment on any exception, so wrapping `publish-status` would both pollute
+     `deferred_failures` (re-conflating the two lists) and spam the issue. Its
+     raise must reach `run_pipeline` directly.
 
 ### Why not a `vergil.toml` opt-in
 
@@ -164,17 +187,23 @@ added then, against a concrete need.
   job into `ctx.deferred_publish_failures`. `confirm_develop`: record a failed
   `docs` job into the same list (do not raise). Add an exact-match helper (named
   constant for `release / release`); keep substring `_find_job` for the sweep.
+- `lib/release/tracking.py` — add `comment_publish_deferred(ctx, jobs)`, which
+  posts the deferred-publish remediation comment via the existing `_comment`
+  helper (names the CD re-run, warns against `--resume`).
 - `lib/release/finalize.py` — `close_and_finalize` honors a non-empty
-  `ctx.deferred_publish_failures`: leave the issue open and post a remediation
-  comment naming the CD re-run and warning against `vrg-release --resume`.
+  `ctx.deferred_publish_failures`: call `comment_publish_deferred` and leave the
+  issue open (but still run finalize-pr cleanup — the release is complete).
+  Checks `deferred_failures` **first** (the resume precedence above).
 - `lib/release/handoff.py` — `consumer_refresh` guards on
   `ctx.deferred_publish_failures`: print a hold-warning instead of upgrade
   guidance when non-empty.
-- `lib/release/context.py` — add `deferred_publish_failures` (job name,
-  conclusion, run URL), separate from the `_tracked`-owned `deferred_failures`.
+- `lib/release/context.py` — add `deferred_publish_failures: list[str]`
+  (ordered-unique failed job families), separate from the `_tracked`-owned
+  `deferred_failures`.
 - `lib/release/orchestrator.py` — append one terminal `publish-status` stage
   (mode `fail_defer`) that raises iff `ctx.deferred_publish_failures` is
-  non-empty. `confirm-main` keeps mode `fail_fast` (its *hard gate* is still
+  non-empty. Wired as a **bare `Stage`, not `_tracked`** (see the publish-status
+  note above). `confirm-main` keeps mode `fail_fast` (its *hard gate* is still
   fatal); the deferral itself is data on the context, surfaced by the new stage.
 
 ## Data flow

--- a/docs/specs/2026-06-24-vrg-release-deferred-publish-plan.md
+++ b/docs/specs/2026-06-24-vrg-release-deferred-publish-plan.md
@@ -1,0 +1,834 @@
+# Defer Artifact-Publish Failures in vrg-release — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `vrg-release` hard-fail only on the release itself (the `release` job + tag/Release/boundary-tag) and defer every other CD-job failure, so a publish failure never strands `develop`.
+
+**Architecture:** `confirm-main` stops vetoing on overall-run status, hard-verifies the `release` job exactly, and records every other failed job into a new `ctx.deferred_publish_failures`. The pipeline runs to completion (back-merge, bump, promote, finalize); a new terminal `publish-status` `fail_defer` stage turns a non-empty list into `exit 1`, `close-finalize` leaves the tracking issue open with a CD-re-run remediation, and `consumer-refresh` prints a hold-warning.
+
+**Tech Stack:** Python (vergil-tooling), `dataclasses`, `pytest`, `unittest.mock`. GitHub interaction via the existing `github`/`git` wrappers.
+
+## Global Constraints
+
+- Repo: `vergil-tooling`; worktree `.worktrees/issue-1853-defer-publish`, branch `feature/1853-defer-publish`.
+- **Fleet-wide default, no `vergil.toml` config** — do not add any config key.
+- The `release` job is matched **exactly** by the constant `"release / release"`; the loose substring `_find_job` is kept only for the deferred sweep.
+- New context field is **`deferred_publish_failures`** (separate from the `_tracked`-owned `deferred_failures`).
+- Run tests with `uv run pytest <path>::<test> -v`.
+- Commit with `vrg-commit --type <t> --scope release --message "<m>" --body "...\n\nRef #1853"` (raw `git commit` is denied). Stage with `vrg-git add`.
+- Final validation: `vrg-container-run -- vrg-validate` must be green.
+
+---
+
+### Task 1: Add `deferred_publish_failures` to the release context
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/context.py:54`
+- Test: `tests/vergil_tooling/test_release_context.py`
+
+**Interfaces:**
+- Produces: `ReleaseContext.deferred_publish_failures: list[str]` (default `[]`) — list of failed CD job *families* (e.g. `["docker-publish", "docs"]`), consumed by Tasks 3–8.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/vergil_tooling/test_release_context.py
+def test_deferred_publish_failures_defaults_empty() -> None:
+    from pathlib import Path
+
+    from vergil_tooling.lib.release.context import ReleaseContext
+
+    ctx = ReleaseContext(
+        repo="o/r", version="2.1.0", repo_root=Path("/tmp/r"), version_override=None  # noqa: S108
+    )
+    assert ctx.deferred_publish_failures == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_context.py::test_deferred_publish_failures_defaults_empty -v`
+Expected: FAIL — `AttributeError: 'ReleaseContext' object has no attribute 'deferred_publish_failures'`
+
+- [ ] **Step 3: Add the field**
+
+In `context.py`, immediately after the `deferred_failures` field (line 54), add:
+
+```python
+    # Families of CD publish jobs that did not succeed (e.g. "docker-publish",
+    # "docs"). The release itself is valid (tag + Release published); these are
+    # re-publishable. Surfaced by the publish-status stage (exit 1), the open
+    # tracking issue, and the consumer-refresh hold-warning. Separate from
+    # deferred_failures, which the _tracked wrapper fills with failed STAGE
+    # names (#1853).
+    deferred_publish_failures: list[str] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_context.py::test_deferred_publish_failures_defaults_empty -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/context.py tests/vergil_tooling/test_release_context.py
+vrg-commit --type feat --scope release --message "add deferred_publish_failures to ReleaseContext" --body "Separate list for failed CD publish job families, distinct from the _tracked-owned deferred_failures (stage names).
+
+Ref #1853"
+```
+
+---
+
+### Task 2: Classification helpers in `confirm.py` (exact release gate + deferred sweep)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/confirm.py` (add constant + two helpers near the other `_verify_*` helpers, ~line 156)
+- Test: `tests/vergil_tooling/test_release_confirm.py`
+
+**Interfaces:**
+- Consumes: the existing `_job(name, status, conclusion)` test helper and `ReleaseError`.
+- Produces:
+  - `_RELEASE_JOB_NAME = "release / release"` (str constant)
+  - `_verify_release_job(jobs: list[dict[str, Any]]) -> None` — raises `ReleaseError` if the exact release job is missing or did not conclude `success`; else returns.
+  - `_collect_deferred_publish(jobs: list[dict[str, Any]]) -> list[str]` — ordered-unique families of non-release jobs whose conclusion is neither `success` nor `skipped`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/vergil_tooling/test_release_confirm.py — add these
+from vergil_tooling.lib.release.confirm import (
+    _RELEASE_JOB_NAME,
+    _collect_deferred_publish,
+    _verify_release_job,
+)
+
+
+def test_verify_release_job_success_returns() -> None:
+    _verify_release_job([_job("release / release")])  # no raise
+
+
+def test_verify_release_job_failure_raises() -> None:
+    with pytest.raises(ReleaseError, match="did not succeed"):
+        _verify_release_job([_job("release / release", conclusion="failure")])
+
+
+def test_verify_release_job_missing_raises() -> None:
+    with pytest.raises(ReleaseError, match="not found"):
+        _verify_release_job([_job("docs / docs")])
+
+
+def test_verify_release_job_is_exact_not_substring() -> None:
+    # a "release-notes" job must NOT satisfy the hard gate
+    with pytest.raises(ReleaseError, match="not found"):
+        _verify_release_job([_job("release-notes / build")])
+
+
+def test_collect_deferred_publish_collapses_families() -> None:
+    jobs = [
+        _job("release / release"),
+        _job("docker-publish / publish: prod-base:latest", conclusion="failure"),
+        _job("docker-publish / publish: prod-python:3.14", conclusion="failure"),
+        _job("docs / docs", conclusion="failure"),
+    ]
+    assert _collect_deferred_publish(jobs) == ["docker-publish", "docs"]
+
+
+def test_collect_deferred_publish_ignores_success_and_skipped() -> None:
+    jobs = [
+        _job("release / release"),
+        _job("docs / docs"),  # success
+        _job("codeql / analyze", conclusion="skipped"),
+    ]
+    assert _collect_deferred_publish(jobs) == []
+
+
+def test_release_job_name_constant() -> None:
+    assert _RELEASE_JOB_NAME == "release / release"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_confirm.py -k "verify_release_job or collect_deferred or release_job_name" -v`
+Expected: FAIL — `ImportError: cannot import name '_RELEASE_JOB_NAME'`
+
+- [ ] **Step 3: Add the constant and helpers**
+
+In `confirm.py`, after `_verify_jobs` (ends ~line 180), add:
+
+```python
+_RELEASE_JOB_NAME = "release / release"
+
+
+def _verify_release_job(jobs: list[dict[str, Any]]) -> None:
+    """Hard gate: the release job must exist and have concluded ``success``.
+
+    Matched EXACTLY (the reusable-workflow leaf ``release / release``), not by
+    the substring ``_find_job`` uses for the deferred sweep — the release job is
+    the single load-bearing assertion, so a future ``release``-prefixed job must
+    not satisfy it. A renamed/absent release job fails closed (#1853).
+    """
+    for job in jobs:
+        if job.get("name") == _RELEASE_JOB_NAME:
+            conclusion = job.get("conclusion")
+            if conclusion != "success":
+                raise ReleaseError(
+                    phase="confirm-main",
+                    command=f"verify job '{_RELEASE_JOB_NAME}'",
+                    message=(
+                        f"Release job did not succeed (conclusion: '{conclusion}')."
+                    ),
+                )
+            return
+    raise ReleaseError(
+        phase="confirm-main",
+        command=f"verify job '{_RELEASE_JOB_NAME}'",
+        message=f"Release job '{_RELEASE_JOB_NAME}' not found in the workflow run.",
+    )
+
+
+def _collect_deferred_publish(jobs: list[dict[str, Any]]) -> list[str]:
+    """Ordered-unique families of non-release jobs that did not succeed.
+
+    A job "did not succeed" when its conclusion is neither ``success`` nor
+    ``skipped`` (a skipped job — e.g. codeql — is not a failure). Reusable
+    leaves are ``<family> / <job>``; collapse to the family so a matrix of
+    failed ``docker-publish`` leaves reports once as ``docker-publish``.
+    """
+    families: list[str] = []
+    for job in jobs:
+        name = job.get("name", "")
+        if name == _RELEASE_JOB_NAME:
+            continue
+        if job.get("conclusion") in ("success", "skipped"):
+            continue
+        family = name.split(" / ", 1)[0]
+        if family and family not in families:
+            families.append(family)
+    return families
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_confirm.py -k "verify_release_job or collect_deferred or release_job_name" -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/confirm.py tests/vergil_tooling/test_release_confirm.py
+vrg-commit --type feat --scope release --message "add exact release-job gate and deferred-publish sweep helpers" --body "_verify_release_job hard-checks the exact 'release / release' job; _collect_deferred_publish returns unique non-release failed job families.
+
+Ref #1853"
+```
+
+---
+
+### Task 3: Rewire `confirm_main` to defer non-release job failures
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/confirm.py:27-36` (`confirm_main`)
+- Test: `tests/vergil_tooling/test_release_confirm.py`
+
+**Interfaces:**
+- Consumes: `_verify_release_job`, `_collect_deferred_publish` (Task 2); `_watch_cd`, `_settled_run_jobs`, `_verify_artifacts` (existing); `ctx.deferred_publish_failures` (Task 1).
+- Produces: `confirm_main(ctx)` populates `ctx.deferred_publish_failures` and never raises for a non-release job failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/vergil_tooling/test_release_confirm.py — add these
+def test_confirm_main_defers_docker_publish_failure() -> None:
+    ctx = _ctx()
+    jobs = [
+        _job("release / release"),
+        _job("docker-publish / publish: prod-base:latest", conclusion="failure"),
+    ]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
+    ):
+        confirm_main(ctx)  # must NOT raise
+    assert ctx.deferred_publish_failures == ["docker-publish"]
+    assert ctx.cd_run_id == "123"
+
+
+def test_confirm_main_release_failure_still_raises() -> None:
+    ctx = _ctx()
+    jobs = [_job("release / release", conclusion="failure")]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
+        pytest.raises(ReleaseError, match="did not succeed"),
+    ):
+        confirm_main(ctx)
+    assert ctx.deferred_publish_failures == []
+
+
+def test_confirm_main_clean_run_defers_nothing() -> None:
+    ctx = _ctx()
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=_MAIN_JOBS_OK),
+        patch(_MOD + "._verify_artifacts"),
+    ):
+        confirm_main(ctx)
+    assert ctx.deferred_publish_failures == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_confirm.py -k confirm_main_defers -v`
+Expected: FAIL — current `confirm_main` calls `_verify_jobs` (raises on the docker-publish-failed overall run) / does not set `deferred_publish_failures`.
+
+- [ ] **Step 3: Rewrite `confirm_main`**
+
+Replace the body of `confirm_main` (lines 27–36) with:
+
+```python
+def confirm_main(ctx: ReleaseContext) -> None:
+    """Watch CD on main: hard-verify the release, defer other publish jobs."""
+    run_id, run_url = _watch_cd(ctx, branch="main", check_status=False)
+    ctx.cd_run_id = run_id
+    ctx.cd_run_url = run_url
+
+    jobs = _settled_run_jobs(ctx, run_id, ("release",))
+    _verify_release_job(jobs)
+
+    deferred = _collect_deferred_publish(jobs)
+    if deferred:
+        ctx.deferred_publish_failures.extend(
+            d for d in deferred if d not in ctx.deferred_publish_failures
+        )
+        print(f"  Publish deferred (release is valid): {', '.join(deferred)}")
+    else:
+        print("  All CD jobs succeeded.")
+
+    _verify_artifacts(ctx)
+    print(f"Release v{ctx.version} confirmed.")
+```
+
+(Note: `check_status=True` → `False`; `_verify_jobs(...)` is replaced. `_MAIN_EXPECTED_JOBS` / `_verify_jobs` stay defined for now — Task 4 removes the last `_verify_jobs` caller; leave the unused-symbol cleanup to Task 4's commit.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_confirm.py -k confirm_main -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/confirm.py tests/vergil_tooling/test_release_confirm.py
+vrg-commit --type feat --scope release --message "defer non-release CD job failures in confirm-main" --body "Watch with check_status=False; hard-verify the release job exactly; record other failed job families into ctx.deferred_publish_failures instead of aborting. Artifacts still hard-verified.
+
+Ref #1853"
+```
+
+---
+
+### Task 4: Rewire `confirm_develop` to defer a docs failure (unified path)
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/confirm.py:39-46` (`confirm_develop`); remove now-unused `_MAIN_EXPECTED_JOBS`, `_DEVELOP_EXPECTED_JOBS`, `_verify_jobs` if no callers remain.
+- Test: `tests/vergil_tooling/test_release_confirm.py` (update the two `_*_EXPECTED_JOBS` assertions — they are being removed)
+
+**Interfaces:**
+- Consumes: `_collect_deferred_publish` (Task 2); `_watch_cd`, `_settled_run_jobs`; `ctx.deferred_publish_failures`.
+- Produces: `confirm_develop(ctx)` records a failed `docs` job into `ctx.deferred_publish_failures` and never raises for it.
+
+- [ ] **Step 1: Write the failing test + delete obsolete assertions**
+
+Delete `test_main_expected_jobs` and `test_develop_expected_jobs` (they assert constants being removed). Add:
+
+```python
+def test_confirm_develop_defers_docs_failure() -> None:
+    ctx = _ctx()
+    jobs = [_job("docs / docs", conclusion="failure")]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("9", "https://run/9")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+    ):
+        confirm_develop(ctx)  # must NOT raise
+    assert ctx.deferred_publish_failures == ["docs"]
+    assert ctx.develop_cd_run_id == "9"
+
+
+def test_confirm_develop_clean_defers_nothing() -> None:
+    ctx = _ctx()
+    with (
+        patch(_MOD + "._watch_cd", return_value=("9", "https://run/9")),
+        patch(_MOD + "._settled_run_jobs", return_value=_DEVELOP_JOBS_OK),
+    ):
+        confirm_develop(ctx)
+    assert ctx.deferred_publish_failures == []
+```
+
+Remove the now-unused imports `_DEVELOP_EXPECTED_JOBS, _MAIN_EXPECTED_JOBS` from the test's import block.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_confirm.py -k confirm_develop -v`
+Expected: FAIL — current `confirm_develop` calls `_verify_jobs`, which raises on the docs failure.
+
+- [ ] **Step 3: Rewrite `confirm_develop` and drop dead code**
+
+Replace `confirm_develop` (lines 39–46) with:
+
+```python
+def confirm_develop(ctx: ReleaseContext) -> None:
+    """Watch CD on develop; defer a docs publish failure rather than raise."""
+    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=False)
+    ctx.develop_cd_run_id = run_id
+    ctx.develop_cd_run_url = run_url
+
+    jobs = _settled_run_jobs(ctx, run_id, ("docs",))
+    deferred = _collect_deferred_publish(jobs)
+    if deferred:
+        ctx.deferred_publish_failures.extend(
+            d for d in deferred if d not in ctx.deferred_publish_failures
+        )
+        print(f"  Publish deferred on develop: {', '.join(deferred)}")
+    else:
+        print("Develop CD verified.")
+```
+
+Then delete the now-unused `_MAIN_EXPECTED_JOBS`, `_DEVELOP_EXPECTED_JOBS` constants (lines 17–18) and the `_verify_jobs` function (no remaining callers).
+
+- [ ] **Step 4: Run the full confirm test module**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_confirm.py -v`
+Expected: PASS (all, including Tasks 2–3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/confirm.py tests/vergil_tooling/test_release_confirm.py
+vrg-commit --type feat --scope release --message "defer docs failure in confirm-develop via unified path" --body "confirm_develop records a failed docs job into ctx.deferred_publish_failures (already a fail_defer stage); drop the now-unused _verify_jobs and _*_EXPECTED_JOBS.
+
+Ref #1853"
+```
+
+---
+
+### Task 5: Add the terminal `publish-status` stage
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/orchestrator.py` (add `_publish_status_stage`; append the `Stage` in `build_stages`)
+- Test: `tests/vergil_tooling/test_release_orchestrator.py`
+
+**Interfaces:**
+- Consumes: `ReleaseState.ctx.deferred_publish_failures`; `ReleaseError` (already imported).
+- Produces: `_publish_status_stage(state: ReleaseState) -> None` (raises when the list is non-empty); a `Stage("publish-status", _publish_status_stage, mode="fail_defer")` as the **last** stage.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/vergil_tooling/test_release_orchestrator.py
+from pathlib import Path
+
+import pytest
+
+from vergil_tooling.lib.release.context import ReleaseContext, ReleaseError
+from vergil_tooling.lib.release.orchestrator import (
+    ReleaseState,
+    _publish_status_stage,
+    build_stages,
+)
+
+
+def _state() -> ReleaseState:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/r"), promote=True)  # noqa: S108
+    state.ctx = ReleaseContext(
+        repo="o/r", version="2.1.2", repo_root=Path("/tmp/r"), version_override=None  # noqa: S108
+    )
+    return state
+
+
+def test_publish_status_raises_when_deferred() -> None:
+    state = _state()
+    state.ctx.deferred_publish_failures = ["docker-publish"]
+    with pytest.raises(ReleaseError, match="docker-publish"):
+        _publish_status_stage(state)
+
+
+def test_publish_status_noop_when_clean() -> None:
+    state = _state()
+    _publish_status_stage(state)  # no raise
+
+
+def test_publish_status_is_terminal_fail_defer() -> None:
+    stages = build_stages()
+    assert stages[-1].name == "publish-status"
+    assert stages[-1].mode == "fail_defer"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_orchestrator.py -k publish_status -v`
+Expected: FAIL — `ImportError: cannot import name '_publish_status_stage'`
+
+- [ ] **Step 3: Implement the stage**
+
+In `orchestrator.py`, add after `_promote_phase` (~line 172):
+
+```python
+def _publish_status_stage(state: ReleaseState) -> None:
+    """Terminal fail_defer: surface deferred artifact-publish failures as exit 1.
+
+    Runs last, after every bookkeeping stage. Raising here marks the run failed
+    (fail_defer → exit 1 with the deferred summary) without aborting anything —
+    the release is already complete. No-op when nothing deferred.
+    """
+    ctx = state.ctx
+    if ctx is None or not ctx.deferred_publish_failures:
+        return
+    jobs = ", ".join(ctx.deferred_publish_failures)
+    raise ReleaseError(
+        phase="publish-status",
+        command="publish-status",
+        message=(
+            f"Release v{ctx.version} is published (tag + GitHub Release), but these "
+            f"CD publish jobs did not succeed: {jobs}. Re-run the CD publish to "
+            "deliver the artifacts — do NOT use vrg-release --resume (the version "
+            "is already tagged)."
+        ),
+    )
+```
+
+In `build_stages()`, append as the final stage (after `consumer-refresh`):
+
+```python
+        Stage("publish-status", _publish_status_stage, mode="fail_defer"),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_orchestrator.py -k publish_status -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/orchestrator.py tests/vergil_tooling/test_release_orchestrator.py
+vrg-commit --type feat --scope release --message "add terminal publish-status fail_defer stage" --body "Raises when ctx.deferred_publish_failures is non-empty so a deferred publish ends the run exit 1 with a clear summary, after all bookkeeping has run.
+
+Ref #1853"
+```
+
+---
+
+### Task 6: `comment_publish_deferred` remediation helper
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/tracking.py` (add public helper using `_comment`)
+- Test: `tests/vergil_tooling/test_release_tracking.py`
+
+**Interfaces:**
+- Consumes: `ctx.deferred_publish_failures`, `ctx.cd_run_url`, `ctx.tag`, `ctx.version`; existing `_comment(ctx, body)`.
+- Produces: `comment_publish_deferred(ctx: ReleaseContext, jobs: list[str]) -> None`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/vergil_tooling/test_release_tracking.py
+def test_comment_publish_deferred_names_jobs_and_warns_resume() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release.tracking import comment_publish_deferred
+
+    ctx = _ctx()  # reuse the module's existing ctx builder
+    ctx.tag = "v2.1.2"
+    ctx.cd_run_url = "https://run/55"
+    with patch("vergil_tooling.lib.release.tracking._comment") as comment:
+        comment_publish_deferred(ctx, ["docker-publish", "docs"])
+    body = comment.call_args[0][1]
+    assert "docker-publish" in body and "docs" in body
+    assert "--resume" in body  # explicitly steers away from it
+    assert "https://run/55" in body
+```
+
+(If `test_release_tracking.py` has no `_ctx()` builder, copy the 6-line builder from `test_release_confirm.py`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_tracking.py::test_comment_publish_deferred_names_jobs_and_warns_resume -v`
+Expected: FAIL — `ImportError: cannot import name 'comment_publish_deferred'`
+
+- [ ] **Step 3: Implement the helper**
+
+In `tracking.py`, after `comment_phase_failed` (~line 126), add:
+
+```python
+def comment_publish_deferred(ctx: ReleaseContext, jobs: list[str]) -> None:
+    """Post a remediation comment for a deferred artifact publish.
+
+    The release is complete (tag + GitHub Release published); these CD publish
+    jobs must be re-run. ``vrg-release --resume`` does NOT apply — the version is
+    already tagged — so the comment says so explicitly (#1853).
+    """
+    job_list = ", ".join(jobs)
+    run = ctx.cd_run_url or "the CD run"
+    lines = [
+        "<!-- vrg-release:publish:deferred -->",
+        "",
+        f"**Artifact publish deferred** for `{ctx.version}`.",
+        "",
+        f"The release tag `{ctx.tag}` and the GitHub Release are published, but "
+        f"these CD publish jobs did not succeed: **{job_list}** ({run}).",
+        "",
+        "**To finish delivery** once the blocker is cleared: re-run the CD publish "
+        "— `gh workflow run cd.yml` (Actions → CD → Run workflow), or the nightly "
+        "`no-cache` ops rebuild.",
+        "",
+        "**Do not** run `vrg-release --resume`: the version is already tagged; "
+        "`--resume` is for a *halted* release, not a *completed-with-deferral* one.",
+    ]
+    _comment(ctx, "\n".join(lines))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_release_tracking.py::test_comment_publish_deferred_names_jobs_and_warns_resume -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/tracking.py tests/vergil_tooling/test_release_tracking.py
+vrg-commit --type feat --scope release --message "add comment_publish_deferred remediation helper" --body "Posts a tracking-issue comment naming the deferred publish jobs, the CD re-run remediation, and an explicit warning against --resume.
+
+Ref #1853"
+```
+
+---
+
+### Task 7: `close-finalize` leaves the issue open on a deferred publish
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/finalize.py:12` (import) and `:37-54` (`close_and_finalize`)
+- Test: `tests/vergil_tooling/test_release.py` (or `test_release_finalize.py` if present)
+
+**Interfaces:**
+- Consumes: `ctx.deferred_failures` (existing), `ctx.deferred_publish_failures` (Task 1), `comment_publish_deferred` (Task 6), `close_tracking_issue`, `_build_summary`.
+- Produces: `close_and_finalize` with three branches — (a) `deferred_failures` → resume path (unchanged); (b) `deferred_publish_failures` → comment + leave open, then still run cleanup; (c) clean → close + cleanup.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# in the finalize test module
+def test_close_and_finalize_publish_deferred_leaves_open() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release import finalize
+
+    ctx = _ctx()
+    ctx.deferred_publish_failures = ["docker-publish"]
+    with (
+        patch.object(finalize, "comment_publish_deferred") as comment,
+        patch.object(finalize, "close_tracking_issue") as close,
+        patch.object(finalize, "progress"),
+    ):
+        finalize.close_and_finalize(ctx)
+    comment.assert_called_once()
+    close.assert_not_called()  # issue stays open
+
+
+def test_close_and_finalize_clean_closes_issue() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release import finalize
+
+    ctx = _ctx()
+    with (
+        patch.object(finalize, "comment_publish_deferred") as comment,
+        patch.object(finalize, "close_tracking_issue") as close,
+        patch.object(finalize, "progress"),
+    ):
+        finalize.close_and_finalize(ctx)
+    close.assert_called_once()
+    comment.assert_not_called()
+
+
+def test_close_and_finalize_stage_failure_short_circuits() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release import finalize
+
+    ctx = _ctx()
+    ctx.deferred_failures = ["confirm-main"]
+    with (
+        patch.object(finalize, "close_tracking_issue") as close,
+        patch.object(finalize, "progress") as prog,
+    ):
+        finalize.close_and_finalize(ctx)
+    close.assert_not_called()
+    prog.run.assert_not_called()  # cleanup skipped — resumable
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/vergil_tooling/test_release.py -k close_and_finalize -v`
+Expected: FAIL — current code only branches on `deferred_failures`; `comment_publish_deferred` not imported.
+
+- [ ] **Step 3: Update the import and `close_and_finalize`**
+
+Change the tracking import (line 12) to:
+
+```python
+from vergil_tooling.lib.release.tracking import close_tracking_issue, comment_publish_deferred
+```
+
+Replace `close_and_finalize`'s body (lines 45–54, the part before "Running vrg-finalize-pr") with:
+
+```python
+    if ctx.deferred_failures:
+        print(
+            "Leaving the tracking issue open and skipping cleanup — earlier "
+            f"stages failed ({', '.join(ctx.deferred_failures)}). Fix the cause "
+            "and resume with vrg-release --resume."
+        )
+        return
+
+    if ctx.deferred_publish_failures:
+        comment_publish_deferred(ctx, ctx.deferred_publish_failures)
+        print(
+            "Leaving the tracking issue open — artifact publish deferred "
+            f"({', '.join(ctx.deferred_publish_failures)}). The release is "
+            "complete; re-run the CD publish to deliver the artifacts (NOT "
+            "--resume)."
+        )
+    else:
+        summary = _build_summary(ctx)
+        close_tracking_issue(ctx, summary)
+        print("Tracking issue closed.")
+```
+
+(The existing "Running vrg-finalize-pr..." block stays as-is and now runs for both the close branch and the publish-deferred branch — the release is complete in both, so the branches must be pruned.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/vergil_tooling/test_release.py -k close_and_finalize -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/finalize.py tests/vergil_tooling/test_release.py
+vrg-commit --type feat --scope release --message "leave tracking issue open on deferred publish in close-finalize" --body "Distinct from the deferred_failures resume path: a deferred publish posts the CD-rerun remediation comment and leaves the issue open, but still runs finalize-pr cleanup (the release is complete).
+
+Ref #1853"
+```
+
+---
+
+### Task 8: `consumer-refresh` hold-warning guard
+
+**Files:**
+- Modify: `src/vergil_tooling/lib/release/handoff.py:15-41` (`consumer_refresh`)
+- Test: `tests/vergil_tooling/test_release.py` (or `test_release_handoff.py` if present)
+
+**Interfaces:**
+- Consumes: `ctx.deferred_publish_failures`.
+- Produces: `consumer_refresh` prints a hold-warning and sets `ctx.consumer_refresh_commands = None` when the list is non-empty, before reading any config.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_consumer_refresh_holds_when_publish_deferred() -> None:
+    from vergil_tooling.lib.release.handoff import consumer_refresh
+
+    ctx = _ctx()
+    ctx.deferred_publish_failures = ["docker-publish"]
+    consumer_refresh(ctx)  # must not read config / must not raise
+    assert ctx.consumer_refresh_commands is None
+    assert "held" in (ctx.consumer_refresh_message or "").lower()
+    assert "2.1.0" in (ctx.consumer_refresh_message or "")  # version named
+```
+
+(The `_ctx()` builder sets `version="2.1.0"`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/vergil_tooling/test_release.py::test_consumer_refresh_holds_when_publish_deferred -v`
+Expected: FAIL — current code calls `config.read_config` unconditionally; no hold-warning.
+
+- [ ] **Step 3: Add the guard**
+
+At the top of `consumer_refresh` (immediately after the docstring, before `cfg = config.read_config(...)`), insert:
+
+```python
+    if ctx.deferred_publish_failures:
+        message = (
+            "⚠ Consumer refresh held: artifact publish was deferred "
+            f"({', '.join(ctx.deferred_publish_failures)}). Do NOT advertise "
+            f"v{ctx.version} to consumers until the CD publish is re-run and the "
+            "artifacts are delivered."
+        )
+        ctx.consumer_refresh_message = message
+        ctx.consumer_refresh_commands = None
+        print()
+        print(message)
+        return
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/vergil_tooling/test_release.py::test_consumer_refresh_holds_when_publish_deferred -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add src/vergil_tooling/lib/release/handoff.py tests/vergil_tooling/test_release.py
+vrg-commit --type feat --scope release --message "hold consumer-refresh when publish deferred" --body "Print a hold-warning instead of upgrade guidance when ctx.deferred_publish_failures is non-empty, so the run never tells consumers to upgrade to a version whose artifacts did not ship.
+
+Ref #1853"
+```
+
+---
+
+### Task 9: Full validation and PR readiness
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full release test suite**
+
+Run: `uv run pytest tests/vergil_tooling/ -k release -v`
+Expected: PASS — all release tests green, including the deleted-constant tests are gone and new ones pass.
+
+- [ ] **Step 2: Run the complete suite (catch cross-module fallout)**
+
+Run: `uv run pytest -q`
+Expected: PASS — no other module imported `_verify_jobs` / `_MAIN_EXPECTED_JOBS` (grep to confirm: `grep -rn "_verify_jobs\|_MAIN_EXPECTED_JOBS\|_DEVELOP_EXPECTED_JOBS" src tests` returns only intended sites).
+
+- [ ] **Step 3: Lint, types, and the repo gate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: green (ruff, mypy/ty, markdownlint of the spec/plan docs).
+
+- [ ] **Step 4: Confirm the design's acceptance criteria by inspection**
+
+- A `docker-publish`/`docs` failure no longer aborts: `confirm_main`/`confirm_develop` do not raise for them (Tasks 3–4).
+- A `release`-job failure or missing artifact still hard-fails (Task 2 `_verify_release_job`, existing `_verify_artifacts`).
+- Deferred publish ends exit 1 (Task 5), issue stays open with remediation (Tasks 6–7), consumer-refresh holds (Task 8).
+- No `vergil.toml` key was added (grep `vergil.toml` / `read_config` shows no new release-gate config).
+
+- [ ] **Step 5: Final commit if any validation fixups were needed**
+
+```bash
+vrg-git add -A
+vrg-commit --type test --scope release --message "validation fixups for deferred-publish feature" --body "Ref #1853"
+```
+
+(Skip if nothing changed in Steps 1–4.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** Hard gate narrowed to release job + artifacts (Tasks 2–3); exact-match release job (Task 2); defer every other job into `deferred_publish_failures` (Tasks 3–4); new field (Task 1); `publish-status` terminal `fail_defer` stage → exit 1 (Task 5); `close-finalize` leaves issue open + remediation, warns off `--resume` (Tasks 6–7); `consumer-refresh` hold-warning (Task 8); `confirm-develop` unified into the same list (Task 4); fleet-wide, no config (Global Constraints + Task 9 Step 4). Watch-blocks-until-terminal is relied on by `check_status=False` (Task 3) and was verified in the spec.
+
+**Placeholder scan:** none — every code/test step carries full content.
+
+**Type consistency:** `deferred_publish_failures: list[str]` used identically across Tasks 1, 3–8; `_RELEASE_JOB_NAME` / `_verify_release_job` / `_collect_deferred_publish` signatures match between Task 2 (definition) and Tasks 3–4 (callers); `comment_publish_deferred(ctx, jobs)` matches between Task 6 (def) and Task 7 (call); `_publish_status_stage(state)` matches Task 5 def and the `Stage` wiring.

--- a/docs/specs/2026-06-24-vrg-release-deferred-publish-plan.md
+++ b/docs/specs/2026-06-24-vrg-release-deferred-publish-plan.md
@@ -496,7 +496,11 @@ def _publish_status_stage(state: ReleaseState) -> None:
     )
 ```
 
-In `build_stages()`, append as the final stage (after `consumer-refresh`):
+In `build_stages()`, append as the final stage (after `consumer-refresh`). Wire
+it as a **bare `Stage`, NOT `_tracked(...)`** (like `teardown-worktree`):
+`_tracked` appends the stage name to `deferred_failures` and posts a
+"phase failed" issue comment on any exception, so wrapping `publish-status`
+would re-conflate the two lists and spam the tracking issue.
 
 ```python
         Stage("publish-status", _publish_status_stage, mode="fail_defer"),
@@ -703,6 +707,13 @@ Replace `close_and_finalize`'s body (lines 45–54, the part before "Running vrg
         close_tracking_issue(ctx, summary)
         print("Tracking issue closed.")
 ```
+
+**Precedence is intentional, not incidental:** `deferred_failures` is checked
+**first** and short-circuits to the resume path. A genuine stage failure means
+the release is halted/resumable (`--resume`), which is the *opposite*
+remediation from a publish deferral (do *not* `--resume`); emitting both would
+contradict. When both lists are non-empty the resume path wins and the publish
+deferral rides along in the same still-open issue. Do not reorder these checks.
 
 (The existing "Running vrg-finalize-pr..." block stays as-is and now runs for both the close branch and the publish-deferred branch — the release is complete in both, so the branches must be pruned.)
 

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -14,8 +14,6 @@ if TYPE_CHECKING:
     from vergil_tooling.lib.release.context import ReleaseContext
 
 _CD_WORKFLOW = "cd.yml"
-_MAIN_EXPECTED_JOBS = ("docs", "release")
-_DEVELOP_EXPECTED_JOBS = ("docs",)
 _CD_POLL_INTERVAL = 10
 _CD_POLL_ATTEMPTS = 30
 # A reusable-workflow leaf job's conclusion can lag the run-level status by a
@@ -47,13 +45,20 @@ def confirm_main(ctx: ReleaseContext) -> None:
 
 
 def confirm_develop(ctx: ReleaseContext) -> None:
-    """Watch CD on develop after back-merge."""
-    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=True)
-    _verify_jobs(ctx, run_id, _DEVELOP_EXPECTED_JOBS, phase="confirm-develop")
-
+    """Watch CD on develop; defer a docs publish failure rather than raise."""
+    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=False)
     ctx.develop_cd_run_id = run_id
     ctx.develop_cd_run_url = run_url
-    print("Develop CD verified.")
+
+    jobs = _settled_run_jobs(ctx, run_id, ("docs",))
+    deferred = _collect_deferred_publish(jobs)
+    if deferred:
+        ctx.deferred_publish_failures.extend(
+            d for d in deferred if d not in ctx.deferred_publish_failures
+        )
+        print(f"  Publish deferred on develop: {', '.join(deferred)}")
+    else:
+        print("Develop CD verified.")
 
 
 def _watch_cd(
@@ -162,32 +167,6 @@ def _settled_run_jobs(
         if attempt < _JOB_SETTLE_ATTEMPTS - 1:
             time.sleep(_JOB_SETTLE_INTERVAL)
     return jobs
-
-
-def _verify_jobs(
-    ctx: ReleaseContext,
-    run_id: str,
-    expected: tuple[str, ...],
-    *,
-    phase: str,
-) -> None:
-    jobs = _settled_run_jobs(ctx, run_id, expected)
-    for job_name in expected:
-        job = _find_job(jobs, job_name)
-        if job is None:
-            raise ReleaseError(
-                phase=phase,
-                command=f"verify job '{job_name}'",
-                message=(f"Expected job '{job_name}' not found in workflow run {run_id}."),
-            )
-        conclusion = job.get("conclusion")
-        if conclusion != "success":
-            raise ReleaseError(
-                phase=phase,
-                command=f"verify job '{job_name}'",
-                message=(f"Job '{job_name}' did not succeed (conclusion: '{conclusion}')."),
-            )
-        print(f"  Job '{job_name}': success")
 
 
 _RELEASE_JOB_NAME = "release / release"

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -180,6 +180,57 @@ def _verify_jobs(
         print(f"  Job '{job_name}': success")
 
 
+_RELEASE_JOB_NAME = "release / release"
+
+
+def _verify_release_job(jobs: list[dict[str, Any]]) -> None:
+    """Hard gate: the release job must exist and have concluded ``success``.
+
+    Matched EXACTLY (the reusable-workflow leaf ``release / release``), not by
+    the substring ``_find_job`` uses for the deferred sweep — the release job is
+    the single load-bearing assertion, so a future ``release``-prefixed job must
+    not satisfy it. A renamed/absent release job fails closed (#1853).
+    """
+    for job in jobs:
+        if job.get("name") == _RELEASE_JOB_NAME:
+            conclusion = job.get("conclusion")
+            if conclusion != "success":
+                raise ReleaseError(
+                    phase="confirm-main",
+                    command=f"verify job '{_RELEASE_JOB_NAME}'",
+                    message=(
+                        f"Release job did not succeed (conclusion: '{conclusion}')."
+                    ),
+                )
+            return
+    raise ReleaseError(
+        phase="confirm-main",
+        command=f"verify job '{_RELEASE_JOB_NAME}'",
+        message=f"Release job '{_RELEASE_JOB_NAME}' not found in the workflow run.",
+    )
+
+
+def _collect_deferred_publish(jobs: list[dict[str, Any]]) -> list[str]:
+    """Ordered-unique families of non-release jobs that did not succeed.
+
+    A job "did not succeed" when its conclusion is neither ``success`` nor
+    ``skipped`` (a skipped job — e.g. codeql — is not a failure). Reusable
+    leaves are ``<family> / <job>``; collapse to the family so a matrix of
+    failed ``docker-publish`` leaves reports once as ``docker-publish``.
+    """
+    families: list[str] = []
+    for job in jobs:
+        name = job.get("name", "")
+        if name == _RELEASE_JOB_NAME:
+            continue
+        if job.get("conclusion") in ("success", "skipped"):
+            continue
+        family = name.split(" / ", 1)[0]
+        if family and family not in families:
+            families.append(family)
+    return families
+
+
 def _verify_artifacts(ctx: ReleaseContext) -> None:
     git.run("fetch", "--tags", "--force", "origin")
 

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -24,7 +24,7 @@ _JOB_SETTLE_ATTEMPTS = 12
 
 def confirm_main(ctx: ReleaseContext) -> None:
     """Watch CD on main: hard-verify the release, defer other publish jobs."""
-    run_id, run_url = _watch_cd(ctx, branch="main", check_status=False)
+    run_id, run_url = _watch_cd(ctx, branch="main")
     ctx.cd_run_id = run_id
     ctx.cd_run_url = run_url
 
@@ -46,7 +46,7 @@ def confirm_main(ctx: ReleaseContext) -> None:
 
 def confirm_develop(ctx: ReleaseContext) -> None:
     """Watch CD on develop; defer a docs publish failure rather than raise."""
-    run_id, run_url = _watch_cd(ctx, branch="develop", check_status=False)
+    run_id, run_url = _watch_cd(ctx, branch="develop")
     ctx.develop_cd_run_id = run_id
     ctx.develop_cd_run_url = run_url
 
@@ -65,7 +65,6 @@ def _watch_cd(
     ctx: ReleaseContext,
     *,
     branch: str,
-    check_status: bool = True,
 ) -> tuple[str, str]:
     print(f"Waiting for {_CD_WORKFLOW} on {branch}...")
     git.run("fetch", "origin", branch)
@@ -86,12 +85,9 @@ def _watch_cd(
     )
     print(f"  Workflow run: {run_url}")
 
-    watch_workflow(ctx.repo, run_id, check_status=check_status)
+    watch_workflow(ctx.repo, run_id, check_status=False)
 
-    if check_status:
-        print(f"  CD workflow succeeded: {run_url}")
-    else:
-        print(f"  CD workflow completed: {run_url}")
+    print(f"  CD workflow completed: {run_url}")
     return run_id, run_url
 
 
@@ -187,9 +183,7 @@ def _verify_release_job(jobs: list[dict[str, Any]]) -> None:
                 raise ReleaseError(
                     phase="confirm-main",
                     command=f"verify job '{_RELEASE_JOB_NAME}'",
-                    message=(
-                        f"Release job did not succeed (conclusion: '{conclusion}')."
-                    ),
+                    message=(f"Release job did not succeed (conclusion: '{conclusion}')."),
                 )
             return
     raise ReleaseError(

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -25,15 +25,25 @@ _JOB_SETTLE_ATTEMPTS = 12
 
 
 def confirm_main(ctx: ReleaseContext) -> None:
-    """Watch CD on main and verify publish artifacts."""
-    run_id, run_url = _watch_cd(ctx, branch="main", check_status=True)
-    _verify_jobs(ctx, run_id, _MAIN_EXPECTED_JOBS, phase="confirm-main")
-
+    """Watch CD on main: hard-verify the release, defer other publish jobs."""
+    run_id, run_url = _watch_cd(ctx, branch="main", check_status=False)
     ctx.cd_run_id = run_id
     ctx.cd_run_url = run_url
 
+    jobs = _settled_run_jobs(ctx, run_id, ("release",))
+    _verify_release_job(jobs)
+
+    deferred = _collect_deferred_publish(jobs)
+    if deferred:
+        ctx.deferred_publish_failures.extend(
+            d for d in deferred if d not in ctx.deferred_publish_failures
+        )
+        print(f"  Publish deferred (release is valid): {', '.join(deferred)}")
+    else:
+        print("  All CD jobs succeeded.")
+
     _verify_artifacts(ctx)
-    print(f"All artifacts confirmed for v{ctx.version}.")
+    print(f"Release v{ctx.version} confirmed.")
 
 
 def confirm_develop(ctx: ReleaseContext) -> None:

--- a/src/vergil_tooling/lib/release/context.py
+++ b/src/vergil_tooling/lib/release/context.py
@@ -53,6 +53,14 @@ class ReleaseContext:
     # release stays resumable (#1612).
     deferred_failures: list[str] = field(default_factory=list)
 
+    # Families of CD publish jobs that did not succeed (e.g. "docker-publish",
+    # "docs"). The release itself is valid (tag + Release published); these are
+    # re-publishable. Surfaced by the publish-status stage (exit 1), the open
+    # tracking issue, and the consumer-refresh hold-warning. Separate from
+    # deferred_failures, which the _tracked wrapper fills with failed STAGE
+    # names (#1853).
+    deferred_publish_failures: list[str] = field(default_factory=list)
+
     promote: bool = True
 
     @property

--- a/src/vergil_tooling/lib/release/finalize.py
+++ b/src/vergil_tooling/lib/release/finalize.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from vergil_tooling.lib import progress
 from vergil_tooling.lib.managed_worktree import remove_worktree
 from vergil_tooling.lib.release.context import ReleaseError
-from vergil_tooling.lib.release.tracking import close_tracking_issue
+from vergil_tooling.lib.release.tracking import close_tracking_issue, comment_publish_deferred
 
 if TYPE_CHECKING:
     from vergil_tooling.lib.release.context import ReleaseContext
@@ -49,9 +49,19 @@ def close_and_finalize(ctx: ReleaseContext) -> None:
             "and resume with vrg-release --resume."
         )
         return
-    summary = _build_summary(ctx)
-    close_tracking_issue(ctx, summary)
-    print("Tracking issue closed.")
+
+    if ctx.deferred_publish_failures:
+        comment_publish_deferred(ctx, ctx.deferred_publish_failures)
+        print(
+            "Leaving the tracking issue open — artifact publish deferred "
+            f"({', '.join(ctx.deferred_publish_failures)}). The release is "
+            "complete; re-run the CD publish to deliver the artifacts (NOT "
+            "--resume)."
+        )
+    else:
+        summary = _build_summary(ctx)
+        close_tracking_issue(ctx, summary)
+        print("Tracking issue closed.")
 
     print("Running vrg-finalize-pr...")
     # --cleanup-only is the non-interactive release path: no PR

--- a/src/vergil_tooling/lib/release/handoff.py
+++ b/src/vergil_tooling/lib/release/handoff.py
@@ -22,6 +22,19 @@ def consumer_refresh(ctx: ReleaseContext) -> None:
     ``ctx.consumer_refresh_commands`` so ``vrg-release --install`` can
     execute exactly what the message shows (issue #1643).
     """
+    if ctx.deferred_publish_failures:
+        message = (
+            "⚠ Consumer refresh held: artifact publish was deferred "
+            f"({', '.join(ctx.deferred_publish_failures)}). Do NOT advertise "
+            f"v{ctx.version} to consumers until the CD publish is re-run and the "
+            "artifacts are delivered."
+        )
+        ctx.consumer_refresh_message = message
+        ctx.consumer_refresh_commands = None
+        print()
+        print(message)
+        return
+
     cfg = config.read_config(ctx.repo_root)
     template = cfg.publish.consumer_refresh
 

--- a/src/vergil_tooling/lib/release/orchestrator.py
+++ b/src/vergil_tooling/lib/release/orchestrator.py
@@ -140,6 +140,7 @@ def build_stages() -> list[Stage]:
             _tracked("consumer-refresh", consumer_refresh),
             mode="fail_defer",
         ),
+        Stage("publish-status", _publish_status_stage, mode="fail_defer"),
     ]
 
 
@@ -169,6 +170,29 @@ def _promote_phase(ctx: ReleaseContext) -> None:
         print("Skipping promote (--no-promote).")
         return
     promote(ctx.version)
+
+
+def _publish_status_stage(state: ReleaseState) -> None:
+    """Terminal fail_defer: surface deferred artifact-publish failures as exit 1.
+
+    Runs last, after every bookkeeping stage. Raising here marks the run failed
+    (fail_defer → exit 1 with the deferred summary) without aborting anything —
+    the release is already complete. No-op when nothing deferred.
+    """
+    ctx = state.ctx
+    if ctx is None or not ctx.deferred_publish_failures:
+        return
+    jobs = ", ".join(ctx.deferred_publish_failures)
+    raise ReleaseError(
+        phase="publish-status",
+        command="publish-status",
+        message=(
+            f"Release v{ctx.version} is published (tag + GitHub Release), but these "
+            f"CD publish jobs did not succeed: {jobs}. Re-run the CD publish to "
+            "deliver the artifacts — do NOT use vrg-release --resume (the version "
+            "is already tagged)."
+        ),
+    )
 
 
 def _phase_details(ctx: ReleaseContext, phase: str) -> str:

--- a/src/vergil_tooling/lib/release/tracking.py
+++ b/src/vergil_tooling/lib/release/tracking.py
@@ -125,6 +125,33 @@ def comment_phase_failed(ctx: ReleaseContext, phase: str, exc: ReleaseError) -> 
     _comment(ctx, "\n".join(lines))
 
 
+def comment_publish_deferred(ctx: ReleaseContext, jobs: list[str]) -> None:
+    """Post a remediation comment for a deferred artifact publish.
+
+    The release is complete (tag + GitHub Release published); these CD publish
+    jobs must be re-run. ``vrg-release --resume`` does NOT apply — the version is
+    already tagged — so the comment says so explicitly (#1853).
+    """
+    job_list = ", ".join(jobs)
+    run = ctx.cd_run_url or "the CD run"
+    lines = [
+        "<!-- vrg-release:publish:deferred -->",
+        "",
+        f"**Artifact publish deferred** for `{ctx.version}`.",
+        "",
+        f"The release tag `{ctx.tag}` and the GitHub Release are published, but "
+        f"these CD publish jobs did not succeed: **{job_list}** ({run}).",
+        "",
+        "**To finish delivery** once the blocker is cleared: re-run the CD publish "
+        "— `gh workflow run cd.yml` (Actions → CD → Run workflow), or the nightly "
+        "`no-cache` ops rebuild.",
+        "",
+        "**Do not** run `vrg-release --resume`: the version is already tagged; "
+        "`--resume` is for a *halted* release, not a *completed-with-deferral* one.",
+    ]
+    _comment(ctx, "\n".join(lines))
+
+
 def close_tracking_issue(ctx: ReleaseContext, summary: str) -> None:
     """Post a summary comment and close the tracking issue."""
     _comment(ctx, summary)

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -133,47 +133,30 @@ def test_confirm_main_fails_no_cd_run() -> None:
         confirm_main(ctx)
 
 
-def test_confirm_main_fails_job_not_found() -> None:
+def test_confirm_main_fails_release_job_not_found() -> None:
+    # The release job is the only hard gate; a missing release job raises.
     ctx = _ctx()
+    jobs = [_job("docs / docs")]  # release job absent
     with (
-        patch(
-            _MOD + ".github.read_output",
-            side_effect=[
-                "12345",
-                "https://github.com/o/r/actions/runs/12345",
-            ],
-        ),
-        # 'docs' never appears — poll exhausts and it is reported missing.
-        patch(_MOD + "._fetch_run_jobs", return_value=[_job("release / release")]),
-        patch(_MOD + ".time.sleep"),
-        patch(_MOD + ".watch_workflow"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.read_output", return_value=_SHA),
-        pytest.raises(ReleaseError, match="not found in workflow run"),
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
+        pytest.raises(ReleaseError, match="not found"),
     ):
         confirm_main(ctx)
 
 
-def test_confirm_main_fails_job_not_success() -> None:
+def test_confirm_main_non_release_job_failure_defers_not_raises() -> None:
+    # A failing docs job is recorded in deferred_publish_failures, not re-raised.
     ctx = _ctx()
+    jobs = [_job("docs / docs", conclusion="failure"), _job("release / release")]
     with (
-        patch(
-            _MOD + ".github.read_output",
-            side_effect=[
-                "12345",
-                "https://github.com/o/r/actions/runs/12345",
-            ],
-        ),
-        patch(
-            _MOD + "._fetch_run_jobs",
-            return_value=[_job("docs / docs", conclusion="failure"), _job("release / release")],
-        ),
-        patch(_MOD + ".watch_workflow"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.read_output", return_value=_SHA),
-        pytest.raises(ReleaseError, match="did not succeed"),
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
     ):
-        confirm_main(ctx)
+        confirm_main(ctx)  # must NOT raise
+    assert "docs" in ctx.deferred_publish_failures
 
 
 def test_confirm_main_fails_tag_missing() -> None:
@@ -436,3 +419,43 @@ def test_release_job_name_constant() -> None:
     from vergil_tooling.lib.release.confirm import _RELEASE_JOB_NAME
 
     assert _RELEASE_JOB_NAME == "release / release"
+
+
+def test_confirm_main_defers_docker_publish_failure() -> None:
+    ctx = _ctx()
+    jobs = [
+        _job("release / release"),
+        _job("docker-publish / publish: prod-base:latest", conclusion="failure"),
+    ]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
+    ):
+        confirm_main(ctx)  # must NOT raise
+    assert ctx.deferred_publish_failures == ["docker-publish"]
+    assert ctx.cd_run_id == "123"
+
+
+def test_confirm_main_release_failure_still_raises() -> None:
+    ctx = _ctx()
+    jobs = [_job("release / release", conclusion="failure")]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
+        pytest.raises(ReleaseError, match="did not succeed"),
+    ):
+        confirm_main(ctx)
+    assert ctx.deferred_publish_failures == []
+
+
+def test_confirm_main_clean_run_defers_nothing() -> None:
+    ctx = _ctx()
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=_MAIN_JOBS_OK),
+        patch(_MOD + "._verify_artifacts"),
+    ):
+        confirm_main(ctx)
+    assert ctx.deferred_publish_failures == []

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -379,3 +379,60 @@ def test_confirm_develop_prints_run_url_before_watching(
         confirm_develop(ctx)
 
     assert "https://github.com/o/r/actions/runs/67890" in watch_output[0]
+
+
+def test_verify_release_job_success_returns() -> None:
+    from vergil_tooling.lib.release.confirm import _verify_release_job
+
+    _verify_release_job([_job("release / release")])  # no raise
+
+
+def test_verify_release_job_failure_raises() -> None:
+    from vergil_tooling.lib.release.confirm import _verify_release_job
+
+    with pytest.raises(ReleaseError, match="did not succeed"):
+        _verify_release_job([_job("release / release", conclusion="failure")])
+
+
+def test_verify_release_job_missing_raises() -> None:
+    from vergil_tooling.lib.release.confirm import _verify_release_job
+
+    with pytest.raises(ReleaseError, match="not found"):
+        _verify_release_job([_job("docs / docs")])
+
+
+def test_verify_release_job_is_exact_not_substring() -> None:
+    from vergil_tooling.lib.release.confirm import _verify_release_job
+
+    # a "release-notes" job must NOT satisfy the hard gate
+    with pytest.raises(ReleaseError, match="not found"):
+        _verify_release_job([_job("release-notes / build")])
+
+
+def test_collect_deferred_publish_collapses_families() -> None:
+    from vergil_tooling.lib.release.confirm import _collect_deferred_publish
+
+    jobs = [
+        _job("release / release"),
+        _job("docker-publish / publish: prod-base:latest", conclusion="failure"),
+        _job("docker-publish / publish: prod-python:3.14", conclusion="failure"),
+        _job("docs / docs", conclusion="failure"),
+    ]
+    assert _collect_deferred_publish(jobs) == ["docker-publish", "docs"]
+
+
+def test_collect_deferred_publish_ignores_success_and_skipped() -> None:
+    from vergil_tooling.lib.release.confirm import _collect_deferred_publish
+
+    jobs = [
+        _job("release / release"),
+        _job("docs / docs"),  # success
+        _job("codeql / analyze", conclusion="skipped"),
+    ]
+    assert _collect_deferred_publish(jobs) == []
+
+
+def test_release_job_name_constant() -> None:
+    from vergil_tooling.lib.release.confirm import _RELEASE_JOB_NAME
+
+    assert _RELEASE_JOB_NAME == "release / release"

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -7,8 +7,6 @@ import pytest
 
 from vergil_tooling.lib.release.confirm import (
     _CD_POLL_ATTEMPTS,
-    _DEVELOP_EXPECTED_JOBS,
-    _MAIN_EXPECTED_JOBS,
     confirm_develop,
     confirm_main,
 )
@@ -61,13 +59,6 @@ def test_watch_cd_check_status_false_reports_completed(
     assert "CD workflow completed" in out
     assert "CD workflow succeeded" not in out
 
-
-def test_main_expected_jobs() -> None:
-    assert _MAIN_EXPECTED_JOBS == ("docs", "release")
-
-
-def test_develop_expected_jobs() -> None:
-    assert _DEVELOP_EXPECTED_JOBS == ("docs",)
 
 
 def test_confirm_main_success() -> None:
@@ -234,27 +225,6 @@ def test_confirm_develop_fails_no_cd_run() -> None:
         confirm_develop(ctx)
 
 
-def test_confirm_develop_fails_job_not_success() -> None:
-    ctx = _ctx()
-    with (
-        patch(
-            _MOD + ".github.read_output",
-            side_effect=[
-                "67890",
-                "https://github.com/o/r/actions/runs/67890",
-            ],
-        ),
-        patch(
-            _MOD + "._fetch_run_jobs",
-            return_value=[_job("docs / docs", conclusion="failure")],
-        ),
-        patch(_MOD + ".watch_workflow"),
-        patch(_MOD + ".git.run"),
-        patch(_MOD + ".git.read_output", return_value=_SHA),
-        pytest.raises(ReleaseError, match="did not succeed"),
-    ):
-        confirm_develop(ctx)
-
 
 def test_fetch_run_jobs_parses_jobs_array() -> None:
     from vergil_tooling.lib.release.confirm import _fetch_run_jobs
@@ -299,7 +269,7 @@ def test_settled_run_jobs_polls_until_leaf_conclusion_settles() -> None:
         patch(_MOD + "._fetch_run_jobs", side_effect=[lagging, settled]),
         patch(_MOD + ".time.sleep") as sleep,
     ):
-        jobs = _settled_run_jobs(ctx, "12345", _MAIN_EXPECTED_JOBS)
+        jobs = _settled_run_jobs(ctx, "12345", ("docs", "release"))
     assert jobs == settled
     sleep.assert_called_once()
 
@@ -458,4 +428,26 @@ def test_confirm_main_clean_run_defers_nothing() -> None:
         patch(_MOD + "._verify_artifacts"),
     ):
         confirm_main(ctx)
+    assert ctx.deferred_publish_failures == []
+
+
+def test_confirm_develop_defers_docs_failure() -> None:
+    ctx = _ctx()
+    jobs = [_job("docs / docs", conclusion="failure")]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("9", "https://run/9")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+    ):
+        confirm_develop(ctx)  # must NOT raise
+    assert ctx.deferred_publish_failures == ["docs"]
+    assert ctx.develop_cd_run_id == "9"
+
+
+def test_confirm_develop_clean_defers_nothing() -> None:
+    ctx = _ctx()
+    with (
+        patch(_MOD + "._watch_cd", return_value=("9", "https://run/9")),
+        patch(_MOD + "._settled_run_jobs", return_value=_DEVELOP_JOBS_OK),
+    ):
+        confirm_develop(ctx)
     assert ctx.deferred_publish_failures == []

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -38,7 +38,7 @@ def _ctx() -> ReleaseContext:
     return ctx
 
 
-def test_watch_cd_check_status_false_reports_completed(
+def test_watch_cd_reports_completed(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     from vergil_tooling.lib.release.confirm import _watch_cd
@@ -53,12 +53,11 @@ def test_watch_cd_check_status_false_reports_completed(
         patch(_MOD + ".git.run"),
         patch(_MOD + ".git.read_output", return_value=_SHA),
     ):
-        run_id, run_url = _watch_cd(ctx, branch="main", check_status=False)
+        run_id, run_url = _watch_cd(ctx, branch="main")
     assert run_id == "12345"
     out = capsys.readouterr().out
     assert "CD workflow completed" in out
     assert "CD workflow succeeded" not in out
-
 
 
 def test_confirm_main_success() -> None:
@@ -223,7 +222,6 @@ def test_confirm_develop_fails_no_cd_run() -> None:
         pytest.raises(ReleaseError, match="No CD workflow run found on develop"),
     ):
         confirm_develop(ctx)
-
 
 
 def test_fetch_run_jobs_parses_jobs_array() -> None:
@@ -451,3 +449,26 @@ def test_confirm_develop_clean_defers_nothing() -> None:
     ):
         confirm_develop(ctx)
     assert ctx.deferred_publish_failures == []
+
+
+def test_settled_run_jobs_exhaust_returns_last_snapshot() -> None:
+    """When no expected job ever settles, _settled_run_jobs exhausts all
+    attempts and returns the final (unsettled) jobs snapshot."""
+    from vergil_tooling.lib.release.confirm import _JOB_SETTLE_ATTEMPTS, _settled_run_jobs
+
+    ctx = _ctx()
+    # Jobs that never contain the expected "release" job.
+    unsettled = [_job("docs / docs")]
+    with (
+        patch(
+            _MOD + "._fetch_run_jobs",
+            return_value=unsettled,
+        ) as mock_fetch,
+        patch(_MOD + ".time.sleep") as mock_sleep,
+    ):
+        result = _settled_run_jobs(ctx, "runid", ("release",))
+
+    assert result == unsettled
+    assert mock_fetch.call_count == _JOB_SETTLE_ATTEMPTS
+    # sleep is called between attempts (not after the last one)
+    assert mock_sleep.call_count == _JOB_SETTLE_ATTEMPTS - 1

--- a/tests/vergil_tooling/test_release_context.py
+++ b/tests/vergil_tooling/test_release_context.py
@@ -127,6 +127,9 @@ def test_release_error_is_exception() -> None:
 
 def test_deferred_publish_failures_defaults_empty() -> None:
     ctx = ReleaseContext(
-        repo="o/r", version="2.1.0", repo_root=Path("/tmp/r"), version_override=None  # noqa: S108
+        repo="o/r",
+        version="2.1.0",
+        repo_root=Path("/tmp/r"),
+        version_override=None,  # noqa: S108
     )
     assert ctx.deferred_publish_failures == []

--- a/tests/vergil_tooling/test_release_context.py
+++ b/tests/vergil_tooling/test_release_context.py
@@ -129,7 +129,7 @@ def test_deferred_publish_failures_defaults_empty() -> None:
     ctx = ReleaseContext(
         repo="o/r",
         version="2.1.0",
-        repo_root=Path("/tmp/r"),
-        version_override=None,  # noqa: S108
+        repo_root=Path("/tmp/r"),  # noqa: S108
+        version_override=None,
     )
     assert ctx.deferred_publish_failures == []

--- a/tests/vergil_tooling/test_release_context.py
+++ b/tests/vergil_tooling/test_release_context.py
@@ -123,3 +123,10 @@ def test_release_error_is_exception() -> None:
             command="git push",
             message="something broke",
         )
+
+
+def test_deferred_publish_failures_defaults_empty() -> None:
+    ctx = ReleaseContext(
+        repo="o/r", version="2.1.0", repo_root=Path("/tmp/r"), version_override=None  # noqa: S108
+    )
+    assert ctx.deferred_publish_failures == []

--- a/tests/vergil_tooling/test_release_finalize.py
+++ b/tests/vergil_tooling/test_release_finalize.py
@@ -169,3 +169,52 @@ def test_close_and_finalize_fails_on_finalize_error() -> None:
     ):
         close_and_finalize(ctx)
     assert excinfo.value.detail == "validation failed"
+
+
+def test_close_and_finalize_publish_deferred_leaves_open() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release import finalize
+
+    ctx = _ctx()
+    ctx.deferred_publish_failures = ["docker-publish"]
+    with (
+        patch.object(finalize, "comment_publish_deferred") as comment,
+        patch.object(finalize, "close_tracking_issue") as close,
+        patch.object(finalize, "progress"),
+    ):
+        finalize.close_and_finalize(ctx)
+    comment.assert_called_once()
+    close.assert_not_called()  # issue stays open
+
+
+def test_close_and_finalize_clean_closes_issue() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release import finalize
+
+    ctx = _ctx()
+    with (
+        patch.object(finalize, "comment_publish_deferred") as comment,
+        patch.object(finalize, "close_tracking_issue") as close,
+        patch.object(finalize, "progress"),
+    ):
+        finalize.close_and_finalize(ctx)
+    close.assert_called_once()
+    comment.assert_not_called()
+
+
+def test_close_and_finalize_stage_failure_short_circuits() -> None:
+    from unittest.mock import patch
+
+    from vergil_tooling.lib.release import finalize
+
+    ctx = _ctx()
+    ctx.deferred_failures = ["confirm-main"]
+    with (
+        patch.object(finalize, "close_tracking_issue") as close,
+        patch.object(finalize, "progress") as prog,
+    ):
+        finalize.close_and_finalize(ctx)
+    close.assert_not_called()
+    prog.run.assert_not_called()  # cleanup skipped — resumable

--- a/tests/vergil_tooling/test_release_handoff.py
+++ b/tests/vergil_tooling/test_release_handoff.py
@@ -109,3 +109,15 @@ def test_run_consumer_refresh_returns_failure_code(
     assert "install commands failed" in err
     # The release itself is not implicated by a failed local refresh.
     assert "release itself completed" in err
+
+
+# -- consumer_refresh holds when publish is deferred (issue #1853) --
+
+
+def test_consumer_refresh_holds_when_publish_deferred() -> None:
+    ctx = _ctx()
+    ctx.deferred_publish_failures = ["docker-publish"]
+    consumer_refresh(ctx)  # must not read config / must not raise
+    assert ctx.consumer_refresh_commands is None
+    assert "held" in (ctx.consumer_refresh_message or "").lower()
+    assert "2.1.0" in (ctx.consumer_refresh_message or "")  # version named

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -9,6 +9,7 @@ from vergil_tooling.lib.release.context import ReleaseContext, ReleaseError
 from vergil_tooling.lib.release.orchestrator import (
     ReleaseState,
     _preflight_stage,
+    _publish_status_stage,
     _tracked,
     build_stages,
 )
@@ -42,6 +43,7 @@ def test_build_stages_order_and_modes() -> None:
         "promote",
         "close-finalize",
         "consumer-refresh",
+        "publish-status",
     ]
     assert stages[0].skip_flag == "skip_audit"
     fail_fast = {s.name for s in stages if s.mode == "fail_fast"}
@@ -344,3 +346,29 @@ def test_merge_release_skips_when_already_merged() -> None:
         merge_release(ctx)
     m_wm.assert_not_called()
     assert ctx.release_merge_sha == "merged"
+
+
+def _state() -> ReleaseState:
+    state = ReleaseState(version_override=None, repo_root=Path("/tmp/r"), promote=True)  # noqa: S108
+    state.ctx = ReleaseContext(
+        repo="o/r", version="2.1.2", repo_root=Path("/tmp/r"), version_override=None  # noqa: S108
+    )
+    return state
+
+
+def test_publish_status_raises_when_deferred() -> None:
+    state = _state()
+    state.ctx.deferred_publish_failures = ["docker-publish"]
+    with pytest.raises(ReleaseError, match="docker-publish"):
+        _publish_status_stage(state)
+
+
+def test_publish_status_noop_when_clean() -> None:
+    state = _state()
+    _publish_status_stage(state)  # no raise
+
+
+def test_publish_status_is_terminal_fail_defer() -> None:
+    stages = build_stages()
+    assert stages[-1].name == "publish-status"
+    assert stages[-1].mode == "fail_defer"

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -351,13 +351,17 @@ def test_merge_release_skips_when_already_merged() -> None:
 def _state() -> ReleaseState:
     state = ReleaseState(version_override=None, repo_root=Path("/tmp/r"), promote=True)  # noqa: S108
     state.ctx = ReleaseContext(
-        repo="o/r", version="2.1.2", repo_root=Path("/tmp/r"), version_override=None  # noqa: S108
+        repo="o/r",
+        version="2.1.2",
+        repo_root=Path("/tmp/r"),
+        version_override=None,  # noqa: S108
     )
     return state
 
 
 def test_publish_status_raises_when_deferred() -> None:
     state = _state()
+    assert state.ctx is not None
     state.ctx.deferred_publish_failures = ["docker-publish"]
     with pytest.raises(ReleaseError, match="docker-publish"):
         _publish_status_stage(state)

--- a/tests/vergil_tooling/test_release_orchestrator.py
+++ b/tests/vergil_tooling/test_release_orchestrator.py
@@ -353,8 +353,8 @@ def _state() -> ReleaseState:
     state.ctx = ReleaseContext(
         repo="o/r",
         version="2.1.2",
-        repo_root=Path("/tmp/r"),
-        version_override=None,  # noqa: S108
+        repo_root=Path("/tmp/r"),  # noqa: S108
+        version_override=None,
     )
     return state
 

--- a/tests/vergil_tooling/test_release_tracking.py
+++ b/tests/vergil_tooling/test_release_tracking.py
@@ -346,3 +346,17 @@ def test_comment_phase_failed_no_detail() -> None:
         patch(_MOD + ".github.run"),
     ):
         comment_phase_failed(ctx, "merge-release", exc)
+
+
+def test_comment_publish_deferred_names_jobs_and_warns_resume() -> None:
+    from vergil_tooling.lib.release.tracking import comment_publish_deferred
+
+    ctx = _ctx()
+    ctx.tag = "v2.1.2"
+    ctx.cd_run_url = "https://run/55"
+    with patch(_MOD + "._comment") as comment:
+        comment_publish_deferred(ctx, ["docker-publish", "docs"])
+    body = comment.call_args[0][1]
+    assert "docker-publish" in body and "docs" in body
+    assert "--resume" in body  # explicitly steers away from it
+    assert "https://run/55" in body


### PR DESCRIPTION
# Pull Request

## Summary

- confirm-main now hard-fails only on the release itself (release job + tag/Release/boundary-tag, matched exactly); every other failed CD job is recorded into ctx.deferred_publish_failures and deferred, so back-merge-bump always runs and a docker/docs publish failure never strands develop.

## Issue Linkage

- Ref #1853

## Notes

- Implements #1853 fleet-wide, no vergil.toml config. Branch carries the design + implementation-plan docs (reviewed via /paad:pushback and /paad:alignment) plus the 9-task TDD implementation built subagent-driven. Changes: context.py (new deferred_publish_failures list[str]); confirm.py (watch with check_status removed/always-False, exact-match release hard gate, _collect_deferred_publish sweep, confirm_develop routes docs into the same list); orchestrator.py (terminal bare publish-status fail_defer stage -> exit 1); finalize.py (close-finalize precedence: deferred_failures resume path checked first, else publish-deferral leaves issue open + remediation comment, cleanup still runs); handoff.py (consumer-refresh hold-warning); tracking.py (comment_publish_deferred, warns against --resume). vrg-validate is GREEN (lint, typecheck, 100% coverage, tests). Final opus whole-branch review: ready to merge, no Critical/Important findings. Two optional one-line test tightenings were accepted as-is (assert develop_cd_run_url; assert cleanup ran on publish-deferred) — available if wanted. NOTE: the 88 failures seen in a bare host pytest run are pre-existing/environmental in untouched modules (vrg_vm/vrg_gh/etc.) — the in-container gate is green.