### PR TITLE
docs(rename): update live references to vergil-containers (#1868)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,11 +251,11 @@ exactly one container per run:
   registry.
 
 Dev container images are maintained in
-[vergil-docker](https://github.com/vergil-project/vergil-docker).
+[vergil-containers](https://github.com/vergil-project/vergil-containers).
 
 ```bash
 # Build the dev image (one-time)
-cd ../vergil-docker && docker/build.sh
+cd ../vergil-containers && docker/build.sh
 
 # Run the full validation pipeline in one container
 # (the [validation] override in vergil.toml expands this to `uv run vrg-validate`)
@@ -304,7 +304,7 @@ Shared libraries under `src/vergil_tooling/lib/`:
 ### Docker Dev Images
 
 Dev container images (Dockerfiles, build script, publish workflow) are
-maintained in [vergil-docker](https://github.com/vergil-project/vergil-docker).
+maintained in [vergil-containers](https://github.com/vergil-project/vergil-containers).
 
 The `vrg-container-test` entry point auto-detects the project
 language (Gemfile, pyproject.toml, go.mod, pom.xml/mvnw) and runs the test

--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -68,7 +68,7 @@ Environment overrides:
 
 !!! tip
     Build the dev images locally before first use:
-    `cd ../vergil-docker && docker/build.sh`
+    `cd ../vergil-containers && docker/build.sh`
 
 Running `vrg-container-run -- uv run vrg-validate` before each commit runs
 common checks and per-language validation. The Claude Code hook guard
@@ -232,7 +232,7 @@ Jobs that remain inline keep their names unchanged:
 ## Dev container images
 
 Published to `ghcr.io/vergil-project/dev-<language>:<version>` from the
-[vergil-docker](https://github.com/vergil-project/vergil-docker)
+[vergil-containers](https://github.com/vergil-project/vergil-containers)
 repository.
 
 ### Available images
@@ -254,7 +254,7 @@ repository.
 ### Building locally
 
 ```bash
-cd ../vergil-docker
+cd ../vergil-containers
 docker/build.sh
 ```
 
@@ -267,7 +267,7 @@ docker build --build-arg RUBY_VERSION=3.4 -t dev-ruby:3.4 docker/ruby/
 ### Publishing
 
 Images are published automatically on push to `develop` or `main` in
-the `vergil-docker` repository via its
+the `vergil-containers` repository via its
 `.github/workflows/docker-publish.yml` workflow.
 
 ### Design principles

--- a/docs/site/docs/guides/releasing.md
+++ b/docs/site/docs/guides/releasing.md
@@ -59,7 +59,7 @@ adding new public surface. Versions: `v1.3.0` → `v1.3.1`.
      the new release.
    - The boundary tag (`develop-v1.3.1`) is created on `develop`.
    - `repository_dispatch` fires a `vergil-tooling-released`
-     event at `vergil-docker`, which rebuilds the dev
+     event at `vergil-containers`, which rebuilds the dev
      images against the now-current `v1.3` tag.
    - `version-bump-pr` opens an auto-bump PR on `develop`
      (e.g., `1.3.1` → `1.3.2`). Merge it.
@@ -88,19 +88,19 @@ A minor release adds backwards-compatible new features. Versions:
 
 Same five steps as patch, with one important addition: the rolling
 minor tag changes from `v1.3` to `v1.4`. The image's pin in
-`vergil-docker` and any per-repo dev-dep declarations
+`vergil-containers` and any per-repo dev-dep declarations
 **must be bumped manually** — the rolling-tag mechanism only handles
 patches within a minor.
 
 1. Cut and merge `release/v1.4.0` exactly like a patch release.
-2. **Bump `vergil-docker`'s pin** in
+2. **Bump `vergil-containers`'s pin** in
    [`docker/common/vergil-tooling-uv.dockerfile`][docker-frag]:
 
    ```dockerfile
    ARG ST_TOOLING_TAG=v1.4   # was v1.3
    ```
 
-   Open a small PR in `vergil-docker`, merge it, and the
+   Open a small PR in `vergil-containers`, merge it, and the
    next image rebuild (whether triggered by your release or a
    subsequent push there) carries the new minor.
 3. **Coordinate consumer bumps.** Each Python repo that has
@@ -111,7 +111,7 @@ patches within a minor.
    (and anywhere else the documentation pins a minor) to the new
    tag.
 
-[docker-frag]: https://github.com/vergil-project/vergil-docker/blob/develop/docker/common/vergil-tooling-uv.dockerfile
+[docker-frag]: https://github.com/vergil-project/vergil-containers/blob/develop/docker/common/vergil-tooling-uv.dockerfile
 
 ### Consumer steps
 
@@ -121,7 +121,7 @@ Minor bumps are **deliberate opt-in** at every deployment target:
 |---|---|
 | Developer host | `uv tool install --reinstall 'vergil-tooling @ git+...@v1.4'` (or update the pinned tag in their notes / shell history) |
 | Python repo `.venv` | Edit `pyproject.toml` `[tool.uv.sources]` to `tag = "v1.4"`, then `uv lock --upgrade-package vergil-tooling` |
-| Dev container image | Wait for `vergil-docker` to land the `ARG` bump, then pull the rebuilt image |
+| Dev container image | Wait for `vergil-containers` to land the `ARG` bump, then pull the rebuilt image |
 
 The release author should announce the minor bump in the GitHub
 Release notes, calling out any new features and the `v1.4` pin
@@ -143,7 +143,7 @@ communication and migration window:
 2. Cut and merge `release/v2.0.0` like a minor release. The
    release notes prominently call out the breaking-change list and
    link to the migration guide.
-3. Bump `vergil-docker`'s `ARG ST_TOOLING_TAG=` to `v2`
+3. Bump `vergil-containers`'s `ARG ST_TOOLING_TAG=` to `v2`
    in a separate PR — coordinate so consumers can opt in on their
    own schedule.
 4. Notify consumer maintainers (e.g., update `vergil-tooling`'s


### PR DESCRIPTION
# Pull Request

## Summary

- Update live references in CLAUDE.md and the docs-site guides (releasing.md, ci-architecture.md) from vergil-docker to vergil-containers, coordinating with the vergil-docker repo rename.

## Issue Linkage

- Ref #1868

## Notes

- Coordination follow-up for vergil-project/vergil-docker#328. The GitHub repo rename (vergil-docker -> vergil-containers) is complete and GHCR write-access is verified, so this is clear to merge. Reference-only; no functional changes; validation green. Published image paths unaffected (stable ghcr.io/vergil-project user namespace). Historical/dated records intentionally left unchanged.