### PR TITLE
docs(cloud-handoff): document cloud/Mac PR-development boundary (#1858 Deliverable A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,35 @@ finalization are human actions. The PR handoff is:
    state file, previews the PR, and submits after confirmation.
 3. The human merges and runs post-merge cleanup (`vrg-finalize-pr`).
 
+### Cloud session prompt contract (off-platform VMs)
+
+The PR handoff above assumes the agent and the human share one
+filesystem — true on the Mac (Lima), where the agent's worktree and the
+local `.vergil/pr-workflow.json` are visible to the human running
+`vrg-submit-pr`. **Cloud x86 VMs have no shared filesystem with the
+Mac**, so that handoff does not yet work there. Until the GitHub-relay
+transport lands (issue
+[#1858](https://github.com/vergil-project/vergil-tooling/issues/1858),
+Deliverable B), a cloud session must observe this boundary:
+
+- **Cloud x86 VMs are for runtime verification, builds,
+  triage/debugging, and issue registration — not PR-development.** The
+  MQ x86 work and other native-x86 / Red Hat stacks that cannot run
+  under Lima are exercised on a cloud VM for triage only.
+- **The GitHub issue is the cloud→Mac message bus.** A cloud triage
+  agent writes structured findings, repro steps, and diagnosis as
+  comments on the tracking issue (via `vrg-gh`); a Mac development agent
+  picks the issue up through the normal flow and does the PR-development
+  there via Lima, where the shared filesystem and `vrg-submit-pr` work
+  unchanged.
+
+This is a **best-effort advisory, not a hard guard.** The session layer
+(not `vrg-pr-workflow` itself) knows it is on a cloud VM, so the
+convention is carried here in the prompt contract. It extends the
+"agents must not run `vrg-submit-pr`" policy upstream: cloud agents do
+not do PR-development at all. If you find yourself about to prepare a PR
+in a cloud context, stop and hand the issue back to the Mac instead.
+
 ## Project Overview
 
 This is a Python package providing shared development tooling for all managed

--- a/docs/specs/2026-06-24-cloud-pr-handoff-design.md
+++ b/docs/specs/2026-06-24-cloud-pr-handoff-design.md
@@ -10,8 +10,10 @@
 **Date:** 2026-06-24
 
 **Status:** Design approved (brainstorming + paad:pushback, 2026-06-24).
-**Implementation parked** — the design lands as documentation; building Deliverables
-A and B is deferred. #1858 stays open to track the parked implementation.
+**Deliverable A shipped** (cloud-session prompt contract in `CLAUDE.md`,
+2026-06-24) — it unblocks the cloud x86 / MQ work with no code beyond the
+advisory. **Deliverable B remains parked** (gated on the channel feasibility
+spike — acceptance criterion 0). #1858 stays open to track B's implementation.
 
 ## Problem
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add an advisory cloud-session prompt contract to CLAUDE.md scoping cloud x86 VMs to triage/runtime/issue-registration (not PR-development), unblocking the MQ x86 work with no code while Deliverable B's GitHub relay stays parked.

## Issue Linkage

- Ref #1858

## Notes

- Deliverable A only, per the human's explicit scope choice. Deliverable B (GitHubTransport relay) remains parked under #1858 because it is gated on a live-GitHub channel feasibility spike (acceptance criterion 0) that cannot run from a code session. Changes: (1) new 'Cloud session prompt contract' subsection under 'Identity modes and PR submission' in CLAUDE.md, satisfying acceptance criterion 6; (2) moved the design spec from docs/superpowers/specs/ to docs/specs/ (the repo's spec home) per human request, and updated its status to 'Deliverable A shipped / B parked'. Docs-only; vrg-validate green.