### PR TITLE
fix(repo-init): omit trailing space on language: for no-language repos

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -365,6 +365,10 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
     from vergil_tooling.lib.languages import CheckKind, language_commands
 
     lang_yaml = ctx.primary_language or ""
+    # A no-primary-language repo must emit a bare `language:` — writing
+    # `language: {empty}` leaves a trailing space that fails yamllint
+    # trailing-spaces (issue #1993).
+    lang_line = f"      language: {lang_yaml}\n" if lang_yaml else "      language:\n"
     suffix = _container_suffix(ctx.primary_language)
     tag = _container_tag(ctx.primary_language, ctx.ci_versions)
     versions_json = json.dumps(ctx.ci_versions)
@@ -404,7 +408,7 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
                 "  audit:\n",
                 "    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.1\n",
                 "    with:\n",
-                f"      language: {lang_yaml}\n",
+                lang_line,
                 f"      versions: '{versions_json}'\n",
                 f"      container-tag: '{tag}'\n",
                 f"      container-suffix: {suffix}\n",
@@ -417,7 +421,7 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
             "  quality:\n",
             "    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1\n",
             "    with:\n",
-            f"      language: {lang_yaml}\n",
+            lang_line,
             f"      versions: '{versions_json}'\n",
             f"      container-tag: '{tag}'\n",
             f"      container-suffix: {suffix}\n",
@@ -431,7 +435,7 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
             "      # needs it on private repos. See vergil-project/vergil-actions#698.\n",
             "      actions: read\n",
             "    with:\n",
-            f"      language: {lang_yaml}\n",
+            lang_line,
             "      run-standards: ${{ inputs.run-release != 'false' }}\n",
             "      run-security: ${{ inputs.run-security != 'false' }}\n",
         ]
@@ -465,7 +469,7 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
                 "  test:\n",
                 "    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.1\n",
                 "    with:\n",
-                f"      language: {lang_yaml}\n",
+                lang_line,
                 f"      versions: '{versions_json}'\n",
                 f"      container-tag: '{tag}'\n",
                 f"      container-suffix: {suffix}\n",
@@ -480,7 +484,7 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
                 "    uses: vergil-project/vergil-actions/"
                 ".github/workflows/ci-version-bump.yml@v2.1\n",
                 "    with:\n",
-                f"      language: {lang_yaml}\n",
+                lang_line,
                 "      run-release: ${{ inputs.run-release != 'false' }}\n",
                 f"      container-tag: '{tag}'\n",
                 f"      container-suffix: {suffix}\n",

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -340,6 +340,17 @@ class TestRenderCiWorkflow:
         assert content.count("container-suffix: base") == 3
         assert content.count("container-tag: 'latest'") == 3
 
+    def test_no_language_omits_trailing_space(self) -> None:
+        """A no-primary-language repo must not scaffold `language: ` with a
+        trailing space — yamllint trailing-spaces rejects it (issue #1993)."""
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.ci_versions = ["latest"]
+        ctx.release_model = "tagged-release"
+        content = render_ci_workflow(ctx)
+        assert "language: \n" not in content
+        trailing = [line for line in content.splitlines() if line != line.rstrip()]
+        assert not trailing, f"lines with trailing whitespace: {trailing!r}"
+
     def test_no_language_no_release_minimal_jobs(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
         ctx.ci_versions = ["latest"]


### PR DESCRIPTION
# Pull Request

## Summary

- Scaffold a bare 'language:' (no trailing space) in ci.yml when a repo has no primary language, so the generated workflow passes yamllint.

## Issue Linkage

- Ref #1993

## Notes

- render_ci_workflow emitted 'language: {lang_yaml}' at five with:-input sites; when primary_language is empty that left 'language: ' with a trailing space, failing vrg-validate's yamllint trailing-spaces gate (hit while bootstrapping vergil-project/docs, #60). Fix introduces a single lang_line built once and reused at all five sites. Added TestRenderCiWorkflow.test_no_language_omits_trailing_space (asserts no trailing whitespace on any rendered line); confirmed red before the fix, green after. Full vrg-container-run -- vrg-validate passes.