### PR TITLE
test(cli): gate --help coverage across vrg-* tools + convention doc

### DIFF
--- a/docs/site/docs/standards/development/cli-help-convention.md
+++ b/docs/site/docs/standards/development/cli-help-convention.md
@@ -1,0 +1,50 @@
+# CLI `--help` Convention
+
+## Purpose
+
+Running a tool with `--help` is the canonical way for both humans and agents to
+learn what a tool does and how to invoke it. Every `vrg-*` console script must
+answer `--help` with a useful description so that no one has to read source to
+discover a tool's behavior or scope.
+
+## Scope
+
+Applies to every human-facing `vrg-*` console script declared in
+`[project.scripts]`. Non-human entry points — hooks invoked by another program
+rather than a person at a prompt — are exempt (see below).
+
+## The rule
+
+A covered tool must respond to `-h` / `--help` by:
+
+1. Exiting `0`.
+2. Printing a non-empty description to stdout that covers:
+   - a one-line statement of what the tool does;
+   - its scope and inputs (what it reads, and — where relevant — whether it
+     operates on the current repo, its org, or something else);
+   - whether it is **read-only** or **makes changes**. A tool that makes
+     changes should document its `--dry-run`.
+
+The standard mechanism is `argparse`: give the tool an `ArgumentParser` with a
+`description` (and `epilog` where useful), and `-h/--help` comes for free.
+Tools that take no flags still get a parser so their `--help` describes them.
+Wrappers that forward to another CLI intercept `--help` themselves to explain
+their wrapper-specific behavior before forwarding.
+
+## Enforcement
+
+`tests/vergil_tooling/test_help_coverage.py` is the gate. It enumerates every
+console script from `[project.scripts]`, runs each covered tool with `--help`
+in a subprocess, and asserts exit `0` with non-empty output. `--help`
+short-circuits before a tool's real work, so the check is hermetic.
+
+Two lists steer the gate:
+
+- **`EXEMPT`** — non-human entry points with no `--help` contract (currently
+  `vrg-hook-guard`, a Claude Code hook invoked with a JSON event on stdin).
+- **`KNOWN_GAPS`** — tools that do not yet answer `--help`. This is a temporary
+  ratchet: `test_gap_set_matches_reality` fails if the documented gaps drift
+  from the source, so fixing a tool forces its removal from the list, and a new
+  tool shipped without help fails until it gains a `--help` (or is added to
+  `EXEMPT`). Do **not** add a tool to `KNOWN_GAPS` to silence the gate — give
+  the tool a `--help` instead.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
           - Environment and Tooling: standards/development/environment-and-tooling.md
           - Runtime Version Support: standards/development/runtime-version-support-policy.md
           - Deprecation Warnings: standards/development/deprecation-warnings.md
+          - CLI Help Convention: standards/development/cli-help-convention.md
           - Python:
               - Overview: standards/development/python/overview.md
               - Naming Conventions: standards/development/python/naming-conventions.md

