### PR TITLE
fix(container-cache): report the real pull error instead of guessing '(offline?)'

### DIFF
--- a/docs/specs/2026-06-29-container-cache-staleness-design.md
+++ b/docs/specs/2026-06-29-container-cache-staleness-design.md
@@ -99,8 +99,10 @@ returns `(digest, verified)`:
 2. `docker image inspect <base_image> --format '{{.Id}}'` → the digest string.
 3. **Offline / registry-down:** if the pull fails but a local copy of the base
    exists, inspect and use the **local** digest, return `verified=False`, and print
-   a one-line warning:
-   `warning: could not verify base image freshness (offline?); using local image`.
+   a one-line warning that surfaces the pull's actual error (e.g. `denied`,
+   `unauthorized`, a network error, or a timeout) rather than guessing the cause:
+   `warning: could not verify base image freshness for '<image>' (pull failed:
+   <reason>); using local image`.
 4. If the pull fails and there is no local base, raise — nothing could run anyway.
 
 `pull` + `inspect` is chosen over `manifest inspect` because both work on docker and

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -48,6 +48,18 @@ def _inspect_image_id(image: str, *, runtime: str) -> str | None:
     return result.stdout.strip() or None
 
 
+def _summarize_pull_error(stderr: str) -> str:
+    """Return the most informative line from a failed pull's stderr.
+
+    Container runtimes print the actionable cause — ``denied``, ``unauthorized``,
+    ``manifest unknown``, or a network error — on the last non-empty stderr line.
+    Surfacing it distinguishes an auth failure from a genuine offline host instead
+    of guessing.
+    """
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    return lines[-1] if lines else "unknown error"
+
+
 def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, bool]:
     """Resolve *base_image*'s content digest, refreshing it from the registry.
 
@@ -59,6 +71,7 @@ def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, boo
     """
     rt = runtime or detect_runtime()
     pull_ok = True
+    pull_error = ""
     try:
         pull = subprocess.run(  # noqa: S603
             [rt, "pull", base_image],  # noqa: S607
@@ -67,20 +80,24 @@ def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, boo
             timeout=_PULL_TIMEOUT_SECONDS,
         )
         pull_ok = pull.returncode == 0
+        if not pull_ok:
+            pull_error = _summarize_pull_error(pull.stderr)
     except subprocess.TimeoutExpired:
         pull_ok = False
+        pull_error = f"pull timed out after {_PULL_TIMEOUT_SECONDS}s"
 
     digest = _inspect_image_id(base_image, runtime=rt)
     if digest is None:
+        outcome = "succeeded" if pull_ok else f"failed ({pull_error})"
         msg = (
             f"Could not resolve base image '{base_image}': pull "
-            f"{'succeeded' if pull_ok else 'failed'} and no local copy is present."
+            f"{outcome} and no local copy is present."
         )
         raise RuntimeError(msg)
     if not pull_ok:
         print(
             f"warning: could not verify base image freshness for '{base_image}' "
-            "(offline?); using local image",
+            f"(pull failed: {pull_error}); using local image",
             file=sys.stderr,
         )
     return digest, pull_ok

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _completed(returncode: int = 0, stdout: str = "") -> MagicMock:
-    return MagicMock(returncode=returncode, stdout=stdout)
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 _VALID_TOML = """\
@@ -670,6 +670,38 @@ def test_resolve_base_digest_offline_uses_local(capsys: pytest.CaptureFixture[st
     assert digest == "sha256:local9"
     assert verified is False
     assert "could not verify base image freshness" in capsys.readouterr().err
+
+
+def test_resolve_base_digest_pull_failure_reports_real_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pull = _completed(
+        1,
+        stderr="Error response from daemon: error from registry: denied\n",
+    )
+    inspect = _completed(0, "sha256:local9\n")  # local copy present
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[pull, inspect],
+    ):
+        resolve_base_digest("img:1", runtime="docker")
+    err = capsys.readouterr().err
+    assert "denied" in err  # the real cause, surfaced
+    assert "(offline?)" not in err  # not a misleading guess
+
+
+def test_resolve_base_digest_pull_timeout_reports_timeout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import subprocess as _sp
+
+    inspect = _completed(0, "sha256:local9\n")
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[_sp.TimeoutExpired(cmd="pull", timeout=1), inspect],
+    ):
+        resolve_base_digest("img:1", runtime="docker")
+    assert "timed out" in capsys.readouterr().err
 
 
 def test_resolve_base_digest_pull_timeout_uses_local() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- resolve_base_digest now surfaces the base-image pull's actual failure (denied/unauthorized/network/timeout) in its warning and the no-local-copy error, instead of the static '(offline?)' guess that misdirected a real incident.

## Issue Linkage

- Ref #1981

## Notes

- Diagnostic-only change for #1981; pull/fallback behavior is unchanged (the silent stale-base fallback itself is tracked separately in #1982). New helper _summarize_pull_error picks the last non-empty stderr line; two new tests cover the denied and timeout cases; existing offline/no-image tests still pass. Design spec example warning updated to match. Full vrg-validate green.