### PR TITLE
feat(vrg-vm): add EXTERNAL IP column to list for off-platform VMs

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1620,19 +1620,22 @@ def _list_rows(
     return rows
 
 
-def _cloud_status(state_dir: Path, state_key: str) -> str:
-    """Best-effort cloud status for one tofu state dir, never raising.
+def _cloud_instance_info(state_dir: Path, state_key: str) -> tuple[str, str]:
+    """Best-effort ``(status, external_ip)`` for one tofu state dir, never raising.
 
     The state_key (the state dir name) cannot be reversed to a spec, so this
     queries gcloud directly with the persisted zone rather than going through
-    ``OffPlatformBackend.status``. Any failure — no zone, no creds, no instance —
-    yields the empty string so the caller can show a degraded placeholder; it
-    never errors the whole ``list``.
+    ``OffPlatformBackend.status``. A single ``describe`` pulls both the run status
+    and the ephemeral external IP (``natIP``) — separator-joined so one round-trip
+    serves both columns. Any failure — no zone, no creds, no instance — yields
+    ``("", "")`` so the caller can show a degraded placeholder; it never errors the
+    whole ``list``. The external IP is ``""`` for an internal-only box (no
+    ``access_config``) or one that isn't running (#1855).
     """
     try:
         zone = vm_cloud.read_zone(state_dir)
     except RuntimeError:
-        return ""
+        return "", ""
     try:
         result = subprocess.run(  # noqa: S603
             [  # noqa: S607
@@ -1642,15 +1645,16 @@ def _cloud_status(state_dir: Path, state_key: str) -> str:
                 "describe",
                 state_key,
                 f"--zone={zone}",
-                "--format=value(status)",
+                "--format=value[separator='|'](status,networkInterfaces[0].accessConfigs[0].natIP)",
             ],
             capture_output=True,
             text=True,
             check=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
-        return ""
-    return result.stdout.strip()
+        return "", ""
+    status, _, external_ip = result.stdout.strip().partition("|")
+    return status, external_ip
 
 
 @dataclass(frozen=True)
@@ -1660,9 +1664,11 @@ class OffPlatformVm:
     ``identity`` / ``org`` / ``repo`` come from the persistent disk's ``vergil-*``
     labels (``None`` for a never-applied or unlabeled state). ``status`` is the raw
     best-effort cloud status (``"RUNNING"`` for a live box; ``""`` when the provider
-    cannot be reached). ``state_dir`` is the ``<state_key>/<provider>`` tofu
-    directory; ``name`` is both the state key and the deterministic cloud resource
-    name (the gcloud instance name).
+    cannot be reached). ``external_ip`` is the box's ephemeral public IP (``natIP``),
+    or ``""`` for an internal-only box or when the provider cannot be reached.
+    ``state_dir`` is the ``<state_key>/<provider>`` tofu directory; ``name`` is both
+    the state key and the deterministic cloud resource name (the gcloud instance
+    name).
     """
 
     name: str
@@ -1675,6 +1681,7 @@ class OffPlatformVm:
     instance: str | None = None
     volume_size: str | None = None
     vm_present: bool = True
+    external_ip: str = ""
 
     @property
     def is_running(self) -> bool:
@@ -1775,7 +1782,9 @@ def _off_platform_vms() -> list[OffPlatformVm]:
         labels = parsed.labels if parsed else {}
         size = f"{parsed.size_gib}GiB" if parsed and parsed.size_gib else None
         vm_present = (provider_dir / "vm.tfstate").exists()
-        status = _cloud_status(provider_dir, state_key) if vm_present else ""
+        status, external_ip = (
+            _cloud_instance_info(provider_dir, state_key) if vm_present else ("", "")
+        )
         vms.append(
             OffPlatformVm(
                 name=state_key,
@@ -1788,6 +1797,7 @@ def _off_platform_vms() -> list[OffPlatformVm]:
                 status=status,
                 volume_size=size,
                 vm_present=vm_present,
+                external_ip=external_ip,
             )
         )
     return vms
@@ -1863,6 +1873,7 @@ def _cloud_list_rows(config: IdentityConfig) -> list[dict[str, object]]:
                 "instance": vm.instance or "—",
                 "backend": vm.provider,
                 "status": status,
+                "external_ip": vm.external_ip or "—",
                 "disk": disk,
                 "spec": spec,
             }
