### PR TITLE
fix(release): confirm-main accepts an inline release job (leaf-match)

### DIFF
--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -166,18 +166,35 @@ def _settled_run_jobs(
 
 
 _RELEASE_JOB_NAME = "release / release"
+_RELEASE_JOB_LEAF = "release"
+
+
+def _is_release_job(name: str) -> bool:
+    """True when *name* is the CD release job, identified by its leaf segment.
+
+    Consumer repos call the reusable ``cd-release`` workflow, so their release
+    job surfaces as the reusable leaf ``release / release``. vergil-actions
+    *defines* that reusable workflow and cannot call itself, so its CD runs an
+    inline job it names ``cd / release`` (#2001). Both share the leaf segment
+    ``release`` — match on the leaf (the part after the last `` / ``), not the
+    full name, so vergil-actions' own release verifies while a decoy like
+    ``release-notes / build`` (leaf ``build``) still fails the #1853 guard.
+    Matching the leaf exactly keeps that guard against loose substrings intact.
+    """
+    return name.rsplit(" / ", 1)[-1] == _RELEASE_JOB_LEAF
 
 
 def _verify_release_job(jobs: list[dict[str, Any]]) -> None:
     """Hard gate: the release job must exist and have concluded ``success``.
 
-    Matched EXACTLY (the reusable-workflow leaf ``release / release``), not by
-    the substring ``_find_job`` uses for the deferred sweep — the release job is
-    the single load-bearing assertion, so a future ``release``-prefixed job must
-    not satisfy it. A renamed/absent release job fails closed (#1853).
+    Identified by its leaf segment ``release`` (see ``_is_release_job``), which
+    matches both the reusable leaf ``release / release`` and vergil-actions'
+    inline ``cd / release`` while still rejecting a ``release``-prefixed decoy —
+    the release job is the single load-bearing assertion. A renamed/absent
+    release job fails closed (#1853, #2001).
     """
     for job in jobs:
-        if job.get("name") == _RELEASE_JOB_NAME:
+        if _is_release_job(job.get("name", "")):
             conclusion = job.get("conclusion")
             if conclusion != "success":
                 raise ReleaseError(
@@ -204,7 +221,7 @@ def _collect_deferred_publish(jobs: list[dict[str, Any]]) -> list[str]:
     families: list[str] = []
     for job in jobs:
         name = job.get("name", "")
-        if name == _RELEASE_JOB_NAME:
+        if _is_release_job(name):
             continue
         if job.get("conclusion") in ("success", "skipped"):
             continue

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -360,6 +360,39 @@ def test_verify_release_job_is_exact_not_substring() -> None:
         _verify_release_job([_job("release-notes / build")])
 
 
+def test_verify_release_job_accepts_inline_release_job() -> None:
+    from vergil_tooling.lib.release.confirm import _verify_release_job
+
+    # vergil-actions defines the reusable cd-release workflow and cannot call
+    # itself, so its CD runs an inline job surfaced as "cd / release" rather
+    # than the reusable leaf "release / release" (#2001). The leaf segment is
+    # still "release", so the hard gate must accept it.
+    _verify_release_job([_job("cd / release")])  # no raise
+
+
+def test_is_release_job_matches_leaf_not_caller() -> None:
+    from vergil_tooling.lib.release.confirm import _is_release_job
+
+    # Both the reusable leaf and vergil-actions' inline job share the leaf.
+    assert _is_release_job("release / release")
+    assert _is_release_job("cd / release")
+    # Decoys whose leaf is not exactly "release" must NOT match (#1853 guard).
+    assert not _is_release_job("release-notes / build")
+    assert not _is_release_job("docs / docs")
+    assert not _is_release_job("docker-publish / publish: prod-base:latest")
+
+
+def test_collect_deferred_publish_excludes_inline_release_job() -> None:
+    from vergil_tooling.lib.release.confirm import _collect_deferred_publish
+
+    # The "cd / release" release job must not be collected as a publish family.
+    jobs = [
+        _job("cd / release"),
+        _job("docs / docs", conclusion="failure"),
+    ]
+    assert _collect_deferred_publish(jobs) == ["docs"]
+
+
 def test_collect_deferred_publish_collapses_families() -> None:
     from vergil_tooling.lib.release.confirm import _collect_deferred_publish
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fixes vrg-release aborting at confirm-main when releasing vergil-actions itself. The hard gate exact-matched the CD release job name against the reusable-workflow leaf 'release / release'; vergil-actions defines that reusable workflow and cannot call itself, so its inline job 'cd / release' failed the match and a fully-successful release was reported as 'Release job not found'. The gate now identifies the release job by its leaf segment ('release'), accepting both forms while preserving the #1853 guard against loose substrings.

## Issue Linkage

- Ref #2001

## Notes

- TDD: added red tests for the inline 'cd / release' job and the _is_release_job leaf predicate, then implemented. Full suite (33 tests) green; vrg-validate passes. No repo-specific logic — leaf-match is general. Discovered during the vergil-actions 2.1.6 release, whose post-confirm-main bookkeeping (develop bump, worktree teardown, close of vergil-actions#715) still needs completing once this lands.