### PR TITLE
feat(linkage): accept Closes as sanctioned PR-body linkage

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
+++ b/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
@@ -1,9 +1,12 @@
 """Check that a pull request body includes primary issue linkage.
 
 Reads the GitHub event payload from ``GITHUB_EVENT_PATH`` and validates
-that the PR body contains ``Ref`` followed by an issue reference.
-Auto-close keywords (Fixes, Closes, Resolves and variants) are
-rejected — issues must remain open until post-merge workflows succeed.
+that the PR body contains ``Ref`` or ``Closes`` followed by an issue
+reference. ``Closes`` is the sanctioned auto-close keyword (a task is one
+PR, so "in develop = done"); ``Fixes``/``Resolves`` and variants remain
+rejected so there is exactly one close keyword. The epic-vs-task policy
+(which keyword is correct for a given issue) lives in ``vrg-submit-pr``;
+this gate is a dependency-free syntax/uniqueness check.
 """
 
 from __future__ import annotations
@@ -42,9 +45,9 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
 
     if AUTOCLOSE_RE.search(pr_body):
         msg = (
-            "pull request body contains a GitHub auto-close keyword "
-            "(close/fix/resolve). Use 'Ref #N' instead. "
-            "Issues must remain open until post-merge workflows succeed."
+            "pull request body contains a banned GitHub auto-close keyword "
+            "(fix/resolve). Use 'Ref #N' to reference, or 'Closes #N' to "
+            "close the task on merge."
         )
         emit_error(msg)
         write_summary(f"## PR Body Compliance Failed\n\n{msg}")
@@ -53,8 +56,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     if not LINKAGE_RE.search(pr_body):
         msg = (
             "pull request body must include primary issue linkage "
-            "(Ref #123). Cross-repo references (Ref owner/repo#123) are "
-            "also accepted."
+            "(Ref #123 or Closes #123). Cross-repo references "
+            "(Ref owner/repo#123) are also accepted."
         )
         emit_error(msg)
         write_summary(f"## PR Body Compliance Failed\n\n{msg}")

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -8,19 +8,33 @@ from __future__ import annotations
 
 import re
 
-# The only linkage keywords allowed in PR bodies and templates.
-# Auto-close keywords (Closes/Fixes/Resolves) are banned repo-wide —
-# issues stay open until post-merge workflows succeed.
+# ``ALLOWED_LINKAGES`` is the keyword set accepted as a PR *submission-field*
+# value (the ``--linkage`` choices for vrg-submit-pr / vrg-pr-fix-body). It stays
+# Ref-only until vrg-submit-pr learns to emit ``Closes`` for managed tasks (epic
+# vergil-project/.github#75, task T3), where ``Closes`` is added alongside the
+# auto-selection logic and its tests.
+#
+# The *body* patterns below already recognize ``Closes`` as sanctioned linkage,
+# so the CI gate and the extract_* helpers accept a task PR that closes its issue
+# by keyword. ``Fixes``/``Resolves`` stay banned so there is one close keyword.
 ALLOWED_LINKAGES = ("Ref",)
 
+# Primary linkage in a PR body: ``Ref`` or the close family (canonical
+# ``Closes``; ``Close``/``Closed`` accepted as equivalents). The keyword is
+# non-capturing, so the two capture groups stay (repo, number) and the
+# extract_* helpers recognize a task linked by either keyword.
 LINKAGE_RE = re.compile(
-    r"^\s*[-*]?\s*Ref:?\s+"
+    r"^\s*[-*]?\s*(?:Ref|Close[sd]?):?\s+"
     r"([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#([0-9]+)",
-    re.MULTILINE,
+    re.MULTILINE | re.IGNORECASE,
 )
 
+# Auto-close keywords that remain BANNED in PR bodies (``Fixes``/``Resolves`` and
+# variants); ``Closes`` is sanctioned above as the one close keyword. Used only
+# by the PR-body gate — commit-message auto-close banning has its own regex in
+# ``commit_message.py``.
 AUTOCLOSE_RE = re.compile(
-    r"^\s*[-*]?\s*(close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+"
+    r"^\s*[-*]?\s*(fix(?:e[sd])?|resolve[sd]?):?\s+"
     r"([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
     re.MULTILINE | re.IGNORECASE,
 )
@@ -73,9 +87,10 @@ def normalize_linkage(value: str) -> tuple[str, str | None]:
 
 
 def extract_tracking_issue(text: str) -> int | None:
-    """Return the tracking issue number from a ``Ref #N`` match.
+    """Return the tracking issue number from a ``Ref #N`` / ``Closes #N`` match.
 
