### PR TITLE
fix(vm): read transcript names end-first to speed up session resume

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -58,35 +58,64 @@ def _project_slug(cwd: str) -> str:
 _NAME_EVENT_FIELDS = {"agent-name": "agentName", "custom-title": "customTitle"}
 
 
+def _name_from_line(raw: bytes) -> str | None:
+    """Extract a session-name value from one transcript line, or ``None``.
+
+    A line names the session only if it is a JSON object whose ``type`` is a
+    recognized naming event (``agent-name``/``custom-title``) carrying a string
+    value in the matching field. The cheap substring guard skips the JSON parse
+    for the overwhelming majority of lines (ordinary turns) that cannot name.
+    """
+    line = raw.strip()
+    if not line or (b'"agent-name"' not in line and b'"custom-title"' not in line):
+        return None
+    try:
+        entry = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    event_type = entry.get("type")
+    if not isinstance(event_type, str):
+        return None
+    field = _NAME_EVENT_FIELDS.get(event_type)
+    if field is None:
+        return None
+    value = entry.get(field)
+    return value if isinstance(value, str) else None
+
+
 def _last_session_name(transcript: Path) -> str | None:
     """Return the last session-name value in a transcript, or ``None``.
 
     The last naming event in file order wins, regardless of which of the two
-    event types (``agent-name`` or ``custom-title``) carries it.
+    event types (``agent-name`` or ``custom-title``) carries it. The file is
+    read end-first in blocks and the scan stops at the first naming event seen
+    from the end — which is the last in file order — so a large transcript need
+    not be read in full. This matters because the resume path runs this for
+    every transcript in a project slug, and that history accumulates on a
+    persistent volume across VM rebuilds; a full forward read of all of it is
+    what stalls reconnect before Claude starts.
     """
-    last: str | None = None
     try:
-        with transcript.open() as fh:
-            for raw in fh:
-                line = raw.strip()
-                if not line or ('"agent-name"' not in line and '"custom-title"' not in line):
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                event_type = entry.get("type")
-                if not isinstance(event_type, str):
-                    continue
-                field = _NAME_EVENT_FIELDS.get(event_type)
-                if field is None:
-                    continue
-                value = entry.get(field)
-                if isinstance(value, str):
-                    last = value
+        with transcript.open("rb") as fh:
+            fh.seek(0, 2)
+            pos = fh.tell()
+            block = 64 * 1024
+            data = b""
+            while pos > 0:
+                step = min(block, pos)
+                pos -= step
+                fh.seek(pos)
+                data = fh.read(step) + data
+                lines = data.split(b"\n")
+                data = lines[0] if pos > 0 else b""
+                candidates = lines[1:] if pos > 0 else lines
+                for raw in reversed(candidates):
+                    name = _name_from_line(raw)
+                    if name is not None:
+                        return name
     except OSError:
         return None
-    return last
+    return None
 
 
 def name_by_session(projects_dir: Path, slug: str | None = None) -> dict[str, str]:

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -146,6 +146,61 @@ def test_last_session_name_ignores_other_type_with_token(tmp_path: Path) -> None
     assert r._last_session_name(f) is None
 
 
