### PR TITLE
feat(finalize): close managed task + roll up epic at finalize (gated on epic parent)

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -46,8 +46,10 @@ from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import (
     config,
+    epics,
     git,
     github,
+    linkage,
     pr_merge,
     pr_provenance,
     progress,
@@ -717,6 +719,36 @@ def _chain_release(root: Path, *, install: bool = False) -> int:
     return result.returncode
 
 
+def _close_managed_task(pr: str) -> None:
+    """Close the PR's tracking task + roll up its epic, gated to the model.
+
+    ``vrg-finalize-pr`` is shared tooling: this runs in every repo on deploy
+    while most issues are still legacy (spec §5). It acts only when the Ref'd
+    issue has an ``epic``-labeled parent; legacy issues (no epic parent) are
+    left open for manual close, with a visible note. The caller invokes this
+    only after the pipeline fully succeeded, so the close follows merge +
+    post-checks.
+    """
+    body = github.read_output("pr", "view", pr, "--json", "body", "--jq", ".body")
+    try:
+        issue_number = linkage.extract_tracking_issue(body)
+    except ValueError:
+        return
+    if issue_number is None:
+        return
+    repo = github.current_repo()
+    owner, name = repo.split("/", 1)
+    task = epics.IssueRef(owner=owner, repo=name, number=issue_number)
+    parent = epics.parent_of(task)
+    if parent is None or not epics.is_epic(parent):
+        print(
+            f"#{issue_number} has no epic parent — left open for manual close (transition policy)."
+        )
+        return
+    github.run("issue", "close", str(issue_number), "--repo", repo)
+    epics.rollup(task)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -780,6 +812,19 @@ def main(argv: list[str] | None = None) -> int:
         args=args,
         repo_root=root,
     )
+
+    # Auto-close the tracking task + roll up its epic once the pipeline fully
+    # succeeded (gated on an epic parent — spec §5 transition gate). Skipped on
+    # dry-run, cleanup-only (no merge), and skip-post-checks (post-checks
+    # deferred, so success is not yet verified).
+    if (
+        rc == 0
+        and args.pr is not None
+        and not args.dry_run
+        and not args.cleanup_only
+        and not args.skip_post_checks
+    ):
+        _close_managed_task(args.pr)
 
     # --release cascade (issue #1634): chain into vrg-release only after a
     # clean finalize. A non-zero pipeline must not trigger a release, and the

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -160,3 +160,32 @@ def all_children_closed(epic: IssueRef) -> bool:
     """True iff *epic* has at least one child and all children are closed."""
     children = child_states(epic)
     return bool(children) and all(child.state == "CLOSED" for child in children)
+
+
+def _labels(ref: IssueRef) -> set[str]:
+    raw: Any = github.read_json(
+        "issue", "view", str(ref.number), "--repo", f"{ref.owner}/{ref.repo}", "--json", "labels"
+    )
+    labels = (raw or {}).get("labels") or [] if isinstance(raw, dict) else []
+    return {str(label.get("name", "")) for label in labels}
+
+
+def is_epic(ref: IssueRef) -> bool:
+    """True if *ref* carries the ``epic`` label (i.e. it is in the model)."""
+    return "epic" in _labels(ref)
+
+
+def rollup(task: IssueRef) -> None:
+    """Close *task*'s parent epic if the epic is finite and all children closed.
+
+    A no-op unless the task has an ``epic``-labeled parent (the transition gate):
+    legacy issues have no epic parent, so finalize never rolls them up. A
+    ``standing`` epic is perpetual and never auto-closes.
+    """
+    parent = parent_of(task)
+    if parent is None or not is_epic(parent):
+        return
+    if "standing" in _labels(parent):
+        return
+    if all_children_closed(parent):
+        github.run("issue", "close", str(parent.number), "--repo", f"{parent.owner}/{parent.repo}")

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -171,3 +171,74 @@ def test_reflink_skips_results_without_repo() -> None:
     ):
         result = epics.child_states(EPIC)
     assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN")]
+
+
+# -- is_epic / rollup --------------------------------------------------------
+
+
+def test_is_epic_true_when_labeled() -> None:
+    labels = {"labels": [{"name": "epic"}, {"name": "enhancement"}]}
+    with patch("vergil_tooling.lib.github.read_json", return_value=labels):
+        assert epics.is_epic(EPIC) is True
+
+
+def test_is_epic_false_without_label() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value={"labels": [{"name": "bug"}]}):
+        assert epics.is_epic(TASK) is False
+
+
+def test_rollup_closes_finite_epic_when_all_children_closed() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic"}),
+        patch("vergil_tooling.lib.epics.all_children_closed", return_value=True),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[:2] == ("issue", "close")
+    assert "40" in mock_run.call_args.args
+
+
+def test_rollup_skips_standing_epic() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "standing"}),
+        patch("vergil_tooling.lib.epics.all_children_closed", return_value=True),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_not_called()
+
+
+def test_rollup_skips_when_children_remain_open() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic"}),
+        patch("vergil_tooling.lib.epics.all_children_closed", return_value=False),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_not_called()
+
+
+def test_rollup_noop_for_unmanaged_task() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=None),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_not_called()
+
+
+def test_rollup_noop_when_parent_not_epic() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=False),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_not_called()

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -16,6 +16,7 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     FinalizeContext,
     FinalizeError,
     _check_cd_workflow_status,
