### PR TITLE
feat(epic-audit): add --help, auto-detect org, --window-days, read-only banner

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -1,22 +1,73 @@
 """Print the epic/task drift audit (read-only safety net).
 
 See :mod:`vergil_tooling.lib.epic_audit`. Surfaces work that slipped through
-auto-close so a human can close it (agents cannot close issues).
+auto-close so a human can close it.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 from datetime import UTC, datetime, timedelta
 
-from vergil_tooling.lib import epic_audit
+from vergil_tooling.lib import epic_audit, github
 
-_WINDOW_DAYS = 30
+_DEFAULT_WINDOW_DAYS = 30
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
-    since = (datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)).date().isoformat()
-    print(epic_audit.render(epic_audit.task_drift(since), epic_audit.epic_drift()))
+def _positive_int(raw: str) -> int:
+    value = int(raw)
+    if value < 1:
+        msg = "must be a positive integer"
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="vrg-epic-audit",
+        description=(
+            "Report epic/task drift for the current repo's GitHub org: merged "
+            "PRs whose Ref'd task issue is still open, and open non-standing "
+            "epics whose children are all closed. Read-only — it changes "
+            "nothing; a human acts on whatever it lists."
+        ),
+        epilog=(
+            "Scope: the org is auto-detected from this repo's 'origin' remote, "
+            "so run it from inside a repo in the org you want to audit (there is "
+            "no --org flag). Output is Markdown on stdout."
+        ),
+    )
+    parser.add_argument(
+        "--window-days",
+        type=_positive_int,
+        default=_DEFAULT_WINDOW_DAYS,
+        metavar="N",
+        help=(f"How many days back to scan for merged PRs (default: {_DEFAULT_WINDOW_DAYS})."),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    org = github.detect_org()
+    if org is None:
+        print(
+            "vrg-epic-audit: could not determine the GitHub org from this "
+            "repo's 'origin' remote; run it from inside a repo in the org you "
+            "want to audit.",
+            file=sys.stderr,
+        )
+        return 1
+    since = (datetime.now(UTC) - timedelta(days=args.window_days)).date().isoformat()
+    print(
+        epic_audit.render(
+            epic_audit.task_drift(since, org=org),
+            epic_audit.epic_drift(),
+            org=org,
+            window_days=args.window_days,
+        )
+    )
     return 0
 
 

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -13,8 +13,6 @@ from typing import Any
 
 from vergil_tooling.lib import github, linkage, roadmap
 
-_ORG = "vergil-project"
-
 
 @dataclass(frozen=True)
 class TaskDrift:
@@ -26,7 +24,7 @@ class TaskDrift:
     pr_url: str
 
 
-def task_drift(since: str, *, org: str = _ORG) -> list[TaskDrift]:
+def task_drift(since: str, *, org: str) -> list[TaskDrift]:
     """Merged PRs (since *since*) whose ``Ref``'d task is still open."""
     raw: Any = github.read_json(
         "search",
@@ -68,13 +66,28 @@ def epic_drift() -> list[roadmap.EpicSummary]:
     return [epic for epic in roadmap.gather() if epic.total > 0 and epic.closed == epic.total]
 
 
-def render(tasks: list[TaskDrift], epics: list[roadmap.EpicSummary]) -> str:
-    """Format the drift report; a clean state says so explicitly."""
+def render(
+    tasks: list[TaskDrift],
+    epics: list[roadmap.EpicSummary],
+    *,
+    org: str,
+    window_days: int,
+) -> str:
+    """Format the drift report; a clean state says so explicitly.
+
+    The report opens with a banner naming the audited org and window and
+    stating the run is read-only, so the output is never mistaken for a list of
+    actions the tool took.
+    """
+    banner = (
+        f"_Read-only audit of the **{org}** org (merged PRs from the last "
+        f"{window_days} days) — this report changes nothing; a human closes "
+        "anything it lists._"
+    )
+    header = ["# Epic/task drift audit", "", banner, ""]
     if not tasks and not epics:
-        return (
-            "# Epic/task drift audit\n\n_No drift — everything that should be closed is closed._\n"
-        )
-    lines = ["# Epic/task drift audit", "", "## Task drift (merged PR, task still open)", ""]
+        return "\n".join([*header, "_No drift — everything that should be closed is closed._", ""])
+    lines = [*header, "## Task drift (merged PR, task still open)", ""]
     if tasks:
         for task in sorted(tasks, key=lambda t: (t.repo, t.task)):
             lines.append(

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -72,7 +72,7 @@ def _load_app_config() -> tuple[str, Path] | None:
     return app_id, key_file
 
 
-def _detect_org() -> str | None:
+def detect_org() -> str | None:
     """Detect the GitHub org from the current repo's git remote."""
     try:
         result = subprocess.run(  # noqa: S603
@@ -183,7 +183,7 @@ def get_installation_token(
     auth is not installation-scoped).
     """
     if org is None:
-        org = _detect_org()
+        org = detect_org()
     if org is None:
         return None
 

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -44,13 +44,13 @@ def test_task_drift_flags_open_task_behind_merged_pr() -> None:
         patch("vergil_tooling.lib.github.read_json", return_value=prs),
         patch("vergil_tooling.lib.github.read_output", side_effect=fake_state),
     ):
-        result = epic_audit.task_drift("2026-06-01")
+        result = epic_audit.task_drift("2026-06-01", org="vergil-project")
     assert result == [TaskDrift("vergil-project/vergil-tooling", 1947, 1948, "u1948")]
 
 
 def test_task_drift_returns_empty_on_non_list() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"x": 1}):
-        assert epic_audit.task_drift("2026-06-01") == []
+        assert epic_audit.task_drift("2026-06-01", org="vergil-project") == []
 
 
 def test_epic_drift_flags_all_done_open_epics() -> None:
@@ -65,11 +65,22 @@ def test_epic_drift_flags_all_done_open_epics() -> None:
 
 
 def test_render_clean() -> None:
-    assert "No drift" in epic_audit.render([], [])
+    out = epic_audit.render([], [], org="vergil-project", window_days=30)
+    assert "No drift" in out
+
+
+def test_render_banner_states_scope_and_read_only() -> None:
+    out = epic_audit.render([], [], org="acme-co", window_days=14)
+    assert "Read-only audit" in out
+    assert "**acme-co**" in out
+    assert "last 14 days" in out
+    assert "changes nothing" in out
 
 
 def test_render_task_drift_only() -> None:
-    out = epic_audit.render([TaskDrift("o/r", 1947, 1948, "u1948")], [])
+    out = epic_audit.render(
+        [TaskDrift("o/r", 1947, 1948, "u1948")], [], org="vergil-project", window_days=30
+    )
     assert "o/r#1947 — open; PR [#1948](u1948) merged" in out
     assert "## Epic drift" in out
     assert out.count("_none_") == 1  # epic section is empty
@@ -77,7 +88,7 @@ def test_render_task_drift_only() -> None:
 
 def test_render_epic_drift_only() -> None:
     epic = roadmap.EpicSummary(40, "Convention", "2026-06-28", None, (), 9, 9, "u40")
-    out = epic_audit.render([], [epic])
+    out = epic_audit.render([], [epic], org="vergil-project", window_days=30)
     assert "[#40](u40) Convention — 9/9 done" in out
     assert "## Task drift" in out
     assert out.count("_none_") == 1  # task section is empty

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -1048,29 +1048,29 @@ class TestDetectOrg:
             mock_run.return_value = _completed(
                 stdout="git@github.com:vergil-project/vergil-tooling.git\n"
             )
-            assert github._detect_org() == "vergil-project"
+            assert github.detect_org() == "vergil-project"
 
     def test_parses_https_remote(self) -> None:
         with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
             mock_run.return_value = _completed(
                 stdout="https://github.com/vergil-project/vergil-tooling.git\n"
             )
-            assert github._detect_org() == "vergil-project"
+            assert github.detect_org() == "vergil-project"
 
     def test_returns_none_on_git_failure(self) -> None:
         with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
             mock_run.side_effect = subprocess.CalledProcessError(1, "git")
-            assert github._detect_org() is None
+            assert github.detect_org() is None
 
     def test_returns_none_for_unrecognized_url(self) -> None:
         with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
             mock_run.return_value = _completed(stdout="https://gitlab.com/org/repo.git\n")
-            assert github._detect_org() is None
+            assert github.detect_org() is None
 
     def test_returns_none_for_empty_org(self) -> None:
         with patch("vergil_tooling.lib.github.subprocess.run") as mock_run:
             mock_run.return_value = _completed(stdout="git@github.com:/repo.git\n")
-            assert github._detect_org() is None
+            assert github.detect_org() is None
 
 
 _URLOPEN = "vergil_tooling.lib.github.urllib.request.urlopen"
@@ -1170,7 +1170,7 @@ class TestGetInstallationToken:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("VRG_APP_ID", raising=False)
         monkeypatch.delenv("VRG_PRIVATE_KEY_PATH", raising=False)
-        with patch("vergil_tooling.lib.github._detect_org", return_value=None):
+        with patch("vergil_tooling.lib.github.detect_org", return_value=None):
             assert github.get_installation_token() is None
 
     def test_exchanges_jwt_for_installation_token(

--- a/tests/vergil_tooling/test_help_coverage.py
+++ b/tests/vergil_tooling/test_help_coverage.py
@@ -37,7 +37,6 @@ KNOWN_GAPS = frozenset(
     {
         "vrg-container-docs",
         "vrg-container-test",
-        "vrg-epic-audit",
         "vrg-gh",
         "vrg-git",
         "vrg-pr-issue-linkage",

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -2,22 +2,60 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from unittest.mock import patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from vergil_tooling.bin.vrg_epic_audit import main
-
-if TYPE_CHECKING:
-    import pytest
 
 _MOD = "vergil_tooling.bin.vrg_epic_audit"
 
 
 def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
     with (
+        patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
     ):
-        rc = main()
+        rc = main([])
+    out = capsys.readouterr().out
     assert rc == 0
-    assert "drift audit" in capsys.readouterr().out
+    assert "drift audit" in out
+    # The read-only banner names the auto-detected org and states nothing changed.
+    assert "Read-only audit" in out
+    assert "**vergil-project**" in out
+
+
+def test_main_errors_when_org_undetectable(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.github.detect_org", return_value=None):
+        rc = main([])
+    assert rc == 1
+    assert "could not determine the GitHub org" in capsys.readouterr().err
+
+
+def test_window_days_controls_since() -> None:
+    task_drift = MagicMock(return_value=[])
+    with (
+        patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.task_drift", task_drift),
+        patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
+    ):
+        rc = main(["--window-days", "7"])
+    assert rc == 0
+    expected_since = (datetime.now(UTC) - timedelta(days=7)).date().isoformat()
+    assert task_drift.call_args.args[0] == expected_since
+    assert task_drift.call_args.kwargs["org"] == "vergil-project"
+
+
+def test_invalid_window_days_rejected() -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--window-days", "0"])
+    assert exc.value.code == 2
+
+
+def test_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    assert "Read-only" in capsys.readouterr().out


### PR DESCRIPTION
# Pull Request

## Summary

- Gives vrg-epic-audit an argparse CLI whose --help documents its scope (the current repo's auto-detected org, a --window-days merged-PR window defaulting to 30, read-only) and adds a banner to the output making its read-only nature explicit; the org is now resolved from the repo's origin instead of a hardcoded constant, erroring clearly when undetectable.

## Issue Linkage

- Ref #2040

## Notes

- Task 2 of epic vergil-project/.github#72 — the trigger case. Promotes github._detect_org to public detect_org (test_github.py updated). No --org flag by design: the org follows the repo you run from. Removes vrg-epic-audit from the task-1 KNOWN_GAPS ratchet. vrg-validate is green.