### PR TITLE
chore(repo-config): bridge marketplace-ref audit to single-channel (main) model

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -171,10 +171,17 @@ def _print_local_diff(diff: ConfigDiff) -> None:
     """Print local config audit results."""
     if diff.is_compliant():
         print("  local: compliant")
-        return
-    print(f"  local: NON-COMPLIANT ({len(diff.items)} issues)")
-    for item in diff.items:
-        print(_format_item(item))
+    else:
+        print(f"  local: NON-COMPLIANT ({len(diff.items)} issues)")
+        for item in diff.items:
+            print(_format_item(item))
+    _print_warnings(diff)
+
+
+def _print_warnings(diff: ConfigDiff) -> None:
+    """Print advisory warnings (non-compliance-affecting) for a diff."""
+    for warning in diff.warnings:
+        print(f"    WARNING: {warning}")
 
 
 def _print_diff(repo: str, diff: ConfigDiff) -> None:
@@ -192,6 +199,7 @@ def _print_diff(repo: str, diff: ConfigDiff) -> None:
             )
         elif field_name.endswith(".bypass_actors"):
             print(f"    {field_name}: skipped (not visible with GitHub App credentials)")
+    _print_warnings(diff)
 
 
 def _apply_repo(repo: str, config: VergilConfig) -> list[str]:

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -649,8 +649,11 @@ class DiffItem:
 class ConfigDiff:
     items: list[DiffItem] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
     def is_compliant(self) -> bool:
+        # Warnings are advisory (e.g. a deprecated-but-tolerated marketplace
+        # ref mid-migration, #1974) and deliberately do not affect compliance.
         return len(self.items) == 0
 
 

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -14,8 +14,9 @@ from vergil_tooling.lib.config import ConfigError, read_config
 from vergil_tooling.lib.github_config import ConfigDiff, DiffItem
 from vergil_tooling.lib.update_deps.context import UpdateDepsError
 from vergil_tooling.lib.vergil_refs import (
+    EXPECTED_MARKETPLACE_REF,
     MARKETPLACE_NAME,
-    expected_claude_ref,
+    is_deprecated_marketplace_ref,
     iter_workflow_refs,
     read_source_version,
 )
@@ -48,12 +49,13 @@ def _load_settings_template() -> dict[str, Any]:
 def audit_local_config(repo_root: Path) -> ConfigDiff:
     """Run all local config checks against a repo root directory."""
     items: list[DiffItem] = []
+    warnings: list[str] = []
     _check_vergil_toml(repo_root, items)
     _check_hook_guard_shim(repo_root, items)
     _check_claude_md(repo_root, items)
-    _check_claude_settings(repo_root, items)
+    _check_claude_settings(repo_root, items, warnings)
     _check_workflow_refs(repo_root, items)
-    return ConfigDiff(items=items)
+    return ConfigDiff(items=items, warnings=warnings)
 
 
 def _check_vergil_toml(repo_root: Path, items: list[DiffItem]) -> None:
@@ -202,7 +204,7 @@ def _check_hook_guard_shim(repo_root: Path, items: list[DiffItem]) -> None:
         )
 
 
