### PR TITLE
fix(vrg-vm): correct off-platform list display — instance name and column widths

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1928,27 +1928,43 @@ def _cmd_list(args: argparse.Namespace) -> int:
     }
     probes = _probe_running(config.identities, discovered, status)
 
+    local_rows = [
+        (id_name, r)
+        for id_name, identity in config.identities.items()
+        for r in _list_rows(id_name, identity, discovered[id_name], status, probes)
+    ]
+    cloud_rows = _cloud_list_rows(config)
+
+    # SCOPE and STATUS carry the only variable-length values — long org/repo handles
+    # and the wide 'unknown (no gcp creds)' placeholder — so size each to its widest
+    # value with the prior fixed widths as floors. A value that overruns a fixed
+    # field shoves every later column out of alignment, which is exactly what a long
+    # handle did to SCOPE (#1866).
+    scopes = [str(r["scope"]) for _id, r in local_rows] + [str(r["scope"]) for r in cloud_rows]
+    statuses = [str(r["status"]) for _id, r in local_rows] + [str(r["status"]) for r in cloud_rows]
+    scope_w = max(40, *(len(s) for s in scopes)) if scopes else 40
+    status_w = max(11, *(len(s) for s in statuses)) if statuses else 11
+
     header = (
-        f"{'IDENTITY':<14} {'SCOPE':<40} {'INSTANCE':<11} {'BACKEND':<13} {'STATUS':<11} "
-        f"{'EXTERNAL IP':<15} {'CPUS':<5} {'MEM':<7} {'DISK':<7} {'AGENTS':<7} {'HUMANS':<7} "
-        f"{'SPEC':<22}"
+        f"{'IDENTITY':<14} {'SCOPE':<{scope_w}} {'INSTANCE':<11} {'BACKEND':<13} "
+        f"{'STATUS':<{status_w}} {'EXTERNAL IP':<15} {'CPUS':<5} {'MEM':<7} {'DISK':<7} "
+        f"{'AGENTS':<7} {'HUMANS':<7} {'SPEC':<22}"
     )
     print(header)
     print("─" * len(header))
 
-    for id_name, identity in config.identities.items():
-        for r in _list_rows(id_name, identity, discovered[id_name], status, probes):
-            print(
-                f"{id_name:<14} {r['scope']!s:<40} {r.get('instance', '—')!s:<11} "
-                f"{r['backend']!s:<13} {r['status']!s:<11} {'—':<15} "
-                f"{r['cpus']!s:<5} {r['memory']!s:<7} {r['disk']!s:<7} "
-                f"{r['agents']!s:<7} {r['humans']!s:<7} {r['spec']!s:<22}"
-            )
-
-    for r in _cloud_list_rows(config):
+    for id_name, r in local_rows:
         print(
-            f"{r['identity']!s:<14} {r['scope']!s:<40} {r['instance']!s:<11} "
-            f"{r['backend']!s:<13} {r['status']!s:<11} {r['external_ip']!s:<15} "
+            f"{id_name:<14} {r['scope']!s:<{scope_w}} {r.get('instance', '—')!s:<11} "
+            f"{r['backend']!s:<13} {r['status']!s:<{status_w}} {'—':<15} "
+            f"{r['cpus']!s:<5} {r['memory']!s:<7} {r['disk']!s:<7} "
+            f"{r['agents']!s:<7} {r['humans']!s:<7} {r['spec']!s:<22}"
+        )
+
+    for r in cloud_rows:
+        print(
+            f"{r['identity']!s:<14} {r['scope']!s:<{scope_w}} {r['instance']!s:<11} "
+            f"{r['backend']!s:<13} {r['status']!s:<{status_w}} {r['external_ip']!s:<15} "
             f"{'—':<5} {'—':<7} {r['disk']!s:<7} {'—':<7} {'—':<7} {r['spec']!s:<22}"
         )
 

--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -1236,7 +1236,7 @@ def _cmd_update_all(args: argparse.Namespace) -> int:
             continue
         try:
             fallback = _off_platform_fallback(config, vm)
-            transport = vm_cloud.off_platform_transport(vm.name, vm.state_dir)
+            transport = vm_cloud.off_platform_transport(vm.cloud_name, vm.state_dir)
             _update_over_transport(transport, box, tag, fallback)
             updated.append(vm.label)
         except subprocess.CalledProcessError as exc:
