### PR TITLE
feat(roadmap): render epics as a table with a Done column and stacked repos

### DIFF
--- a/src/vergil_tooling/lib/roadmap.py
+++ b/src/vergil_tooling/lib/roadmap.py
@@ -79,13 +79,17 @@ def gather() -> list[EpicSummary]:
 
 
 def _row(epic: EpicSummary) -> str:
-    repos = ", ".join(epic.repos) if epic.repos else "—"
-    head = f"- **[#{epic.number}]({epic.url}) {epic.title}**"
-    return f"{head} — {epic.closed}/{epic.total} done · repos: {repos} · created {epic.created}"
+    """One markdown table row for an epic (repos stacked in-cell)."""
+    repos = "<br>".join(r.split("/")[-1] for r in epic.repos) if epic.repos else "—"
+    title = epic.title.replace("|", "\\|")
+    return (
+        f"| [#{epic.number}]({epic.url}) {title} "
+        f"| {epic.closed}/{epic.total} | {repos} | {epic.created} |"
+    )
 
 
 def render(summaries: list[EpicSummary]) -> str:
-    """Render the roadmap markdown, grouped by milestone."""
+    """Render the roadmap markdown as a table per milestone."""
     if not summaries:
         return "# Roadmap\n\n_No active epics._\n"
     by_milestone: dict[str, list[EpicSummary]] = {}
@@ -100,6 +104,8 @@ def render(summaries: list[EpicSummary]) -> str:
     for milestone in sorted(by_milestone):
         lines.append(f"## {milestone}")
         lines.append("")
+        lines.append("| Epic | Done | Repos | Created |")
+        lines.append("| --- | --- | --- | --- |")
         for epic in sorted(by_milestone[milestone], key=lambda e: e.number):
             lines.append(_row(epic))
         lines.append("")

--- a/tests/vergil_tooling/test_roadmap.py
+++ b/tests/vergil_tooling/test_roadmap.py
@@ -84,14 +84,27 @@ def test_render_empty() -> None:
 def test_render_groups_by_milestone() -> None:
     summaries = [
         EpicSummary(
-            40, "Convention", "2026-06-28", "v2.2", ("vergil-project/vergil-tooling",), 2, 1, "u40"
+            40,
+            "Convention | edge",
+            "2026-06-28",
+            "v2.2",
+            ("vergil-project/.github", "vergil-project/vergil-tooling"),
+            2,
+            1,
+            "u40",
         ),
         EpicSummary(7, "Orphan", "2026-02-02", None, (), 0, 0, "u7"),
     ]
     out = roadmap.render(summaries)
     assert "## v2.2" in out
     assert "## No milestone" in out
-    assert "[#40](u40) Convention" in out
-    assert "1/2 done" in out
-    assert "repos: vergil-project/vergil-tooling" in out
-    assert "repos: —" in out
+    # Table scaffolding, one header per milestone section.
+    assert "| Epic | Done | Repos | Created |" in out
+    assert out.count("| --- | --- | --- | --- |") == 2
+    # Epic row: link + title (pipe escaped), Done as X/Y, repos stacked short
+    # names via <br>, and the created date now has its own visible column.
+    assert (
+        "| [#40](u40) Convention \\| edge | 1/2 | .github<br>vergil-tooling | 2026-06-28 |" in out
+    )
+    # No repos renders an em dash in the cell.
+    assert "| [#7](u7) Orphan | 0/0 | — | 2026-02-02 |" in out


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-roadmap now emits a markdown table per milestone (Epic | Done | Repos | Created) instead of a bullet list, so the done count and created date are readable at a glance and repos stack in-cell.

## Issue Linkage

- Ref #1994

## Notes

- Repos use short names joined with <br>; empty repos render an em dash. Epic titles are pipe-escaped so a | in a title cannot break the table. render test updated; validation green at 100% coverage.