### PR TITLE
ci(workflows): add on: issues.closed caller for event-driven epic rollup

### DIFF
--- a/.github/workflows/epic-rollup.yml
+++ b/.github/workflows/epic-rollup.yml
@@ -1,0 +1,25 @@
+name: Epic Rollup
+
+# Event-driven epic rollup (epic vergil-project/.github#75). When any issue in
+# this repo closes, hand off to the reusable ops-epic-rollup workflow, which
+# runs `vrg-epic-rollup` to close the parent epic once all its sibling tasks are
+# closed. A no-op unless the closed issue is a managed task with a finite,
+# non-standing epic parent, so it is safe to fire on every close. Per repo
+# convention, all logic (token, checkout, install, run) lives in the reusable
+# workflow; this caller is thin (cf. ops.yml).
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  epic-rollup:
+    uses: vergil-project/vergil-actions/.github/workflows/ops-epic-rollup.yml@v2.1
+    permissions:
+      contents: read
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
# Pull Request

## Summary

- Add the thin on: issues.closed workflow that hands off to vergil-actions' reusable ops-epic-rollup workflow, making epic rollup event-driven in vergil-tooling regardless of which command closed the task.

## Issue Linkage

- Ref #2052

## Notes

- Task #2052 of epic vergil-project/.github#75, the vergil-tooling half of the rollup Action. Pairs with the reusable ops-epic-rollup workflow (vergil-actions #732/#733, released 2.1.9) and the vrg-epic-rollup CLI (#2042). Thin caller per repo convention; validated (actionlint) green. After this lands, closing a managed task rolls up its finite parent epic automatically.