### PR TITLE
fix(plugins): register marketplaces referenced by enabled plugins even when undeclared

### DIFF
--- a/src/vergil_tooling/lib/vm_guest.py
+++ b/src/vergil_tooling/lib/vm_guest.py
@@ -15,7 +15,7 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vergil_tooling.lib.identity import Identity
@@ -269,15 +269,15 @@ def update_tooling(transport: Transport, tag: str | None = None, *, fallback_tag
 _PLUGIN_PATH_EXPORT = 'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"'
 
 
-def _desired_enabled_plugins(transport: Transport) -> set[str]:
-    """Return the plugin ids the guest settings.json marks enabled.
+_OFFICIAL_MARKETPLACE = "claude-plugins-official"
+_OFFICIAL_MARKETPLACE_SOURCE = "anthropics/claude-plugins-official"
 
-    The desired set is declarative: ``enabledPlugins`` in the guest
-    ``~/.claude/settings.json`` (seeded from the host). Since Claude Code
-    v2.1.195 an enabled entry no longer auto-installs, so this is the
-    authoritative list of what *should* be present, independent of what is
-    installed. Absent or unreadable settings yield an empty set — the caller
-    still refreshes anything already installed-and-enabled.
+
+def _read_guest_settings(transport: Transport) -> dict[str, Any]:
+    """Return the guest ``~/.claude/settings.json`` as a dict.
+
+    Absent, unreadable, or non-object settings yield ``{}`` — the caller then
+    registers no marketplaces and refreshes only what is already installed.
     """
     try:
         result = transport.run(
@@ -286,42 +286,53 @@ def _desired_enabled_plugins(transport: Transport) -> set[str]:
             f"{_PLUGIN_PATH_EXPORT} && cat ~/.claude/settings.json",
         )
     except subprocess.CalledProcessError:
-        return set()
+        return {}
     try:
         data = json.loads(result.stdout)
     except json.JSONDecodeError:
-        return set()
-    enabled = data.get("enabledPlugins", {})
-    return {pid for pid, on in enabled.items() if on}
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
-def _declared_marketplace_sources(transport: Transport) -> list[str]:
-    """Return the ``marketplace add`` sources declared in the guest settings.json.
+def _enabled_plugin_ids(settings: dict[str, Any]) -> set[str]:
+    """Return the plugin ids ``enabledPlugins`` marks true.
 
-    Each ``extraKnownMarketplaces`` entry's ``source`` maps to an add-arg
-    (``owner/repo``, a URL, or a path). Headless ``claude plugin marketplace
-    update``/``list`` do NOT register these on a fresh box (#2021) — only
-    ``marketplace add <source>`` clones the catalog — so update_plugins registers
-    them explicitly before installing. Absent/unreadable settings yield [].
+    Declarative desired set: since Claude Code v2.1.195 an enabled entry no
+    longer auto-installs, so this is the authoritative list of what *should* be
+    present, independent of what is installed.
     """
-    try:
-        result = transport.run(
-            "bash",
-            "-c",
-            f"{_PLUGIN_PATH_EXPORT} && cat ~/.claude/settings.json",
-        )
-    except subprocess.CalledProcessError:
-        return []
-    try:
-        data = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return []
+    return {pid for pid, on in (settings.get("enabledPlugins") or {}).items() if on}
+
+
+def _marketplace_sources(settings: dict[str, Any]) -> list[str]:
+    """Return the ``marketplace add`` sources needed for the enabled plugins.
+
+    Primarily the ``extraKnownMarketplaces`` entries (each ``source`` -> an
+    add-arg: ``owner/repo``, a URL, or a path). Headless ``claude plugin
+    marketplace update``/``list`` do NOT register these on a fresh box (#2021) —
+    only ``marketplace add <source>`` clones the catalog.
+
+    Hardening (#2029): an enabled plugin can reference a marketplace not declared
+    in ``extraKnownMarketplaces`` — notably the built-in ``claude-plugins-official``,
+    which is not always listed. For such a plugin, derive a source where we can
+    (official -> its Anthropic repo); an undecidable third-party marketplace has
+    no derivable source and is left for the install to surface, never invented.
+    """
+    extra = settings.get("extraKnownMarketplaces") or {}
     sources: list[str] = []
-    for spec in (data.get("extraKnownMarketplaces") or {}).values():
+    for spec in extra.values():
         src = spec.get("source") or {}
         arg = src.get("repo") or src.get("url") or src.get("path")
         if arg:
             sources.append(arg)
+    for pid in _enabled_plugin_ids(settings):
+        if "@" not in pid:
+            continue
+        market = pid.split("@", 1)[1]
+        if market in extra:
+            continue
+        if market == _OFFICIAL_MARKETPLACE and _OFFICIAL_MARKETPLACE_SOURCE not in sources:
+            sources.append(_OFFICIAL_MARKETPLACE_SOURCE)
     return sources
 
 
@@ -354,11 +365,12 @@ def update_plugins(transport: Transport) -> None:
     """
     print("  Refreshing Claude plugins...")
     failures: list[str] = []
-    # Register the declared marketplaces so their catalogs are cloned. Headless
-    # `marketplace update`/`list` do NOT register a fresh box's extraKnownMarketplaces
-    # (#2021) — only `marketplace add <source>` clones the catalog, so a subsequent
-    # install can find the plugin. Idempotent (re-add is a no-op) and best-effort.
-    for source in _declared_marketplace_sources(transport):
+    settings = _read_guest_settings(transport)
+    # Register every marketplace the enabled plugins reference so their catalogs
+    # are cloned. Headless `marketplace update`/`list` do NOT register a fresh
+    # box's extraKnownMarketplaces (#2021) — only `marketplace add <source>` does.
+    # Idempotent (re-add is a no-op) and best-effort.
+    for source in _marketplace_sources(settings):
         print(f"    registering marketplace {source}...")
         try:
             transport.run(
@@ -373,7 +385,7 @@ def update_plugins(transport: Transport) -> None:
         "-c",
         f"{_PLUGIN_PATH_EXPORT} && claude plugin marketplace update",
     )
-    desired = _desired_enabled_plugins(transport)
+    desired = _enabled_plugin_ids(settings)
     listing = transport.run(
         "bash",
         "-c",

--- a/tests/vergil_tooling/test_vm_guest.py
+++ b/tests/vergil_tooling/test_vm_guest.py
@@ -889,3 +889,97 @@ class TestUpdatePlugins:
         transport.run.side_effect = side_effect
         with pytest.raises(RuntimeError, match="marketplace:x/bad"):
             update_plugins(transport)
+
+    def test_derives_official_marketplace_when_undeclared(self) -> None:
+        # #2029: an enabled plugin can reference a marketplace not in
+        # extraKnownMarketplaces — notably claude-plugins-official, which isn't
+        # always declared. Derive its source so add+install still work.
+        settings = json.dumps(
+            {
+                "extraKnownMarketplaces": {},
+                "enabledPlugins": {"superpowers@claude-plugins-official": True},
+            }
+        )
+
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "cat ~/.claude/settings.json" in cmd:
+                out = settings
+            elif "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        update_plugins(transport)
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        assert any("marketplace add anthropics/claude-plugins-official" in c for c in cmds)
+        assert any(
+            "plugin install superpowers@claude-plugins-official --scope user" in c for c in cmds
+        )
+
+    def test_undecidable_undeclared_marketplace_is_not_added(self) -> None:
+        # #2029: a plugin against an unknown third-party marketplace has no
+        # derivable source — we do not invent one; the install surfaces the error.
+        settings = json.dumps(
+            {
+                "extraKnownMarketplaces": {},
+                "enabledPlugins": {"thing@some-third-party": True},
+            }
+        )
+
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "cat ~/.claude/settings.json" in cmd:
+                out = settings
+            elif "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        update_plugins(transport)
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        assert not any("marketplace add" in c for c in cmds)
+
+    def test_non_object_settings_is_tolerated(self) -> None:
+        # #2029: settings.json that isn't a JSON object (e.g. an array) is treated
+        # as empty, not crashed on.
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "cat ~/.claude/settings.json" in cmd or "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        update_plugins(transport)  # no raise
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        assert not any("marketplace add" in c for c in cmds)
+
+    def test_enabled_id_without_marketplace_suffix_is_skipped(self) -> None:
+        # #2029: an enabled id with no @marketplace can't map to a marketplace, so
+        # it yields no add command (its install surfaces any problem).
+        settings = json.dumps({"extraKnownMarketplaces": {}, "enabledPlugins": {"bare-id": True}})
+
+        def side_effect(*args: str, **_kw: object) -> MagicMock:
+            cmd = args[-1]
+            if "cat ~/.claude/settings.json" in cmd:
+                out = settings
+            elif "plugin list --json" in cmd:
+                out = "[]"
+            else:
+                out = ""
+            return MagicMock(stdout=out, returncode=0)
+
+        transport = MagicMock()
+        transport.run.side_effect = side_effect
+        update_plugins(transport)
+        cmds = [c.args[-1] for c in transport.run.call_args_list]
+        assert not any("marketplace add" in c for c in cmds)


### PR DESCRIPTION
# Pull Request

## Summary

- update_plugins now derives a marketplace source for enabled plugins whose marketplace isn't in extraKnownMarketplaces (claude-plugins-official -> anthropics/claude-plugins-official) so their catalogs are cloned and install succeeds; undecidable third-party marketplaces are surfaced, not invented.

## Issue Linkage

- Ref #2029

## Notes

- Hardening follow-up to #2021/#2023. Consolidates the settings read into _read_guest_settings/_enabled_plugin_ids/_marketplace_sources. Part of epic vergil-project/.github#69.