### PR TITLE
feat(reporting): make vrg-roadmap/vrg-activity-log org-aware

### DIFF
--- a/src/vergil_tooling/bin/vrg_activity_log.py
+++ b/src/vergil_tooling/bin/vrg_activity_log.py
@@ -6,17 +6,25 @@ nightly job that writes/publishes the rendered markdown is separate (T8c).
 
 from __future__ import annotations
 
+import argparse
 import sys
 from datetime import UTC, datetime, timedelta
 
-from vergil_tooling.lib import activity_log
+from vergil_tooling.lib import activity_log, github
 
 _WINDOW_DAYS = 30
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print the project activity log.")
+    parser.add_argument(
+        "--org",
+        help="GitHub org whose closed issues to list (default: current repo's owner).",
+    )
+    args = parser.parse_args(argv)
+    org = args.org or github.current_org()
     since = (datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)).date().isoformat()
-    print(activity_log.render(activity_log.gather(since)))
+    print(activity_log.render(activity_log.gather(since, org=org)))
     return 0
 
 

--- a/src/vergil_tooling/bin/vrg_roadmap.py
+++ b/src/vergil_tooling/bin/vrg_roadmap.py
@@ -6,13 +6,21 @@ nightly job that writes/publishes the rendered markdown is separate (T8c).
 
 from __future__ import annotations
 
+import argparse
 import sys
 
-from vergil_tooling.lib import roadmap
+from vergil_tooling.lib import github, roadmap
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    print(roadmap.render(roadmap.gather()))
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print the generated project roadmap.")
+    parser.add_argument(
+        "--org",
+        help="GitHub org whose .github epics to read (default: current repo's owner).",
+    )
+    args = parser.parse_args(argv)
+    org = args.org or github.current_org()
+    print(roadmap.render(roadmap.gather(org), org))
     return 0
 
 

--- a/src/vergil_tooling/lib/activity_log.py
+++ b/src/vergil_tooling/lib/activity_log.py
@@ -13,8 +13,6 @@ from typing import Any
 
 from vergil_tooling.lib import github
 
-_ORG = "vergil-project"
-
 
 @dataclass(frozen=True)
 class ActivityItem:
@@ -27,8 +25,13 @@ class ActivityItem:
     closed_date: str  # YYYY-MM-DD
 
 
-def gather(since: str, *, org: str = _ORG) -> list[ActivityItem]:
-    """Closed issues across *org* with ``closedAt`` on or after *since* (YYYY-MM-DD)."""
+def gather(since: str, *, org: str | None = None) -> list[ActivityItem]:
+    """Closed issues across *org* with ``closedAt`` on or after *since* (YYYY-MM-DD).
+
+    *org* defaults to the owner of the current repo's git remote.
+    """
+    if org is None:
+        org = github.current_org()
     raw: Any = github.read_json(
         "search",
         "issues",

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -625,6 +625,11 @@ def current_repo() -> str:
     return read_output("repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
 
 
+def current_org() -> str:
+    """Return the OWNER of the current directory's git remote."""
+    return current_repo().split("/", 1)[0]
+
+
 def head_sha(pr: str) -> str:
     """Return the HEAD commit SHA for a PR."""
     return read_output("pr", "view", pr, "--json", "headRefOid", "--jq", ".headRefOid")

--- a/src/vergil_tooling/lib/roadmap.py
+++ b/src/vergil_tooling/lib/roadmap.py
@@ -13,8 +13,6 @@ from typing import Any
 
 from vergil_tooling.lib import epics, github
 
-_ORG_GITHUB = "vergil-project/.github"
-
 
 @dataclass(frozen=True)
 class EpicSummary:
@@ -30,12 +28,12 @@ class EpicSummary:
     url: str
 
 
-def _open_epics() -> list[Any]:
+def _open_epics(org: str) -> list[Any]:
     raw: Any = github.read_json(
         "issue",
         "list",
         "--repo",
-        _ORG_GITHUB,
+        f"{org}/.github",
         "--label",
         "epic",
         "--state",
@@ -52,14 +50,20 @@ def _is_standing(epic: Any) -> bool:
     return any((label or {}).get("name") == "standing" for label in (epic.get("labels") or []))
 
 
-def gather() -> list[EpicSummary]:
-    """Summarize every open finite (non-standing) epic in the org ``.github``."""
+def gather(org: str | None = None) -> list[EpicSummary]:
+    """Summarize every open finite (non-standing) epic in *org*'s ``.github``.
+
+    *org* defaults to the owner of the current repo's git remote, so the same
+    command reports each org's own roadmap.
+    """
+    if org is None:
+        org = github.current_org()
     summaries: list[EpicSummary] = []
-    for epic in _open_epics():
+    for epic in _open_epics(org):
         if _is_standing(epic):
             continue
         number = int(epic["number"])
-        children = epics.child_states(epics.IssueRef("vergil-project", ".github", number))
+        children = epics.child_states(epics.IssueRef(org, ".github", number))
         repos = tuple(sorted({f"{c.ref.owner}/{c.ref.repo}" for c in children}))
         closed = sum(1 for c in children if c.state == "CLOSED")
         milestone = epic.get("milestone")
@@ -88,17 +92,18 @@ def _row(epic: EpicSummary) -> str:
     )
 
 
-def render(summaries: list[EpicSummary]) -> str:
+def render(summaries: list[EpicSummary], org: str | None = None) -> str:
     """Render the roadmap markdown as a table per milestone."""
     if not summaries:
         return "# Roadmap\n\n_No active epics._\n"
+    source = f"{org}/.github" if org else "the org .github repo"
     by_milestone: dict[str, list[EpicSummary]] = {}
     for epic in summaries:
         by_milestone.setdefault(epic.milestone or "No milestone", []).append(epic)
     lines = [
         "# Roadmap",
         "",
-        "_Generated from open epics in vergil-project/.github. Do not edit by hand._",
+        f"_Generated from open epics in {source}. Do not edit by hand._",
         "",
     ]
     for milestone in sorted(by_milestone):

--- a/tests/vergil_tooling/test_activity_log.py
+++ b/tests/vergil_tooling/test_activity_log.py
@@ -26,7 +26,7 @@ def test_gather_parses_and_skips_incomplete() -> None:
         },
     ]
     with patch("vergil_tooling.lib.github.read_json", return_value=results) as mock_search:
