### PR TITLE
feat(vm): make cloud boot/root disk size configurable

### DIFF
--- a/docs/site/docs/reference/vm-spec.md
+++ b/docs/site/docs/reference/vm-spec.md
@@ -68,6 +68,7 @@ any `[vm]` key marks the spec customized, which gives the repo a dedicated VM.
 | `region` | string | *(none)* | Provider-native region when off-platform (e.g. `"us-central1"`) |
 | `instance` | string | *(none)* | Provider-native, nested-virt-capable instance type when off-platform (e.g. `"n2-standard-16"`) |
 | `volume` | string `"<N>GiB"` | *(none)* | **Persistent** block-volume size when off-platform — created once, reused, outlives the VM. Does **not** fall back to `disk` |
+| `boot_disk` | string `"<N>GiB"` | *(module default, ~30 GiB)* | **Ephemeral** boot/root-disk size when off-platform. Optional — unset keeps the image default. Sizes the disk that holds scratch data living outside `volume` |
 
 The vergil-vm template owns *how* declarative installs happen — repos
 never supply scripts.
@@ -116,7 +117,7 @@ mounted into every VM, so both checkouts are present).
   which owns the box.
 - One hop only — the lender may not itself declare `shared_from`.
 
-## Off-platform (cloud) backend (`backend`, `provider`, `region`, `instance`, `volume`)
+## Off-platform (cloud) backend (`backend`, `provider`, `region`, `instance`, `volume`, `boot_disk`)
 
 By default a repo's VM is a local macOS Lima box (`backend = "local"`).
 Setting `backend = "off-platform"` switches it to a **remote
@@ -129,14 +130,15 @@ design spec is
 
 ```toml
 [vm.vergil-user]
-backend  = "off-platform"
-provider = "gcp"              # selects the OpenTofu module
-region   = "us-central1"      # provider-native region
-instance = "n2-standard-16"   # provider-native, nested-virt-capable
-volume   = "300GiB"           # PERSISTENT volume — outlives the VM
-nested   = true               # /dev/kvm in the cloud box too
-cpus     = 12                 # request / under-provision intent (see below)
-memory   = "64GiB"
+backend   = "off-platform"
+provider  = "gcp"              # selects the OpenTofu module
+region    = "us-central1"      # provider-native region
+instance  = "n2-standard-16"   # provider-native, nested-virt-capable
+volume    = "300GiB"           # PERSISTENT volume — outlives the VM
+boot_disk = "100GiB"           # EPHEMERAL boot disk — optional; dies with the VM
+nested    = true               # /dev/kvm in the cloud box too
+cpus      = 12                 # request / under-provision intent (see below)
+memory    = "64GiB"
 ```
 
 - The five keys are **last-wins scalars** that ride the same five-tier
@@ -151,9 +153,16 @@ memory   = "64GiB"
   — the tooling does not enumerate them, so adding a provider is a
   vergil-vm module change with no tooling change.
 - **`disk` is ignored off-platform.** On cloud there are two disks with
-  opposite lifecycles: the ephemeral VM boot disk (a fixed module
-  default) and the persistent `volume` declared above. Only `volume` is
-  author-facing.
+  opposite lifecycles: the ephemeral VM boot disk and the persistent
+  `volume` declared above. The Lima `disk` knob drives neither — use
+  `volume` for the persistent disk and `boot_disk` for the ephemeral one.
+- **`boot_disk` sizes the ephemeral boot/root disk** (optional). Unset,
+  the boot disk inherits the cloud image's default (~30 GiB); set it
+  (`"<N>GiB"`) to grow the disk for workloads whose scratch data lives
+  *outside* the persistent `volume` — e.g. a nested-virt image pool and
+  qcow2 overlays, which belong on the wipe-on-rebuild boot disk rather
+  than the never-wiped `volume`. Unlike `volume` it is **not required**
+  off-platform, and it never enters the local (Lima) spec.
 - **`instance` is authoritative over `cpus`/`memory` on cloud.** They
   stay in the spec as human-readable intent; a session-time
   under-provisioning warning (instance smaller than the declared
@@ -242,4 +251,7 @@ the payload (it is not a cloud knob). A local profile therefore keeps
 its byte-for-byte fingerprint from before these keys existed — existing
 Lima VMs never falsely read `NEEDS-REBUILD` — while flipping a repo
 Lima→cloud, or resizing the `instance`/`volume`, trips `NEEDS-REBUILD`
-as expected.
+as expected. `boot_disk` enters the off-platform payload **only when
+set**, so cloud VMs created before the knob existed keep their
+fingerprints; declaring or resizing it trips `NEEDS-REBUILD` like
+`volume`.

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -128,6 +128,10 @@ class RoleOverlay:
     region: str | None = None
     instance: str | None = None
     volume: str | None = None
+    # Ephemeral boot/root-disk size when off-platform (vergil-tooling #1907).
+    # Optional even off-platform: unset -> the vergil-vm module's boot_disk_gib
+    # default (unchanged behaviour). Format-checked (`<N>GiB`) at composition.
+    boot_disk: str | None = None
     zone: str | None = None
     # Named-instance overlays (vergil-tooling #1831). Each value is itself a
     # RoleOverlay parsed from [vm.<identity>.instances.<name>]; an instance overlay
@@ -154,6 +158,7 @@ class VmStanza:
     region: str | None = None
     instance: str | None = None
     volume: str | None = None
+    boot_disk: str | None = None
     zone: str | None = None
 
 
@@ -180,6 +185,7 @@ _VM_KEYS = frozenset(
         "region",
         "instance",
         "volume",
+        "boot_disk",
         "zone",
     }
 )