+def test_last_session_name_reads_via_bounded_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A large transcript whose only naming event is the last line: the scan must
+    # find it from the end via a bounded read, not by reading the whole file
+    # (the resume path runs this for every transcript in a slug, so a full
+    # forward read of accumulated history is what stalls reconnect).
+    f = tmp_path / "s.jsonl"
+    pad = "x" * 1000
+    lines = [f'{{"type":"user","message":"{pad}"}}' for _ in range(300)]
+    lines.append('{"type":"custom-title","customTitle":"id:09:z","sessionId":"s"}')
+    f.write_text("\n".join(lines) + "\n")
+    total = f.stat().st_size
+    assert total > 128 * 1024  # comfortably larger than one tail block
+
+    consumed = 0
+    real_open = type(f).open
+
+    class _CountingFile:
+        # Counts bytes/chars consumed however the implementation reads — line
+        # iteration (current forward scan) or block reads (a tail scan) — so the
+        # assertion below measures behavior, not a particular read strategy.
+        def __init__(self, fh: object) -> None:
+            self._fh = fh
+
+        def read(self, *a: object, **k: object) -> object:
+            nonlocal consumed
+            data = self._fh.read(*a, **k)  # type: ignore[attr-defined]
+            consumed += len(data)
+            return data
+
+        def __iter__(self) -> object:
+            nonlocal consumed
+            for line in self._fh:  # type: ignore[attr-defined]
+                consumed += len(line)
+                yield line
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._fh, name)
+
+        def __enter__(self) -> _CountingFile:
+            self._fh.__enter__()  # type: ignore[attr-defined]
+            return self
+
+        def __exit__(self, *exc: object) -> object:
+            return self._fh.__exit__(*exc)  # type: ignore[attr-defined]
+
+    def counting_open(self: Path, *a: object, **k: object) -> _CountingFile:
+        return _CountingFile(real_open(self, *a, **k))
+
+    monkeypatch.setattr(type(f), "open", counting_open)
+    assert r._last_session_name(f) == "id:09:z"
+    assert consumed < total  # bounded tail read, not the whole file
+
+
 # --- custom-title naming events (issue #1493) ---
 
 

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import os
 import textwrap
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -162,38 +162,38 @@ def test_last_session_name_reads_via_bounded_tail(
     assert total > 128 * 1024  # comfortably larger than one tail block
 
     consumed = 0
-    real_open = type(f).open
+    real_open: Any = type(f).open
 
     class _CountingFile:
         # Counts bytes/chars consumed however the implementation reads — line
-        # iteration (current forward scan) or block reads (a tail scan) — so the
+        # iteration (a forward scan) or block reads (a tail scan) — so the
         # assertion below measures behavior, not a particular read strategy.
-        def __init__(self, fh: object) -> None:
+        def __init__(self, fh: Any) -> None:
             self._fh = fh
 
-        def read(self, *a: object, **k: object) -> object:
+        def read(self, *a: Any, **k: Any) -> Any:
             nonlocal consumed
-            data = self._fh.read(*a, **k)  # type: ignore[attr-defined]
+            data = self._fh.read(*a, **k)
             consumed += len(data)
             return data
 
-        def __iter__(self) -> object:
+        def __iter__(self) -> Any:
             nonlocal consumed
-            for line in self._fh:  # type: ignore[attr-defined]
+            for line in self._fh:
                 consumed += len(line)
                 yield line
 
-        def __getattr__(self, name: str) -> object:
+        def __getattr__(self, name: str) -> Any:
             return getattr(self._fh, name)
 
         def __enter__(self) -> _CountingFile:
-            self._fh.__enter__()  # type: ignore[attr-defined]
+            self._fh.__enter__()
             return self
 
-        def __exit__(self, *exc: object) -> object:
-            return self._fh.__exit__(*exc)  # type: ignore[attr-defined]
+        def __exit__(self, *exc: Any) -> Any:
+            return self._fh.__exit__(*exc)
 
-    def counting_open(self: Path, *a: object, **k: object) -> _CountingFile:
+    def counting_open(self: Path, *a: Any, **k: Any) -> _CountingFile:
         return _CountingFile(real_open(self, *a, **k))
 
     monkeypatch.setattr(type(f), "open", counting_open)


### PR DESCRIPTION
# Pull Request

## Summary

- Read each transcript end-first in blocks and stop at the first naming event from the end, instead of a full forward read, so the session resolver no longer stalls reconnect by reading all accumulated transcript history before Claude starts.

## Issue Linkage

- Ref #1896

## Notes

- Output-identical optimization mirroring the existing _last_activity tail read. Line-parsing factored into _name_from_line and reused. New test test_last_session_name_reads_via_bounded_tail asserts a bounded read via a byte-counting file wrapper. Full vrg-validate green in-container; the 15 host-only test_vrg_vm failures are pre-existing env artifacts (no limactl/cloud tooling on host) and pass in-container.