@@ -1888,7 +1899,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
 
     header = (
         f"{'IDENTITY':<14} {'SCOPE':<40} {'INSTANCE':<11} {'BACKEND':<13} {'STATUS':<11} "
-        f"{'CPUS':<5} {'MEM':<7} {'DISK':<7} {'AGENTS':<7} {'HUMANS':<7} {'SPEC':<22}"
+        f"{'EXTERNAL IP':<15} {'CPUS':<5} {'MEM':<7} {'DISK':<7} {'AGENTS':<7} {'HUMANS':<7} "
+        f"{'SPEC':<22}"
     )
     print(header)
     print("─" * len(header))
@@ -1897,7 +1909,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
         for r in _list_rows(id_name, identity, discovered[id_name], status, probes):
             print(
                 f"{id_name:<14} {r['scope']!s:<40} {r.get('instance', '—')!s:<11} "
-                f"{r['backend']!s:<13} {r['status']!s:<11} "
+                f"{r['backend']!s:<13} {r['status']!s:<11} {'—':<15} "
                 f"{r['cpus']!s:<5} {r['memory']!s:<7} {r['disk']!s:<7} "
                 f"{r['agents']!s:<7} {r['humans']!s:<7} {r['spec']!s:<22}"
             )
@@ -1905,7 +1917,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
     for r in _cloud_list_rows(config):
         print(
             f"{r['identity']!s:<14} {r['scope']!s:<40} {r['instance']!s:<11} "
-            f"{r['backend']!s:<13} {r['status']!s:<11} "
+            f"{r['backend']!s:<13} {r['status']!s:<11} {r['external_ip']!s:<15} "
             f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {r['spec']!s:<22}"
         )
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4019,18 +4019,110 @@ class TestCloudList:
         assert "gcp" in out
         assert "unknown (no gcp creds)" in out
 