-def _check_claude_settings(repo_root: Path, items: list[DiffItem]) -> None:
+def _check_claude_settings(repo_root: Path, items: list[DiffItem], warnings: list[str]) -> None:
     settings_path = repo_root / ".claude" / "settings.json"
     if not settings_path.is_file():
         items.append(
@@ -237,7 +239,7 @@ def _check_claude_settings(repo_root: Path, items: list[DiffItem]) -> None:
         return
 
     template = _load_settings_template()
-    _check_marketplace_ref(repo_root, raw, template, items)
+    _check_marketplace_ref(raw, template, items, warnings)
     _check_settings_section(
         raw,
         template,
@@ -248,17 +250,21 @@ def _check_claude_settings(repo_root: Path, items: list[DiffItem]) -> None:
 
 
 def _check_marketplace_ref(
-    repo_root: Path,
     raw: dict[str, Any],
     template: dict[str, Any],
     items: list[DiffItem],
+    warnings: list[str],
 ) -> None:
-    """Assert the marketplace matches the template (except its version-derived
-    ``source.ref``) and carries the expected ref.
+    """Assert the marketplace matches the template (except its ``source.ref``)
+    and carries the expected ref.
 
-    The ref is ``develop`` for the marketplace source repo, else the version
-    from ``vergil.toml``. Everything else under the entry must equal the
-    canonical template, so a wrong repo or source kind is still caught.
+    Under the single-channel model (#1974) the ref is ``main`` for *every*
+    repo. During the bridge period a repo still carrying a deprecated old ref
+    (``develop`` or a version tag) emits a deprecation warning rather than a
+    hard failure, so not-yet-migrated repos keep passing while they are swept
+    one by one. Any other ref — or a missing one — is a hard failure.
+    Everything else under the entry must equal the canonical template, so a
+    wrong repo or source kind is still caught.
     """
     expected_source = (
         template.get("extraKnownMarketplaces", {}).get(MARKETPLACE_NAME, {}).get("source", {})
@@ -294,19 +300,23 @@ def _check_marketplace_ref(
             )
         )
         return
-    try:
-        expected_ref = expected_claude_ref(repo_root)
-    except (UpdateDepsError, OSError, ValueError):
-        return  # vergil.toml problems are reported by _check_vergil_toml
     actual_ref = source.get("ref")
-    if actual_ref != expected_ref:
-        items.append(
-            DiffItem(
-                field="local.claude_settings.marketplace_ref",
-                expected=f"ref = {expected_ref}",
-                actual=f"ref = {actual_ref}",
-            )
+    if actual_ref == EXPECTED_MARKETPLACE_REF:
+        return
+    if isinstance(actual_ref, str) and is_deprecated_marketplace_ref(actual_ref):
+        warnings.append(
+            f"{MARKETPLACE_NAME} source.ref = {actual_ref!r} is deprecated. "
+            f"The plugin now has a single released channel; pin it at "
+            f"{EXPECTED_MARKETPLACE_REF!r} in .claude/settings.json (#1974)."
         )
+        return
+    items.append(
+        DiffItem(
+            field="local.claude_settings.marketplace_ref",
+            expected=f"ref = {EXPECTED_MARKETPLACE_REF}",
+            actual=f"ref = {actual_ref}",
+        )
+    )
 
 
 def _check_workflow_refs(repo_root: Path, items: list[DiffItem]) -> None:

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from vergil_tooling.lib import git, github, repo_config
 from vergil_tooling.lib.config import _ENUMS
+from vergil_tooling.lib.vergil_refs import EXPECTED_MARKETPLACE_REF
 
 _CHECKPOINT_RE = re.compile(r"chore\(init\): step (\d+) -")
 
@@ -179,15 +180,16 @@ def _load_data_file(filename: str) -> str:
     return ref.read_text(encoding="utf-8")
 
 
-def render_claude_settings(vergil_version: str) -> str:
+def render_claude_settings() -> str:
     """Return the .claude/settings.json text with the marketplace ref seeded.
 
-    The packaged template is ref-less; a consuming repo pins the marketplace to
-    the same vergil version it declares in vergil.toml.
+    The packaged template is ref-less; under the single-channel model (#1974)
+    every repo pins the marketplace at ``main``, the plugin's one released
+    channel.
     """
     data = json.loads(_load_data_file("claude_settings.json"))
     market = data["extraKnownMarketplaces"]["vergil-marketplace"]
-    market["source"]["ref"] = vergil_version
+    market["source"]["ref"] = EXPECTED_MARKETPLACE_REF
     return json.dumps(data, indent=2) + "\n"
 
 
@@ -783,8 +785,8 @@ def step_scaffold_config_files(ctx: RepoInitContext) -> None:
     # .claude/settings.json
     claude_dir = wd / ".claude"
     claude_dir.mkdir(exist_ok=True)
-    # marketplace ref seeded from the chosen vergil version (consumer repos)
-    (claude_dir / "settings.json").write_text(render_claude_settings(ctx.vergil_version))
+    # marketplace ref seeded at the single released channel (main)
+    (claude_dir / "settings.json").write_text(render_claude_settings())
 
     # .claude/hooks/guard.sh
     hooks_dir = claude_dir / "hooks"

--- a/src/vergil_tooling/lib/update_deps/updaters/vergil_eco.py
+++ b/src/vergil_tooling/lib/update_deps/updaters/vergil_eco.py
@@ -1,10 +1,11 @@
 """Vergil ecosystem updater: normalize internal refs, optionally bump the version.
 
 The source of truth is ``[dependencies].vergil`` in ``vergil.toml`` (see
-``vergil_tooling.lib.vergil_refs``). Every secondary reference — workflow
-``uses: vergil-*/...@vX.Y`` and the Claude marketplace ref — must match it.
-``normalize`` rewrites drifting refs to the source-of-truth version; ``bump``
-first rewrites the source of truth, then normalizes.
+``vergil_tooling.lib.vergil_refs``). Workflow pins (``uses: vergil-*/...@vX.Y``)
+must match it. The Claude marketplace ref is decoupled: under the single-channel
+model (#1974) it is always ``main``, the plugin's one released channel, never a
+version. ``normalize`` rewrites drifting refs; ``bump`` first rewrites the
+source of truth, then normalizes.
 """
 
 from __future__ import annotations
@@ -16,9 +17,9 @@ from vergil_tooling.lib.update_deps.updater import UpdateResult
 from vergil_tooling.lib.vergil_refs import (
     _REF_RE,
     _SOURCE_RE,
+    EXPECTED_MARKETPLACE_REF,
     MARKETPLACE_NAME,
     format_version,
-    is_marketplace_source_repo,
     read_source_version,
 )
 
@@ -66,7 +67,7 @@ def normalize_refs(base: Path, target: str) -> list[Path]:
 def normalize_claude_ref(base: Path, target: str) -> Path | None:
     """Set the marketplace ``source.ref`` in ``.claude/settings.json`` to *target*.
 
-    *target* is the derived ``vX.Y`` (or ``develop`` for the source repo). The
+    *target* is the single released channel ``main`` (#1974). The
     file is edited structurally (parsed JSON, re-dumped at indent 2) because the
     ref may need to be *inserted* where none exists — a regex cannot do that
     safely. Returns the path if changed, else ``None``. A missing file or
@@ -102,12 +103,11 @@ class VergilUpdater:
 
     def apply(self, ctx: UpdateDepsContext) -> UpdateResult:
         base = _base(ctx)
-        is_self = is_marketplace_source_repo(base)
         if ctx.vergil_bump is not None:
             target = format_version(ctx.vergil_bump)
             bumped = set_source_version(base, target)
             normalized = normalize_refs(base, target)
-            claude = normalize_claude_ref(base, "develop" if is_self else target)
+            claude = normalize_claude_ref(base, EXPECTED_MARKETPLACE_REF)
             return UpdateResult(
                 updater=self.name,
                 changed=bumped or bool(normalized) or claude is not None,
@@ -116,7 +116,7 @@ class VergilUpdater:
             )
         target = read_source_version(base)
         normalized = normalize_refs(base, target)
-        claude = normalize_claude_ref(base, "develop" if is_self else target)
+        claude = normalize_claude_ref(base, EXPECTED_MARKETPLACE_REF)
         changed = bool(normalized) or claude is not None
         return UpdateResult(
             updater=self.name,

--- a/src/vergil_tooling/lib/vergil_refs.py
+++ b/src/vergil_tooling/lib/vergil_refs.py
@@ -1,11 +1,13 @@
 """Shared derivation of vergil-ecosystem version references.
 
-The source of truth is ``[dependencies].vergil`` in ``vergil.toml``. Every
-derived reference — reusable-workflow pins and the Claude plugin marketplace
-ref — must equal the version computed from it. The marketplace source repo
-(the plugin repo itself, identified by ``.claude-plugin/marketplace.json``) is
-exempt: its marketplace ref is ``develop`` so plugin development dogfoods the
-latest in-progress plugin.
+The source of truth is ``[dependencies].vergil`` in ``vergil.toml``. The
+reusable-workflow pins must equal the version computed from it. The Claude
+plugin marketplace ref is the exception: under the single-channel distribution
+model (epic vergil-project/.github#45) the plugin has exactly one released
+channel on ``main``, so *every* repo — consumers and the plugin source repo
+alike — pins the marketplace at ``main``. The old model (source repo on
+``develop``, consumers on the version tag) is deprecated; a repo still carrying
+one of those refs warns-then-enforces toward ``main`` (#1974).
 
 This module holds the pure derivation and read helpers shared by the
 update_deps writer (``vergil_eco``) and the repo_config auditor, so the two can
@@ -38,6 +40,25 @@ _VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)$")
 #: The marketplace name keyed under ``extraKnownMarketplaces``.
 MARKETPLACE_NAME = "vergil-marketplace"
 
+#: The single released channel every repo pins the marketplace at. Under the
+#: single-channel model (#1974) there is no per-repo or source-repo variation.
+EXPECTED_MARKETPLACE_REF = "main"
+
+#: A pre-single-channel marketplace ref: a bare version (``2.1``, ``2.0.7``) or
+#: a ``vX.Y[.Z]`` tag. ``develop`` is handled separately in
+#: ``is_deprecated_marketplace_ref``.
+_VERSION_REF_RE = re.compile(r"^v?\d+\.\d+(?:\.\d+)?$")
+
+
+def is_deprecated_marketplace_ref(ref: str) -> bool:
+    """True if *ref* is a pre-single-channel marketplace ref.
+
+    The old model pinned the source repo at ``develop`` and consumers at the
+    version tag. Either earns a deprecation warning (not a hard failure) during
+    the bridge period while repos migrate to ``main`` (#1974).
+    """
+    return ref == "develop" or bool(_VERSION_REF_RE.match(ref))
+
 
 def format_version(raw: str) -> str:
     """Normalize a user-supplied version (``2.2`` or ``v2.2``) to ``vX.Y``."""
@@ -64,22 +85,6 @@ def read_source_version(base: Path) -> str:
             message="vergil.toml [dependencies].vergil not found.",
         ) from exc
     return value
-
-
-def is_marketplace_source_repo(base: Path) -> bool:
-    """True if *base* is the plugin/marketplace source repo (exempt → develop)."""
-    return (base / ".claude-plugin" / "marketplace.json").is_file()
-
-
-def expected_claude_ref(base: Path) -> str:
-    """The marketplace ref *base* should carry.
-
-    ``develop`` for the marketplace source repo, else the derived version from
-    ``vergil.toml``.
-    """
-    if is_marketplace_source_repo(base):
-        return "develop"
-    return read_source_version(base)
 
 
 def iter_workflow_refs(base: Path) -> Iterator[tuple[Path, str]]:

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.repo_config import audit_local_config
+
+if TYPE_CHECKING:
+    from vergil_tooling.lib.github_config import ConfigDiff
 
 _MINIMAL_VERGIL_TOML = """\
 [project]
@@ -238,6 +242,8 @@ _MINIMAL_SETTINGS = {
             "source": {
                 "source": "github",
                 "repo": "vergil-project/vergil-claude-plugin",
+                # single-channel model (#1974): a compliant repo pins main
+                "ref": "main",
             }
         }
     },
@@ -245,6 +251,18 @@ _MINIMAL_SETTINGS = {
         "vergil@vergil-marketplace": True,
     },
 }
+
+
+def _template_marketplaces_with_main() -> dict:
+    """The packaged (ref-less) template marketplaces with ``ref: main`` seeded.
+
+    The shipped template carries no ref; repo_init seeds it. A repo is only
+    compliant once the ref is pinned, so compliant-settings tests add it here.
+    """
+    market = json.loads(json.dumps(_SETTINGS_TEMPLATE["extraKnownMarketplaces"]))
+    market["vergil-marketplace"]["source"]["ref"] = "main"
+    return market
+
 
 _SETTINGS_TEMPLATE_PATH = (
     Path(__file__).resolve().parents[2] / "src" / "vergil_tooling" / "data" / "claude_settings.json"
@@ -338,7 +356,7 @@ class TestClaudeSettings:
 
     def test_canonical_template_sections_compliant(self, tmp_path: Path) -> None:
         settings = {
-            "extraKnownMarketplaces": _SETTINGS_TEMPLATE["extraKnownMarketplaces"],
+            "extraKnownMarketplaces": _template_marketplaces_with_main(),
             "enabledPlugins": _SETTINGS_TEMPLATE["enabledPlugins"],
         }
         _write_settings(tmp_path, settings)
@@ -351,7 +369,7 @@ class TestClaudeSettings:
     def test_extra_entries_allowed(self, tmp_path: Path) -> None:
         settings = {
             "extraKnownMarketplaces": {
-                **_SETTINGS_TEMPLATE["extraKnownMarketplaces"],
+                **_template_marketplaces_with_main(),
                 "other-marketplace": {"source": {"source": "github", "repo": "other/repo"}},
             },
             "enabledPlugins": {
@@ -426,8 +444,8 @@ def _write_compliant_repo(root: Path) -> None:
                 "source": {
                     "source": "github",
                     "repo": "vergil-project/vergil-claude-plugin",
-                    # ref must match _MINIMAL_VERGIL_TOML's [dependencies].vergil
-                    "ref": "v2.0.7",
+                    # single-channel model (#1974): every repo pins main
+                    "ref": "main",
                 }
             }
         },
@@ -457,11 +475,10 @@ class TestMarketplaceRef:
         self,
         base: Path,
         *,
-        version: str,
         ref: str | None,
         self_repo: bool = False,
     ) -> None:
-        (base / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML_VER.format(version=version))
+        (base / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML_VER.format(version="v2.1"))
         if self_repo:
             (base / ".claude-plugin").mkdir()
             (base / ".claude-plugin" / "marketplace.json").write_text("{}")
@@ -478,32 +495,66 @@ class TestMarketplaceRef:
         (claude / "hooks").mkdir(parents=True, exist_ok=True)
         (claude / "hooks" / "guard.sh").write_text("#!/bin/sh\n")
 
-    def test_consumer_ref_matches(self, tmp_path: Path) -> None:
-        self._write(tmp_path, version="v2.0", ref="v2.0")
-        diff = audit_local_config(tmp_path)
-        assert not [i for i in diff.items if "marketplace_ref" in i.field]
+    @staticmethod
+    def _ref_items(diff: ConfigDiff) -> list:
+        return [i for i in diff.items if i.field == "local.claude_settings.marketplace_ref"]
 
-    def test_consumer_ref_missing_flagged(self, tmp_path: Path) -> None:
-        self._write(tmp_path, version="v2.0", ref=None)
+    def test_main_is_compliant(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ref="main")
         diff = audit_local_config(tmp_path)
-        flagged = [i for i in diff.items if i.field == "local.claude_settings.marketplace_ref"]
+        assert not self._ref_items(diff)
+        assert not diff.warnings
+
+    def test_deprecated_develop_warns(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ref="develop")
+        diff = audit_local_config(tmp_path)
+        assert not self._ref_items(diff)
+        assert any("develop" in w for w in diff.warnings)
+
+    def test_deprecated_version_warns(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ref="v2.0")
+        diff = audit_local_config(tmp_path)
+        assert not self._ref_items(diff)
+        assert any("v2.0" in w for w in diff.warnings)
+
+    def test_deprecated_ref_keeps_repo_compliant(self, tmp_path: Path) -> None:
+        # The whole point of the bridge: an otherwise-compliant repo that has
+        # not yet migrated its marketplace ref still passes (warning only).
+        _write_compliant_repo(tmp_path)
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        settings["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] = "develop"
+        settings_path.write_text(json.dumps(settings))
+        diff = audit_local_config(tmp_path)
+        assert diff.is_compliant(), [f"{i.field}: {i.actual}" for i in diff.items]
+        assert any("develop" in w for w in diff.warnings)
+
+    def test_missing_ref_flagged(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ref=None)
+        diff = audit_local_config(tmp_path)
+        flagged = self._ref_items(diff)
         assert len(flagged) == 1
-        assert "v2.0" in str(flagged[0].expected)
+        assert "main" in str(flagged[0].expected)
+        assert not diff.warnings
 
-    def test_consumer_ref_wrong_flagged(self, tmp_path: Path) -> None:
-        self._write(tmp_path, version="v2.1", ref="v2.0")
+    def test_unknown_ref_flagged(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ref="some-feature-branch")
         diff = audit_local_config(tmp_path)
-        assert [i for i in diff.items if i.field == "local.claude_settings.marketplace_ref"]
+        assert self._ref_items(diff)
+        assert not diff.warnings
 
-    def test_self_repo_requires_develop(self, tmp_path: Path) -> None:
-        self._write(tmp_path, version="v2.1", ref="develop", self_repo=True)
+    def test_self_repo_main_is_compliant(self, tmp_path: Path) -> None:
+        # No source-repo exemption anymore: the plugin repo also pins main.
+        self._write(tmp_path, ref="main", self_repo=True)
         diff = audit_local_config(tmp_path)
-        assert not [i for i in diff.items if "marketplace_ref" in i.field]
+        assert not self._ref_items(diff)
+        assert not diff.warnings
 
-    def test_self_repo_version_ref_flagged(self, tmp_path: Path) -> None:
-        self._write(tmp_path, version="v2.1", ref="v2.1", self_repo=True)
+    def test_self_repo_develop_warns(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ref="develop", self_repo=True)
         diff = audit_local_config(tmp_path)
-        assert [i for i in diff.items if i.field == "local.claude_settings.marketplace_ref"]
+        assert not self._ref_items(diff)
+        assert any("develop" in w for w in diff.warnings)
 
 
 class TestWorkflowRefs:

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -1244,18 +1244,12 @@ class TestRunWizard:
             run_wizard(ctx)
 
 
-def test_render_claude_settings_injects_ref() -> None:
-    text = render_claude_settings("v2.1")
+def test_render_claude_settings_seeds_main() -> None:
+    text = render_claude_settings()
     data = json.loads(text)
     src = data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]
-    assert src["ref"] == "v2.1"
+    assert src["ref"] == "main"
     assert text.endswith("\n")
-
-
-def test_render_claude_settings_other_version() -> None:
-    data = json.loads(render_claude_settings("v2.0"))
-    src = data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]
-    assert src["ref"] == "v2.0"
 
 
 def test_multi_choice_numbers() -> None:

--- a/tests/vergil_tooling/test_update_deps_vergil_eco.py
+++ b/tests/vergil_tooling/test_update_deps_vergil_eco.py
@@ -187,29 +187,31 @@ def _mark_self_repo(base: Path) -> None:
     (base / ".claude-plugin" / "marketplace.json").write_text("{}")
 
 
-def test_apply_normalize_sets_consumer_ref(tmp_path: Path) -> None:
+def test_apply_normalize_sets_marketplace_ref_to_main(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text('[dependencies]\nvergil = "v2.0"\n')
     _seed_settings(tmp_path, ref=None)
     result = VergilUpdater().apply(_ctx(tmp_path))
     assert result.changed is True
     data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-    assert data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] == "v2.0"
+    assert data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] == "main"
 
 
-def test_apply_normalize_self_repo_uses_develop(tmp_path: Path) -> None:
+def test_apply_normalize_self_repo_also_uses_main(tmp_path: Path) -> None:
+    # Single-channel model (#1974): no source-repo → develop exemption anymore.
     (tmp_path / "vergil.toml").write_text('[dependencies]\nvergil = "v2.1"\n')
     _mark_self_repo(tmp_path)
     _seed_settings(tmp_path, ref=None)
     VergilUpdater().apply(_ctx(tmp_path))
     data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-    assert data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] == "develop"
+    assert data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] == "main"
 
 
-def test_apply_bump_sets_ref_to_bumped_version(tmp_path: Path) -> None:
+def test_apply_bump_keeps_marketplace_ref_at_main(tmp_path: Path) -> None:
+    # Workflow/source refs follow the version; the marketplace ref does not.
     (tmp_path / "vergil.toml").write_text('[dependencies]\nvergil = "v2.0"\n')
     _seed_settings(tmp_path, ref="v2.0")
     ctx = _ctx(tmp_path)
     ctx.vergil_bump = "2.1"
     VergilUpdater().apply(ctx)
     data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-    assert data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] == "v2.1"
