### PR TITLE
fix(vm): drop redundant per-session tooling reinstall

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -67,7 +67,6 @@ from vergil_tooling.lib.vm_guest import (
     inject_credentials,
     install_tooling,
     link_claude_dirs,
-    try_update_tooling,
     update_plugins,
     update_tooling,
     vm_probe,
@@ -525,8 +524,7 @@ def _st_copy_config(state: _LifecycleState) -> None:
 
 def _st_update_tooling(state: _LifecycleState) -> None:
     # Runs as a warn-mode stage: a failed update surfaces as ⚠ in the summary
-    # and the start continues — the same warn-and-continue contract
-    # try_update_tooling provided before the pipeline port.
+    # and the start continues — a warn-and-continue contract.
     fallback = resolve_vergil_version(state.target.config, state.target.identity)
     transport = state.target.backend.transport(state.target.instance)
     update_tooling(transport, fallback_tag=fallback)
@@ -2392,9 +2390,11 @@ def _cmd_session(args: argparse.Namespace) -> int:
             )
             return 1
 
-    fallback = resolve_vergil_version(config, identity)
+    # No per-session tooling reinstall: create/rebuild/start/update already
+    # install or refresh the tooling, so by the time a VM is sessionable its
+    # tooling is current. Reinstalling again here cost ~21s on a cold uv cache
+    # for no benefit (issue #1901). The transport is still needed below.
     transport = target.backend.transport(target.instance)
-    try_update_tooling(transport, fallback_tag=fallback)
 
     claude_dir = Path.home() / ".claude"
     copy_claude_config(transport, claude_dir)