@@ -1620,17 +1620,23 @@ def _list_rows(
     return rows
 
 
-def _cloud_instance_info(state_dir: Path, state_key: str) -> tuple[str, str]:
+def _cloud_instance_info(state_dir: Path, instance_name: str) -> tuple[str, str]:
     """Best-effort ``(status, external_ip)`` for one tofu state dir, never raising.
 
-    The state_key (the state dir name) cannot be reversed to a spec, so this
-    queries gcloud directly with the persisted zone rather than going through
-    ``OffPlatformBackend.status``. A single ``describe`` pulls both the run status
-    and the ephemeral external IP (``natIP``) — separator-joined so one round-trip
-    serves both columns. Any failure — no zone, no creds, no instance — yields
-    ``("", "")`` so the caller can show a degraded placeholder; it never errors the
-    whole ``list``. The external IP is ``""`` for an internal-only box (no
-    ``access_config``) or one that isn't running (#1855).
+    ``instance_name`` is the gcloud instance name (``cloud_resource_name(slug)``,
+    i.e. ``vrg-<hash>``) — NOT the readable state key, which names no GCP resource
+    and would 404 (#1866). Queries gcloud directly with the persisted zone rather
+    than going through ``OffPlatformBackend.status``. A single ``describe`` pulls
+    both the run status and the ephemeral external IP (``natIP``) — separator-joined
+    so one round-trip serves both columns. The external IP is ``""`` for an
+    internal-only box (no ``access_config``) or one that isn't running (#1855).
+
+    Failures degrade rather than raising, so ``list`` never errors on one box:
+    ``("MISSING", "")`` when the provider reports the instance absent (drift — torn
+    down out of band), and ``("", "")`` for any other failure (no zone, no creds,
+    gcloud absent) so the caller shows the credential-less placeholder. The two are
+    kept distinct so a real ``no creds`` is never confused with a vanished VM
+    (#1866).
     """
     try:
         zone = vm_cloud.read_zone(state_dir)
@@ -1643,7 +1649,7 @@ def _cloud_instance_info(state_dir: Path, state_key: str) -> tuple[str, str]:
                 "compute",
                 "instances",
                 "describe",
-                state_key,
+                instance_name,
                 f"--zone={zone}",
                 "--format=value[separator='|'](status,networkInterfaces[0].accessConfigs[0].natIP)",
             ],
@@ -1651,7 +1657,12 @@ def _cloud_instance_info(state_dir: Path, state_key: str) -> tuple[str, str]:
             text=True,
             check=True,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except FileNotFoundError:
+        return "", ""
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").lower()
+        if "not found" in stderr or "was not found" in stderr:
+            return "MISSING", ""
         return "", ""
     status, _, external_ip = result.stdout.strip().partition("|")
     return status, external_ip
@@ -1666,9 +1677,11 @@ class OffPlatformVm:
     best-effort cloud status (``"RUNNING"`` for a live box; ``""`` when the provider
     cannot be reached). ``external_ip`` is the box's ephemeral public IP (``natIP``),
     or ``""`` for an internal-only box or when the provider cannot be reached.
