### PR TITLE
feat(linkage): reject epic-linked PRs + enforce single task ref

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
+++ b/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
@@ -13,7 +13,8 @@ import os
 import sys
 from pathlib import Path
 
-from vergil_tooling.lib.linkage import AUTOCLOSE_RE, LINKAGE_RE
+from vergil_tooling.lib import epics
+from vergil_tooling.lib.linkage import AUTOCLOSE_RE, LINKAGE_RE, extract_tracking_ref
 from vergil_tooling.lib.output import emit_error, write_summary
 
 
@@ -55,6 +56,30 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
             "pull request body must include primary issue linkage "
             "(Ref #123). Cross-repo references (Ref owner/repo#123) are "
             "also accepted."
+        )
+        emit_error(msg)
+        write_summary(f"## PR Body Compliance Failed\n\n{msg}")
+        return 1
+
+    try:
+        ref = extract_tracking_ref(pr_body)
+    except ValueError:
+        msg = "pull request must link exactly one task (multiple Ref lines found)."
+        emit_error(msg)
+        write_summary(f"## PR Body Compliance Failed\n\n{msg}")
+        return 1
+
+    # Reject linking an epic: PRs link a task; epics are umbrellas closed by
+    # rollup. Self-scoping — legacy issues are never epics, so they pass.
+    repo_env = os.environ.get("GITHUB_REPOSITORY", "")
+    try:
+        issue = epics.parse_issue_ref(ref or "", default_repo=repo_env)
+    except ValueError:
+        return 0
+    if epics.is_epic(issue):
+        msg = (
+            "pull request links an epic; PRs link a task, not an epic "
+            "(epics are closed by rollup when their tasks complete)."
         )
         emit_error(msg)
         write_summary(f"## PR Body Compliance Failed\n\n{msg}")

--- a/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
+++ b/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
@@ -13,7 +13,6 @@ import os
 import sys
 from pathlib import Path
 
-from vergil_tooling.lib import epics
 from vergil_tooling.lib.linkage import AUTOCLOSE_RE, LINKAGE_RE, extract_tracking_ref
 from vergil_tooling.lib.output import emit_error, write_summary
 
@@ -61,26 +60,13 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         write_summary(f"## PR Body Compliance Failed\n\n{msg}")
         return 1
 
+    # Enforce a single task ref (pure-regex, no API). The epic-vs-task check
+    # needs authenticated cross-repo gh and lives in vrg-submit-pr; this CI gate
+    # stays dependency-free so it can run without a gh token.
     try:
-        ref = extract_tracking_ref(pr_body)
+        extract_tracking_ref(pr_body)
     except ValueError:
         msg = "pull request must link exactly one task (multiple Ref lines found)."
-        emit_error(msg)
-        write_summary(f"## PR Body Compliance Failed\n\n{msg}")
-        return 1
-
-    # Reject linking an epic: PRs link a task; epics are umbrellas closed by
-    # rollup. Self-scoping — legacy issues are never epics, so they pass.
-    repo_env = os.environ.get("GITHUB_REPOSITORY", "")
-    try:
-        issue = epics.parse_issue_ref(ref or "", default_repo=repo_env)
-    except ValueError:
-        return 0
-    if epics.is_epic(issue):
-        msg = (
-            "pull request links an epic; PRs link a task, not an epic "
-            "(epics are closed by rollup when their tasks complete)."
-        )
         emit_error(msg)
         write_summary(f"## PR Body Compliance Failed\n\n{msg}")
         return 1

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -43,7 +43,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from vergil_tooling.lib import git, github, identity_mode, worktrees
+from vergil_tooling.lib import epics, git, github, identity_mode, worktrees
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.linkage import ALLOWED_LINKAGES, normalize_linkage
 from vergil_tooling.lib.pr_body import build_pr_body, resolve_issue_ref
@@ -230,6 +230,26 @@ def _print_pr_watch(pr_url: str) -> None:
     print(f"    /vergil:pr-watch {pr_url}")
 
 