-        items = activity_log.gather("2026-06-01")
+        items = activity_log.gather("2026-06-01", org="vergil-project")
     assert items == [
         ActivityItem("vergil-project/vergil-tooling", 1912, "labels", "u1912", "2026-06-29")
     ]
@@ -38,7 +38,17 @@ def test_gather_parses_and_skips_incomplete() -> None:
 
 def test_gather_returns_empty_on_non_list() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"x": 1}):
+        assert activity_log.gather("2026-06-01", org="vergil-project") == []
+
+
+def test_gather_defaults_org_to_current_repo_owner() -> None:
+    with (
+        patch("vergil_tooling.lib.github.current_org", return_value="acme") as mock_org,
+        patch("vergil_tooling.lib.github.read_json", return_value=[]) as mock_search,
+    ):
         assert activity_log.gather("2026-06-01") == []
+    mock_org.assert_called_once()
+    assert "acme" in mock_search.call_args.args
 
 
 def test_render_empty() -> None:

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -56,6 +56,11 @@ def test_read_output_returns_stripped_stdout() -> None:
     )
 
 
+def test_current_org_returns_remote_owner() -> None:
+    with patch("vergil_tooling.lib.github.current_repo", return_value="logical-minds-foundry/docs"):
+        assert github.current_org() == "logical-minds-foundry"
+
+
 def test_create_pr_returns_url() -> None:
     with patch("vergil_tooling.lib.github.read_output", return_value="https://github.com/pr/1"):
         url = github.create_pr(base="main", title="title", body_file="body.md")

--- a/tests/vergil_tooling/test_roadmap.py
+++ b/tests/vergil_tooling/test_roadmap.py
@@ -39,7 +39,7 @@ def test_gather_summarizes_open_epics_and_skips_standing() -> None:
         patch("vergil_tooling.lib.github.read_json", return_value=epic_list),
         patch("vergil_tooling.lib.epics.child_states", return_value=children),
     ):
-        result = roadmap.gather()
+        result = roadmap.gather("vergil-project")
     assert len(result) == 1
     summary = result[0]
     assert summary.number == 40
@@ -67,14 +67,14 @@ def test_gather_handles_no_milestone_and_no_children() -> None:
         patch("vergil_tooling.lib.github.read_json", return_value=epic_list),
         patch("vergil_tooling.lib.epics.child_states", return_value=[]),
     ):
-        result = roadmap.gather()
+        result = roadmap.gather("vergil-project")
     assert result[0].milestone is None
     assert result[0].repos == ()
 
 
 def test_gather_returns_empty_on_non_list() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"unexpected": True}):
-        assert roadmap.gather() == []
+        assert roadmap.gather("vergil-project") == []
 
 
 def test_render_empty() -> None:
@@ -95,9 +95,11 @@ def test_render_groups_by_milestone() -> None:
         ),
         EpicSummary(7, "Orphan", "2026-02-02", None, (), 0, 0, "u7"),
     ]
-    out = roadmap.render(summaries)
+    out = roadmap.render(summaries, "vergil-project")
     assert "## v2.2" in out
     assert "## No milestone" in out