@@ -188,7 +194,7 @@ _VM_KEYS = frozenset(
 # string when present); the *required-when-off-platform* contract and the value
 # enums/formats are enforced at composition (compose_vm_spec), where the cascade
 # is resolved to one effective value per key.
-_VM_STR_SCALARS = ("backend", "provider", "region", "instance", "volume", "zone")
+_VM_STR_SCALARS = ("backend", "provider", "region", "instance", "volume", "boot_disk", "zone")
 
 
 def _vm_str_scalar(raw: dict[str, Any], key: str, ctx: str, source: str) -> str | None:

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -639,6 +639,7 @@ def apply_vm(
     ssh_user: str,
     provision_env: str,
     labels: dict[str, str],
+    boot_disk_gib: int | None = None,
     provider: str = "gcp",
 ) -> dict[str, str]:
     """Apply the VM module against the existing volume; return its outputs (host, ssh_user).
@@ -656,23 +657,22 @@ def apply_vm(
     strategy = strategy_for(provider)
     module_dir = modules_root / provider / "vm"
     state = state_dir / "vm.tfstate"
+    tofu_vars: dict[str, object] = {
+        "name": name,
+        "zone": zone,
+        "instance_type": instance_type,
+        "nested": nested,
+        "volume_id": volume_id,
+        "ssh_user": ssh_user,
+        "provision_env": provision_env,
+        "labels": labels,
+    }
+    # Only override the module's boot_disk_gib default when an explicit size was
+    # composed — omitting the var keeps the unchanged-default behaviour (#1907).
+    if boot_disk_gib is not None:
+        tofu_vars["boot_disk_gib"] = boot_disk_gib
     try:
-        _run_tofu(
-            module_dir,
-            state,
-            "apply",
-            {
-                "name": name,
-                "zone": zone,
-                "instance_type": instance_type,
-                "nested": nested,
-                "volume_id": volume_id,
-                "ssh_user": ssh_user,
-                "provision_env": provision_env,
-                "labels": labels,
-            },
-            strategy=strategy,
-        )
+        _run_tofu(module_dir, state, "apply", tofu_vars, strategy=strategy)
     except subprocess.CalledProcessError:
         # Best-effort rollback: tear down the partial state (the orphaned NIC/VM on
         # Azure, or the orphan firewall on GCP) so the retry starts clean.  The
@@ -1276,6 +1276,10 @@ class OffPlatformBackend:
             "provision_env": provision_env,
             "labels": self.labels,
         }
+        # boot_disk is optional: thread it as the tofu boot_disk_gib var only when the
+        # spec declares one, so an unset profile rides the module default (#1907).
+        if self.spec.boot_disk:
+            result["boot_disk_gib"] = int(self.spec.boot_disk.removesuffix("GiB"))
         # Azure: generate/persist an ed25519 keypair and pass the public key to the
         # module so it can install it in cloud-init's authorized_keys. GCP uses IAP
         # (OS Login / metadata keys managed by gcloud) so it needs no injected key —

--- a/src/vergil_tooling/lib/vm_spec.py
+++ b/src/vergil_tooling/lib/vm_spec.py
@@ -75,6 +75,11 @@ class ComposedSpec:
     region: str = ""
     instance: str = ""
     volume: str = ""
+    # Optional ephemeral boot/root-disk size (vergil-tooling #1907). Unlike `volume`
+    # it is NOT required off-platform: empty -> the vergil-vm module's boot_disk_gib
+    # default (~30 GiB), so unset behaviour is unchanged. Set it (`<N>GiB`) to grow the
+    # ephemeral disk for workloads whose scratch data lives on the boot disk.
+    boot_disk: str = ""
     # Optional explicit zone (vergil-tooling #1797). Empty -> the volume module's
     # ${region}-b default; set it to dodge a per-zone capacity stockout in the region.
     zone: str = ""
@@ -106,6 +111,7 @@ class _Acc:
     region: str
     instance: str
     volume: str
+    boot_disk: str
     zone: str
     # Repo-declared footprint (tiers 3+4 only) — the floor an override is measured
     # against. None means the repo never declared that scalar, so no floor applies.
@@ -161,6 +167,9 @@ def _apply_overlay(acc: _Acc, overlay: VmStanza | RoleOverlay) -> None:
     if overlay.volume is not None:
         acc.volume = overlay.volume
         acc.customized = True
+    if overlay.boot_disk is not None:
+        acc.boot_disk = overlay.boot_disk
+        acc.customized = True
     if overlay.zone is not None:
         acc.zone = overlay.zone
         acc.customized = True
@@ -192,6 +201,7 @@ def compose_vm_spec(
         region="",
         instance="",
         volume="",
+        boot_disk="",
         zone="",
         declared_cpus=None,
         declared_mem=None,
@@ -238,7 +248,7 @@ def compose_vm_spec(
             acc.stale_days = cast("int", override["stale_days"])
         # The off-platform scalars also cascade through the host-override tier
         # (built-in → identity → [vm] → [vm.<identity>] → identities.toml override).
-        for key in ("backend", "provider", "region", "instance", "volume", "zone"):
+        for key in ("backend", "provider", "region", "instance", "volume", "boot_disk", "zone"):
             if key in override:
                 setattr(acc, key, str(override[key]))
 
@@ -261,6 +271,7 @@ def compose_vm_spec(
         region=acc.region,
         instance=acc.instance,
         volume=acc.volume,
+        boot_disk=acc.boot_disk,
         zone=acc.zone,
     )
 
@@ -289,6 +300,15 @@ def _validate_backend(identity: str, acc: _Acc) -> None:
         msg = (
             f"identity {identity!r}: [vm] volume must be '<number>GiB' "
             f'(e.g. "300GiB"), got {acc.volume!r}'
+        )
+        raise SpecError(msg)
+    # boot_disk is optional (unset -> the module's boot_disk_gib default), but when
+    # declared it must carry the same `<N>GiB` format as volume — never silently
+    # accept a malformed size.
+    if acc.boot_disk and not _SIZE_RE.fullmatch(acc.boot_disk):
+        msg = (
+            f"identity {identity!r}: [vm] boot_disk must be '<number>GiB' "
+            f'(e.g. "100GiB"), got {acc.boot_disk!r}'
         )
         raise SpecError(msg)
 
@@ -485,5 +505,10 @@ def spec_fingerprint(spec: ComposedSpec) -> str:
         fields.append(f"region={spec.region}")
         fields.append(f"instance={spec.instance}")
         fields.append(f"volume={spec.volume}")
+        # boot_disk enters only when set, so cloud profiles that never declared it keep
+        # their pre-boot-disk fingerprint (no spurious NEEDS-REBUILD when the knob was
+        # introduced); setting or resizing it flips the hash and triggers a rebuild.
+        if spec.boot_disk:
+            fields.append(f"boot_disk={spec.boot_disk}")
     payload = "\n".join(fields)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -905,6 +905,39 @@ class TestParseVmStanza:
         with pytest.raises(ConfigError, match="cannot be combined"):
             parse_vm_stanza({"vm": {"shared_from": "lmf/mq", "backend": "off-platform"}})
 
+    # -- boot_disk (ephemeral root-disk size) — vergil-tooling #1907 ----------
+
+    def test_boot_disk_parsed_at_vm_tier(self) -> None:
+        stanza = parse_vm_stanza({"vm": {"boot_disk": "100GiB"}})
+        assert stanza is not None
+        assert stanza.boot_disk == "100GiB"
+
+    def test_boot_disk_parsed_at_role_tier(self) -> None:
+        stanza = parse_vm_stanza({"vm": {"vergil-user": {"boot_disk": "120GiB"}}})
+        assert stanza is not None
+        assert stanza.roles["vergil-user"].boot_disk == "120GiB"
+        assert stanza.boot_disk is None  # only the role tier declared it
+
+    def test_boot_disk_parsed_at_instance_tier(self) -> None:
+        stanza = parse_vm_stanza(
+            {"vm": {"vergil-user": {"instances": {"big": {"boot_disk": "150GiB"}}}}}
+        )
+        assert stanza is not None
+        assert stanza.roles["vergil-user"].instances["big"].boot_disk == "150GiB"
+
+    def test_boot_disk_absent_is_none(self) -> None:
+        stanza = parse_vm_stanza({"vm": {"packages": []}})
+        assert stanza is not None
+        assert stanza.boot_disk is None
+
+    def test_boot_disk_not_flagged_unrecognized(self, capsys: pytest.CaptureFixture[str]) -> None:
+        parse_vm_stanza({"vm": {"vergil-user": {"boot_disk": "100GiB"}}})
+        assert "unrecognized" not in capsys.readouterr().err
+
+    def test_boot_disk_non_string_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="'boot_disk' must be a string"):
+            parse_vm_stanza({"vm": {"boot_disk": 100}})
+
 
 # -- [project] ghas key -------------------------------------------------------
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -821,6 +821,51 @@ class TestRunTofu:
         assert data["nested"] is True
         assert data["volume_id"] == "vol-1"
         assert data["provision_env"] == "VERGIL_USER=ubuntu"
+        # boot_disk_gib not supplied -> stays out of the tfvars (module default holds).
+        assert "boot_disk_gib" not in data
+
+    def _run_apply_vm(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, boot_disk_gib: int | None
+    ) -> dict[str, object]:
+        """Run apply_vm with stub tofu and return the written vm tfvars dict."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state_dir = tofu_state_dir("k", "gcp")
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.run", MagicMock(return_value=0))
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.subprocess.run",
+            MagicMock(
+                return_value=subprocess.CompletedProcess(
+                    [], 0, stdout=_tofu_output_json({"host": "vm-x", "ssh_user": "ubuntu"})
+                )
+            ),
+        )
+        apply_vm(
+            tmp_path / "modules",
+            state_dir,
+            name="vm-x",
+            zone="us-central1-a",
+            instance_type="n2-standard-16",
+            nested=True,
+            volume_id="vol-1",
+            ssh_user="ubuntu",
+            provision_env="VERGIL_USER=ubuntu",
+            labels={},
+            boot_disk_gib=boot_disk_gib,
+        )
+        tfvars = (state_dir / "vm.tfstate.tfvars.json").read_text()
+        return cast("dict[str, object]", json.loads(tfvars))
+
+    def test_apply_vm_threads_boot_disk_gib_into_tfvars(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data = self._run_apply_vm(tmp_path, monkeypatch, boot_disk_gib=100)
+        assert data["boot_disk_gib"] == 100
+
+    def test_apply_vm_omits_boot_disk_gib_when_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data = self._run_apply_vm(tmp_path, monkeypatch, boot_disk_gib=None)
+        assert "boot_disk_gib" not in data
 
     def test_apply_vm_rolls_back_on_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1777,6 +1822,17 @@ class TestOffPlatformBackend:
         from vergil_tooling.lib.vm_spec import spec_fingerprint
 
         assert f"SPEC_FINGERPRINT={spec_fingerprint(_off_spec(nested=True))}" in env
+
+    def test_vm_vars_omits_boot_disk_gib_when_unset(self) -> None:
+        # Unset boot_disk -> no boot_disk_gib var, so the tofu module default holds.
+        b = OffPlatformBackend(_off_spec(), "vergil-user", "o", "r")
+        vars_ = b.vm_vars(zone="us-central1-b", volume_id="vol-1")
+        assert "boot_disk_gib" not in vars_
+
+    def test_vm_vars_threads_boot_disk_gib_when_set(self) -> None:
+        b = OffPlatformBackend(_off_spec(boot_disk="100GiB"), "vergil-user", "o", "r")
+        vars_ = b.vm_vars(zone="us-central1-b", volume_id="vol-1")
+        assert vars_["boot_disk_gib"] == 100
 
     def test_vm_vars_includes_ssh_public_key_for_azure_and_absent_for_gcp(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/vergil_tooling/test_vm_spec.py
+++ b/tests/vergil_tooling/test_vm_spec.py
@@ -358,6 +358,41 @@ class TestOffPlatformCompose:
                 override=None,
             )
 
+    def test_boot_disk_defaults_empty_and_is_not_required(self) -> None:
+        # boot_disk is optional even off-platform: an otherwise-valid profile that
+        # never declares it composes cleanly with boot_disk == "" (module default).
+        spec = compose_vm_spec(
+            identity="vergil-user", base=BASE, stanza=_off_platform_stanza(), override=None
+        )
+        assert spec.boot_disk == ""
+
+    def test_boot_disk_composes_across_tiers(self) -> None:
+        spec = compose_vm_spec(
+            identity="vergil-user",
+            base=BASE,
+            stanza=_off_platform_stanza(boot_disk="120GiB"),
+            override=None,
+        )
+        assert spec.boot_disk == "120GiB"
+
+    def test_boot_disk_host_override_wins(self) -> None:
+        spec = compose_vm_spec(
+            identity="vergil-user",
+            base=BASE,
+            stanza=_off_platform_stanza(boot_disk="120GiB"),
+            override={"boot_disk": "200GiB"},
+        )
+        assert spec.boot_disk == "200GiB"
+
+    def test_bad_boot_disk_format_raises(self) -> None:
+        with pytest.raises(SpecError, match="boot_disk must be '<number>GiB'"):
+            compose_vm_spec(
+                identity="vergil-user",
+                base=BASE,
+                stanza=_off_platform_stanza(boot_disk="100"),
+                override=None,
+            )
+
     def test_audit_role_without_keys_does_not_satisfy_required(self) -> None:
         # backend is all-identity ([vm] tier) but the cloud keys live only in the
         # vergil-user role; vergil-audit therefore composes off-platform WITHOUT them
@@ -703,6 +738,47 @@ class TestFingerprint:
         )
         expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         assert spec_fingerprint(self._op_spec()) == expected
