### PR TITLE
feat(observability): vrg-activity-log generator (recently closed work -> ledger)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license-files = ["LICENSE"]
 dependencies = ["rich>=13.0", "pyyaml>=6.0"]
 
 [project.scripts]
+vrg-activity-log = "vergil_tooling.bin.vrg_activity_log:main"
 vrg-audit-approve = "vergil_tooling.bin.vrg_audit_approve:main"
 vrg-await = "vergil_tooling.bin.vrg_await:main"
 vrg-changelog = "vergil_tooling.bin.vrg_changelog:main"

--- a/src/vergil_tooling/bin/vrg_activity_log.py
+++ b/src/vergil_tooling/bin/vrg_activity_log.py
@@ -1,0 +1,24 @@
+"""Print the project activity log (recently closed work across the org).
+
+A pure read-and-render command — see :mod:`vergil_tooling.lib.activity_log`. The
+nightly job that writes/publishes the rendered markdown is separate (T8c).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+
+from vergil_tooling.lib import activity_log
+
+_WINDOW_DAYS = 30
+
+
+def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
+    since = (datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)).date().isoformat()
+    print(activity_log.render(activity_log.gather(since)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vergil_tooling/lib/activity_log.py
+++ b/src/vergil_tooling/lib/activity_log.py
@@ -1,0 +1,83 @@
+"""Generate the project activity log — recently closed work across the org.
+
+The backward-looking companion to the roadmap ("where we've been"). ``gather``
+queries closed issues across the org via ``gh search``; ``render`` groups them by
+close-date, most recent first. This is best-effort reporting (search-based) — a
+roughly-right ledger is the goal, unlike the exact epic rollup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vergil_tooling.lib import github
+
+_ORG = "vergil-project"
+
+
+@dataclass(frozen=True)
+class ActivityItem:
+    """One closed issue in the ledger."""
+
+    repo: str  # owner/name
+    number: int
+    title: str
+    url: str
+    closed_date: str  # YYYY-MM-DD
+
+
+def gather(since: str, *, org: str = _ORG) -> list[ActivityItem]:
+    """Closed issues across *org* with ``closedAt`` on or after *since* (YYYY-MM-DD)."""
+    raw: Any = github.read_json(
+        "search",
+        "issues",
+        "--owner",
+        org,
+        "--state",
+        "closed",
+        "--closed",
+        f">={since}",
+        "--limit",
+        "100",
+        "--json",
+        "number,title,repository,url,closedAt",
+    )
+    items: list[ActivityItem] = []
+    for entry in raw if isinstance(raw, list) else []:
+        repo = str((entry.get("repository") or {}).get("nameWithOwner", ""))
+        closed = str(entry.get("closedAt") or "")
+        if not repo or not closed:
+            continue
+        items.append(
+            ActivityItem(
+                repo=repo,
+                number=int(entry["number"]),
+                title=str(entry["title"]),
+                url=str(entry["url"]),
+                closed_date=closed[:10],
+            )
+        )
+    return items
+
+
+def render(items: list[ActivityItem]) -> str:
+    """Render the ledger markdown, grouped by close-date (most recent first)."""
+    if not items:
+        return "# Activity log\n\n_No recently closed issues._\n"
+    by_date: dict[str, list[ActivityItem]] = {}
+    for item in items:
+        by_date.setdefault(item.closed_date, []).append(item)
+    lines = [
+        "# Activity log",
+        "",
+        f"_{len(items)} issue(s) closed in the last 30 days. Generated; do not edit._",
+        "",
+    ]
+    for date in sorted(by_date, reverse=True):
+        lines.append(f"## {date}")
+        lines.append("")
+        for item in sorted(by_date[date], key=lambda i: (i.repo, i.number)):
+            lines.append(f"- [{item.repo}#{item.number}]({item.url}) {item.title}")
+        lines.append("")
+    return "\n".join(lines)

--- a/tests/vergil_tooling/test_activity_log.py
+++ b/tests/vergil_tooling/test_activity_log.py
@@ -1,0 +1,59 @@
+"""Tests for vergil_tooling.lib.activity_log."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from vergil_tooling.lib import activity_log
+from vergil_tooling.lib.activity_log import ActivityItem
+
+
+def test_gather_parses_and_skips_incomplete() -> None:
+    results = [
+        {
+            "number": 1912,
+            "title": "labels",
+            "repository": {"nameWithOwner": "vergil-project/vergil-tooling"},
+            "url": "u1912",
+            "closedAt": "2026-06-29T10:00:00Z",
+        },
+        {  # missing repository -> skipped
+            "number": 99,
+            "title": "orphan",
+            "repository": {},
+            "url": "u99",
+            "closedAt": "2026-06-29T11:00:00Z",
+        },
+    ]
+    with patch("vergil_tooling.lib.github.read_json", return_value=results) as mock_search:
+        items = activity_log.gather("2026-06-01")
+    assert items == [
+        ActivityItem("vergil-project/vergil-tooling", 1912, "labels", "u1912", "2026-06-29")
+    ]
+    # the search carries org scope (--owner) and the since cutoff (--closed)
+    args = mock_search.call_args.args
+    assert "vergil-project" in args
+    assert ">=2026-06-01" in args
+
+
+def test_gather_returns_empty_on_non_list() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value={"x": 1}):
+        assert activity_log.gather("2026-06-01") == []
+
+
+def test_render_empty() -> None:
+    assert "No recently closed issues" in activity_log.render([])
+
+
+def test_render_groups_by_date_descending() -> None:
+    items = [
+        ActivityItem("vergil-project/vergil-tooling", 1912, "labels", "u1912", "2026-06-28"),
+        ActivityItem("vergil-project/vergil-tooling", 1926, "umbrella", "u1926", "2026-06-29"),
+        ActivityItem("vergil-project/.github", 41, "docs", "u41", "2026-06-29"),
+    ]
+    out = activity_log.render(items)
+    assert "3 issue(s) closed" in out
+    # most recent date first
+    assert out.index("## 2026-06-29") < out.index("## 2026-06-28")
+    assert "[vergil-project/.github#41](u41) docs" in out
+    assert "[vergil-project/vergil-tooling#1912](u1912) labels" in out

--- a/tests/vergil_tooling/test_vrg_activity_log.py
+++ b/tests/vergil_tooling/test_vrg_activity_log.py
@@ -1,0 +1,23 @@
+"""Tests for vergil_tooling.bin.vrg_activity_log."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from vergil_tooling.bin.vrg_activity_log import main
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_main_prints_ledger(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(
+        "vergil_tooling.bin.vrg_activity_log.activity_log.gather", return_value=[]
+    ) as mock_gather:
+        rc = main()
+    assert rc == 0
+    assert "Activity log" in capsys.readouterr().out
+    # the CLI computes and passes a YYYY-MM-DD cutoff
+    since = mock_gather.call_args.args[0]
+    assert len(since) == 10 and since.count("-") == 2


### PR DESCRIPTION
# Pull Request

## Summary

- Add vrg-activity-log, the backward-looking ledger: it queries closed issues across the org over the last 30 days and renders them grouped by close-date, most recent first.

## Issue Linkage

- Ref #1953

## Notes

- Companion to vrg-roadmap. Validated live (100 issues in 30 days). The gh search flag syntax (--owner/--state/--closed) was caught by the real run, not the mocked unit tests. 100% coverage. Possible refinement: filter out release-tracking issues. Follow-on: 8c nightly job + publish (profile/README).