### PR TITLE
feat(epics): umbrella link helpers — github.graphql() + lib/epics.py

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -1,0 +1,162 @@
+"""Epic <-> task umbrella relationship, mechanism-agnostic.
+
+An *epic* is an umbrella over *task* issues that may live in other repos within
+the same org. The link is GitHub **native sub-issues** where available, with a
+portable **cross-repo reference fallback** — a ``Parent: <owner>/<repo>#<N>``
+line in the task body — for forges (Forgejo/Codeberg) that lack sub-issues. All
+consumers (the finalize close+rollup, the roadmap generator) speak this module's
+``IssueRef`` vocabulary, never the underlying mechanism.
+
+Node-id resolution and issue state use REST (``gh api``); the parent/children
+traversal and the link mutation use GraphQL (``github.graphql``). The unit tests
+mock the ``github`` boundary; real GraphQL/REST correctness is exercised in use.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from vergil_tooling.lib import github
+
+
+@dataclass(frozen=True)
+class IssueRef:
+    """A cross-repo issue coordinate."""
+
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def slug(self) -> str:
+        return f"{self.owner}/{self.repo}#{self.number}"
+
+
+@dataclass(frozen=True)
+class ChildState:
+    """A child task and whether it is open or closed."""
+
+    ref: IssueRef
+    state: str  # "OPEN" | "CLOSED"
+
+
+_PARENT_RE = re.compile(
+    r"^\s*Parent:\s*([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)#(\d+)\s*$",
+    re.MULTILINE,
+)
+
+_SUBISSUES_QUERY = """
+query($id: ID!) {
+  node(id: $id) {
+    ... on Issue {
+      subIssues(first: 100) {
+        nodes { number state repository { name owner { login } } }
+      }
+    }
+  }
+}
+"""
+
+_PARENT_QUERY = """
+query($id: ID!) {
+  node(id: $id) {
+    ... on Issue {
+      parent { number repository { name owner { login } } }
+    }
+  }
+}
+"""
+
+_ADD_SUBISSUE = """
+mutation($parent: ID!, $child: ID!) {
+  addSubIssue(input: {issueId: $parent, subIssueId: $child}) {
+    subIssue { number }
+  }
+}
+"""
+
+
+def _issue_endpoint(ref: IssueRef) -> str:
+    return f"repos/{ref.owner}/{ref.repo}/issues/{ref.number}"
+
+
+def _node_id(ref: IssueRef) -> str:
+    """Resolve an issue's GraphQL global node id via REST."""
+    return github.read_output("api", _issue_endpoint(ref), "--jq", ".node_id")
+
+
+def _issue_state(ref: IssueRef) -> str:
+    """Return ``"OPEN"`` or ``"CLOSED"`` for an issue."""
+    return github.read_output("api", _issue_endpoint(ref), "--jq", ".state").upper()
+
+
+def _ref_from_node(node: Any) -> IssueRef:
+    """Build an ``IssueRef`` from a GraphQL issue node (number + repository)."""
+    repo = node["repository"]
+    return IssueRef(
+        owner=str(repo["owner"]["login"]), repo=str(repo["name"]), number=int(node["number"])
+    )
+
+
+def _native_child_states(epic: IssueRef) -> list[ChildState]:
+    data: Any = github.graphql(_SUBISSUES_QUERY, id=_node_id(epic))
+    nodes = (((data or {}).get("node") or {}).get("subIssues") or {}).get("nodes") or []
+    return [ChildState(ref=_ref_from_node(n), state=str(n["state"]).upper()) for n in nodes]
+
+
+def _reflink_child_states(epic: IssueRef) -> list[ChildState]:
+    """Portable fallback: issues whose body references this epic as ``Parent:``."""
+    results: Any = github.read_json(
+        "search", "issues", f"Parent: {epic.slug}", "--json", "number,state,repository"
+    )
+    states: list[ChildState] = []
+    for item in results if isinstance(results, list) else []:
+        name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
+        if "/" not in name_with_owner:
+            continue
+        owner, name = name_with_owner.split("/", 1)
+        states.append(
+            ChildState(
+                ref=IssueRef(owner=owner, repo=name, number=int(item["number"])),
+                state=str(item["state"]).upper(),
+            )
+        )
+    return states
+
+
+def child_states(epic: IssueRef) -> list[ChildState]:
+    """All child tasks of *epic*: native sub-issues preferred, reflink fallback."""
+    native = _native_child_states(epic)
+    return native if native else _reflink_child_states(epic)
+
+
+def parent_of(task: IssueRef) -> IssueRef | None:
+    """The epic *task* belongs to: native parent preferred, reflink fallback."""
+    data: Any = github.graphql(_PARENT_QUERY, id=_node_id(task))
+    parent = ((data or {}).get("node") or {}).get("parent")
+    if isinstance(parent, dict):
+        return _ref_from_node(parent)
+    body = github.read_output("api", _issue_endpoint(task), "--jq", ".body")
+    match = _PARENT_RE.search(body or "")
+    if match:
+        return IssueRef(owner=match.group(1), repo=match.group(2), number=int(match.group(3)))
+    return None
+
+
+def add_child(epic: IssueRef, task: IssueRef) -> None:
+    """Link *task* under *epic*. Reopen the epic first if it is closed.
+
+    Adding a task to an already-closed finite epic must reopen it (the
+    reopen-on-late-child rule); the later finalize rollup closes it again.
+    """
+    if _issue_state(epic) == "CLOSED":
+        github.run("issue", "reopen", str(epic.number), "--repo", f"{epic.owner}/{epic.repo}")
+    github.graphql(_ADD_SUBISSUE, parent=_node_id(epic), child=_node_id(task))
+
+
+def all_children_closed(epic: IssueRef) -> bool:
+    """True iff *epic* has at least one child and all children are closed."""
+    children = child_states(epic)
+    return bool(children) and all(child.state == "CLOSED" for child in children)

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -322,6 +322,25 @@ def read_json(*args: str) -> dict[str, object] | list[object]:
     return result
 
 