+
+    def test_boot_disk_set_changes_fingerprint(self) -> None:
+        # Declaring a boot_disk on a profile that had none flips the hash (rebuild).
+        assert spec_fingerprint(self._op_spec()) != spec_fingerprint(
+            self._op_spec(boot_disk="100GiB")
+        )
+
+    def test_boot_disk_change_changes_fingerprint(self) -> None:
+        assert spec_fingerprint(self._op_spec(boot_disk="100GiB")) != spec_fingerprint(
+            self._op_spec(boot_disk="200GiB")
+        )
+
+    def test_boot_disk_unset_keeps_legacy_fingerprint(self) -> None:
+        """An unset boot_disk must not flip an existing cloud profile's fingerprint.
+
+        Pins the encoding: ``boot_disk`` enters the off-platform payload only when set,
+        so cloud VMs created before the knob existed never falsely read NEEDS-REBUILD.
+        """
+        payload = "\n".join(
+            (
+                "cpus=12",
+                "memory=64GiB",
+                "stale_days=7",
+                "packages=a,b",
+                "apt_repos=" + "|".join(f"{k}={_REPO[k]}" for k in sorted(_REPO)),
+                "vagrant_plugins=vagrant-libvirt",
+                "backend=off-platform",
+                "provider=gcp",
+                "region=us-central1",
+                "instance=n2-standard-16",
+                "volume=300GiB",
+            )
+        )
+        expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        assert spec_fingerprint(self._op_spec(boot_disk="")) == expected
+
+    def test_boot_disk_ignored_on_local_fingerprint(self) -> None:
+        # boot_disk is a cloud-only knob: it must not enter the Lima fingerprint.
+        assert spec_fingerprint(self._spec(boot_disk="100GiB")) == spec_fingerprint(
+            self._spec(boot_disk="200GiB")
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Add an optional author-facing boot_disk scalar to the off-platform VM instance schema that sets the GCP boot/root disk size at create/rebuild, analogous to volume but for the ephemeral disk.

## Issue Linkage

- Ref #1907

## Notes

- boot_disk is a last-wins <N>GiB scalar across the [vm] cascade, format-validated at composition and threaded into apply_vm's tofu vars as boot_disk_gib only when set. Unset → unchanged behaviour (the vergil-vm module's boot_disk_gib default holds). It enters the spec fingerprint only when set (no spurious NEEDS-REBUILD for existing cloud VMs); declaring or resizing it triggers a rebuild like volume. Unlike volume it is optional even off-platform and never enters the local (Lima) spec. Tests cover parse (vm/role/instance tiers, non-string rejection), compose (default empty, optional, host-override, bad-format error), fingerprint (set/unset/change/local-ignored), and the apply_vm/vm_vars threading. Docs updated in vm-spec.md. The vergil-vm OpenTofu side already shipped boot_disk_gib. vrg-validate is green.