+    _close_managed_task,
     _parse_pr_list,
     _resolve_open_prs,
     _resolve_strategy,
@@ -29,6 +30,7 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     main,
     parse_args,
 )
+from vergil_tooling.lib import epics
 from vergil_tooling.lib.pr_merge import MergeAbortError
 from vergil_tooling.lib.pr_provenance import Action, ProvenanceResult, Role
 from vergil_tooling.lib.worktrees import Worktree, WorktreeState, WorktreeStatus
@@ -37,6 +39,19 @@ _MOD = "vergil_tooling.bin.vrg_finalize_pr"
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _no_managed_close() -> Iterator[None]:
+    """Default: neutralize the post-pipeline task close+rollup.
+
+    main() now calls ``_close_managed_task`` after a successful pipeline; the
+    broad main() tests don't exercise it (and would hit a real ``gh pr view``).
+    The dedicated ``_close_managed_task`` tests call the imported function
+    directly, so this module-attr patch doesn't shadow them.
+    """
+    with patch(_MOD + "._close_managed_task"):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -1968,3 +1983,70 @@ def test_main_comma_list_routes_to_batch() -> None:
         rc = main(["123,124"])
     assert rc == 0
     run_batch.assert_called_once()
+
+
+# -- _close_managed_task (transition gate, issue/epic auto-close) -------------
+
+
+def test_close_managed_task_skips_legacy_issue(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(_FIN_MOD + ".github.read_output", return_value="Ref #210"),
+        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=210),
+        patch(_FIN_MOD + ".github.current_repo", return_value="org/repo-a"),
+        patch(_FIN_MOD + ".epics.parent_of", return_value=None),
+        patch(_FIN_MOD + ".github.run") as mock_run,
+        patch(_FIN_MOD + ".epics.rollup") as mock_rollup,
+    ):
+        _close_managed_task("210")
+    mock_run.assert_not_called()
+    mock_rollup.assert_not_called()
+    assert "no epic parent" in capsys.readouterr().out
+
+
+def test_close_managed_task_skips_when_parent_not_epic() -> None:
+    with (
+        patch(_FIN_MOD + ".github.read_output", return_value="Ref #210"),
+        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=210),
+        patch(_FIN_MOD + ".github.current_repo", return_value="org/repo-a"),
+        patch(_FIN_MOD + ".epics.parent_of", return_value=epics.IssueRef("org", ".github", 40)),
+        patch(_FIN_MOD + ".epics.is_epic", return_value=False),
+        patch(_FIN_MOD + ".github.run") as mock_run,
+    ):
+        _close_managed_task("210")
+    mock_run.assert_not_called()
+
+
+def test_close_managed_task_closes_and_rolls_up() -> None:
+    with (
+        patch(_FIN_MOD + ".github.read_output", return_value="Ref #101"),
+        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=101),
+        patch(_FIN_MOD + ".github.current_repo", return_value="org/repo-a"),
+        patch(_FIN_MOD + ".epics.parent_of", return_value=epics.IssueRef("org", ".github", 40)),
+        patch(_FIN_MOD + ".epics.is_epic", return_value=True),
+        patch(_FIN_MOD + ".github.run") as mock_run,
+        patch(_FIN_MOD + ".epics.rollup") as mock_rollup,
+    ):
+        _close_managed_task("101")
+    assert mock_run.call_args.args[:2] == ("issue", "close")
+    assert "101" in mock_run.call_args.args
+    mock_rollup.assert_called_once()
+
+
+def test_close_managed_task_noop_without_tracking_issue() -> None:
+    with (
+        patch(_FIN_MOD + ".github.read_output", return_value="no ref"),
+        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=None),
+        patch(_FIN_MOD + ".github.run") as mock_run,
+    ):
+        _close_managed_task("101")
+    mock_run.assert_not_called()
+
+
+def test_close_managed_task_noop_on_multiple_refs() -> None:
+    with (
+        patch(_FIN_MOD + ".github.read_output", return_value="Ref #1\nRef #2"),
+        patch(_FIN_MOD + ".linkage.extract_tracking_issue", side_effect=ValueError("multiple")),
+        patch(_FIN_MOD + ".github.run") as mock_run,
+    ):
+        _close_managed_task("101")
+    mock_run.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- After a fully successful vrg-finalize-pr pipeline, close the Ref'd task and roll up its epic when (and only when) the issue has an epic-labeled parent, automating the issue/epic close for the new model while leaving the legacy backlog untouched.

## Issue Linkage

- Ref #1932

## Notes

- SAFE MID-MIGRATION (spec §5 transition gate): no epic parent -> finalize closes nothing and logs 'left open for manual close (transition policy)'. So the entire un-migrated backlog and active lab PRs are a no-op; auto-close turns on per-issue as repos migrate. Close runs only on rc==0, not on dry-run/cleanup-only/skip-post-checks. Single-PR path wired (the task-finalize case); batch path (release orchestrator) left as-is. Adds epics.is_epic + epics.rollup; 100% coverage. Follow-up: optionally backfill the native #40<-#41 sub-issue link via epics.add_child (the reflink already holds it today).