### PR TITLE
fix(retry): retry net/http transport failures (TLS handshake, DNS, EOF)

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -1,8 +1,9 @@
 """GitHub CLI (``gh``) subprocess wrappers.
 
 All functions that use ``check=True`` retry transparently on transient
-GitHub API errors (HTTP 401, 502, 503, 504, 429 and network-level
-timeouts) with exponential backoff.
+GitHub API errors (HTTP 401, 502, 503, 504, 429 and ``net/http``
+transport failures such as TLS handshake/i/o timeouts, connection
+refused, DNS lookup failures, and EOF) with exponential backoff.
 """
 
 from __future__ import annotations

--- a/src/vergil_tooling/lib/retry.py
+++ b/src/vergil_tooling/lib/retry.py
@@ -1,14 +1,21 @@
 """Retry logic for transient GitHub API errors.
 
 Shared by ``github.py`` (library wrappers) and ``vrg_gh.py`` (CLI wrapper)
-so both paths handle HTTP 401/502/503/504/429 and network timeouts
-identically.
+so both paths handle HTTP 401/502/503/504/429 and ``net/http`` transport
+failures (TLS handshake, i/o timeout, connection refused, DNS lookup,
+EOF) identically.
 
 HTTP 401 "Bad credentials" is treated as transient: GitHub's API
 (notably the GraphQL endpoint behind ``gh pr checks --watch``)
 intermittently rejects a valid token, with the immediately following
 call succeeding. Retrying is safe even for write operations because a
 401 is rejected at authentication, before any mutation occurs.
+
+Transport-layer failures (TLS handshake timeout, i/o timeout, connection
+refused, DNS "no such host", "server misbehaving", EOF) are emitted by
+``gh``'s Go ``net/http`` stack when the request never reaches GitHub's
+application layer. Like the 401 case they occur before any server-side
+mutation, so retrying is safe for writes as well as reads.
 """
 
 from __future__ import annotations
@@ -25,14 +32,23 @@ MAX_RETRIES = 4
 BASE_DELAY_SECS = 2.0
 MAX_DELAY_SECS = 60.0
 _RETRYABLE_PATTERNS = (
+    # HTTP-layer transients
     "http 401",
     "bad credentials",
     "http 502",
     "http 503",
     "http 504",
     "http 429",
+    # net/http transport-layer transients (request never reached the app
+    # layer, so retrying is safe for writes too)
     "timed out",
+    "timeout",  # "TLS handshake timeout", "i/o timeout", "Client.Timeout"
+    "tls handshake",
     "connection reset",
+    "connection refused",
+    "no such host",  # DNS resolution failure
+    "server misbehaving",  # Go DNS resolver transient
+    "eof",  # "unexpected EOF" / "EOF" mid-request
 )
 
 

--- a/tests/vergil_tooling/test_retry.py
+++ b/tests/vergil_tooling/test_retry.py
@@ -37,6 +37,14 @@ class TestIsRetryable:
             "Bad credentials",
             "request timed out",
             "connection reset by peer",
+            # net/http transport-layer transients
+            'Post "https://api.github.com/graphql": net/http: TLS handshake timeout',
+            'Get "https://api.github.com/...": net/http: TLS handshake timeout',
+            "dial tcp: i/o timeout",
+            "dial tcp 140.82.112.5:443: connect: connection refused",
+            "lookup api.github.com on 127.0.0.53:53: no such host",
+            "lookup api.github.com: server misbehaving",
+            "unexpected EOF",
         ],
     )
     def test_retryable_errors(self, stderr: str) -> None:
@@ -45,8 +53,18 @@ class TestIsRetryable:
     def test_retryable_error_in_stdout(self) -> None:
         assert retry.is_retryable(_api_error(stdout="HTTP 504")) is True
 
-    def test_non_retryable_error(self) -> None:
-        assert retry.is_retryable(_api_error(stderr="HTTP 404 Not Found")) is False
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "HTTP 404 Not Found",
+            "HTTP 422 Unprocessable Entity",
+            "GraphQL: Pull request is not mergeable (mergePullRequest)",
+            "could not resolve to a Repository with the name 'x/y'",
+            "HTTP 403: Resource not accessible by integration",
+        ],
+    )
+    def test_non_retryable_error(self, stderr: str) -> None:
+        assert retry.is_retryable(_api_error(stderr=stderr)) is False
 
     def test_empty_output(self) -> None:
         assert retry.is_retryable(_api_error()) is False


### PR DESCRIPTION
# Pull Request

## Summary

- Broaden the GitHub retry layer's transient-error matching to cover the Go net/http transport failures that gh emits when a request never reaches GitHub's app layer — most notably 'net/http: TLS handshake timeout', which slipped past the 'timed out' substring and surfaced as hard failures in release steps (close-finalize, consumer-refresh).

## Issue Linkage

- Ref #1869

## Notes

- Adds general 'timeout', 'tls handshake', 'connection refused', DNS 'no such host'/'server misbehaving', and 'eof' to _RETRYABLE_PATTERNS in retry.py. These transport errors occur before any server-side mutation, so retrying is safe for writes as well as reads (same rationale already documented for HTTP 401). Docstrings in retry.py and github.py updated. Tests add is_retryable cases for each new pattern (including the exact observed GraphQL TLS-handshake error) plus parametrized non-retryable guards (404/422/403/validation/not-mergeable) so the broader matching doesn't over-match common gh errors. Full vrg-validate passes: 3607 tests, 100% coverage.