### PR TITLE
fix(off-platform): cloud session self-seeds Claude config; idempotent volume linking

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2352,6 +2352,14 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
     _warn_cloud_under(target)
 
     transport = backend.transport()
+    # #1999 (Fix A): seed the operator's ~/.claude config (settings.json carries
+    # permissions.defaultMode=bypassPermissions) and relink the volume history dirs
+    # before the process-replacing exec_session, mirroring the Lima _cmd_session path.
+    # Idempotent, so a box left unseeded by a bad rebuild self-heals on the next session
+    # instead of running with no bypass and writing history off the persistent volume.
+    claude_dir = Path.home() / ".claude"
+    copy_claude_config(transport, claude_dir)
+    vm_cloud.link_cloud_claude_dirs(transport)
     workspace_abs = os.path.normpath(resolve_workspace(args.workspace, identity.projects_dir))
     rel_path = os.path.relpath(workspace_abs, identity.projects_dir)
     inner = _session_inner(

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -481,15 +481,25 @@ def link_cloud_claude_dirs(transport: Transport) -> None:
     history survives teardown, while injected credentials (``.credentials.json``,
     ``.claude.json``) stay on the ephemeral boot disk and die with the VM
     (acceptance: no injected credential on the detachable volume).
+
+    Idempotent and merge-safe (#1999, Fix A'): a re-seed (e.g. from the cloud
+    session path) may find ``~/.claude/<sub>`` already an equivalent symlink, or
+    a *real* directory that Claude created on a box that was never linked. A real
+    directory is merged onto the volume and then replaced by the symlink, rather
+    than clobbered or left as a nested ``ln -sfn`` target.
     """
     volume_dirs = " ".join(f"{_CLOUD_CLAUDE_VOLUME}/{sub}" for sub in _CLOUD_CLAUDE_LINK_DIRS)
-    transport.run("bash", "-c", f"mkdir -p ~/.claude {volume_dirs}")
+    parts = [f"mkdir -p ~/.claude {volume_dirs}"]
     for sub in _CLOUD_CLAUDE_LINK_DIRS:
-        transport.run(
-            "bash",
-            "-c",
-            f"ln -sfn {_CLOUD_CLAUDE_VOLUME}/{sub} ~/.claude/{sub}",
+        vol = f"{_CLOUD_CLAUDE_VOLUME}/{sub}"
+        link = f'"$HOME/.claude/{sub}"'
+        parts.append(
+            f"if [ -L {link} ]; then ln -sfn {vol} {link}; "
+            f"elif [ -d {link} ]; then cp -a {link}/. {vol}/ 2>/dev/null || true; "
+            f"rm -rf {link}; ln -s {vol} {link}; "
+            f"else ln -s {vol} {link}; fi"
         )
+    transport.run("bash", "-c", " ; ".join(parts))
 
 
 # --- OpenTofu two-state runner -----------------------------------------------

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -699,6 +699,20 @@ class TestCloudClaudeLayout:
         assert "/vergil/claude/.credentials.json" not in joined
         assert ".credentials.json" not in joined
 
+    def test_relinks_existing_real_dir_by_merging(self) -> None:
+        # #1999 (Fix A'): when ~/.claude/<sub> already exists as a real directory
+        # (Claude created it on a box that was never linked), its contents are merged
+        # onto the volume and the dir is replaced by a symlink — not left as a nested
+        # broken `ln -sfn` target, and not clobbered.
+        transport = MagicMock()
+        transport.run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        link_cloud_claude_dirs(transport)
+        joined = " ".join(c for call in transport.run.call_args_list for c in call.args)
+        assert "-L" in joined  # branch on symlink vs real dir
+        assert "cp -a" in joined  # merge real-dir contents onto the volume
+        assert "rm -rf" in joined  # remove the real dir before linking
+        assert "ln -s" in joined
+
 
 def _tofu_output_json(values: dict[str, str]) -> str:
     return json.dumps({k: {"value": v} for k, v in values.items()})

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3900,6 +3900,28 @@ class TestCloudSession:
         assert kwargs["workdir"] == "/vergil/projects/lmf/cloud"
         assert "vrg-vm-resolve-session" in kwargs["inner"]
 
+    def test_cloud_session_seeds_claude_config(self, _cloud_repo: Path, tmp_path: Path) -> None:
+        # #1999 (Fix A): the cloud session path must seed the operator's ~/.claude
+        # config (settings.json carries permissions.defaultMode=bypassPermissions) and
+        # relink the volume dirs BEFORE the process-replacing exec_session, mirroring
+        # the Lima _cmd_session path. Without this an off-platform box never self-heals
+        # a bad rebuild: it runs with no bypass and writes history off the volume.
+        transport = MagicMock()
+        with _CloudPatches(tmp_path / "state") as m:
+            m["transport"].return_value = transport
+            manager = MagicMock()
+            manager.attach_mock(m["copy_claude_config"], "copy")
+            manager.attach_mock(m["link_cloud_claude_dirs"], "link")
+            manager.attach_mock(transport.exec_session, "exec")
+            main(["session", "lmf/cloud", "--config", str(_cloud_repo)])
+        m["copy_claude_config"].assert_called_once()
+        assert m["copy_claude_config"].call_args.args[0] is transport
+        m["link_cloud_claude_dirs"].assert_called_once_with(transport)
+        transport.exec_session.assert_called_once()
+        order = [name for name, _, _ in manager.mock_calls]
+        assert order.index("copy") < order.index("exec")
+        assert order.index("link") < order.index("exec")
+
 
 class TestCloudUpdate:
     def test_cloud_update_in_place_over_iap(self, _cloud_repo: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Cloud _cloud_session now seeds ~/.claude config (settings.json/bypass) and relinks the volume dirs before launch, mirroring Lima; link_cloud_claude_dirs is idempotent and merge-safe over an existing real dir. Fixes cloud VMs that came up with no bypass and history off the volume.

## Issue Linkage

- Ref #1999

## Notes

- Part of epic vergil-project/.github#69 (Fix A + A'). Backend-agnostic plugin install/update (Fix C), volume plugin persistence (Fix B), and the host guardrail (Fix D) follow as separate tasks.