### PR TITLE
feat(validate): honor repo-local ansible-lint skip_list/exclude_paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "VERGIL — Validation Engine for Repository Governance, Integrati
 requires-python = ">=3.12,<4.0"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
-dependencies = ["rich>=13.0"]
+dependencies = ["rich>=13.0", "pyyaml>=6.0"]
 
 [project.scripts]
 vrg-audit-approve = "vergil_tooling.bin.vrg_audit_approve:main"
@@ -61,7 +61,7 @@ vrg-whoami = "vergil_tooling.bin.vrg_whoami:main"
 vrg-worktree-status = "vergil_tooling.bin.vrg_worktree_status:main"
 
 [dependency-groups]
-dev = ["ruff", "mypy", "ty", "pytest", "pytest-cov", "pip-audit", "pip-licenses"]
+dev = ["ruff", "mypy", "ty", "pytest", "pytest-cov", "pip-audit", "pip-licenses", "types-pyyaml"]
 
 [tool.uv]
 # Security floors for TRANSITIVE dependencies. These are not direct dependencies —

--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -10,7 +10,8 @@ Runs inside the dev container via ``vrg-container-run``:
   5. hadolint on Dockerfile* files at the repo root
   6. actionlint on ``.github/workflows/``
   7. ansible-lint when the repo carries Ansible content, using the
-     bundled canonical config (issue #1667)
+     bundled canonical config as the rule baseline while honoring the
+     repo's local ``skip_list`` / ``exclude_paths`` (issues #1667, #1952)
 """
 
 from __future__ import annotations
@@ -19,6 +20,8 @@ import subprocess
 import sys
 from importlib.resources import files
 from typing import TYPE_CHECKING
+
+import yaml
 
 from vergil_tooling.bin import vrg_repo_profile
 from vergil_tooling.lib import git
@@ -135,6 +138,58 @@ def _has_ansible_content(repo_root: Path) -> bool:
     return any((repo_root / name).is_dir() for name in _ANSIBLE_DIR_SIGNALS)
 
 
+# Repo-local ansible-lint config filenames, in ansible-lint's own discovery
+# order. We pass the bundled config via ``-c``, which suppresses ansible-lint's
+# config discovery entirely, so we read these ourselves to recover the two
+# repo-side levers the gate must still honor (issue #1952).
+_ANSIBLE_LINT_CONFIG_NAMES = (
+    ".ansible-lint",
+    ".ansible-lint.yml",
+    ".ansible-lint.yaml",
+)
+
+
+def _find_ansible_lint_config(repo_root: Path) -> Path | None:
+    """Return the repo's local ansible-lint config file, if any."""
+    for name in _ANSIBLE_LINT_CONFIG_NAMES:
+        candidate = repo_root / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _ansible_lint_overrides(config_path: Path) -> list[str]:
+    """Translate a repo's local ansible-lint ``skip_list`` / ``exclude_paths``
+    into CLI flags layered on top of the bundled ``-c`` baseline.
+
+    Passing ``-c <bundled>`` makes ansible-lint ignore the repo's own config
+    discovery, so a consuming repo otherwise cannot defer rules (``skip_list``)
+    or scope out non-Ansible YAML (``exclude_paths``). We read those two keys
+    ourselves and re-express them as ``-x rule1,rule2`` and ``--exclude <path>``
+    flags, which apply on top of the bundled rule baseline (issue #1952).
+
+    Raises ``yaml.YAMLError`` if the config is not valid YAML; the caller
+    surfaces that as a hard failure rather than silently dropping the repo's
+    intended skips.
+    """
+    raw = yaml.safe_load(config_path.read_text())
+    if not isinstance(raw, dict):
+        return []
+
+    overrides: list[str] = []
+
+    skip_list = raw.get("skip_list")
+    if isinstance(skip_list, list) and skip_list:
+        overrides += ["-x", ",".join(str(rule) for rule in skip_list)]
+
+    exclude_paths = raw.get("exclude_paths")
+    if isinstance(exclude_paths, list):
+        for entry in exclude_paths:
+            overrides += ["--exclude", str(entry)]
+
+    return overrides
+
+
 def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     repo_root = git.repo_root()
 
@@ -197,8 +252,19 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     if _has_ansible_content(repo_root):
         print("Running: ansible-lint")
         ansible_config = files("vergil_tooling.configs") / "ansible-lint.yaml"
+        overrides: list[str] = []
+        local_config = _find_ansible_lint_config(repo_root)
+        if local_config is not None:
+            try:
+                overrides = _ansible_lint_overrides(local_config)
+            except yaml.YAMLError as exc:
+                print(
+                    f"error: failed to parse {local_config}: {exc}",
+                    file=sys.stderr,
+                )
+                return 1
         result = subprocess.run(  # noqa: S603
-            ["ansible-lint", "-c", str(ansible_config)],  # noqa: S607
+            ["ansible-lint", "-c", str(ansible_config), *overrides],  # noqa: S607
             check=False,
         )
         if result.returncode != 0:

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -6,7 +6,12 @@ import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import pytest
+import yaml
+
 from vergil_tooling.bin.validate_common import (
+    _ansible_lint_overrides,
+    _find_ansible_lint_config,
     _find_dockerfiles,
     _find_markdown_files,
     _find_shell_files,
@@ -787,3 +792,162 @@ def test_main_ansible_lint_fails(tmp_path: Path) -> None:
         ),
     ):
         assert main() == 1