+def graphql(query: str, **variables: object) -> dict[str, object]:
+    """Run a GraphQL query/mutation via ``gh api graphql`` and return ``data``.
+
+    String variables pass with ``-f`` (kept verbatim — e.g. node IDs); other
+    scalars use ``-F`` (typed, e.g. an ``Int`` issue number). ``gh`` exits
+    non-zero when the GraphQL response carries errors, so those surface as
+    :class:`GitHubAPIError` from :func:`read_output`; the explicit ``errors``
+    check guards the rarer 200-with-errors case.
+    """
+    args = ["api", "graphql", "-f", f"query={query}"]
+    for name, value in variables.items():
+        args += ["-f" if isinstance(value, str) else "-F", f"{name}={value}"]
+    payload = json.loads(read_output(*args))
+    if isinstance(payload, dict) and payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    data = payload.get("data") if isinstance(payload, dict) else None
+    return data if isinstance(data, dict) else {}
+
+
 def write_json(method: str, endpoint: str, body: dict[str, object]) -> None:
     """Call gh api with a JSON body via stdin."""
     _run_with_retry(

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -1,0 +1,173 @@
+"""Tests for vergil_tooling.lib.epics (umbrella relationship)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from vergil_tooling.lib import epics
+from vergil_tooling.lib.epics import ChildState, IssueRef
+
+EPIC = IssueRef("org", ".github", 40)
+TASK = IssueRef("org", "repo-a", 101)
+
+
+def _repo_node(login: str, name: str) -> dict[str, object]:
+    return {"name": name, "owner": {"login": login}}
+
+
+# -- child_states ------------------------------------------------------------
+
+
+def test_child_states_native() -> None:
+    data = {
+        "node": {
+            "subIssues": {
+                "nodes": [
+                    {"number": 101, "state": "CLOSED", "repository": _repo_node("org", "repo-a")},
+                    {"number": 102, "state": "OPEN", "repository": _repo_node("org", "repo-b")},
+                ]
+            }
+        }
+    }
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=data),
+    ):
+        result = epics.child_states(EPIC)
+    assert result == [
+        ChildState(IssueRef("org", "repo-a", 101), "CLOSED"),
+        ChildState(IssueRef("org", "repo-b", 102), "OPEN"),
+    ]
+
+
+def test_child_states_reflink_fallback_when_native_empty() -> None:
+    empty = {"node": {"subIssues": {"nodes": []}}}
+    search = [{"number": 41, "state": "OPEN", "repository": {"nameWithOwner": "org/.github"}}]
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=empty),
+        patch("vergil_tooling.lib.github.read_json", return_value=search) as mock_search,
+    ):
+        result = epics.child_states(EPIC)
+    assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN")]
+    # the fallback searches for the epic's Parent: marker
+    assert "Parent: org/.github#40" in mock_search.call_args.args
+
+
+# -- parent_of ---------------------------------------------------------------
+
+
+def test_parent_of_native() -> None:
+    data = {"node": {"parent": {"number": 40, "repository": _repo_node("org", ".github")}}}
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=data),
+    ):
+        assert epics.parent_of(TASK) == IssueRef("org", ".github", 40)
+
+
+def test_parent_of_reflink_fallback_parses_body() -> None:
+    no_parent = {"node": {"parent": None}}
+    body = "Some description.\n\nParent: org/.github#40\n"
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=no_parent),
+        patch("vergil_tooling.lib.github.read_output", return_value=body),
+    ):
+        assert epics.parent_of(TASK) == IssueRef("org", ".github", 40)
+
+
+def test_parent_of_none_when_unlinked() -> None:
+    no_parent = {"node": {"parent": None}}
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=no_parent),
+        patch("vergil_tooling.lib.github.read_output", return_value="no marker here"),
+    ):
+        assert epics.parent_of(TASK) is None
+
+
+# -- add_child (reopen-on-late-child) ----------------------------------------
+
+
+def test_add_child_reopens_closed_epic_before_linking() -> None:
+    with (
+        patch("vergil_tooling.lib.epics._issue_state", return_value="CLOSED"),
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+        patch("vergil_tooling.lib.github.graphql") as mock_graphql,
+    ):
+        epics.add_child(EPIC, TASK)
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[:2] == ("issue", "reopen")
+    assert "40" in mock_run.call_args.args
+    mock_graphql.assert_called_once()
+
+
+def test_add_child_open_epic_is_not_reopened() -> None:
+    with (
+        patch("vergil_tooling.lib.epics._issue_state", return_value="OPEN"),
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+        patch("vergil_tooling.lib.github.graphql") as mock_graphql,
+    ):
+        epics.add_child(EPIC, TASK)
+    mock_run.assert_not_called()
+    mock_graphql.assert_called_once()
+
+
+# -- all_children_closed -----------------------------------------------------
+
+
+def test_all_children_closed_true_when_all_closed() -> None:
+    children = [
+        ChildState(IssueRef("o", "r", 1), "CLOSED"),
+        ChildState(IssueRef("o", "r", 2), "CLOSED"),
+    ]
+    with patch("vergil_tooling.lib.epics.child_states", return_value=children):
+        assert epics.all_children_closed(EPIC) is True
+
+
+def test_all_children_closed_false_with_an_open_child() -> None:
+    children = [
+        ChildState(IssueRef("o", "r", 1), "CLOSED"),
+        ChildState(IssueRef("o", "r", 2), "OPEN"),
+    ]
+    with patch("vergil_tooling.lib.epics.child_states", return_value=children):
+        assert epics.all_children_closed(EPIC) is False
+
+
+def test_all_children_closed_false_when_no_children() -> None:
+    with patch("vergil_tooling.lib.epics.child_states", return_value=[]):
+        assert epics.all_children_closed(EPIC) is False
+
+
+# -- helpers (node id / state / malformed reflink) ---------------------------
+
+
+def test_node_id_resolves_via_rest() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value="I_node123") as mock_read:
+        assert epics._node_id(TASK) == "I_node123"
+    assert mock_read.call_args.args == ("api", "repos/org/repo-a/issues/101", "--jq", ".node_id")
+
+
+def test_issue_state_uppercases() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value="closed"):
+        assert epics._issue_state(EPIC) == "CLOSED"
+
+
+def test_reflink_skips_results_without_repo() -> None:
+    search = [
+        {"number": 41, "state": "OPEN", "repository": {"nameWithOwner": "org/.github"}},
+        {"number": 99, "state": "OPEN", "repository": {}},  # malformed -> skipped
+    ]
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch(
+            "vergil_tooling.lib.github.graphql",
+            return_value={"node": {"subIssues": {"nodes": []}}},
+        ),
+        patch("vergil_tooling.lib.github.read_json", return_value=search),
+    ):
+        result = epics.child_states(EPIC)
+    assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN")]

--- a/tests/vergil_tooling/test_github_graphql.py
+++ b/tests/vergil_tooling/test_github_graphql.py
@@ -1,0 +1,48 @@
+"""Tests for vergil_tooling.lib.github.graphql."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from vergil_tooling.lib import github
+
+
+def test_graphql_returns_data() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_output",
+        return_value='{"data": {"node": {"number": 41}}}',
+    ) as mock_read:
+        result = github.graphql("query($id:ID!){node(id:$id){number}}", id="ABC")
+    assert result == {"node": {"number": 41}}
+    args = mock_read.call_args.args
+    assert args[0] == "api"
+    assert args[1] == "graphql"
+    assert any(a.startswith("query=") for a in args)
+    assert "id=ABC" in args
+
+
+def test_graphql_string_var_uses_lowercase_f() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value='{"data": {}}') as mock_read:
+        github.graphql("q", node_id="ABC")
+    args = list(mock_read.call_args.args)
+    assert args[args.index("node_id=ABC") - 1] == "-f"
+
+
+def test_graphql_int_var_uses_uppercase_f() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value='{"data": {}}') as mock_read:
+        github.graphql("q", number=41)
+    args = list(mock_read.call_args.args)
+    assert args[args.index("number=41") - 1] == "-F"
+
+
+def test_graphql_raises_on_payload_errors() -> None:
+    with (
+        patch(
+            "vergil_tooling.lib.github.read_output",
+            return_value='{"errors": [{"message": "boom"}]}',
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        github.graphql("q")


### PR DESCRIPTION
# Pull Request

## Summary

- Add a mechanism-agnostic epic<->task umbrella layer: github.graphql() plus lib/epics.py (native GitHub sub-issues with a portable Parent: reflink fallback), providing the child/parent traversal, add-child-with-reopen, and all-children-closed predicate that finalize rollup (Task 4) and the roadmap (Task 8) build on.

## Issue Linkage

- Ref #1926

## Notes

- Unit tests mock the github boundary (graphql/read_output/read_json/run); 100% branch coverage. add_child reopens a closed parent before linking (reopen-on-late-child rule). Next: Task 4 wires a close+rollup stage into vrg-finalize-pr using all_children_closed, and backfills the native #40<-#41 link via add_child.