### PR TITLE
docs(reword): rescope vrg-reword away from the dead commit-message-fidelity check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,10 +270,11 @@ CLI tools installed as `vrg-*` console scripts:
 - **`vrg-commit`** — Construct standards-compliant conventional
   commits with co-author resolution
 - **`vrg-reword`** — Reword a branch-local commit's message via a scripted,
-  non-interactive rebase; the agent-safe path to fix a
-  `commit-message-fidelity` failure. Bounded: refuses shared/merged history
-  and protected branches, refuses a foreign author without
-  `--allow-foreign-author`, and pushes the rewrite with `--force-with-lease`
+  non-interactive rebase; the agent-safe path to correct a branch-local
+  commit message (raw interactive rebase is blocked repo-wide). Bounded:
+  refuses shared/merged history and protected branches, refuses a foreign
+  author without `--allow-foreign-author`, and pushes the rewrite with
+  `--force-with-lease`
 - **`vrg-submit-pr`** — Create standards-compliant PRs (manual merge;
   human-run — agents hand off via `.vergil/pr-workflow.json`)
 - **`vrg-pr-fix-body`** — Regenerate a PR body from corrected fields via

--- a/src/vergil_tooling/bin/vrg_reword.py
+++ b/src/vergil_tooling/bin/vrg_reword.py
@@ -2,11 +2,12 @@
 
 The agent tool surface otherwise cannot fix a commit message:
 ``vrg-git commit`` is denied, ``vrg-commit`` only creates new commits,
-and interactive rebase is unavailable. Yet ``commit-message-fidelity``
-is a judgment gate, so a USER agent needs a way to act on it. This tool
-rewords *any of the current branch's own commits* via a scripted,
-non-interactive rebase, re-stamping the new message through the same
-standards/identity path ``vrg-commit`` uses.
+and interactive rebase is unavailable. When a branch-local commit
+message needs correcting — a typo, a wrong type or scope, a stale
+subject — an agent (or human) needs a safe, scripted way to do it.
+This tool rewords *any of the current branch's own commits* via a
+scripted, non-interactive rebase, re-stamping the new message through
+the same standards/identity path ``vrg-commit`` uses.
 
 It is a deliberate relaxation of a tight restriction, so it is bounded:
 


### PR DESCRIPTION
# Pull Request

## Summary

- Post-#1872 stale-code sweep: rescope vrg-reword's docstring and CLAUDE.md description from the now-dead commit-message-fidelity audit check to a general-purpose branch-local commit-message reword; keep vrg-pr-fix-body unchanged after assessment.

## Issue Linkage

- Ref #1887

## Notes

- Tool behavior unchanged (docstring/description only). Both tools assessed as still needed and kept; deleting vrg-reword was considered and rejected (it is the only safe branch-local reword path with interactive rebase blocked) — separate decision if you prefer removal.