-    def test_cloud_status_reads_live_status(self, tmp_path: Path) -> None:
-        from vergil_tooling.bin.vrg_vm import _cloud_status
+    def test_external_ip_column_header_present(self, config_file: Path) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with (
+            patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[]),
+            patch("vergil_tooling.bin.vrg_vm._cloud_list_rows", return_value=[]),
+            redirect_stdout(buf),
+        ):
+            result = main(["list", "--config", str(config_file)])
+        assert result == 0
+        assert "EXTERNAL IP" in buf.getvalue()
+
+    def test_cloud_list_rows_carries_external_ip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_list_rows
+
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        (tofu / "volume.tfstate").write_text("{}")
+        (tofu / "vm.tfstate").write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+        config = IdentityConfig(identities={}, default_identity=None)
+        with patch(
+            "vergil_tooling.bin.vrg_vm._cloud_instance_info",
+            return_value=("RUNNING", "34.42.0.7"),
+        ):
+            rows = _cloud_list_rows(config)
+        assert len(rows) == 1
+        assert rows[0]["external_ip"] == "34.42.0.7"
+
+    def test_cloud_list_rows_external_ip_degrades_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_list_rows
+
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        (tofu / "volume.tfstate").write_text("{}")
+        (tofu / "vm.tfstate").write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+        config = IdentityConfig(identities={}, default_identity=None)
+        # Internal-only box: running, but no external IP -> degrade to "—".
+        with patch(
+            "vergil_tooling.bin.vrg_vm._cloud_instance_info",
+            return_value=("RUNNING", ""),
+        ):
+            rows = _cloud_list_rows(config)
+        assert rows[0]["external_ip"] == "—"
+
+    def test_list_prints_external_ip_for_cloud_vm(
+        self, config_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        (tofu / "volume.tfstate").write_text("{}")
+        (tofu / "vm.tfstate").write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with (
+            patch("vergil_tooling.bin.vrg_vm.list_vms", return_value=[]),
+            patch(
+                "vergil_tooling.bin.vrg_vm._cloud_instance_info",
+                return_value=("RUNNING", "34.42.0.7"),
+            ),
+            redirect_stdout(buf),
+        ):
+            result = main(["list", "--config", str(config_file)])
+        assert result == 0
+        assert "34.42.0.7" in buf.getvalue()
+
+    def test_cloud_instance_info_reads_live_status_and_external_ip(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_instance_info
 
         state_dir = tmp_path / "state"
         state_dir.mkdir()
         with patch("vergil_tooling.bin.vrg_vm.vm_cloud.read_zone", return_value="us-central1-a"):
-            completed = MagicMock(stdout="RUNNING\n")
+            # One describe pulls both fields, separator-joined (status|natIP).
+            completed = MagicMock(stdout="RUNNING|34.42.0.7\n")
             with patch("vergil_tooling.bin.vrg_vm.subprocess.run", return_value=completed):
-                assert _cloud_status(state_dir, "key") == "RUNNING"
+                assert _cloud_instance_info(state_dir, "key") == ("RUNNING", "34.42.0.7")
 
-    def test_cloud_status_gcloud_failure_is_empty(self, tmp_path: Path) -> None:
-        from vergil_tooling.bin.vrg_vm import _cloud_status
+    def test_cloud_instance_info_internal_only_has_no_external_ip(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_instance_info
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        with patch("vergil_tooling.bin.vrg_vm.vm_cloud.read_zone", return_value="us-central1-a"):
+            # An internal-only box (no access_config) yields an empty natIP field.
+            completed = MagicMock(stdout="RUNNING|\n")
+            with patch("vergil_tooling.bin.vrg_vm.subprocess.run", return_value=completed):
+                assert _cloud_instance_info(state_dir, "key") == ("RUNNING", "")
+
+    def test_cloud_instance_info_gcloud_failure_is_empty(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_instance_info
 
         state_dir = tmp_path / "state"
         state_dir.mkdir()
@@ -4041,7 +4133,7 @@ class TestCloudList:
                 side_effect=subprocess.CalledProcessError(1, "gcloud"),
             ),
         ):
-            assert _cloud_status(state_dir, "key") == ""
+            assert _cloud_instance_info(state_dir, "key") == ("", "")
 
     def test_cloud_list_rows_empty_when_no_tofu_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -4084,7 +4176,7 @@ class TestCloudList:
         }
         (tofu / "volume.tfstate").write_text(json.dumps(state))
         monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
-        # No persisted zone file -> _cloud_status degrades to "" without raising.
+        # No persisted zone file -> _cloud_instance_info degrades to ("", "") without raising.
         vms = _off_platform_vms()
         assert len(vms) == 1
         vm = vms[0]
@@ -4096,6 +4188,7 @@ class TestCloudList:
         assert vm.label == "lmf/cloud [lmf]"
         assert vm.update_ref == "lmf/cloud --identity lmf"
         assert vm.status == ""
+        assert vm.external_ip == ""
         assert vm.is_running is False
 
     def test_off_platform_vm_unlabeled_falls_back_to_resource_name(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm list now shows each off-platform box's ephemeral public IP, folded into the existing status describe so it stays one round-trip per VM.

## Issue Linkage

- Ref #1855

## Notes

- Renamed _cloud_status -> _cloud_instance_info, returning (status, external_ip) from a single gcloud describe (status + networkInterfaces[0].accessConfigs[0].natIP, separator-joined). Added external_ip to OffPlatformVm and the cloud list rows, plus an EXTERNAL IP column in _cmd_list. Degrades to a placeholder for internal-only/unreachable boxes and for Lima rows; never raises. Pairs with vergil-vm #260 (which adds the IPs). Follow-on for per-QM ports tracked in lab #345.