+    # Caption names the org the epics were read from.
+    assert "open epics in vergil-project/.github" in out
     # Table scaffolding, one header per milestone section.
     assert "| Epic | Done | Repos | Created |" in out
     assert out.count("| --- | --- | --- | --- |") == 2
@@ -108,3 +110,32 @@ def test_render_groups_by_milestone() -> None:
     )
     # No repos renders an em dash in the cell.
     assert "| [#7](u7) Orphan | 0/0 | — | 2026-02-02 |" in out
+
+
+def test_render_without_org_uses_generic_source() -> None:
+    summaries = [EpicSummary(7, "Orphan", "2026-02-02", None, (), 0, 0, "u7")]
+    out = roadmap.render(summaries)
+    assert "open epics in the org .github repo" in out
+
+
+def test_gather_defaults_org_to_current_repo_owner() -> None:
+    epic_list = [
+        {
+            "number": 9,
+            "title": "Y",
+            "createdAt": "2026-03-03T00:00:00Z",
+            "milestone": None,
+            "labels": [{"name": "epic"}],
+            "url": "u9",
+        }
+    ]
+    with (
+        patch("vergil_tooling.lib.github.current_org", return_value="logical-minds-foundry"),
+        patch("vergil_tooling.lib.github.read_json", return_value=epic_list) as mock_read,
+        patch("vergil_tooling.lib.epics.child_states", return_value=[]) as mock_children,
+    ):
+        result = roadmap.gather()
+    assert result[0].number == 9
+    # The derived org drives both the epic query and the child rollup.
+    assert "logical-minds-foundry/.github" in mock_read.call_args.args
+    assert mock_children.call_args.args[0].owner == "logical-minds-foundry"

--- a/tests/vergil_tooling/test_vrg_activity_log.py
+++ b/tests/vergil_tooling/test_vrg_activity_log.py
@@ -15,9 +15,25 @@ def test_main_prints_ledger(capsys: pytest.CaptureFixture[str]) -> None:
     with patch(
         "vergil_tooling.bin.vrg_activity_log.activity_log.gather", return_value=[]
     ) as mock_gather:
-        rc = main()
+        rc = main(["--org", "vergil-project"])
     assert rc == 0
     assert "Activity log" in capsys.readouterr().out
     # the CLI computes and passes a YYYY-MM-DD cutoff
     since = mock_gather.call_args.args[0]
     assert len(since) == 10 and since.count("-") == 2
+    assert mock_gather.call_args.kwargs["org"] == "vergil-project"
+
+
+def test_main_defaults_org_to_current_repo() -> None:
+    with (
+        patch(
+            "vergil_tooling.bin.vrg_activity_log.github.current_org", return_value="acme"
+        ) as mock_org,
+        patch(
+            "vergil_tooling.bin.vrg_activity_log.activity_log.gather", return_value=[]
+        ) as mock_gather,
+    ):
+        rc = main([])
+    assert rc == 0
+    mock_org.assert_called_once()
+    assert mock_gather.call_args.kwargs["org"] == "acme"

--- a/tests/vergil_tooling/test_vrg_roadmap.py
+++ b/tests/vergil_tooling/test_vrg_roadmap.py
@@ -13,6 +13,17 @@ if TYPE_CHECKING:
 
 def test_main_prints_roadmap(capsys: pytest.CaptureFixture[str]) -> None:
     with patch("vergil_tooling.bin.vrg_roadmap.roadmap.gather", return_value=[]):
-        rc = main()
+        rc = main(["--org", "vergil-project"])
     assert rc == 0
     assert "Roadmap" in capsys.readouterr().out
+
+
+def test_main_defaults_org_to_current_repo() -> None:
+    with (
+        patch("vergil_tooling.bin.vrg_roadmap.github.current_org", return_value="acme") as mock_org,
+        patch("vergil_tooling.bin.vrg_roadmap.roadmap.gather", return_value=[]) as mock_gather,
+    ):
+        rc = main([])
+    assert rc == 0
+    mock_org.assert_called_once()
+    assert mock_gather.call_args.args[0] == "acme"


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-roadmap and vrg-activity-log now derive the org from the current repo's git remote (new github.current_org()) instead of hardcoding vergil-project, with an optional --org override — so the portable cd-docs-refresh workflow generates each org's own roadmap/activity.

## Issue Linkage

- Ref #2020

## Notes

- Dropped hardcoded _ORG_GITHUB / _ORG constants; threaded org through roadmap.gather/render + activity_log.gather; both bins take --org (default = current repo owner). 100% coverage held. Verified live: 'vrg-roadmap --org logical-minds-foundry' renders the LMF epics with real progress. Needs a vergil-tooling release to reach v2.1 before the LMF docs site (Part 2) generates correctly. Under epic #60.