-    Raises ``ValueError`` if multiple ``Ref`` lines are found.
+    Recognizes a task linked by either sanctioned keyword. Raises ``ValueError``
+    if multiple linkage lines are found.
     """
     matches = LINKAGE_RE.findall(text)
     if not matches:
@@ -87,11 +102,12 @@ def extract_tracking_issue(text: str) -> int | None:
 
 
 def extract_tracking_ref(text: str) -> str | None:
-    """Return the single ``Ref`` as ``"#N"`` or ``"owner/repo#N"`` (cross-repo).
+    """Return the single linkage as ``"#N"`` or ``"owner/repo#N"`` (cross-repo).
 
     Like :func:`extract_tracking_issue` but preserves the optional ``owner/repo``
     so callers can identify a cross-repo linkage (e.g. a mistaken link to an epic
-    in ``.github``). Raises ``ValueError`` if multiple ``Ref`` lines are found.
+    in ``.github``). Matches ``Ref`` or ``Closes``. Raises ``ValueError`` if
+    multiple linkage lines are found.
     """
     matches = LINKAGE_RE.findall(text)
     if not matches:

--- a/tests/vergil_tooling/test_linkage.py
+++ b/tests/vergil_tooling/test_linkage.py
@@ -58,8 +58,25 @@ def test_multiple_refs_raises_value_error() -> None:
         extract_tracking_issue(body)
 
 
-def test_autoclose_keyword_not_matched() -> None:
+def test_banned_autoclose_keyword_not_matched() -> None:
     assert extract_tracking_issue("Fixes #42") is None
+    assert extract_tracking_issue("Resolves #42") is None
+
+
+def test_closes_keyword_matched() -> None:
+    assert extract_tracking_issue("Closes #42") == 42
+    assert extract_tracking_issue("Close #7") == 7
+    assert extract_tracking_issue("Closed #9") == 9
+    assert extract_tracking_issue("closes #5") == 5
+
+
+def test_closes_cross_repo() -> None:
+    assert extract_tracking_issue("Closes org/repo#42") == 42
+
+
+def test_extract_tracking_ref_closes() -> None:
+    assert extract_tracking_ref("Closes org/.github#40") == "org/.github#40"
+    assert extract_tracking_ref("Closes #42") == "#42"
 
 
 def test_normalize_bare_keyword_no_warning() -> None:
@@ -92,7 +109,9 @@ def test_normalize_rejects_wrong_keyword_with_number() -> None:
     assert "Ref" in str(exc.value)
 
 
-def test_normalize_rejects_autoclose_keyword() -> None:
+def test_normalize_rejects_non_ref_keyword() -> None:
+    # ALLOWED_LINKAGES stays Ref-only as a submit-field value until T3 adds
+    # Closes with the auto-selection logic; the body regex recognizes Closes.
     with pytest.raises(ValueError, match="bare keyword"):
         normalize_linkage("Closes")
 

--- a/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
+++ b/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
@@ -93,24 +93,39 @@ def test_ref_indented(tmp_path: Path) -> None:
     "body",
     [
         "Fixes #42",
-        "Closes #99",
         "Resolves #7",
-        "closes #42",
         "FIXES #42",
         "Fixed #42",
-        "Close #42",
         "Resolved #42",
         "- Fixes #42",
-        "* Closes #42",
         "  Resolves #42",
         "Fixes: #42",
         "Fixes owner/repo#123",
     ],
 )
-def test_rejects_autoclose_keywords(tmp_path: Path, body: str) -> None:
+def test_rejects_banned_autoclose_keywords(tmp_path: Path, body: str) -> None:
     event_path = _write_event(tmp_path, body)
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
         assert main() == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #99",
+        "closes #42",
+        "Close #42",
+        "Closed #42",
+        "* Closes #42",
+        "Closes: #42",
+        "Closes owner/repo#123",
+    ],
+)
+def test_accepts_closes_keyword(tmp_path: Path, body: str) -> None:
+    """Closes is the sanctioned auto-close keyword (epic .github#75)."""
+    event_path = _write_event(tmp_path, body)
+    with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
+        assert main() == 0
 
 
 def test_no_pull_request_key(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Teach the linkage regexes and the pr-issue-linkage CI gate to accept Closes as the one sanctioned auto-close keyword for task PRs, while keeping Fixes/Resolves banned and leaving the submit-field policy (ALLOWED_LINKAGES) Ref-only until T3.

## Issue Linkage

- Ref #2043

## Notes

- Task T2 of epic vergil-project/.github#75. Gate change: LINKAGE_RE matches Ref|Close[sd]?; AUTOCLOSE_RE narrows to fix/resolve; extract_* recognize either keyword. The submit-side ALLOWED_LINKAGES flip and Closes auto-selection are intentionally deferred to T3 (they carry vrg-submit-pr/pr-fix-body policy + tests) so this PR is the gate/recognition half only. commit_message.py's separate autoclose ban is untouched (commits still ban all autoclose). Full vrg-validate green (3848 passed).