--- a/tests/vergil_tooling/test_help_coverage.py
+++ b/tests/vergil_tooling/test_help_coverage.py
@@ -1,0 +1,109 @@
+"""Gate: every human-facing ``vrg-*`` console script answers ``--help``.
+
+Part of epic vergil-project/.github#72 ("Every vrg-* tool answers --help,
+enforced"). See docs/site/docs/standards/development/cli-help-convention.md.
+
+The gate runs each *covered* console script with ``--help`` in a subprocess and
+asserts it exits 0 with non-empty output. ``--help`` short-circuits before any
+of a tool's real work, so the check is hermetic. Tools that do not yet answer
+``--help`` are listed in ``KNOWN_GAPS`` and are never executed; each is fixed by
+a later task of the epic, and ``test_gap_set_matches_reality`` forces that list
+to stay in sync with the source.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# vrg-hook-guard is a Claude Code PreToolUse hook: the hook system invokes it
+# with a JSON event on stdin, never a human at a prompt, so it has no --help
+# contract.
+EXEMPT = frozenset({"vrg-hook-guard"})
+
+# Tools that do not yet answer --help. Each is fixed by a later task of epic
+# vergil-project/.github#72; removing a tool from this set is part of its fix.
+# When the set is empty the gate is fully enforcing. Do NOT add a new tool here
+# to silence the gate — give the tool a --help instead.
+KNOWN_GAPS = frozenset(
+    {
+        "vrg-container-docs",
+        "vrg-container-test",
+        "vrg-epic-audit",
+        "vrg-gh",
+        "vrg-git",
+        "vrg-pr-issue-linkage",
+        "vrg-repo-profile",
+    }
+)
+
+
+def _scripts() -> dict[str, str]:
+    """Map console-script name -> ``module:attr`` entry from pyproject."""
+    data = tomllib.loads(_PYPROJECT.read_text())
+    return dict(data["project"]["scripts"])
+
+
+def _module_of(entry: str) -> str:
+    # "vergil_tooling.bin.vrg_foo:main" -> "vergil_tooling.bin.vrg_foo"
+    return entry.split(":", 1)[0]
+
+
+def _declares_help(module: str) -> bool:
+    """True if the module builds an argparse parser or handles --help itself."""
+    spec = importlib.util.find_spec(module)
+    assert spec is not None and spec.origin is not None, module
+    src = Path(spec.origin).read_text()
+    return "ArgumentParser" in src or "--help" in src
+
+
+_SCRIPTS = _scripts()
+_COVERED = sorted(n for n in _SCRIPTS if n not in EXEMPT and n not in KNOWN_GAPS)
+
+
+def test_exempt_and_known_gaps_are_real_scripts() -> None:
+    """EXEMPT and KNOWN_GAPS may only name scripts that actually exist."""
+    names = set(_SCRIPTS)
+    assert names >= EXEMPT, f"stale EXEMPT entries: {sorted(EXEMPT - names)}"
+    assert names >= KNOWN_GAPS, f"stale KNOWN_GAPS entries: {sorted(KNOWN_GAPS - names)}"
+
+
+def test_gap_set_matches_reality() -> None:
+    """Documented gaps must equal the tools that actually lack ``--help``.
+
+    Fix a tool (add argparse or --help handling) and it leaves the real gap set
+    — remove it from KNOWN_GAPS. Add a tool without help and it enters the real
+    gap set — give it a --help, or (for a non-human hook) add it to EXEMPT.
+    """
+    actual = {
+        n for n in _SCRIPTS if n not in EXEMPT and not _declares_help(_module_of(_SCRIPTS[n]))
+    }
+    assert actual == set(KNOWN_GAPS), (
+        "help-gap set drifted from source; symmetric difference: "
+        f"{sorted(actual ^ set(KNOWN_GAPS))}"
+    )
+
+
+@pytest.mark.parametrize("name", _COVERED)
+def test_tool_answers_help(name: str) -> None:
+    """Every covered tool exits 0 and prints something for ``--help``."""
+    module = _module_of(_SCRIPTS[name])
+    result = subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"{name} (--help) exited {result.returncode}; stderr:\n{result.stderr}"
+    )
+    assert result.stdout.strip(), f"{name} (--help) produced no stdout"


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a validation gate that runs every covered vrg-* console script with --help and asserts exit 0 + non-empty output, plus the standards doc defining the convention; vrg-hook-guard is exempt and seven not-yet-covered tools are tracked in KNOWN_GAPS for tasks 2-4.

## Issue Linkage

- Ref #2030

## Notes

- Task 1 of epic vergil-project/.github#72. The gate already caught a stale assumption — vrg-activity-log and vrg-roadmap gained argparse on the newer develop, so they are NOT gaps. KNOWN_GAPS ratchet: test_gap_set_matches_reality fails if the documented gaps drift from source, forcing each later task to remove the tool it fixes. vrg-validate is green (3831 passed). Does not change any tool's behavior; gap tools are fixed in tasks 2-4.