### PR TITLE
feat(vrg-git): anchor worktree add to <root>/.worktrees to prevent nesting

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 from vergil_tooling.lib import github, identity_mode
-from vergil_tooling.lib.git import _git_auth_env
+from vergil_tooling.lib.git import _git_auth_env, main_worktree_root
 
 _ALLOWED_SIMPLE: set[str] = {
     # Read-only inspection commands. These only read history, objects, or
@@ -301,6 +301,66 @@ def _check_worktree_convention(subcmd: str, args: list[str]) -> str | None:
     )
 
 
+# `worktree add` options that consume the following token as their value, so
+# the path-positional scan must skip both the flag and its argument. `=`-joined
+# forms (e.g. `--reason=busy`) start with `-` and are skipped as plain flags.
+_WORKTREE_ADD_VALUE_OPTS: set[str] = {"-b", "-B", "--reason"}
+
+
+def _parse_worktree_add_path(args: list[str]) -> str | None:
+    """Return the ``<path>`` positional from ``worktree add`` *args*, or None.
+
+    *args* are the tokens after ``add``. The first token that is neither an
+    option nor an option's consumed value is the path; the optional
+    ``<commit-ish>`` that follows is ignored.
+    """
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in _WORKTREE_ADD_VALUE_OPTS:
+            skip_next = True
+            continue
+        if arg.startswith("-"):
+            continue
+        return arg
+    return None
+
+
+def _check_worktree_add(args: list[str]) -> str | None:
+    """Reject a ``worktree add`` that would not land directly under .worktrees/.
+
+    The new worktree's resolved path must be a direct child of
+    ``<main_worktree_root>/.worktrees/``. This one invariant rejects every way
+    the convention gets violated: a relative path resolved from inside another
+    worktree (the nesting bug, #1922), and any absolute or ``../`` path that
+    escapes the canonical container. When the main worktree root cannot be
+    resolved (not in a repo), the guard is skipped so git reports its own
+    error rather than this layer masking it.
+    """
+    path = _parse_worktree_add_path(args)
+    if path is None:
+        return None
+    try:
+        root = main_worktree_root()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    target = Path(path)
+    if not target.is_absolute():
+        target = Path.cwd() / target
+    target = target.resolve()
+    canonical = (root / ".worktrees").resolve()
+    if target.parent == canonical:
+        return None
+    return (
+        f"worktree add target must be a direct child of {canonical} "
+        f"(it resolved to {target}). Run the command from the project root "
+        f"with a relative path like .worktrees/issue-<N>-<slug>; never create "
+        f"a worktree from inside another worktree."
+    )
+
+
 _WORKFLOW_PERMISSION_RE = re.compile(
     r"refusing to allow.*workflow.*without.*workflows.*permission",
     re.IGNORECASE,
@@ -358,6 +418,12 @@ def main(argv: list[str] | None = None) -> int:
         if flag_err:
             print(f"vrg-git: {flag_err}", file=sys.stderr)
             return 1
+
+        if subcmd == "worktree" and argv[1] == "add":
+            add_err = _check_worktree_add(argv[2:])
+            if add_err:
+                print(f"vrg-git: {add_err}", file=sys.stderr)
+                return 1
 
         result = subprocess.run(["git", *argv], check=False)  # noqa: S603, S607
         return result.returncode

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -12,6 +12,7 @@ from vergil_tooling.bin.vrg_git import (
     _noninteractive_rebase_env,
     _org_from_clone_url,
     _parse_branch_target,
+    _parse_worktree_add_path,
     _worktree_convention_active,
     main,
 )
@@ -957,6 +958,107 @@ class TestWorktreeConvention:
             mock_run.return_value.returncode = 0
             rc = main(["switch", "feature/123-foo"])
         assert rc == 0
+
+
+# -- worktree add anchoring (#1922) -------------------------------------------
+
+
+class TestParseWorktreeAddPath:
+    """Extract the <path> positional from `worktree add` args (after "add")."""
+
+    def test_simple_path(self) -> None:
+        assert _parse_worktree_add_path([".worktrees/x", "origin/develop"]) == ".worktrees/x"
+
+    def test_new_branch_flag_value_skipped(self) -> None:
+        assert (
+            _parse_worktree_add_path(["-b", "feature/x", ".worktrees/x", "origin/develop"])
+            == ".worktrees/x"
+        )
+
+    def test_boolean_flag_skipped(self) -> None:
+        assert _parse_worktree_add_path(["--force", ".worktrees/x"]) == ".worktrees/x"
+
+    def test_reason_value_skipped(self) -> None:
+        assert (
+            _parse_worktree_add_path(["--lock", "--reason", "busy", ".worktrees/x"])
+            == ".worktrees/x"
+        )
+
+    def test_no_path_returns_none(self) -> None:
+        assert _parse_worktree_add_path([]) is None
+
+    def test_only_flags_returns_none(self) -> None:
+        assert _parse_worktree_add_path(["--force"]) is None
+
+
+class TestWorktreeAddAnchoring:
+    """`worktree add` targets must be direct children of <root>/.worktrees/."""
+
+    @staticmethod
+    def _make_root(tmp_path: Path) -> Path:
+        root = tmp_path / "repo"
+        (root / ".worktrees").mkdir(parents=True)
+        return root
+
+    def test_canonical_path_from_root_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = self._make_root(tmp_path)
+        monkeypatch.chdir(root)
+        with (
+            patch("vergil_tooling.bin.vrg_git.main_worktree_root", return_value=root),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            rc = main(
+                ["worktree", "add", "-b", "feature/1-x", ".worktrees/issue-1-x", "origin/develop"]
+            )
+        assert rc == 0
+        assert mock_run.call_args[0][0][:3] == ["git", "worktree", "add"]
+
+    def test_nested_path_from_inside_worktree_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = self._make_root(tmp_path)
+        inner = root / ".worktrees" / "issue-389-x"
+        (inner / ".worktrees").mkdir(parents=True)
+        monkeypatch.chdir(inner)
+        with (
+            patch("vergil_tooling.bin.vrg_git.main_worktree_root", return_value=root),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+        ):
+            rc = main(["worktree", "add", ".worktrees/issue-390-y", "origin/develop"])
+        assert rc != 0
+        mock_run.assert_not_called()
+        assert ".worktrees" in capsys.readouterr().err
+
+    def test_absolute_escape_path_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = self._make_root(tmp_path)
+        monkeypatch.chdir(root)
+        outside = tmp_path / "elsewhere" / "wt"
+        with (
+            patch("vergil_tooling.bin.vrg_git.main_worktree_root", return_value=root),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+        ):
+            rc = main(["worktree", "add", str(outside), "origin/develop"])
+        assert rc != 0
+        mock_run.assert_not_called()
+
+    def test_not_in_repo_skips_guard(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_git.main_worktree_root",
+                side_effect=subprocess.CalledProcessError(128, ["git"]),
+            ),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            rc = main(["worktree", "add", "anything", "origin/develop"])
+        assert rc == 0
+        mock_run.assert_called_once()
 
 
 # -- non-interactive rebase (#1742) -------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-git worktree add now rejects any target that is not a direct child of <main_worktree_root>/.worktrees/. This prevents the Russian-doll nesting that occurs when a relative .worktrees/<name> path is used while the CWD is inside another worktree — the failure that corrupted a consuming repo's batch run and aborted vrg-submit-pr --finalize --all on exit 128.

## Issue Linkage

- Ref #1922

## Notes

- Guard lives in vrg_git.py: parse the worktree-add path positional, resolve it, require parent == <root>/.worktrees. Rejects relative-from-inside-a-worktree and absolute/.. escapes alike; skips cleanly when not in a repo so git reports its own error. Internal managed_worktree callers bypass the wrapper and are unaffected. TDD: 10 new unit tests (parser + anchoring, including not-in-repo skip); full vrg-validate green; vrg_git.py at 100% coverage. Verified live that a nested add from inside a worktree is blocked with an actionable message and no side effect.