### PR TITLE
feat(vrg-vm): warn when run off the macOS host

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -6,6 +6,7 @@ import argparse
 import datetime
 import json
 import os
+import platform
 import random
 import shlex
 import shutil
@@ -2490,6 +2491,33 @@ def _add_name_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _off_host_reason(system: str) -> str | None:
+    """Pure-logic core of warn_if_off_host (testable without a host).
+
+    vrg-vm is the macOS-host tool that creates and manages Vergil VMs; it reads
+    the operator's ~/.claude and drives Lima / cloud from the laptop. Returns why
+    this is the wrong place to run it, or None on macOS.
+    """
+    if system != "Darwin":
+        return (
+            "vrg-vm is a macOS host tool for creating and managing Vergil VMs; "
+            f"host OS is {system or 'unknown'}. Run it from the macOS host — not "
+            "from inside a VM or container, where it reads the wrong ~/.claude."
+        )
+    return None
+
+
+def warn_if_off_host() -> None:
+    """Warn (never block) when vrg-vm runs off its macOS host (#2009, Fix D).
+
+    A warning rather than a refusal: read-only edge cases still work, and the
+    operator gets a clear signal instead of silently mis-seeded config.
+    """
+    reason = _off_host_reason(platform.system())
+    if reason:
+        print(f"WARNING: {reason}", file=sys.stderr)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="vrg-vm",
@@ -2716,6 +2744,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+    warn_if_off_host()
     if args.command is None:
         parser.print_help()
         return 1

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -28,6 +28,7 @@ from vergil_tooling.bin.vrg_vm import (
     _cs_tofu_volume,
     _list_rows,
     _log_root,
+    _off_host_reason,
     _preflight_target,
     _probe_running,
     _read_repo_vm,
@@ -41,6 +42,7 @@ from vergil_tooling.bin.vrg_vm import (
     main,
     recover_handle,
     resolve_borrow,
+    warn_if_off_host,
 )
 from vergil_tooling.lib import vm_cloud
 from vergil_tooling.lib.identity import Identity, IdentityConfig
@@ -5771,3 +5773,39 @@ def test_restart_named_off_platform_still_rejected(
     assert vrg_vm._cmd_restart(args) == 1
     assert stopped == []
     assert "ephemeral" in capsys.readouterr().err.lower()
+
+
+class TestHostGuard:
+    # #2009 (Fix D): vrg-vm is a macOS host tool; run off-host it reads the wrong
+    # ~/.claude. Warn (never block), mirroring the nested_virt pure-core pattern.
+    def test_off_host_reason_flags_non_darwin(self) -> None:
+        assert _off_host_reason("Darwin") is None
+        reason = _off_host_reason("Linux")
+        assert reason is not None
+        assert "macOS host" in reason
+        assert "Linux" in reason
+
+    def test_off_host_reason_names_unknown_system(self) -> None:
+        assert "unknown" in (_off_host_reason("") or "")
+
+    def test_warn_if_off_host_emits_on_linux(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("vergil_tooling.bin.vrg_vm.platform.system", lambda: "Linux")
+        warn_if_off_host()
+        assert "vrg-vm is a macOS host tool" in capsys.readouterr().err
+
+    def test_warn_if_off_host_silent_on_darwin(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("vergil_tooling.bin.vrg_vm.platform.system", lambda: "Darwin")
+        warn_if_off_host()
+        assert capsys.readouterr().err == ""
+
+    def test_main_warns_when_off_host(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("vergil_tooling.bin.vrg_vm.platform.system", lambda: "Linux")
+        # No subcommand: main prints help and returns 1 — the warning still fires.
+        assert main([]) == 1
+        assert "vrg-vm is a macOS host tool" in capsys.readouterr().err


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm now warns (via a pure-core + wrapper mirroring nested_virt) when run on a non-Darwin host, since off-host it reads the wrong ~/.claude and silently mis-seeds VM config.

## Issue Linkage

- Ref #2009

## Notes

- Warning, not a refusal, so read-only edge cases still work. Wired at main() top; 119 existing main() tests use in-style stderr assertions so they're unaffected. Part of epic vergil-project/.github#69 (Fix D).