### PR TITLE
feat(labels): add epic/task convention labels (additive)

### DIFF
--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -9,7 +9,12 @@
     {"name": "build", "color": "bfd4f2", "description": "Build system or dependencies"},
     {"name": "research", "color": "d876e3", "description": "Investigation or spike"},
     {"name": "rtfm", "color": "f9d0c4", "description": "Resolved by reading existing docs"},
-    {"name": "observability", "color": "1d76db", "description": "Monitoring, reporting, health checks"}
+    {"name": "observability", "color": "1d76db", "description": "Monitoring, reporting, health checks"},
+    {"name": "epic", "color": "6f42c1", "description": "Umbrella issue; finite epics close when all sub-issues close"},
+    {"name": "standing", "color": "5319e7", "description": "Perpetual umbrella for ad-hoc work; never auto-closes"},
+    {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
+    {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
+    {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"}
   ],
   "delete": ["enhancement"]
 }

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -59,3 +59,19 @@ def test_delete_list_is_strings() -> None:
     registry = load_labels()
     for name in registry["delete"]:
         assert isinstance(name, str)
+
+
+def test_registry_includes_convention_labels() -> None:
+    # epic/task convention (epic #40): Role (epic, standing), Stage (triage),
+    # Kind (idea), Exception (hotfix). The remaining Kind axis reuses the
+    # existing conventional-commit labels already in the registry.
+    names = {label["name"] for label in load_labels()["labels"]}
+    for required in {"epic", "standing", "triage", "idea", "hotfix"}:
+        assert required in names, f"convention label missing: {required}"
+
+
+def test_label_change_is_additive_only() -> None:
+    # Convention labels are added additively; retiring default cruft is deferred
+    # to the per-repo migration pass (epic #40, Task 9). This task must not
+    # enqueue any new deletions beyond the pre-existing one.
+    assert load_labels()["delete"] == ["enhancement"]

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -124,7 +124,7 @@ def test_main_sync_provisions_all_labels() -> None:
     assert result == 0
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
-    assert len(label_calls) == 10  # 10 labels in the registry
+    assert len(label_calls) == 15  # 10 base + 5 epic/task convention labels
 
 
 def test_main_sync_uses_force_with_color_description() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add epic, standing, triage, idea, and hotfix to the vrg-ensure-label registry additively (Role/Stage/Kind/Exception axes), so the convention's label namespace provisions across managed repos.

## Issue Linkage

- Ref #1912

## Notes

- Additive only per the convention's transition plan (epic #40): the delete list is untouched; cruft retirement happens per-repo during the migration pass. Updated the sync count assertion (10 -> 15). Rebased onto develop after the #1913 hermeticity fix; vrg-validate green.