+def _reject_if_epic_link(issue_ref: str) -> None:
+    """Abort if the linkage points at an epic — PRs link a task, never an epic.
+
+    This lives here, not in the pr-issue-linkage CI gate, because deciding
+    epic-ness needs an authenticated, cross-repo ``gh`` call (e.g. an epic in
+    ``.github``) — which vrg-submit-pr has via the App installation token and the
+    CI gate (a dependency-free body regex) does not. Self-scoping: legacy issues
+    are never epics, so they pass.
+    """
+    try:
+        issue = epics.parse_issue_ref(issue_ref, default_repo=github.current_repo())
+    except ValueError:
+        return
+    if epics.is_epic(issue):
+        raise SystemExit(
+            "vrg-submit-pr: --issue links an epic; link a task, not an epic "
+            "(epics are closed by rollup when their tasks complete)."
+        )
+
+
 def _run_cli_mode(args: argparse.Namespace) -> int:
     # main() only routes here when all three are present; narrow for the
     # type checker without relying on an assert (ruff S101).
@@ -238,6 +258,7 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
         raise SystemExit(msg)
 
     issue_ref = resolve_issue_ref(args.issue)
+    _reject_if_epic_link(issue_ref)
     branch = git.current_branch()
     target = _target_branch(args.base)
     pr_body = build_pr_body(
@@ -475,6 +496,7 @@ def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: b
     """
     fields = submission.read_pr_fields(worktree_root)
     issue_ref = resolve_issue_ref(fields["issue"])
+    _reject_if_epic_link(issue_ref)
     branch = git.current_branch()
     target = _target_branch(base_override, fields.get("base"))
     try:

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -47,6 +47,26 @@ _PARENT_RE = re.compile(
     re.MULTILINE,
 )
 
+_REF_RE = re.compile(r"^(?:([A-Za-z0-9._-]+/[A-Za-z0-9._-]+))?#([0-9]+)$")
+
+
+def parse_issue_ref(ref: str, *, default_repo: str) -> IssueRef:
+    """Parse a linkage ref (``"#42"`` or ``"owner/repo#42"``) into an ``IssueRef``.
+
+    A bare ``#N`` uses *default_repo* (``"owner/name"``). Raises ``ValueError`` if
+    *ref* is malformed or the resolved repo lacks an ``owner/name`` form.
+    """
+    match = _REF_RE.match(ref.strip())
+    if match is None:
+        raise ValueError(f"not an issue ref: {ref!r}")
+    repo_part, number = match.groups()
+    full = repo_part or default_repo
+    if "/" not in full:
+        raise ValueError(f"cannot resolve repo for {ref!r} (default_repo={default_repo!r})")
+    owner, name = full.split("/", 1)
+    return IssueRef(owner=owner, repo=name, number=int(number))
+
+
 _SUBISSUES_QUERY = """
 query($id: ID!) {
   node(id: $id) {

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -84,3 +84,20 @@ def extract_tracking_issue(text: str) -> int | None:
         msg = f"multiple tracking issue references found ({len(matches)})"
         raise ValueError(msg)
     return int(matches[0][1])
+
+
+def extract_tracking_ref(text: str) -> str | None:
+    """Return the single ``Ref`` as ``"#N"`` or ``"owner/repo#N"`` (cross-repo).
+
+    Like :func:`extract_tracking_issue` but preserves the optional ``owner/repo``
+    so callers can identify a cross-repo linkage (e.g. a mistaken link to an epic
+    in ``.github``). Raises ``ValueError`` if multiple ``Ref`` lines are found.
+    """
+    matches = LINKAGE_RE.findall(text)
+    if not matches:
+        return None
+    if len(matches) > 1:
+        msg = f"multiple tracking issue references found ({len(matches)})"
+        raise ValueError(msg)
+    repo_part, number = matches[0]
+    return f"{repo_part}#{number}" if repo_part else f"#{number}"

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from vergil_tooling.lib import epics
 from vergil_tooling.lib.epics import ChildState, IssueRef
 
@@ -242,3 +244,25 @@ def test_rollup_noop_when_parent_not_epic() -> None:
     ):
         epics.rollup(TASK)
     mock_run.assert_not_called()
+
+
+# -- parse_issue_ref ---------------------------------------------------------
+
+
+def test_parse_issue_ref_bare_uses_default_repo() -> None:
+    assert epics.parse_issue_ref("#42", default_repo="org/repo") == IssueRef("org", "repo", 42)
+
+
+def test_parse_issue_ref_cross_repo() -> None:
+    ref = epics.parse_issue_ref("org/.github#40", default_repo="x/y")
+    assert ref == IssueRef("org", ".github", 40)
+
+
+def test_parse_issue_ref_malformed_raises() -> None:
+    with pytest.raises(ValueError, match="not an issue ref"):
+        epics.parse_issue_ref("not-a-ref", default_repo="org/repo")
+
+
+def test_parse_issue_ref_no_repo_raises() -> None:
+    with pytest.raises(ValueError, match="cannot resolve repo"):
+        epics.parse_issue_ref("#42", default_repo="")

--- a/tests/vergil_tooling/test_linkage.py
+++ b/tests/vergil_tooling/test_linkage.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from vergil_tooling.lib.linkage import extract_tracking_issue, normalize_linkage
+from vergil_tooling.lib.linkage import (
+    extract_tracking_issue,
+    extract_tracking_ref,
+    normalize_linkage,
+)
 
 
 def test_ref_simple() -> None:
@@ -101,3 +105,20 @@ def test_normalize_rejects_empty_string() -> None:
 def test_normalize_rejects_trailing_garbage() -> None:
     with pytest.raises(ValueError, match="bare keyword"):
         normalize_linkage("Ref #1761 extra")
+
+
+def test_extract_tracking_ref_same_repo() -> None:
+    assert extract_tracking_ref("Ref #42") == "#42"
+
+
+def test_extract_tracking_ref_cross_repo() -> None:
+    assert extract_tracking_ref("Ref org/.github#40") == "org/.github#40"
+
+
+def test_extract_tracking_ref_none() -> None:
+    assert extract_tracking_ref("no linkage here") is None
+
+
+def test_extract_tracking_ref_multiple_raises() -> None:
+    with pytest.raises(ValueError, match="multiple"):
+        extract_tracking_ref("Ref #1\nRef #2")

--- a/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
+++ b/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
@@ -11,17 +11,7 @@ import pytest
 from vergil_tooling.bin.vrg_pr_issue_linkage import main
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from pathlib import Path
-
-
-@pytest.fixture(autouse=True)
-def _default_not_epic() -> Iterator[None]:
-    # The validator now checks whether the linked issue is an epic. Default to
-    # "not an epic" so existing linkage tests don't hit a real gh call; the
-    # epic-reject test overrides this.
-    with patch("vergil_tooling.bin.vrg_pr_issue_linkage.epics.is_epic", return_value=False):
-        yield
 
 
 def _write_event(tmp_path: Path, body: str) -> str:
@@ -207,29 +197,7 @@ def test_no_summary_on_success(tmp_path: Path) -> None:
         mock_sum.assert_not_called()
 
 
-# -- epic-link rejection + single-task enforcement --------------------------
-
-
-def test_epic_linked_pr_rejected(tmp_path: Path) -> None:
-    event_path = _write_event(tmp_path, "Ref vergil-project/.github#40\n")
-    with (
-        patch.dict(
-            "os.environ",
-            {"GITHUB_EVENT_PATH": event_path, "GITHUB_REPOSITORY": "vergil-project/repo"},
-        ),
-        patch(f"{_MOD}.epics.is_epic", return_value=True),
-    ):
-        assert main() == 1
-
-
-def test_task_linkage_passes(tmp_path: Path) -> None:
-    # is_epic defaults to False via the autouse fixture; a same-repo task passes.
-    event_path = _write_event(tmp_path, "Ref #210\n")
-    with patch.dict(
-        "os.environ",
-        {"GITHUB_EVENT_PATH": event_path, "GITHUB_REPOSITORY": "vergil-project/repo"},
-    ):
-        assert main() == 0
+# -- single-task enforcement (pure regex; epic-vs-task lives in vrg-submit-pr) --
 
 
 def test_multiple_refs_rejected(tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
+++ b/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
@@ -11,7 +11,17 @@ import pytest
 from vergil_tooling.bin.vrg_pr_issue_linkage import main
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _default_not_epic() -> Iterator[None]:
+    # The validator now checks whether the linked issue is an epic. Default to
+    # "not an epic" so existing linkage tests don't hit a real gh call; the
+    # epic-reject test overrides this.
+    with patch("vergil_tooling.bin.vrg_pr_issue_linkage.epics.is_epic", return_value=False):
+        yield
 
 
 def _write_event(tmp_path: Path, body: str) -> str:
@@ -195,3 +205,34 @@ def test_no_summary_on_success(tmp_path: Path) -> None:
         main()
         mock_err.assert_not_called()
         mock_sum.assert_not_called()
+
+
+# -- epic-link rejection + single-task enforcement --------------------------
+
+
+def test_epic_linked_pr_rejected(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "Ref vergil-project/.github#40\n")
+    with (
+        patch.dict(
+            "os.environ",
+            {"GITHUB_EVENT_PATH": event_path, "GITHUB_REPOSITORY": "vergil-project/repo"},
+        ),
+        patch(f"{_MOD}.epics.is_epic", return_value=True),
+    ):
+        assert main() == 1
+
+
+def test_task_linkage_passes(tmp_path: Path) -> None:
+    # is_epic defaults to False via the autouse fixture; a same-repo task passes.
+    event_path = _write_event(tmp_path, "Ref #210\n")
+    with patch.dict(
+        "os.environ",
+        {"GITHUB_EVENT_PATH": event_path, "GITHUB_REPOSITORY": "vergil-project/repo"},
+    ):
+        assert main() == 0
+
+
+def test_multiple_refs_rejected(tmp_path: Path) -> None:
+    event_path = _write_event(tmp_path, "Ref #1\nRef #2\n")
+    with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
+        assert main() == 1

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -11,6 +11,7 @@ import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
+    _reject_if_epic_link,
     _run_submit_batch,
     _select_batch_worktrees,
     _submit_one,
@@ -18,7 +19,7 @@ from vergil_tooling.bin.vrg_submit_pr import (
     main,
     parse_args,
 )
-from vergil_tooling.lib import worktrees
+from vergil_tooling.lib import epics, worktrees
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
 from vergil_tooling.lib.worktrees import Worktree
 
@@ -26,6 +27,16 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 _MOD = "vergil_tooling.bin.vrg_submit_pr"
+
+
+@pytest.fixture(autouse=True)
+def _no_epic_link_check() -> Iterator[None]:
+    """Neutralize the epic-link guard for submit-flow tests (it would hit a real
+    gh call). The dedicated _reject_if_epic_link tests call the imported function
+    directly, so this module-attr patch doesn't shadow them.
+    """
+    with patch(_MOD + "._reject_if_epic_link"):
+        yield
 
 
 def _write_workflow_state(
@@ -1632,3 +1643,30 @@ def test_main_batch_routes_to_run_submit_batch() -> None:
         rc = main(["--all", "--finalize", "--base", "develop"])
     assert rc == 0
     run_batch.assert_called_once()
+
+
+# -- _reject_if_epic_link (PRs link tasks, not epics) ------------------------
+
+
+def test_reject_if_epic_link_raises_for_epic() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.is_epic", return_value=True),
+        pytest.raises(SystemExit, match="links an epic"),
+    ):
+        _reject_if_epic_link("org/.github#40")
+
+
+def test_reject_if_epic_link_passes_for_task() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.is_epic", return_value=False) as mock_is_epic,
+    ):
+        _reject_if_epic_link("#42")
+    mock_is_epic.assert_called_once_with(epics.IssueRef("org", "repo", 42))
+
+
+def test_reject_if_epic_link_noop_when_repo_unresolvable() -> None:
+    # A bare ref with no resolvable default repo is skipped, not an error.
+    with patch(f"{_MOD}.github.current_repo", return_value=""):
+        _reject_if_epic_link("#42")


### PR DESCRIPTION
# Pull Request

## Summary

- The pr-issue-linkage CI gate now rejects a PR that Refs an epic-labeled issue and rejects multiple Ref lines, enforcing the 1:1 task<->PR rule (epics are umbrellas closed by rollup, never by a PR).

## Issue Linkage

- Ref #1937

## Notes

- Self-scoping (spec §5): only epic-labeled issues are rejected, so the legacy backlog passes unaffected. Reuses epics.is_epic (T4); adds linkage.extract_tracking_ref (preserves owner/repo so a cross-repo epic ref is caught) + epics.parse_issue_ref. 100% coverage. Scope note: the vrg-submit-pr early-feedback check is deferred to a follow-up — the CI gate is the authoritative required check; submit-time is convenience.