### PR TITLE
fix(container-cache): key the per-branch cache on the base image digest

### DIFF
--- a/docs/specs/2026-06-29-container-cache-staleness-design.md
+++ b/docs/specs/2026-06-29-container-cache-staleness-design.md
@@ -114,9 +114,12 @@ per machine/platform, which is all the cache key requires (caches are local).
 
 Because step 2 already pulled the base, `_build_cached_image`'s
 `docker create <base>` now builds from the fresh local base, closing the
-re-bake-stale-base gap. We additionally pass `--pull=always` (or equivalent) to
-`docker create` as belt-and-suspenders so the build is correct even if invoked
-without a preceding `resolve_base_digest`.
+re-bake-stale-base gap. We additionally pass `--pull=missing` to `docker create`
+as a safety net — pull only if the image is absent locally. We deliberately do
+**not** use `--pull=always`: an offline `create --pull=always` would fail even
+when a usable local copy exists, defeating the offline fallback. With
+`--pull=missing`, a present local base (always the case after `resolve_base_digest`
+ran) is used as-is, and an offline build never breaks on a registry it can't reach.
 
 ### 4. Placement
 

--- a/docs/specs/2026-06-29-container-cache-staleness-design.md
+++ b/docs/specs/2026-06-29-container-cache-staleness-design.md
@@ -1,0 +1,192 @@
+# Container cache staleness — base-digest-aware cache key
+
+- **Issue:** vergil-project/vergil-tooling#1973
+- **Date:** 2026-06-29
+- **Status:** Approved (design)
+
+## Problem
+
+`src/vergil_tooling/lib/container_cache.py` maintains a per-branch dev image with
+vergil-tooling and language dependencies pre-installed. The cached image is reused
+when its **cache key** matches. Today that key (`compute_cache_hash`) is a SHA-256
+over:
+
+- the repo's cache-sensitive dependency files (`uv.lock`, `go.sum`, `pom.xml`,
+  `Gemfile.lock`, `Cargo.lock`, plus `vergil.toml`), and
+- the repo directory name (as salt).
+
+It **never incorporates the identity of the base image** the cache was built from.
+The base is referenced by a moving tag (`…-base:latest` or a major tag). When
+`vergil-containers` republishes that tag — e.g. adding `ansible-lint` in v2.1.1 —
+the base image's content changes but the tag string does not, the dependency files
+do not, so the cache key is unchanged and the **stale cached image is reused
+indefinitely**.
+
+### Why `develop` is uniquely affected
+
+The cache tag is `{base_repo}:{base_tag}--{sanitized-branch}--{dep-hash}`. Two
+properties have to hold for an old cache to keep matching: a stable branch name and
+a stable dependency hash.
+
+- **Feature / worktree branches** have ever-changing names, so each new branch
+  lands in a fresh tag namespace with no prior cache → forced rebuild; and
+  `vrg-finalize-pr` removes them on merge. They self-heal.
+- **`develop`** is one permanent name, and its dependency files rarely change, so
+  both properties hold. The same cached image is reused for weeks across many
+  upstream image rebuilds. This is the trap.
+
+### Observed impact
+
+On the MQ Resiliency Lab for Linux repo, `vrg-validate` on `develop` failed during
+finalize with `FileNotFoundError: 'ansible-lint'`. The host `vrg-validate` now runs
+the ansible-lint check (vergil-tooling#1667), but the `develop` cache had been built
+from a base image predating ansible-lint (added in vergil-containers v2.1.1). New
+check code, old cached image.
+
+### Compounding gap
+
+`_build_cached_image` runs `docker create <base>` with **no `--pull`**, so even a
+forced rebuild can re-bake a stale *local* base image. The reuse path does no
+network at all, so a republished tag is never noticed.
+
+## Goals / non-goals
+
+**Goals**
+
+- A cached image is reused only if it was built from the base image currently
+  published under its tag.
+- When the base moves, the cache rebuilds **automatically** on the next container
+  run — no manual step, picked up the morning after a nightly central rebuild.
+- Detection uses a principled signal (the base image's content digest), not an
+  inventory of expected tools.
+- Offline / registry-unreachable runs degrade gracefully rather than breaking the
+  dev loop.
+
+**Non-goals**
+
+- Throttling the freshness check. We check on every container run for simplicity
+  (the user accepted the per-run cost). A timestamp-based throttle is a trivial
+  later addition if the overhead bites; explicitly out of scope here.
+- Probing the image for specific tools / an image capability manifest. Rejected as
+  brittle and tactical.
+- Changing the direct-run (non-cached) path, which already uses `--pull=always`.
+
+## Design
+
+### 1. Base digest in the cache key
+
+`compute_cache_hash` gains the base image's content digest as an input:
+
+```
+hash = sha256( sorted(dep file bytes) + base_digest + salt )[:8]
+```
+
+When the central image moves, the digest changes → the hash changes →
+`ensure_cached_image` finds the old `…--develop--<oldhash>` image, sees the suffix
+no longer matches the current hash, removes it, and rebuilds. **No new comparison
+logic and no tool list** — the existing "hash mismatch → rebuild" path does the
+work, and it is correct for any change to the base image (CVE patch, new tool,
+anything).
+
+### 2. Resolving the current base digest
+
+A new helper `resolve_base_digest(base_image, *, runtime) -> tuple[str, bool]`
+returns `(digest, verified)`:
+
+1. `docker pull <base_image>` with a bounded timeout. This refreshes the local copy
+   so a moved base is both **seen** and **available to rebuild from**. A pull of an
+   unchanged image is a cheap manifest check with no layer downloads.
+2. `docker image inspect <base_image> --format '{{.Id}}'` → the digest string.
+3. **Offline / registry-down:** if the pull fails but a local copy of the base
+   exists, inspect and use the **local** digest, return `verified=False`, and print
+   a one-line warning:
+   `warning: could not verify base image freshness (offline?); using local image`.
+4. If the pull fails and there is no local base, raise — nothing could run anyway.
+
+`pull` + `inspect` is chosen over `manifest inspect` because both work on docker and
+podman (the runtime is already auto-detected). `manifest inspect` is lighter but
+less portable; noted as a possible future optimization.
+
+The digest used in the key is the locally-resolved image `Id`. It is consistent
+per machine/platform, which is all the cache key requires (caches are local).
+
+### 3. Build-path fix
+
+Because step 2 already pulled the base, `_build_cached_image`'s
+`docker create <base>` now builds from the fresh local base, closing the
+re-bake-stale-base gap. We additionally pass `--pull=always` (or equivalent) to
+`docker create` as belt-and-suspenders so the build is correct even if invoked
+without a preceding `resolve_base_digest`.
+
+### 4. Placement
+
+All changes are contained in `container_cache.py`, threaded through the single
+chokepoint `ensure_cached_image`. Callers (`vrg-container-run`, `vrg-validate`, the
+validators) are unchanged.
+
+`vrg-container-cache status` (`bin/vrg_container_cache.py`) must compute its hash
+**identically to `ensure_cached_image`**. It currently calls
+`compute_cache_hash(files)` with no salt, while `ensure_cached_image` passes
+`salt=repo_root.name` — so `status` already computes a different hash than the one
+baked into the cached tag and its `current`/`stale` readout is unreliable today
+(independently of this bug). The fix aligns it to the same computation: the
+`repo_root.name` salt **and** the base digest (via `resolve_base_digest`). After
+this, `status` reports `stale` exactly when `ensure_cached_image` would rebuild —
+including when the base image has moved.
+
+## Data flow
+
+```
+ensure_cached_image(repo_root, lang, base_image)
+  files            = cache_sensitive_files(...)        # unchanged
+  base_digest, ok  = resolve_base_digest(base_image)   # NEW: pull + inspect
+  current_hash     = compute_cache_hash(files, base_digest, salt=repo_root.name)
+  existing         = find_cached_image(base_image, branch)
+    if existing and existing_hash == current_hash:  reuse
+    else:                                           rmi old (if any) + rebuild
+  rebuild uses the freshly-pulled base
+```
+
+## Error handling
+
+- **Registry unreachable, local base present:** warn, use local digest, continue
+  (`verified=False`). The dev loop never breaks because GHCR is down.
+- **Registry unreachable, no local base:** hard error (cannot run a container at
+  all).
+- **Pull timeout:** treated as registry-unreachable (above), via a bounded timeout
+  on the pull subprocess.
+- **`inspect` failure on a present image:** hard error (unexpected; surfaced, not
+  swallowed).
+
+No failure is silently swallowed; the only soft path is the explicit offline
+fallback, which warns.
+
+## Testing
+
+Existing tests already mock `subprocess.run` for runtime calls; these fit the same
+pattern.
+
+- `compute_cache_hash`: hash changes iff `base_digest` changes; stable when files
+  and digest are unchanged.
+- `resolve_base_digest`:
+  - pull succeeds → returns inspected digest, `verified=True`;
+  - pull fails, local image present → returns local digest, `verified=False`,
+    emits warning;
+  - pull fails, no local image → raises.
+- `ensure_cached_image`:
+  - base digest changed vs existing cache → old image removed, rebuild invoked;
+  - base digest same → existing image reused, no rebuild, no extra build calls;
+  - rebuild path pulls the base.
+- `vrg-container-cache status`: computes the same hash as `ensure_cached_image`
+  (salt + base digest); reports `stale` when the resolved base digest differs from
+  the cached image's hash (or when dep files differ), `current` otherwise. Add a
+  regression test that a current cache reports `current` (guards the prior
+  missing-salt inconsistency).
+
+## Rollout
+
+- No config or interface changes; purely internal to the cache layer.
+- First run after upgrade resolves the live base digest and rebuilds any cache that
+  was built from an older base — self-correcting on landing.
+- The MQ `develop` failure is resolved the next time `vrg-validate` runs there once
+  this ships (the rebuild picks up the ansible-lint-bearing base).

--- a/src/vergil_tooling/bin/vrg_container_cache.py
+++ b/src/vergil_tooling/bin/vrg_container_cache.py
@@ -27,6 +27,7 @@ from vergil_tooling.lib.container_cache import (
     compute_cache_hash,
     ensure_cached_image,
     find_cached_image,
+    resolve_base_digest,
 )
 
 
@@ -64,19 +65,22 @@ def _cmd_status(_args: argparse.Namespace, *, runtime: str) -> int:
     base = default_image(lang, fallback=True)
     branch = git.current_branch()
     existing = find_cached_image(base, branch, runtime=runtime)
+    files = cache_sensitive_files(repo_root, lang)
+
+    def _current_hash() -> str:
+        # Match ensure_cached_image exactly: salt (repo name) + base digest.
+        base_digest, _ = resolve_base_digest(base, runtime=runtime)
+        return compute_cache_hash(files, base_digest=base_digest, salt=repo_root.name)
+
     if existing is None:
         print("No cached image for this branch.")
-        files = cache_sensitive_files(repo_root, lang)
         if files:
-            current_hash = compute_cache_hash(files)
-            expected = cache_image_tag(base, branch, current_hash)
-            print(f"Expected tag: {expected}")
+            print(f"Expected tag: {cache_image_tag(base, branch, _current_hash())}")
         return 0
     print(f"Cached image: {existing[0]}")
     print(f"Hash:         {existing[1]}")
-    files = cache_sensitive_files(repo_root, lang)
     if files:
-        current_hash = compute_cache_hash(files)
+        current_hash = _current_hash()
         if current_hash == existing[1]:
             print("Status:       current")
         else:

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -108,11 +108,18 @@ def cache_sensitive_files(repo_root: Path, lang: str) -> list[Path]:
     return [repo_root / n for n in names if (repo_root / n).is_file()]
 
 
-def compute_cache_hash(files: list[Path], *, salt: str = "") -> str:
-    """SHA-256 over sorted file contents plus optional salt, first 8 hex chars."""
+def compute_cache_hash(files: list[Path], *, base_digest: str = "", salt: str = "") -> str:
+    """SHA-256 over sorted file contents, base image digest, and optional salt.
+
+    Folding ``base_digest`` (the content id of the base image the cache is built
+    from) into the key means a republished base tag yields a different hash, so the
+    stale cache is rebuilt instead of reused. Returns the first 8 hex chars.
+    """
     h = hashlib.sha256()
     for f in sorted(files):
         h.update(f.read_bytes())
+    if base_digest:
+        h.update(base_digest.encode())
     if salt:
         h.update(salt.encode())
     return h.hexdigest()[:8]

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.config import vrg_install_tag
@@ -17,6 +18,8 @@ if TYPE_CHECKING:
 _SELF_PROJECT_NAME = "vergil-tooling"
 
 _VRG_GIT_URL = "https://github.com/vergil-project/vergil-tooling"
+
+_PULL_TIMEOUT_SECONDS = 120
 
 _CACHE_FILES: dict[str, list[str]] = {
     "python": ["uv.lock", "vergil.toml"],
@@ -31,6 +34,56 @@ _DEFAULT_CACHE_FILES = ["vergil.toml"]
 def _warmup_command(lang: str) -> str:
     cmds = language_commands(lang, CheckKind.INSTALL)
     return " && ".join(" ".join(cmd) for cmd in cmds) if cmds else ""
+
+
+def _inspect_image_id(image: str, *, runtime: str) -> str | None:
+    """Return the local content id (``.Id``) of *image*, or None if absent."""
+    result = subprocess.run(  # noqa: S603
+        [runtime, "image", "inspect", image, "--format", "{{.Id}}"],  # noqa: S607
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, bool]:
+    """Resolve *base_image*'s content digest, refreshing it from the registry.
+
+    Pulls the base (so a moved tag is both detected and available to build from),
+    then inspects the local image id. Returns ``(digest, verified)`` where
+    ``verified`` is False when the pull failed and a previously-pulled local copy
+    was used instead. Raises ``RuntimeError`` when neither a pull nor a local
+    inspect yields a digest.
+    """
+    rt = runtime or detect_runtime()
+    pull_ok = True
+    try:
+        pull = subprocess.run(  # noqa: S603
+            [rt, "pull", base_image],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=_PULL_TIMEOUT_SECONDS,
+        )
+        pull_ok = pull.returncode == 0
+    except subprocess.TimeoutExpired:
+        pull_ok = False
+
+    digest = _inspect_image_id(base_image, runtime=rt)
+    if digest is None:
+        msg = (
+            f"Could not resolve base image '{base_image}': pull "
+            f"{'succeeded' if pull_ok else 'failed'} and no local copy is present."
+        )
+        raise RuntimeError(msg)
+    if not pull_ok:
+        print(
+            f"warning: could not verify base image freshness for '{base_image}' "
+            "(offline?); using local image",
+            file=sys.stderr,
+        )
+    return digest, pull_ok
 
 
 def _is_self_repo(repo_root: Path) -> bool:

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -257,7 +257,8 @@ def ensure_cached_image(
     from vergil_tooling.lib import git as _git
 
     branch = _git.current_branch()
-    current_hash = compute_cache_hash(files, salt=repo_root.name)
+    base_digest, _verified = resolve_base_digest(base_image, runtime=rt)
+    current_hash = compute_cache_hash(files, base_digest=base_digest, salt=repo_root.name)
     existing = find_cached_image(base_image, branch, runtime=rt)
 
     if existing is not None:

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -197,6 +197,10 @@ def _build_cached_image(
             rt,
             "create",
             f"--platform={container_platform()}",
+            # Use the freshly-pulled base (resolve_base_digest pulled it). Only pull
+            # here if it is somehow absent locally; never --pull=always, which would
+            # fail an offline build that has a usable local copy.
+            "--pull=missing",
             "-v",
             f"{repo_root}:/workspace",
             "-w",

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -176,11 +176,15 @@ def test_ensure_returns_existing_cache_on_hash_match(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text(_VALID_TOML)
     cached_tag = "ghcr.io/r/dev-go:1.26--feature-42--"
     files = cache_sensitive_files(tmp_path, "go")
-    expected_hash = compute_cache_hash(files, salt=tmp_path.name)
+    expected_hash = compute_cache_hash(files, base_digest="sha256:abc", salt=tmp_path.name)
     full_tag = cached_tag + expected_hash
 
     with (
         patch("vergil_tooling.lib.git.current_branch") as mock_branch,
+        patch(
+            "vergil_tooling.lib.container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
         patch(
             "vergil_tooling.lib.container_cache.find_cached_image",
             return_value=(full_tag, expected_hash),
@@ -198,6 +202,10 @@ def test_ensure_rebuilds_on_hash_mismatch(tmp_path: Path) -> None:
 
     with (
         patch("vergil_tooling.lib.git.current_branch") as mock_branch,
+        patch(
+            "vergil_tooling.lib.container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
         patch(
             "vergil_tooling.lib.container_cache.find_cached_image",
             return_value=(stale_tag, "oldold00"),
@@ -226,6 +234,10 @@ def test_ensure_builds_on_cache_miss(tmp_path: Path) -> None:
     with (
         patch("vergil_tooling.lib.git.current_branch") as mock_branch,
         patch(
+            "vergil_tooling.lib.container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
+        patch(
             "vergil_tooling.lib.container_cache.find_cached_image",
             return_value=None,
         ),
@@ -238,6 +250,40 @@ def test_ensure_builds_on_cache_miss(tmp_path: Path) -> None:
         result = ensure_cached_image(tmp_path, "go", "ghcr.io/r/dev-go:1.26", runtime="docker")
     assert result == "new:tag"
     mock_build.assert_called_once()
+
+
+def test_ensure_rebuilds_when_base_digest_changes(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    files = cache_sensitive_files(tmp_path, "go")
+    # The on-disk image was cached before digest-awareness: its hash was computed
+    # WITHOUT any base digest. With the same dep files, the pre-digest code would
+    # recompute that exact hash and reuse it. Once the base digest is keyed in, the
+    # hash differs and the stale image must be rebuilt instead.
+    legacy_hash = compute_cache_hash(files, salt=tmp_path.name)
+    stale_tag = f"ghcr.io/r/dev-go:1.26--feature-42--{legacy_hash}"
+
+    with (
+        patch("vergil_tooling.lib.git.current_branch", return_value="feature/42"),
+        patch(
+            "vergil_tooling.lib.container_cache.resolve_base_digest",
+            return_value=("sha256:NEW", True),
+        ),
+        patch(
+            "vergil_tooling.lib.container_cache.find_cached_image",
+            return_value=(stale_tag, legacy_hash),
+        ),
+        patch("vergil_tooling.lib.container_cache.subprocess.run") as mock_run,
+        patch(
+            "vergil_tooling.lib.container_cache._build_cached_image",
+            return_value="rebuilt:tag",
+        ) as mock_build,
+    ):
+        result = ensure_cached_image(tmp_path, "go", "ghcr.io/r/dev-go:1.26", runtime="docker")
+
+    assert result == "rebuilt:tag"
+    mock_build.assert_called_once()
+    # The stale image was removed.
+    assert stale_tag in mock_run.call_args[0][0]
 
 
 # -- clean_branch_images ------------------------------------------------------
@@ -439,6 +485,10 @@ def test_ensure_python_builds_cached_image(tmp_path: Path) -> None:
 
     with (
         patch("vergil_tooling.lib.git.current_branch", return_value="develop"),
+        patch(
+            "vergil_tooling.lib.container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
         patch("vergil_tooling.lib.container_cache.find_cached_image", return_value=None),
         patch(
             "vergil_tooling.lib.container_cache._build_cached_image",
@@ -487,6 +537,10 @@ def test_ensure_repo_name_included_in_hash(tmp_path: Path) -> None:
 
     with (
         patch("vergil_tooling.lib.git.current_branch", return_value="develop"),
+        patch(
+            "vergil_tooling.lib.container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
         patch("vergil_tooling.lib.container_cache.find_cached_image", return_value=None),
         patch("vergil_tooling.lib.container_cache._build_cached_image", side_effect=capture_build),
     ):

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -605,6 +605,27 @@ def test_build_cached_image_self_repo_skips_uv_install(tmp_path: Path) -> None:
     assert "uv sync --frozen --group dev" in setup_cmd
 
 
+# -- _build_cached_image pull policy ------------------------------------------
+
+
+def test_build_cached_image_uses_pull_missing(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    create = MagicMock(returncode=0, stdout="cid123\n")
+    start = MagicMock(returncode=0)
+    commit = MagicMock(returncode=0)
+    rm = MagicMock(returncode=0)
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[create, start, commit, rm],
+    ) as mock_run:
+        _build_cached_image(
+            tmp_path, "go", "ghcr.io/r/dev-go:1.26", "target:tag", runtime="docker"
+        )
+    create_argv = mock_run.call_args_list[0][0][0]
+    assert "create" in create_argv
+    assert "--pull=missing" in create_argv
+
+
 # -- compute_cache_hash base digest -------------------------------------------
 
 

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -17,10 +17,15 @@ from vergil_tooling.lib.container_cache import (
     compute_cache_hash,
     ensure_cached_image,
     find_cached_image,
+    resolve_base_digest,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _completed(returncode: int = 0, stdout: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout)
 
 _VALID_TOML = """\
 [project]
@@ -544,3 +549,57 @@ def test_build_cached_image_self_repo_skips_uv_install(tmp_path: Path) -> None:
     setup_cmd = create_cmd[-1]
     assert "uv tool install" not in setup_cmd
     assert "uv sync --frozen --group dev" in setup_cmd
+
+
+# -- resolve_base_digest ------------------------------------------------------
+
+
+def test_resolve_base_digest_pull_ok() -> None:
+    pull = _completed(0)
+    inspect = _completed(0, "sha256:abc123\n")
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[pull, inspect],
+    ):
+        digest, verified = resolve_base_digest("img:1", runtime="docker")
+    assert digest == "sha256:abc123"
+    assert verified is True
+
+
+def test_resolve_base_digest_offline_uses_local(capsys: pytest.CaptureFixture[str]) -> None:
+    pull = _completed(1)  # pull failed (offline)
+    inspect = _completed(0, "sha256:local9\n")  # local copy present
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[pull, inspect],
+    ):
+        digest, verified = resolve_base_digest("img:1", runtime="docker")
+    assert digest == "sha256:local9"
+    assert verified is False
+    assert "could not verify base image freshness" in capsys.readouterr().err
+
+
+def test_resolve_base_digest_pull_timeout_uses_local() -> None:
+    import subprocess as _sp
+
+    inspect = _completed(0, "sha256:local9\n")
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[_sp.TimeoutExpired(cmd="pull", timeout=1), inspect],
+    ):
+        digest, verified = resolve_base_digest("img:1", runtime="docker")
+    assert digest == "sha256:local9"
+    assert verified is False
+
+
+def test_resolve_base_digest_no_image_raises() -> None:
+    pull = _completed(1)
+    inspect = _completed(1, "")  # no local copy either
+    with (
+        patch(
+            "vergil_tooling.lib.container_cache.subprocess.run",
+            side_effect=[pull, inspect],
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        resolve_base_digest("img:1", runtime="docker")

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 def _completed(returncode: int = 0, stdout: str = "") -> MagicMock:
     return MagicMock(returncode=returncode, stdout=stdout)
 
+
 _VALID_TOML = """\
 [project]
 repository-type = "library"
@@ -618,9 +619,7 @@ def test_build_cached_image_uses_pull_missing(tmp_path: Path) -> None:
         "vergil_tooling.lib.container_cache.subprocess.run",
         side_effect=[create, start, commit, rm],
     ) as mock_run:
-        _build_cached_image(
-            tmp_path, "go", "ghcr.io/r/dev-go:1.26", "target:tag", runtime="docker"
-        )
+        _build_cached_image(tmp_path, "go", "ghcr.io/r/dev-go:1.26", "target:tag", runtime="docker")
     create_argv = mock_run.call_args_list[0][0][0]
     assert "create" in create_argv
     assert "--pull=missing" in create_argv

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -551,6 +551,25 @@ def test_build_cached_image_self_repo_skips_uv_install(tmp_path: Path) -> None:
     assert "uv sync --frozen --group dev" in setup_cmd
 
 
+# -- compute_cache_hash base digest -------------------------------------------
+
+
+def test_compute_cache_hash_changes_with_base_digest(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text("[vergil-tooling]\n")
+    files = cache_sensitive_files(tmp_path, "go")
+    h1 = compute_cache_hash(files, base_digest="sha256:aaa", salt="r")
+    h2 = compute_cache_hash(files, base_digest="sha256:bbb", salt="r")
+    assert h1 != h2
+
+
+def test_compute_cache_hash_stable_for_same_inputs(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text("[vergil-tooling]\n")
+    files = cache_sensitive_files(tmp_path, "go")
+    h1 = compute_cache_hash(files, base_digest="sha256:aaa", salt="r")
+    h2 = compute_cache_hash(files, base_digest="sha256:aaa", salt="r")
+    assert h1 == h2
+
+
 # -- resolve_base_digest ------------------------------------------------------
 
 

--- a/tests/vergil_tooling/test_vrg_container_cache.py
+++ b/tests/vergil_tooling/test_vrg_container_cache.py
@@ -152,6 +152,10 @@ def test_status_no_cache_with_expected_tag(
             return_value="feature/42",
         ),
         patch("vergil_tooling.bin.vrg_container_cache.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
         patch("vergil_tooling.bin.vrg_container_cache.find_cached_image", return_value=None),
         patch("vergil_tooling.bin.vrg_container_cache.detect_language", return_value="go"),
         patch(
@@ -169,7 +173,9 @@ def test_status_current(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
     from vergil_tooling.lib.container_cache import cache_sensitive_files, compute_cache_hash
 
     files = cache_sensitive_files(tmp_path, "go")
-    h = compute_cache_hash(files)
+    # status must compute the hash the same way ensure_cached_image does:
+    # salt (repo name) + base digest.
+    h = compute_cache_hash(files, base_digest="sha256:abc", salt=tmp_path.name)
     cached = (f"ghcr.io/r/dev-go:1.26--feature-42--{h}", h)
     with (
         patch("vergil_tooling.bin.vrg_container_cache.git.repo_root", return_value=tmp_path),
@@ -178,6 +184,10 @@ def test_status_current(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
             return_value="feature/42",
         ),
         patch("vergil_tooling.bin.vrg_container_cache.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
         patch("vergil_tooling.bin.vrg_container_cache.find_cached_image", return_value=cached),
         patch("vergil_tooling.bin.vrg_container_cache.detect_language", return_value="go"),
         patch(
@@ -199,6 +209,42 @@ def test_status_stale(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> Non
             return_value="feature/42",
         ),
         patch("vergil_tooling.bin.vrg_container_cache.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_cache.resolve_base_digest",
+            return_value=("sha256:abc", True),
+        ),
+        patch("vergil_tooling.bin.vrg_container_cache.find_cached_image", return_value=cached),
+        patch("vergil_tooling.bin.vrg_container_cache.detect_language", return_value="go"),
+        patch(
+            "vergil_tooling.bin.vrg_container_cache.default_image",
+            return_value="ghcr.io/r/dev-go:1.26",
+        ),
+    ):
+        assert main(["status"]) == 0
+    assert "stale" in capsys.readouterr().out
+
+
+def test_status_stale_when_base_digest_changes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    from vergil_tooling.lib.container_cache import cache_sensitive_files, compute_cache_hash
+
+    files = cache_sensitive_files(tmp_path, "go")
+    # Cache built against an OLD base digest; the live base now has a NEW digest.
+    old_hash = compute_cache_hash(files, base_digest="sha256:OLD", salt=tmp_path.name)
+    cached = (f"ghcr.io/r/dev-go:1.26--feature-42--{old_hash}", old_hash)
+    with (
+        patch("vergil_tooling.bin.vrg_container_cache.git.repo_root", return_value=tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_container_cache.git.current_branch",
+            return_value="feature/42",
+        ),
+        patch("vergil_tooling.bin.vrg_container_cache.detect_runtime", return_value="docker"),
+        patch(
+            "vergil_tooling.bin.vrg_container_cache.resolve_base_digest",
+            return_value=("sha256:NEW", True),
+        ),
         patch("vergil_tooling.bin.vrg_container_cache.find_cached_image", return_value=cached),
         patch("vergil_tooling.bin.vrg_container_cache.detect_language", return_value="go"),
         patch(


### PR DESCRIPTION
# Pull Request

## Summary

- Folds the base image's content digest into the cache key so a republished base tag rebuilds the cache automatically, fixing long-lived develop caches that silently ran a stale image (the ansible-lint FileNotFoundError on MQ Resiliency Lab).

## Issue Linkage

- Ref #1973

## Notes

- Approach (full design in docs/specs/2026-06-29-container-cache-staleness-design.md): a new resolve_base_digest helper pulls the base each run (cheap manifest check when unchanged) and inspects its content id, with a graceful offline fallback — pull failure with a local copy present warns and proceeds (verified=False), no local copy raises. compute_cache_hash folds the digest in, so the existing hash-mismatch->rebuild path fires on any base change. _build_cached_image now passes --pull=missing (deliberately NOT --pull=always, which would break the offline fallback). vrg-container-cache status is aligned to the identical hash computation (it previously omitted the repo-name salt, an independent latent inconsistency). Checks every container run per agreed design; a daily throttle is a trivial future add if overhead bites. 61 unit tests green; vrg-validate green. After this ships, the MQ develop cache self-heals on its next run.