+    assert data["extraKnownMarketplaces"]["vergil-marketplace"]["source"]["ref"] == "main"

--- a/tests/vergil_tooling/test_vergil_refs.py
+++ b/tests/vergil_tooling/test_vergil_refs.py
@@ -6,10 +6,10 @@ import pytest
 
 from vergil_tooling.lib.update_deps.context import UpdateDepsError
 from vergil_tooling.lib.vergil_refs import (
+    EXPECTED_MARKETPLACE_REF,
     MARKETPLACE_NAME,
-    expected_claude_ref,
     format_version,
-    is_marketplace_source_repo,
+    is_deprecated_marketplace_ref,
     iter_workflow_refs,
     read_source_version,
 )
@@ -47,26 +47,22 @@ def test_read_source_version_missing_key(tmp_path: Path) -> None:
         read_source_version(tmp_path)
 
 
-def test_is_marketplace_source_repo_true(tmp_path: Path) -> None:
-    (tmp_path / ".claude-plugin").mkdir()
-    (tmp_path / ".claude-plugin" / "marketplace.json").write_text("{}")
-    assert is_marketplace_source_repo(tmp_path) is True
+def test_expected_marketplace_ref_constant() -> None:
+    assert EXPECTED_MARKETPLACE_REF == "main"
 
 
-def test_is_marketplace_source_repo_false(tmp_path: Path) -> None:
-    assert is_marketplace_source_repo(tmp_path) is False
+def test_is_deprecated_marketplace_ref_develop() -> None:
+    assert is_deprecated_marketplace_ref("develop") is True
 
 
-def test_expected_claude_ref_consumer(tmp_path: Path) -> None:
-    _seed_toml(tmp_path, "v2.0")
-    assert expected_claude_ref(tmp_path) == "v2.0"
+@pytest.mark.parametrize("ref", ["2.1", "v2.1", "2.0.7", "v2.0.7"])
+def test_is_deprecated_marketplace_ref_versions(ref: str) -> None:
+    assert is_deprecated_marketplace_ref(ref) is True
 
 
-def test_expected_claude_ref_self_repo(tmp_path: Path) -> None:
-    _seed_toml(tmp_path, "v2.1")
-    (tmp_path / ".claude-plugin").mkdir()
-    (tmp_path / ".claude-plugin" / "marketplace.json").write_text("{}")
-    assert expected_claude_ref(tmp_path) == "develop"
+@pytest.mark.parametrize("ref", ["main", "feature/x", "", "v2", "latest"])
+def test_is_deprecated_marketplace_ref_other(ref: str) -> None:
+    assert is_deprecated_marketplace_ref(ref) is False
 
 
 def test_iter_workflow_refs(tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -142,6 +142,24 @@ def test_audit_both_compliant_returns_zero() -> None:
         assert main(["audit", "--repo", "o/r"]) == 0
 
 
+def test_audit_warning_prints_but_stays_compliant(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A deprecated-but-tolerated marketplace ref (#1974) warns without failing.
+    warned = ConfigDiff(items=[], warnings=["vergil-marketplace source.ref deprecated"])
+    with (
+        patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
+        patch(f"{_MODULE}.audit_local_config", return_value=warned),
+        patch(f"{_MODULE}._audit_repo", return_value=_mock_github_compliant()),
+        patch(f"{_MODULE}._resolve_repo", return_value="o/r"),
+        patch(f"{_MODULE}._resolve_config"),
+    ):
+        assert main(["audit", "--repo", "o/r"]) == 0
+    out = capsys.readouterr().out
+    assert "local: compliant" in out
+    assert "WARNING: vergil-marketplace source.ref deprecated" in out
+
+
 def test_audit_local_noncompliant_returns_one() -> None:
     with (
         patch(f"{_MODULE}._cwd_matches_repo", return_value=True),


### PR DESCRIPTION
# Pull Request

## Summary

- Make 'main' the expected marketplace ref for all repos, warn (don't fail) on deprecated develop/version refs during the bridge period, and seed 'main' in the init and dep-update writers.

## Issue Linkage

- Ref #1974

## Notes

- Unblocks the vergil-claude-plugin release: a repo on the old ref now emits a deprecation WARNING via the new ConfigDiff.warnings channel (which deliberately does not affect is_compliant()), so not-yet-migrated repos keep passing while they are swept one by one. 'main' is compliant; any other or missing ref is still a hard failure. Removes the source-repo->develop exemption and version-pinned consumer ref (is_marketplace_source_repo / expected_claude_ref removed in favour of EXPECTED_MARKETPLACE_REF and is_deprecated_marketplace_ref). Workflow reusable-action pins still follow the vergil.toml version. Hardening the warning into an error is a separate follow-up once every repo is on main. Note: this repo's own .claude/settings.json is still on 'v2.1' and will now emit the deprecation warning by design.