### PR TITLE
feat(vrg-gh): re-allow issue close for the USER agent

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -42,7 +42,13 @@ _DENIED_AGENT: dict[str, dict[str, str]] = {
         "merge": "PR merge requires a human maintainer.",
     },
     "issue": {
-        "close": "Issue close requires a human maintainer.",
+        # `issue close` is intentionally NOT denied here: closing is now
+        # automated (vrg-finalize-pr closes tasks, rollup closes epics) and
+        # documented as mechanical, so a manual USER close is safe and is the
+        # one genuinely useful case (repo migration). AUDIT stays barred from
+        # closing because `issue` is not in its allowlist at all (least
+        # privilege). `reopen` stays denied for agents — the lib path covers
+        # reopen-on-late-child. See issue #1966.
         "reopen": "Issue reopen requires a human maintainer.",
     },
 }

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -450,7 +450,6 @@ class TestAgentDenials:
     @pytest.mark.parametrize(
         ("top", "sub"),
         [
-            ("issue", "close"),
             ("issue", "reopen"),
             ("pr", "edit"),
             ("pr", "merge"),
@@ -477,8 +476,26 @@ class TestAgentDenials:
         args = mock_run.call_args[0][0]
         assert args[:3] == ["gh", "issue", "edit"]
 
-    def test_issue_close_says_human_maintainer(self, capsys: pytest.CaptureFixture[str]) -> None:
-        main(["issue", "close", "42"])
+    def test_issue_close_allowed_for_user_agent(self) -> None:
+        # Re-allowed for USER: closing is now automated and documented as
+        # mechanical, so a manual close is safe and useful (issue #1966).
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "close", "42"])
+        assert rc == 0
+        args = mock_run.call_args[0][0]
+        assert args[:3] == ["gh", "issue", "close"]
+
+    def test_issue_reopen_still_says_human_maintainer(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        main(["issue", "reopen", "42"])
         err = capsys.readouterr().err
         assert "human maintainer" in err.lower()
 
@@ -609,6 +626,8 @@ class TestAuditAllowlist:
             ("issue", "list"),
             ("issue", "create"),
             ("issue", "edit"),
+            ("issue", "close"),
+            ("issue", "reopen"),
             ("run", "list"),
             ("repo", "view"),
             ("label", "list"),


### PR DESCRIPTION
# Pull Request

## Summary

- Removes 'issue close' from the agent deny list so the USER identity can close issues directly, while keeping it denied for AUDIT (least privilege) and keeping 'issue reopen' denied for all agents.

## Issue Linkage

- Ref #1966

## Notes

- Closing is now automated (vrg-finalize-pr closes tasks, rollup closes epics) and documented as mechanical, resolving the original ambiguity. The automation uses the internal github lib (direct gh), which bypasses vrg-gh, so this only affects manual agent closes. AUDIT remains barred because 'issue' is not in its allowlist at all. Enables /vergil:migrate-repo to close done/stale/dup issues on batch approval. Tests: USER close allowed, USER reopen still denied, AUDIT close+reopen denied; vrg-validate green.