### PR TITLE
fix(container_cache): fail hard on base-pull failure instead of silent stale fallback

### DIFF
--- a/docs/specs/2026-06-29-container-cache-staleness-design.md
+++ b/docs/specs/2026-06-29-container-cache-staleness-design.md
@@ -2,7 +2,19 @@
 
 - **Issue:** vergil-project/vergil-tooling#1973
 - **Date:** 2026-06-29
-- **Status:** Approved (design)
+- **Status:** Approved (design); offline-fallback default amended by #1982
+
+> **Amendment (vergil-project/vergil-tooling#1982).** The "offline / registry-down
+> → use the local base, warn, continue (`verified=False`)" path described below was
+> the *default*. In practice it let a host validate against a stale local base for
+> an unknown length of time (the exact `ansible-lint` failure that motivated #1973),
+> with only a soft `(offline?)` warning — a silent failure. As of #1982 a failed
+> base pull is a **hard error by default**: `resolve_base_digest` raises with a
+> message that names the real pull error and the stale-cache risk. The local-base
+> degradation is retained as an **explicit opt-in** via `VRG_ALLOW_STALE_BASE=1`
+> (or `resolve_base_digest(..., allow_stale=True)`); only on that opt-in path does
+> it warn and return `verified=False`. The "no local base → raise" and
+> "pull succeeds → `verified=True`" behaviours are unchanged.
 
 ## Problem
 

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import subprocess
 import sys
@@ -20,6 +21,18 @@ _SELF_PROJECT_NAME = "vergil-tooling"
 _VRG_GIT_URL = "https://github.com/vergil-project/vergil-tooling"
 
 _PULL_TIMEOUT_SECONDS = 120
+
+# Opt-in escape hatch: when set to a truthy value, a failed base-image pull
+# during the staleness check degrades to using the local base instead of
+# failing hard. Off by default — see resolve_base_digest.
+_ALLOW_STALE_BASE_ENV = "VRG_ALLOW_STALE_BASE"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _allow_stale_base() -> bool:
+    """Return True when the operator has opted in to a possibly-stale base."""
+    return os.environ.get(_ALLOW_STALE_BASE_ENV, "").strip().lower() in _TRUTHY
+
 
 _CACHE_FILES: dict[str, list[str]] = {
     "python": ["uv.lock", "vergil.toml"],
@@ -60,16 +73,29 @@ def _summarize_pull_error(stderr: str) -> str:
     return lines[-1] if lines else "unknown error"
 
 
-def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, bool]:
+def resolve_base_digest(
+    base_image: str, *, runtime: str = "", allow_stale: bool | None = None
+) -> tuple[str, bool]:
     """Resolve *base_image*'s content digest, refreshing it from the registry.
 
     Pulls the base (so a moved tag is both detected and available to build from),
-    then inspects the local image id. Returns ``(digest, verified)`` where
-    ``verified`` is False when the pull failed and a previously-pulled local copy
-    was used instead. Raises ``RuntimeError`` when neither a pull nor a local
-    inspect yields a digest.
+    then inspects the local image id. The pull *is* the staleness check: if it
+    fails, we genuinely cannot tell whether the local base is current.
+
+    By default a failed pull is a hard error — running against a possibly-stale
+    local base silently is the worst available outcome (a host can validate
+    against an old image that predates a tool addition and never know). Set
+    ``VRG_ALLOW_STALE_BASE`` (or pass ``allow_stale=True``) to opt in to the
+    degraded "use the local base anyway" path, which warns and continues.
+
+    Returns ``(digest, verified)`` where ``verified`` is False only on the
+    opted-in stale path. Raises ``RuntimeError`` when no digest can be resolved,
+    or when the pull failed and the stale-base opt-in is not set.
     """
     rt = runtime or detect_runtime()
+    if allow_stale is None:
+        allow_stale = _allow_stale_base()
+
     pull_ok = True
     pull_error = ""
     try:
@@ -84,7 +110,7 @@ def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, boo
             pull_error = _summarize_pull_error(pull.stderr)
     except subprocess.TimeoutExpired:
         pull_ok = False
-        pull_error = f"pull timed out after {_PULL_TIMEOUT_SECONDS}s"
+        pull_error = f"timed out after {_PULL_TIMEOUT_SECONDS}s"
 
     digest = _inspect_image_id(base_image, runtime=rt)
     if digest is None:
@@ -94,10 +120,20 @@ def resolve_base_digest(base_image: str, *, runtime: str = "") -> tuple[str, boo
             f"{outcome} and no local copy is present."
         )
         raise RuntimeError(msg)
+
     if not pull_ok:
+        if not allow_stale:
+            msg = (
+                f"Could not verify base image freshness for '{base_image}': "
+                f"base pull failed ({pull_error}). Refusing to run against a "
+                f"possibly-stale local cache. Set {_ALLOW_STALE_BASE_ENV}=1 to "
+                "accept the local base anyway."
+            )
+            raise RuntimeError(msg)
         print(
-            f"warning: could not verify base image freshness for '{base_image}' "
-            f"(pull failed: {pull_error}); using local image",
+            f"warning: could not verify base image freshness for '{base_image}': "
+            f"base pull failed ({pull_error}); {_ALLOW_STALE_BASE_ENV} set, "
+            "using local image",
             file=sys.stderr,
         )
     return digest, pull_ok

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vergil_tooling.lib.container_cache import (
+    _allow_stale_base,
     _build_cached_image,
     _is_self_repo,
     _sanitize_branch,
@@ -659,9 +660,62 @@ def test_resolve_base_digest_pull_ok() -> None:
     assert verified is True
 
 
-def test_resolve_base_digest_offline_uses_local(capsys: pytest.CaptureFixture[str]) -> None:
-    pull = _completed(1)  # pull failed (offline)
+def test_resolve_base_digest_pull_failure_is_hard_error() -> None:
+    """By default a failed pull is a hard error, even with a local copy present."""
+    pull = _completed(1, stderr="unauthorized: stale credential")
     inspect = _completed(0, "sha256:local9\n")  # local copy present
+    with (
+        patch(
+            "vergil_tooling.lib.container_cache.subprocess.run",
+            side_effect=[pull, inspect],
+        ),
+        pytest.raises(RuntimeError) as exc,
+    ):
+        resolve_base_digest("img:1", runtime="docker")
+    message = str(exc.value)
+    # Names the real cause and the stale-cache risk, and points at the opt-in.
+    assert "unauthorized: stale credential" in message
+    assert "possibly-stale local cache" in message
+    assert "VRG_ALLOW_STALE_BASE" in message
+
+
+def test_resolve_base_digest_pull_failure_no_stderr_uses_fallback() -> None:
+    pull = _completed(7, stderr="")
+    inspect = _completed(0, "sha256:local9\n")
+    with (
+        patch(
+            "vergil_tooling.lib.container_cache.subprocess.run",
+            side_effect=[pull, inspect],
+        ),
+        pytest.raises(RuntimeError, match="unknown error"),
+    ):
+        resolve_base_digest("img:1", runtime="docker")
+
+
+def test_resolve_base_digest_allow_stale_uses_local(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The opt-in degrades to the local base, warning with the real cause."""
+    pull = _completed(1, stderr="connection refused")
+    inspect = _completed(0, "sha256:local9\n")
+    with patch(
+        "vergil_tooling.lib.container_cache.subprocess.run",
+        side_effect=[pull, inspect],
+    ):
+        digest, verified = resolve_base_digest("img:1", runtime="docker", allow_stale=True)
+    assert digest == "sha256:local9"
+    assert verified is False
+    err = capsys.readouterr().err
+    assert "could not verify base image freshness" in err
+    assert "connection refused" in err
+
+
+def test_resolve_base_digest_allow_stale_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VRG_ALLOW_STALE_BASE", "1")
+    pull = _completed(1, stderr="offline")
+    inspect = _completed(0, "sha256:local9\n")
     with patch(
         "vergil_tooling.lib.container_cache.subprocess.run",
         side_effect=[pull, inspect],
@@ -669,30 +723,43 @@ def test_resolve_base_digest_offline_uses_local(capsys: pytest.CaptureFixture[st
         digest, verified = resolve_base_digest("img:1", runtime="docker")
     assert digest == "sha256:local9"
     assert verified is False
-    assert "could not verify base image freshness" in capsys.readouterr().err
 
 
-def test_resolve_base_digest_pull_failure_reports_real_error(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
+def test_resolve_base_digest_pull_failure_reports_real_error() -> None:
+    """The hard error surfaces the real pull cause, not a guessed '(offline?)'."""
     pull = _completed(
         1,
         stderr="Error response from daemon: error from registry: denied\n",
     )
     inspect = _completed(0, "sha256:local9\n")  # local copy present
-    with patch(
-        "vergil_tooling.lib.container_cache.subprocess.run",
-        side_effect=[pull, inspect],
+    with (
+        patch(
+            "vergil_tooling.lib.container_cache.subprocess.run",
+            side_effect=[pull, inspect],
+        ),
+        pytest.raises(RuntimeError) as exc,
     ):
         resolve_base_digest("img:1", runtime="docker")
-    err = capsys.readouterr().err
-    assert "denied" in err  # the real cause, surfaced
-    assert "(offline?)" not in err  # not a misleading guess
+    message = str(exc.value)
+    assert "denied" in message  # the real cause, surfaced
+    assert "(offline?)" not in message  # not a misleading guess
 
 
-def test_resolve_base_digest_pull_timeout_reports_timeout(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
+def test_resolve_base_digest_pull_timeout_is_hard_error() -> None:
+    import subprocess as _sp
+
+    inspect = _completed(0, "sha256:local9\n")
+    with (
+        patch(
+            "vergil_tooling.lib.container_cache.subprocess.run",
+            side_effect=[_sp.TimeoutExpired(cmd="pull", timeout=1), inspect],
+        ),
+        pytest.raises(RuntimeError, match="timed out after"),
+    ):
+        resolve_base_digest("img:1", runtime="docker")
+
+
+def test_resolve_base_digest_pull_timeout_allow_stale_uses_local() -> None:
     import subprocess as _sp
 
     inspect = _completed(0, "sha256:local9\n")
@@ -700,31 +767,52 @@ def test_resolve_base_digest_pull_timeout_reports_timeout(
         "vergil_tooling.lib.container_cache.subprocess.run",
         side_effect=[_sp.TimeoutExpired(cmd="pull", timeout=1), inspect],
     ):
-        resolve_base_digest("img:1", runtime="docker")
-    assert "timed out" in capsys.readouterr().err
-
-
-def test_resolve_base_digest_pull_timeout_uses_local() -> None:
-    import subprocess as _sp
-
-    inspect = _completed(0, "sha256:local9\n")
-    with patch(
-        "vergil_tooling.lib.container_cache.subprocess.run",
-        side_effect=[_sp.TimeoutExpired(cmd="pull", timeout=1), inspect],
-    ):
-        digest, verified = resolve_base_digest("img:1", runtime="docker")
+        digest, verified = resolve_base_digest("img:1", runtime="docker", allow_stale=True)
     assert digest == "sha256:local9"
     assert verified is False
 
 
-def test_resolve_base_digest_no_image_raises() -> None:
-    pull = _completed(1)
+def test_resolve_base_digest_no_image_raises_names_cause() -> None:
+    pull = _completed(1, stderr="manifest unknown")
     inspect = _completed(1, "")  # no local copy either
     with (
         patch(
             "vergil_tooling.lib.container_cache.subprocess.run",
             side_effect=[pull, inspect],
         ),
-        pytest.raises(RuntimeError),
+        pytest.raises(RuntimeError, match="manifest unknown"),
     ):
         resolve_base_digest("img:1", runtime="docker")
+
+
+def test_resolve_base_digest_no_image_pull_ok_raises() -> None:
+    pull = _completed(0)
+    inspect = _completed(1, "")  # pull "succeeded" but nothing local
+    with (
+        patch(
+            "vergil_tooling.lib.container_cache.subprocess.run",
+            side_effect=[pull, inspect],
+        ),
+        pytest.raises(RuntimeError, match="pull succeeded"),
+    ):
+        resolve_base_digest("img:1", runtime="docker")
+
+
+# -- _allow_stale_base --------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+def test_allow_stale_base_truthy(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("VRG_ALLOW_STALE_BASE", value)
+    assert _allow_stale_base() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "nope"])
+def test_allow_stale_base_falsy(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("VRG_ALLOW_STALE_BASE", value)
+    assert _allow_stale_base() is False
+
+
+def test_allow_stale_base_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VRG_ALLOW_STALE_BASE", raising=False)
+    assert _allow_stale_base() is False


### PR DESCRIPTION
# Pull Request

## Summary

- A failed base-image pull during the staleness probe is now a hard error by default (naming the real pull cause and stale-cache risk), with the local-base degradation retained as an explicit VRG_ALLOW_STALE_BASE opt-in.

## Issue Linkage

- Ref #1982

## Notes

- Reverses the silent offline fallback added in #1973. Rebased onto develop after #1981/#1985 landed: keeps that PR's _summarize_pull_error diagnostic and layers the hard-fail-by-default + opt-in on top, so the merged resolve_base_digest both surfaces the real pull cause and refuses to run against a possibly-stale base unless VRG_ALLOW_STALE_BASE is set. The #1973 design spec carries a superseding amendment note. Validation green; suite enforces 100% coverage.