### PR TITLE
fix(plugins): register marketplaces before install, not bare update

### DIFF
--- a/src/vergil_tooling/lib/vm_guest.py
+++ b/src/vergil_tooling/lib/vm_guest.py
@@ -295,6 +295,36 @@ def _desired_enabled_plugins(transport: Transport) -> set[str]:
     return {pid for pid, on in enabled.items() if on}
 
 
+def _declared_marketplace_sources(transport: Transport) -> list[str]:
+    """Return the ``marketplace add`` sources declared in the guest settings.json.
+
+    Each ``extraKnownMarketplaces`` entry's ``source`` maps to an add-arg
+    (``owner/repo``, a URL, or a path). Headless ``claude plugin marketplace
+    update``/``list`` do NOT register these on a fresh box (#2021) — only
+    ``marketplace add <source>`` clones the catalog — so update_plugins registers
+    them explicitly before installing. Absent/unreadable settings yield [].
+    """
+    try:
+        result = transport.run(
+            "bash",
+            "-c",
+            f"{_PLUGIN_PATH_EXPORT} && cat ~/.claude/settings.json",
+        )
+    except subprocess.CalledProcessError:
+        return []
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+    sources: list[str] = []
+    for spec in (data.get("extraKnownMarketplaces") or {}).values():
+        src = spec.get("source") or {}
+        arg = src.get("repo") or src.get("url") or src.get("path")
+        if arg:
+            sources.append(arg)
+    return sources
+
+
 def update_plugins(transport: Transport) -> None:
     """Reconcile enabled Claude Code plugins inside the guest.
 
@@ -323,6 +353,21 @@ def update_plugins(transport: Transport) -> None:
     failures are collected and surfaced by raising afterwards (never swallowed).
     """
     print("  Refreshing Claude plugins...")
+    failures: list[str] = []
+    # Register the declared marketplaces so their catalogs are cloned. Headless
+    # `marketplace update`/`list` do NOT register a fresh box's extraKnownMarketplaces
+    # (#2021) — only `marketplace add <source>` clones the catalog, so a subsequent
+    # install can find the plugin. Idempotent (re-add is a no-op) and best-effort.
+    for source in _declared_marketplace_sources(transport):
+        print(f"    registering marketplace {source}...")
+        try:
+            transport.run(
+                "bash",
+                "-c",
+                f"{_PLUGIN_PATH_EXPORT} && claude plugin marketplace add {shlex.quote(source)}",
+            )
+        except subprocess.CalledProcessError:
+            failures.append(f"marketplace:{source}")
     transport.run(
         "bash",
         "-c",
@@ -340,7 +385,6 @@ def update_plugins(transport: Transport) -> None:
     # refreshing anything already installed-and-enabled (the pre-#2006 behaviour).
     targets = desired | {pid for pid, plugin in installed.items() if plugin.get("enabled")}
 
-    failures: list[str] = []
     for pid in sorted(targets):
         if pid in installed:
             action = "update"
@@ -360,7 +404,7 @@ def update_plugins(transport: Transport) -> None:
 
     if failures:
         joined = ", ".join(failures)
-        msg = f"failed to reconcile plugin(s): {joined}"
+        msg = f"failed to reconcile: {joined}"
         print(f"ERROR: {msg}", file=sys.stderr)
         raise RuntimeError(msg)
 

--- a/tests/vergil_tooling/test_vm_guest.py
+++ b/tests/vergil_tooling/test_vm_guest.py
@@ -779,3 +779,113 @@ class TestUpdatePlugins:
         assert any(
             "claude plugin update vergil@vergil-marketplace --scope project" in c for c in cmds
         )
+
+    def test_registers_declared_marketplaces_before_install(self) -> None:
+        # #2021 (Fix C v2): headless `marketplace update`/`list` do NOT register the
+        # marketplaces declared in settings.json extraKnownMarketplaces — only
+        # `marketplace add <source>` does. Without it, install fails "not found in
+        # marketplace, local copy out of date" on a fresh box.
+        settings = json.dumps(
+            {
+                "extraKnownMarketplaces": {
+                    "vergil-marketplace": {
+                        "source": {
+                            "source": "github",
+                            "repo": "vergil-project/vergil-claude-plugin",
+                        }
+                    },
+                    "paad": {"source": {"source": "github", "repo": "Ovid/paad"}},
+                },
+                "enabledPlugins": {"vergil@vergil-marketplace": True},
+            }
+        )
+
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "cat ~/.claude/settings.json" in cmd:
+                out = settings
+            elif "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        update_plugins(transport)
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+
+        def find(sub: str) -> int:
+            return next((i for i, c in enumerate(cmds) if sub in c), -1)
+
+        # Each declared marketplace is registered by source...
+        assert find("marketplace add vergil-project/vergil-claude-plugin") >= 0
+        assert find("marketplace add Ovid/paad") >= 0
+        # ...before the enabled plugin is installed.
+        assert find("plugin install vergil@vergil-marketplace") >= 0
+        assert find("marketplace add vergil-project/vergil-claude-plugin") < find(
+            "plugin install vergil@vergil-marketplace"
+        )
+
+    def test_marketplace_sources_handles_url_and_path_and_skips_sourceless(self) -> None:
+        # #2021: non-github sources (url, path) are registered; entries with no
+        # usable source are skipped, not crashed on.
+        settings = json.dumps(
+            {
+                "extraKnownMarketplaces": {
+                    "u": {"source": {"source": "git", "url": "https://example.com/y.git"}},
+                    "p": {"source": {"path": "./local-mp"}},
+                    "empty": {"source": {}},
+                    "nosrc": {},
+                },
+                "enabledPlugins": {},
+            }
+        )
+
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "cat ~/.claude/settings.json" in cmd:
+                out = settings
+            elif "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        update_plugins(transport)  # no raise (nothing enabled)
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        assert any("marketplace add https://example.com/y.git" in c for c in cmds)
+        assert any("marketplace add ./local-mp" in c for c in cmds)
+        # sourceless entries produced no add command
+        assert sum("marketplace add" in c for c in cmds) == 2
+
+    def test_marketplace_add_failure_is_surfaced(self) -> None:
+        # #2021: a marketplace that fails to register is collected and surfaced,
+        # never silently skipped.
+        settings = json.dumps(
+            {
+                "extraKnownMarketplaces": {
+                    "bad": {"source": {"source": "github", "repo": "x/bad"}}
+                },
+                "enabledPlugins": {},
+            }
+        )
+
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "marketplace add x/bad" in cmd:
+                raise subprocess.CalledProcessError(1, "claude plugin marketplace add")
+            if "cat ~/.claude/settings.json" in cmd:
+                out = settings
+            elif "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        with pytest.raises(RuntimeError, match="marketplace:x/bad"):
+            update_plugins(transport)


### PR DESCRIPTION
# Pull Request

## Summary

- update_plugins now 'claude plugin marketplace add's each extraKnownMarketplaces source before installing, because headless marketplace update/list do not register declared marketplaces on a fresh box — the reason a rebuilt box installed zero plugins ('not found in marketplace, local copy out of date').

## Issue Linkage

- Ref #2021

## Notes

- Root cause reproduced on a live Lima box. Idempotent, best-effort, add failures surfaced. Fixes both Lima and off-platform rebuilds. Follow-up to #2006/#2010. Part of epic vergil-project/.github#69.