### PR TITLE
fix(off-platform): persist ~/.claude/plugins on the /vergil volume

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -470,17 +470,22 @@ def await_readiness(transport: Transport, fingerprint: str, *, verbose: bool = F
         raise RuntimeError("spec fingerprint mismatch on the cloud box — rebuild the VM")
 
 
-_CLOUD_CLAUDE_LINK_DIRS = ("projects", "todos")
+_CLOUD_CLAUDE_LINK_DIRS = ("projects", "todos", "plugins")
 _CLOUD_CLAUDE_VOLUME = "/vergil/claude"
 
 
 def link_cloud_claude_dirs(transport: Transport) -> None:
-    """Link only the ~/.claude history subdirs onto the persistent volume.
+    """Link the durable ~/.claude subdirs onto the persistent volume.
 
     ``projects`` and ``todos`` are symlinked onto ``/vergil/claude`` so session
-    history survives teardown, while injected credentials (``.credentials.json``,
-    ``.claude.json``) stay on the ephemeral boot disk and die with the VM
-    (acceptance: no injected credential on the detachable volume).
+    history survives teardown. ``plugins`` is linked too (#2008, Fix B): the
+    marketplace clones and installed plugins otherwise sit on the ephemeral boot
+    disk and are wiped on every rebuild, forcing a full reinstall on each cold
+    boot. It is safe on the ext4 volume — the EXDEV atomic-rename problem that
+    keeps Lima plugins VM-local does not arise on a real block device. Injected
+    credentials (``.credentials.json``, ``.claude.json``) stay on the ephemeral
+    boot disk and die with the VM (acceptance: no injected credential on the
+    detachable volume).
 
     Idempotent and merge-safe (#1999, Fix A'): a re-seed (e.g. from the cloud
     session path) may find ``~/.claude/<sub>`` already an equivalent symlink, or

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -713,6 +713,17 @@ class TestCloudClaudeLayout:
         assert "rm -rf" in joined  # remove the real dir before linking
         assert "ln -s" in joined
 
+    def test_symlinks_plugins_dir_to_volume(self) -> None:
+        # #2008 (Fix B): the plugin cache/install sits on the ephemeral boot disk and
+        # is wiped on every rebuild, so a cold boot reinstalls the whole set. Persist
+        # it on the volume by adding it to the share set. Credentials stay ephemeral.
+        transport = MagicMock()
+        transport.run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        link_cloud_claude_dirs(transport)
+        joined = " ".join(c for call in transport.run.call_args_list for c in call.args)
+        assert "/vergil/claude/plugins" in joined
+        assert ".credentials.json" not in joined
+
 
 def _tofu_output_json(values: dict[str, str]) -> str:
     return json.dumps({k: {"value": v} for k, v in values.items()})


### PR DESCRIPTION
# Pull Request

## Summary

- Add plugins to the off-platform ~/.claude share set so marketplace clones and installed plugins persist on the /vergil volume across rebuilds instead of being wiped and reinstalled on every cold boot.

## Issue Linkage

- Ref #2008

## Notes

- Safe on ext4 (no EXDEV/virtiofs rename issue); Fix A's merge-safe linker handles a pre-existing real plugins dir; credentials remain ephemeral. Part of epic vergil-project/.github#69 (Fix B).