-    ``state_dir`` is the ``<state_key>/<provider>`` tofu directory; ``name`` is both
-    the state key and the deterministic cloud resource name (the gcloud instance
-    name).
+    ``state_dir`` is the ``<state_key>/<provider>`` tofu directory; ``name`` is the
+    readable state-key slug — it keys the local state path / labels and the display
+    fallback, but it is **not** what GCP calls the VM. The gcloud instance name is
+    the deterministic hash of the slug — use ``cloud_name`` for every gcloud / IAP
+    call, never ``name`` (#1866).
     """
 
     name: str
@@ -1682,6 +1695,20 @@ class OffPlatformVm:
     volume_size: str | None = None
     vm_present: bool = True
     external_ip: str = ""
+
+    @property
+    def cloud_name(self) -> str:
+        """The gcloud instance name for this box — ``cloud_resource_name(slug)``.
+
+        The four-segment state-key slug overflows GCP's 63-char name limit, so the
+        backend names the live resource ``vrg-<hash>`` at create time
+        (``vm_cloud.cloud_resource_name``); identity/org/repo ride in labels, never
+        in the name. ``name`` keys local state and display, so every call that
+        addresses the box in GCP — ``describe`` for ``list`` status, the IAP
+        transport for ``update`` / session listing — must use this, not ``name``,
+        or it queries an instance that does not exist (#1866).
+        """
+        return vm_cloud.cloud_resource_name(self.name)
 
     @property
     def is_running(self) -> bool:
@@ -1782,8 +1809,12 @@ def _off_platform_vms() -> list[OffPlatformVm]:
         labels = parsed.labels if parsed else {}
         size = f"{parsed.size_gib}GiB" if parsed and parsed.size_gib else None
         vm_present = (provider_dir / "vm.tfstate").exists()
+        # GCP names the instance vrg-<hash>, not the readable state key, so the live
+        # describe must target the deterministic cloud resource name (#1866).
         status, external_ip = (
-            _cloud_instance_info(provider_dir, state_key) if vm_present else ("", "")
+            _cloud_instance_info(provider_dir, vm_cloud.cloud_resource_name(state_key))
+            if vm_present
+            else ("", "")
         )
         vms.append(
             OffPlatformVm(
@@ -2078,7 +2109,7 @@ def _off_platform_active_sessions(vm: OffPlatformVm) -> dict[str, dict[str, obje
     transport instead of limactl. The box owns its own roster, so it is the only
     source for a live session's name — exactly as for a Lima box.
     """
-    transport = vm_cloud.off_platform_transport(vm.name, vm.state_dir)
+    transport = vm_cloud.off_platform_transport(vm.cloud_name, vm.state_dir)
     result = transport.run("vrg-vm-resolve-session", "--list-json")
     rows = json.loads(result.stdout)
     return {row["sessionId"]: row for row in rows if row.get("state") == "active"}

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -4397,6 +4397,48 @@ def test_list_shows_instance_column_and_no_vm_row(
     assert "200GiB" in out
 
 
+def test_list_widens_scope_and_status_to_keep_columns_aligned(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    # A long org/repo handle (49 chars) overruns the old fixed 40-wide SCOPE, and the
+    # 22-char 'unknown (no gcp creds)' overruns the 11-wide STATUS — both shoved every
+    # later column out of alignment. The columns now size to their content (#1866).
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from vergil_tooling.bin import vrg_vm
+
+    long_scope = "logical-minds-foundry/mq-resiliency-lab-for-linux"
+    row = {
+        "identity": "vergil-user",
+        "scope": long_scope,
+        "instance": "cloud",
+        "backend": "gcp",
+        "status": "unknown (no gcp creds)",
+        "external_ip": "—",
+        "disk": "—",
+        "spec": "ok",
+    }
+    monkeypatch.setattr(vrg_vm, "list_vms", lambda: [])
+    monkeypatch.setattr(vrg_vm, "_cloud_list_rows", lambda _config: [row])
+    monkeypatch.setattr(
+        vrg_vm, "load_config", lambda p: IdentityConfig(identities={}, default_identity=None)
+    )
+    args = argparse.Namespace(config=None, sessions=False)
+    assert vrg_vm._cmd_list(args) == 0
+
+    lines = capsys.readouterr().out.splitlines()
+    header = lines[0]
+    data = next(line for line in lines if long_scope in line)
+    # The full handle and full status both render, and because each column was sized
+    # to its widest value, the field after each — INSTANCE after SCOPE, EXTERNAL IP
+    # after STATUS — starts at the same column in the header and the data row.
+    assert long_scope in data
+    assert "unknown (no gcp creds)" in data
+    inst_col = header.index("INSTANCE")
+    assert data[inst_col:].startswith("cloud")
+    ip_col = header.index("EXTERNAL IP")
+    assert data[ip_col:].startswith("—")
+
+
 # ---------------------------------------------------------------------------
 # Helpers for _classify_off_platform tests
 # ---------------------------------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1685,7 +1685,11 @@ class TestUpdateAll:
         assert result == 0
         # Both boxes updated in place: Lima over limactl, off-platform over IAP.
         assert mock_update.call_count == 2
-        mock_transport.assert_called_once_with("vergil-lmf-cloud", Path("/x/gcp"))
+        # The IAP transport must address the box by its gcloud instance name
+        # (vrg-<hash>), not the readable state key, or the tunnel 404s (#1866).
+        mock_transport.assert_called_once_with(
+            vm_cloud.cloud_resource_name("vergil-lmf-cloud"), Path("/x/gcp")
+        )
         assert fake_transport in [c.args[0] for c in mock_update.call_args_list]
         out = capsys.readouterr().out
         assert "off-platform box 'lmf/cloud [lmf]'" in out
@@ -4053,6 +4057,27 @@ class TestCloudList:
         assert len(rows) == 1
         assert rows[0]["external_ip"] == "34.42.0.7"
 
+    def test_cloud_list_rows_surfaces_missing_distinct_from_no_creds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_list_rows
+
+        # A torn-down box reports MISSING (real drift), kept distinct from the
+        # credential-less "" placeholder so neither is mistaken for the other (#1866).
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        (tofu / "volume.tfstate").write_text("{}")
+        (tofu / "vm.tfstate").write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+        config = IdentityConfig(identities={}, default_identity=None)
+        with patch(
+            "vergil_tooling.bin.vrg_vm._cloud_instance_info",
+            return_value=("MISSING", ""),
+        ):
+            rows = _cloud_list_rows(config)
+        assert rows[0]["status"] == "MISSING"
+
     def test_cloud_list_rows_external_ip_degrades_when_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -4135,6 +4160,56 @@ class TestCloudList:
         ):
             assert _cloud_instance_info(state_dir, "key") == ("", "")
 
+    def test_cloud_instance_info_no_gcloud_is_empty(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_instance_info
+
+        # No gcloud on PATH is a credential-less environment, not drift -> the empty
+        # placeholder, kept distinct from MISSING (#1866).
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        with (
+            patch("vergil_tooling.bin.vrg_vm.vm_cloud.read_zone", return_value="us-central1-a"),
+            patch("vergil_tooling.bin.vrg_vm.subprocess.run", side_effect=FileNotFoundError),
+        ):
+            assert _cloud_instance_info(state_dir, "vrg-abc") == ("", "")
+
+    def test_cloud_instance_info_not_found_is_missing(self, tmp_path: Path) -> None:
+        from vergil_tooling.bin.vrg_vm import _cloud_instance_info
+
+        # A describe that 404s means the instance is gone (drift), NOT a creds
+        # failure — surface it as MISSING so the two stay distinct (#1866).
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        not_found = subprocess.CalledProcessError(
+            1, "gcloud", stderr="ERROR: The resource 'vrg-deadbeef' was not found"
+        )
+        with (
+            patch("vergil_tooling.bin.vrg_vm.vm_cloud.read_zone", return_value="us-central1-a"),
+            patch("vergil_tooling.bin.vrg_vm.subprocess.run", side_effect=not_found),
+        ):
+            assert _cloud_instance_info(state_dir, "vrg-deadbeef") == ("MISSING", "")
+
+    def test_off_platform_vms_describes_by_cloud_resource_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vergil_tooling.bin.vrg_vm import _off_platform_vms
+
+        # The live describe must target the gcloud instance name (vrg-<hash>), not
+        # the readable state key — querying by the state key 404s and degrades the
+        # whole row to a misleading "no gcp creds" (#1866).
+        fake_home = tmp_path / "home"
+        tofu = fake_home / ".config" / "vergil" / "tofu" / "vergil-lmf-cloud" / "gcp"
+        tofu.mkdir(parents=True)
+        (tofu / "volume.tfstate").write_text("{}")
+        (tofu / "vm.tfstate").write_text("{}")
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+        with patch(
+            "vergil_tooling.bin.vrg_vm._cloud_instance_info",
+            return_value=("RUNNING", "34.42.0.7"),
+        ) as info:
+            _off_platform_vms()
+        info.assert_called_once_with(tofu, vm_cloud.cloud_resource_name("vergil-lmf-cloud"))
+
     def test_cloud_list_rows_empty_when_no_tofu_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -4181,6 +4256,10 @@ class TestCloudList:
         assert len(vms) == 1
         vm = vms[0]
         assert vm.name == "vergil-lmf-cloud"
+        # name is the readable slug; the gcloud instance name is its deterministic
+        # hash, which is what every cloud/IAP call must address (#1866).
+        assert vm.cloud_name == vm_cloud.cloud_resource_name("vergil-lmf-cloud")
+        assert vm.cloud_name.startswith("vrg-")
         assert vm.provider == "gcp"
         assert (vm.identity, vm.org, vm.repo) == ("lmf", "lmf", "cloud")
         assert vm.scope == "lmf/cloud"
@@ -4270,7 +4349,9 @@ class TestCloudList:
             "vergil_tooling.bin.vrg_vm.vm_cloud.off_platform_transport", return_value=transport
         ) as mk:
             rows = _off_platform_active_sessions(vm)
-        mk.assert_called_once_with("vergil-lmf-cloud", Path("/x/gcp"))
+        # The IAP session query addresses the box by its gcloud instance name
+        # (vrg-<hash>), not the readable state key (#1866).
+        mk.assert_called_once_with(vm_cloud.cloud_resource_name("vergil-lmf-cloud"), Path("/x/gcp"))
         transport.run.assert_called_once_with("vrg-vm-resolve-session", "--list-json")
         # Only the active row is retained, keyed by session id.
         assert set(rows) == {"c1"}


### PR DESCRIPTION
# Pull Request

## Summary

- Fixes two display defects in vrg-vm list for off-platform GCP boxes: it queried GCP by the readable state-key slug instead of the deterministic vrg-<hash> instance name (so a healthy VM showed 'unknown (no gcp creds)'), now routed through a cloud_name accessor across list/update/session paths; and the SCOPE/STATUS columns were fixed-width and overflowed on long handles, now sized to their content.

## Issue Linkage

- Ref #1866

## Notes

- Both fixes are display/transport-only — the connect path already used the spec-derived name. MISSING is now distinguished from a real credential failure. Tests cover cloud_name derivation, describe-by-cloud-name, the MISSING vs no-creds/no-gcloud split, and column alignment under a long handle. Validation green at 100% coverage.