+
+
+# -- _find_ansible_lint_config -----------------------------------------------
+
+
+def test_find_ansible_lint_config_none(tmp_path: Path) -> None:
+    assert _find_ansible_lint_config(tmp_path) is None
+
+
+def test_find_ansible_lint_config_prefers_discovery_order(tmp_path: Path) -> None:
+    (tmp_path / ".ansible-lint.yml").write_text("skip_list: [name]\n")
+    (tmp_path / ".ansible-lint").write_text("skip_list: [yaml]\n")
+    assert _find_ansible_lint_config(tmp_path) == tmp_path / ".ansible-lint"
+
+
+def test_find_ansible_lint_config_yaml_suffix(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yaml"
+    cfg.write_text("skip_list: [name]\n")
+    assert _find_ansible_lint_config(tmp_path) == cfg
+
+
+# -- _ansible_lint_overrides -------------------------------------------------
+
+
+def test_ansible_lint_overrides_skip_list(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("skip_list:\n  - name[casing]\n  - yaml[line-length]\n")
+    assert _ansible_lint_overrides(cfg) == ["-x", "name[casing],yaml[line-length]"]
+
+
+def test_ansible_lint_overrides_exclude_paths(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("exclude_paths:\n  - config/app.yml\n  - vendor/\n")
+    assert _ansible_lint_overrides(cfg) == [
+        "--exclude",
+        "config/app.yml",
+        "--exclude",
+        "vendor/",
+    ]
+
+
+def test_ansible_lint_overrides_both_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("skip_list: [name]\nexclude_paths: [config/app.yml]\n")
+    assert _ansible_lint_overrides(cfg) == [
+        "-x",
+        "name",
+        "--exclude",
+        "config/app.yml",
+    ]
+
+
+def test_ansible_lint_overrides_empty_config(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("")
+    assert _ansible_lint_overrides(cfg) == []
+
+
+def test_ansible_lint_overrides_only_baseline_keys(tmp_path: Path) -> None:
+    # Keys we do not translate are ignored; only skip_list / exclude_paths
+    # become CLI flags.
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("profile: min\nwarn_list:\n  - experimental\n")
+    assert _ansible_lint_overrides(cfg) == []
+
+
+def test_ansible_lint_overrides_empty_lists(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("skip_list: []\nexclude_paths: []\n")
+    assert _ansible_lint_overrides(cfg) == []
+
+
+def test_ansible_lint_overrides_malformed_yaml_raises(tmp_path: Path) -> None:
+    cfg = tmp_path / ".ansible-lint.yml"
+    cfg.write_text("skip_list: [unterminated\n")
+    with pytest.raises(yaml.YAMLError):
+        _ansible_lint_overrides(cfg)
+
+
+# -- main: ansible-lint local-config integration -----------------------------
+
+
+def test_main_ansible_lint_passes_local_overrides(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / ".ansible-lint.yml").write_text(
+        "skip_list:\n  - name[casing]\nexclude_paths:\n  - config/app.yml\n"
+    )
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == "ansible-lint"
+    assert call_args[1] == "-c"
+    assert call_args[2].endswith("ansible-lint.yaml")
+    # The bundled baseline is preserved and the repo's levers are layered on.
+    assert call_args[3:] == ["-x", "name[casing]", "--exclude", "config/app.yml"]
+
+
+def test_main_ansible_lint_no_local_config_no_overrides(tmp_path: Path) -> None:
+    # Ansible content present (roles/) but no local ansible-lint config: the
+    # command is exactly the bundled baseline, unchanged.
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / "roles").mkdir()
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == "ansible-lint"
+    assert len(call_args) == 3  # ansible-lint, -c, <bundled config>
+
+
+def test_main_ansible_lint_malformed_local_config_fails(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    (tmp_path / ".ansible-lint.yml").write_text("skip_list: [unterminated\n")
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 1
+    # We fail before invoking ansible-lint rather than silently dropping skips.
+    tool_names = [call[0][0][0] for call in mock_run.call_args_list]
+    assert "ansible-lint" not in tool_names

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -827,6 +873,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -849,6 +904,7 @@ name = "vergil-tooling"
 version = "2.1.85"
 source = { editable = "." }
 dependencies = [
+    { name = "pyyaml" },
     { name = "rich" },
 ]
 
@@ -861,10 +917,14 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "rich", specifier = ">=13.0" }]
+requires-dist = [
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -875,6 +935,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "types-pyyaml" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Summary

- The vrg-validate ansible-lint stage now layers a consuming repo's local .ansible-lint skip_list/exclude_paths onto the bundled rule baseline instead of ignoring the repo config entirely.

## Issue Linkage

- Ref #1952

## Notes

- Implementation: `_find_ansible_lint_config` discovers the repo's `.ansible-lint`/`.yml`/`.yaml` in ansible-lint's own order; `_ansible_lint_overrides` reads `skip_list` -> `-x rule1,rule2` and `exclude_paths` -> repeated `--exclude <path>`, appended after the bundled `-c <config>`. A malformed local config fails the stage loudly (returns 1 before invoking ansible-lint) rather than silently dropping the intended skips. Adds pyyaml (runtime) + types-pyyaml (dev) and updates uv.lock. 13 new tests; full `vrg-validate` green at 100% coverage.