### PR TITLE
feat(epic-audit): add human-gated --close to perform the drift closes

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -10,7 +10,7 @@ import argparse
 import sys
 from datetime import UTC, datetime, timedelta
 
-from vergil_tooling.lib import epic_audit, github
+from vergil_tooling.lib import epic_audit, github, identity_mode
 
 _DEFAULT_WINDOW_DAYS = 30
 
@@ -29,8 +29,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         description=(
             "Report epic/task drift for the current repo's GitHub org: merged "
             "PRs whose Ref'd task issue is still open, and open non-standing "
-            "epics whose children are all closed. Read-only — it changes "
-            "nothing; a human acts on whatever it lists."
+            "epics whose children are all closed. Read-only by default; pass "
+            "--close (as a human) to actually close what it finds."
         ),
         epilog=(
             "Scope: the org is auto-detected from this repo's 'origin' remote, "
@@ -45,11 +45,30 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         metavar="N",
         help=(f"How many days back to scan for merged PRs (default: {_DEFAULT_WINDOW_DAYS})."),
     )
+    parser.add_argument(
+        "--close",
+        action="store_true",
+        help=(
+            "Close the drifted task issues and rolled-up epics (with an "
+            "explanatory comment on each) instead of only reporting them. A "
+            "human action — refused in agent sessions. Default: read-only."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    # Gate the write path before any network work so a rejected agent run is
+    # cheap and unambiguous.
+    if args.close and not identity_mode.is_human():
+        print(
+            "vrg-epic-audit: --close is a human action and was refused in an "
+            "agent session; run without --close to preview the drift, or run as "
+            "a human to apply the closes.",
+            file=sys.stderr,
+        )
+        return 1
     org = github.detect_org()
     if org is None:
         print(
@@ -60,14 +79,13 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     since = (datetime.now(UTC) - timedelta(days=args.window_days)).date().isoformat()
-    print(
-        epic_audit.render(
-            epic_audit.task_drift(since, org=org),
-            epic_audit.epic_drift(),
-            org=org,
-            window_days=args.window_days,
-        )
-    )
+    tasks = epic_audit.task_drift(since, org=org)
+    epics = epic_audit.epic_drift()
+    if args.close:
+        closed = epic_audit.close_drift(tasks, epics, org=org)
+        print(epic_audit.render_closed(closed, org=org, window_days=args.window_days))
+        return 0
+    print(epic_audit.render(tasks, epics, org=org, window_days=args.window_days))
     return 0
 
 

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -1,9 +1,10 @@
 """Audit for epic/task drift — work that slipped through auto-close.
 
-A read-only safety net (agents cannot close issues). ``task_drift`` finds merged
-PRs whose ``Ref``'d task is still open; ``epic_drift`` finds open, non-standing
-epics whose children are all closed (should have rolled up). ``render`` formats
-both sections for a human to act on.
+``task_drift`` finds merged PRs whose ``Ref``'d task is still open;
+``epic_drift`` finds open, non-standing epics whose children are all closed
+(should have rolled up). ``render`` formats both sections for review;
+``close_drift`` closes them with an explanatory comment — a human action, gated
+by the caller.
 """
 
 from __future__ import annotations
@@ -81,8 +82,8 @@ def render(
     """
     banner = (
         f"_Read-only audit of the **{org}** org (merged PRs from the last "
-        f"{window_days} days) — this report changes nothing; a human closes "
-        "anything it lists._"
+        f"{window_days} days) — this report changes nothing; run `--close` (as "
+        "a human) to close what it lists._"
     )
     header = ["# Epic/task drift audit", "", banner, ""]
     if not tasks and not epics:
@@ -103,5 +104,64 @@ def render(
             )
     else:
         lines.append("- _none_")
+    lines.append("")
+    return "\n".join(lines)
+
+
+_TASK_CLOSE_COMMENT = (
+    "Closed by `vrg-epic-audit`: PR #{pr} merged but the tracking task's auto-close did not fire."
+)
+_EPIC_CLOSE_COMMENT = (
+    "Closed by `vrg-epic-audit`: all {total} child tasks are closed; the epic rolled up."
+)
+
+
+def close_drift(
+    tasks: list[TaskDrift],
+    epics: list[roadmap.EpicSummary],
+    *,
+    org: str,
+) -> list[str]:
+    """Close each drifted task and rolled-up epic, leaving a comment on each.
+
+    Epics live in ``{org}/.github``. Returns the ``owner/repo#n`` slugs closed,
+    in the order acted on. This performs outward-effecting GitHub writes; the
+    caller is responsible for gating it to a human.
+    """
+    closed: list[str] = []
+    for task in sorted(tasks, key=lambda t: (t.repo, t.task)):
+        github.run(
+            "issue",
+            "close",
+            str(task.task),
+            "--repo",
+            task.repo,
+            "--comment",
+            _TASK_CLOSE_COMMENT.format(pr=task.pr_number),
+        )
+        closed.append(f"{task.repo}#{task.task}")
+    epic_repo = f"{org}/.github"
+    for epic in sorted(epics, key=lambda e: e.number):
+        github.run(
+            "issue",
+            "close",
+            str(epic.number),
+            "--repo",
+            epic_repo,
+            "--comment",
+            _EPIC_CLOSE_COMMENT.format(total=epic.total),
+        )
+        closed.append(f"{epic_repo}#{epic.number}")
+    return closed
+
+
+def render_closed(closed: list[str], *, org: str, window_days: int) -> str:
+    """Summarize a ``--close`` run: what was actually closed."""
+    banner = f"_Closed drift on the **{org}** org (merged PRs from the last {window_days} days)._"
+    header = ["# Epic/task drift audit — closed", "", banner, ""]
+    if not closed:
+        return "\n".join([*header, "_No drift — nothing to close._", ""])
+    lines = [*header, "## Closed", ""]
+    lines += [f"- {slug}" for slug in closed]
     lines.append("")
     return "\n".join(lines)

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from vergil_tooling.lib import epic_audit, roadmap
 from vergil_tooling.lib.epic_audit import TaskDrift
@@ -92,3 +92,47 @@ def test_render_epic_drift_only() -> None:
     assert "[#40](u40) Convention — 9/9 done" in out
     assert "## Task drift" in out
     assert out.count("_none_") == 1  # task section is empty
+
+
+def test_close_drift_closes_tasks_in_repo_and_epics_in_dot_github() -> None:
+    tasks = [TaskDrift("vergil-project/vergil-tooling", 1947, 1948, "u1948")]
+    epics = [roadmap.EpicSummary(40, "Convention", "2026-06-28", None, (), 9, 9, "u40")]
+    run = MagicMock()
+    with patch("vergil_tooling.lib.github.run", run):
+        closed = epic_audit.close_drift(tasks, epics, org="vergil-project")
+    assert closed == ["vergil-project/vergil-tooling#1947", "vergil-project/.github#40"]
+    task_call = run.call_args_list[0]
+    assert task_call.args[:5] == (
+        "issue",
+        "close",
+        "1947",
+        "--repo",
+        "vergil-project/vergil-tooling",
+    )
+    assert "PR #1948 merged" in task_call.args[-1]
+    epic_call = run.call_args_list[1]
+    assert epic_call.args[:5] == ("issue", "close", "40", "--repo", "vergil-project/.github")
+    assert "all 9 child tasks" in epic_call.args[-1]
+
+
+def test_close_drift_empty_is_noop() -> None:
+    run = MagicMock()
+    with patch("vergil_tooling.lib.github.run", run):
+        assert epic_audit.close_drift([], [], org="vergil-project") == []
+    run.assert_not_called()
+
+
+def test_render_closed_lists_what_closed() -> None:
+    out = epic_audit.render_closed(
+        ["vergil-project/vergil-tooling#1947", "vergil-project/.github#40"],
+        org="vergil-project",
+        window_days=30,
+    )
+    assert "— closed" in out
+    assert "vergil-project/vergil-tooling#1947" in out
+    assert "vergil-project/.github#40" in out
+
+
+def test_render_closed_empty_says_nothing_to_close() -> None:
+    out = epic_audit.render_closed([], org="vergil-project", window_days=30)
+    assert "nothing to close" in out

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -59,3 +59,28 @@ def test_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
         main(["--help"])
     assert exc.value.code == 0
     assert "Read-only" in capsys.readouterr().out
+
+
+def test_close_refused_for_agent(capsys: pytest.CaptureFixture[str]) -> None:
+    # Refusal happens before any network work, so nothing else needs mocking.
+    with patch(f"{_MOD}.identity_mode.is_human", return_value=False):
+        rc = main(["--close"])
+    assert rc == 1
+    assert "human action" in capsys.readouterr().err
+
+
+def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]) -> None:
+    close_drift = MagicMock(return_value=["o/r#1"])
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=True),
+        patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
+        patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
+        patch(f"{_MOD}.epic_audit.close_drift", close_drift),
+    ):
+        rc = main(["--close"])
+    assert rc == 0
+    close_drift.assert_called_once_with(["T"], ["E"], org="vergil-project")
+    out = capsys.readouterr().out
+    assert "closed" in out.lower()
+    assert "o/r#1" in out


### PR DESCRIPTION
# Pull Request

## Summary

- Adds vrg-epic-audit --close, which actually closes the drifted task issues and rolled-up epics (with an explanatory comment on each) and prints a summary; read-only stays the default and --close is refused unless identity resolves to human, checked before any network work.

## Issue Linkage

- Ref #2041

## Notes

- Feature #2041 (the 'make it do the closes' capability), built on the #2040 argparse CLI. Human-gated via identity_mode.is_human(), mirroring the vrg-submit-pr boundary; closes via github.run('issue','close',...) as vrg-finalize-pr already does. I did NOT exercise --close for real (it is a live destructive path and in-container identity can default to human) — the gate and close paths are covered by mocked tests. vrg-validate green.