--- a/src/vergil_tooling/lib/vm_guest.py
+++ b/src/vergil_tooling/lib/vm_guest.py
@@ -259,39 +259,6 @@ def update_tooling(transport: Transport, tag: str | None = None, *, fallback_tag
         transport.pipe(f"cat > {_TOOLING_TAG_FILE}", f"{tag}\n")
 
 
-def try_update_tooling(
-    transport: Transport,
-    tag: str | None = None,
-    *,
-    fallback_tag: str = "",
-) -> bool:
-    """Update vergil-tooling, returning False on failure instead of aborting.
-
-    A soft failure is only safe when a working install remains: continuing into
-    a session with *no* tooling installed would leave the user with no ``vrg-*``
-    commands. So when the update fails, check what is actually installed — warn
-    and continue only if a version is still present, otherwise abort loudly.
-    """
-    try:
-        update_tooling(transport, tag, fallback_tag=fallback_tag)
-        return True
-    except (subprocess.CalledProcessError, SystemExit):
-        if get_tooling_version(transport) is None:
-            print(
-                "ERROR: vergil-tooling update failed and no working tooling "
-                "remains in the VM (the uv cache is likely corrupt).\n"
-                "Recover by rebuilding the VM, or clear the cache manually:\n"
-                "  uv cache clean (inside the VM)",
-                file=sys.stderr,
-            )
-            raise SystemExit(1) from None
-        print(
-            "WARNING: vergil-tooling update failed — continuing with installed version",
-            file=sys.stderr,
-        )
-        return False
-
-
 # Prepended to every in-guest `claude` invocation. claude itself is on the base
 # PATH (/usr/bin/claude, from apt node + `npm install -g`), but exporting PATH
 # explicitly — exactly as update_tooling does — keeps resolution independent of

--- a/tests/vergil_tooling/test_vm_guest.py
+++ b/tests/vergil_tooling/test_vm_guest.py
@@ -18,7 +18,6 @@ from vergil_tooling.lib.vm_guest import (
     install_tooling,
     link_claude_dirs,
     read_fingerprint,
-    try_update_tooling,
     update_plugins,
     update_tooling,
     vm_occupancy,
@@ -500,63 +499,6 @@ class TestLinkClaudeDirs:
         link_claude_dirs(transport, claude_dir)
 
         transport.run.assert_not_called()
-
-
-class TestTryUpdateTooling:
-    @patch("vergil_tooling.lib.vm_guest.update_tooling")
-    def test_returns_true_on_success(self, mock_update: MagicMock) -> None:
-        transport = _transport()
-        result = try_update_tooling(transport, fallback_tag="v2.0")
-        assert result is True
-        mock_update.assert_called_once_with(transport, None, fallback_tag="v2.0")
-
-    @patch("vergil_tooling.lib.vm_guest.get_tooling_version", return_value="v2.0.63")
-    @patch("vergil_tooling.lib.vm_guest.update_tooling")
-    def test_returns_false_on_subprocess_error(
-        self,
-        mock_update: MagicMock,
-        _mock_version: MagicMock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        mock_update.side_effect = subprocess.CalledProcessError(1, "uv")
-        result = try_update_tooling(_transport(), fallback_tag="v2.0")
-        assert result is False
-        captured = capsys.readouterr()
-        assert "WARNING" in captured.err
-
-    @patch("vergil_tooling.lib.vm_guest.get_tooling_version", return_value="v2.0.63")
-    @patch("vergil_tooling.lib.vm_guest.update_tooling")
-    def test_returns_false_on_system_exit(
-        self,
-        mock_update: MagicMock,
-        _mock_version: MagicMock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        mock_update.side_effect = SystemExit(1)
-        result = try_update_tooling(_transport(), fallback_tag="v2.0")
-        assert result is False
-        captured = capsys.readouterr()
-        assert "WARNING" in captured.err
-
-    @patch("vergil_tooling.lib.vm_guest.get_tooling_version", return_value=None)
-    @patch("vergil_tooling.lib.vm_guest.update_tooling")
-    def test_raises_when_no_tooling_remains_after_failure(
-        self,
-        mock_update: MagicMock,
-        _mock_version: MagicMock,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        mock_update.side_effect = subprocess.CalledProcessError(1, "uv")
-        with pytest.raises(SystemExit):
-            try_update_tooling(_transport(), fallback_tag="v2.0")
-        captured = capsys.readouterr()
-        assert "no working tooling" in captured.err.lower()
-
-    @patch("vergil_tooling.lib.vm_guest.update_tooling")
-    def test_passes_explicit_tag(self, mock_update: MagicMock) -> None:
-        transport = _transport()
-        try_update_tooling(transport, tag="v2.1", fallback_tag="v2.0")
-        mock_update.assert_called_once_with(transport, "v2.1", fallback_tag="v2.0")
 
 
 class TestToolingInstallSelfHeal:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -1939,14 +1939,12 @@ class TestOffPlatformFallback:
 class TestSessionStaleness:
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
     @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=9.0)
     def test_session_rejects_stale_vm(
         self,
         _age: MagicMock,
         _copy: MagicMock,
-        _update: MagicMock,
         _link: MagicMock,
         _exec: MagicMock,
         config_file: Path,
@@ -1959,14 +1957,12 @@ class TestSessionStaleness:
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
     @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=9.0)
     def test_session_allows_stale_with_override(
         self,
         _age: MagicMock,
         _copy: MagicMock,
-        _update: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
         config_file: Path,
@@ -1976,14 +1972,12 @@ class TestSessionStaleness:
 
     @patch("vergil_tooling.bin.vrg_vm.os.execvp")
     @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
-    @patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
     @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
     @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
     def test_session_passes_fresh_vm(
         self,
         _age: MagicMock,
         _copy: MagicMock,
-        _update: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
         config_file: Path,
@@ -1995,25 +1989,26 @@ class TestSessionStaleness:
 @patch("vergil_tooling.bin.vrg_vm.os.execvp")
 @patch("vergil_tooling.bin.vrg_vm.link_claude_dirs")
 @patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
-@patch("vergil_tooling.bin.vrg_vm.try_update_tooling")
 @patch("vergil_tooling.bin.vrg_vm.vm_age_days", return_value=1.0)
 class TestSession:
     def _inner(self, mock_exec: MagicMock) -> str:
         cmd = mock_exec.call_args[0][1]
         return cmd[cmd.index("-c") + 1]
 
+    @patch("vergil_tooling.bin.vrg_vm.update_tooling")
     def test_session_basic(
         self,
-        _age: MagicMock,
         mock_update: MagicMock,
+        _age: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
         config_file: Path,
     ) -> None:
         main(["session", "--config", str(config_file), "."])
-        mock_update.assert_called_once_with(ANY, fallback_tag="v2.0")
-        _assert_transport(mock_update, "vergil-agent")
+        # Session must not reinstall tooling — create/rebuild/start/update
+        # already keep it current (issue #1901).
+        mock_update.assert_not_called()
         mock_exec.assert_called_once()
         args = mock_exec.call_args[0]
         assert args[0] == "limactl"
@@ -2025,7 +2020,6 @@ class TestSession:
     def test_session_sets_terminal_env_forwarding(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         _exec: MagicMock,
@@ -2039,7 +2033,6 @@ class TestSession:
     def test_session_default_launches_resolver(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2056,7 +2049,6 @@ class TestSession:
     def test_session_explicit_claude_uses_resolver(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2069,7 +2061,6 @@ class TestSession:
     def test_session_claude_with_flags_passes_extra(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2093,7 +2084,6 @@ class TestSession:
     def test_session_raw_command_override(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2107,7 +2097,6 @@ class TestSession:
     def test_session_identity_after_workspace(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2126,7 +2115,6 @@ class TestSession:
     def test_session_identity_before_subcommand(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2139,7 +2127,6 @@ class TestSession:
     def test_session_identity_between_subcommand_and_workspace(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2152,7 +2139,6 @@ class TestSession:
     def test_session_passthrough_unknown_flag_after_dashdash(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2178,7 +2164,6 @@ class TestSession:
     def test_session_unknown_flag_without_dashdash_errors(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         _exec: MagicMock,
@@ -2201,7 +2186,6 @@ class TestSession:
     def test_session_slot_passed_to_resolver(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2214,7 +2198,6 @@ class TestSession:
     def test_session_fork_passed_to_resolver(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2238,7 +2221,6 @@ class TestSession:
     def test_session_no_model_no_flag(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2250,7 +2232,6 @@ class TestSession:
     def test_session_cli_model_passed(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2262,7 +2243,6 @@ class TestSession:
     def test_session_config_model_default(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2274,7 +2254,6 @@ class TestSession:
     def test_session_cli_model_overrides_config(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,
@@ -2288,7 +2267,6 @@ class TestSession:
     def test_session_top_level_model_default(
         self,
         _age: MagicMock,
-        _update: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
         mock_exec: MagicMock,


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the per-session vergil-tooling reinstall from vrg-vm session, which cost ~21s on a cold uv cache and was redundant because create/rebuild/start/update already keep the tooling current.

## Issue Linkage

- Ref #1901

## Notes

- Deletes the now-orphaned try_update_tooling helper (its only production caller was _cmd_session) and its dedicated tests; update_tooling stays for the lifecycle stages. Session tests drop the try_update_tooling patches; test_session_basic now asserts no reinstall occurs. vrg-validate green: 3619 passed, 100% coverage.