### PR TITLE
feat(cli): descriptive --help for container-test, pr-issue-linkage, repo-profile

### DIFF
--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -194,7 +194,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     repo_root = git.repo_root()
 
     print("Running: repo-profile")
-    rc = vrg_repo_profile.main()
+    rc = vrg_repo_profile.main([])
     if rc != 0:
         return rc
 

--- a/src/vergil_tooling/bin/vrg_container_test.py
+++ b/src/vergil_tooling/bin/vrg_container_test.py
@@ -7,6 +7,7 @@ via environment variables.
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import sys
@@ -83,7 +84,25 @@ def _runtime_is_available(runtime: str) -> bool:
 _docker_is_available = _runtime_is_available
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="vrg-container-test",
+        description=(
+            "Run the current repository's test suite inside a dev container. "
+            "The project language is auto-detected from its package-manager "
+            "files to choose a default image and test command."
+        ),
+        epilog=(
+            "Environment overrides: DOCKER_DEV_IMAGE (image), DOCKER_TEST_CMD "
+            "(command), DOCKER_NETWORK (network to join). Requires a running "
+            "container runtime (docker or nerdctl)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _parse_args(argv)
     runtime = detect_runtime()
     repo_root = git.repo_root()
     lang = detect_language(repo_root)

--- a/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
+++ b/src/vergil_tooling/bin/vrg_pr_issue_linkage.py
@@ -11,6 +11,7 @@ this gate is a dependency-free syntax/uniqueness check.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -20,7 +21,26 @@ from vergil_tooling.lib.linkage import AUTOCLOSE_RE, LINKAGE_RE, extract_trackin
 from vergil_tooling.lib.output import emit_error, write_summary
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="vrg-pr-issue-linkage",
+        description=(
+            "Validate that a pull request body includes primary issue linkage "
+            "(Ref #N or Closes #N) and exactly one task reference. A "
+            "dependency-free CI gate: pure regex over the PR body, no GitHub "
+            "API calls."
+        ),
+        epilog=(
+            "Reads the pull request from the GitHub event payload at "
+            "$GITHUB_EVENT_PATH. Exit codes: 0 ok, 1 compliance failure, "
+            "2 configuration error (event path unset or missing)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _parse_args(argv)
     event_path = os.environ.get("GITHUB_EVENT_PATH", "")
 
     if not event_path:

--- a/src/vergil_tooling/bin/vrg_repo_profile.py
+++ b/src/vergil_tooling/bin/vrg_repo_profile.py
@@ -8,6 +8,7 @@ Contents heading, no heading-level skips).
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -62,7 +63,26 @@ def _structural_check(file_path: str) -> bool:
     return len(errors) == 0
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="vrg-repo-profile",
+        description=(
+            "Validate the current repository's configuration and README "
+            "structure: that vergil.toml is present and valid (required "
+            "fields, enum values, co-author format, dependencies) and that "
+            "README.md follows the structural conventions (exactly one H1, a "
+            "Table of Contents, no heading-level skips)."
+        ),
+        epilog=(
+            "Run from the repository root. Exit codes: 0 ok, 1 validation "
+            "failure, 2 vergil.toml not found."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _parse_args(argv)
     try:
         read_config(Path.cwd())
     except FileNotFoundError:

--- a/tests/vergil_tooling/test_help_coverage.py
+++ b/tests/vergil_tooling/test_help_coverage.py
@@ -36,11 +36,8 @@ EXEMPT = frozenset({"vrg-hook-guard"})
 KNOWN_GAPS = frozenset(
     {
         "vrg-container-docs",
-        "vrg-container-test",
         "vrg-gh",
         "vrg-git",
-        "vrg-pr-issue-linkage",
-        "vrg-repo-profile",
     }
 )
 

--- a/tests/vergil_tooling/test_vrg_container_test.py
+++ b/tests/vergil_tooling/test_vrg_container_test.py
@@ -150,7 +150,7 @@ def test_main_no_language_no_env(tmp_path: Path) -> None:
         patch("vergil_tooling.bin.vrg_container_test.detect_runtime", return_value="docker"),
         patch.dict("os.environ", {}, clear=True),
     ):
-        assert main() == 1
+        assert main([]) == 1
 
 
 def test_main_runtime_not_available(tmp_path: Path) -> None:
@@ -162,7 +162,7 @@ def test_main_runtime_not_available(tmp_path: Path) -> None:
         patch("vergil_tooling.bin.vrg_container_test.os.execvp") as mock_exec,
         patch.dict("os.environ", {}, clear=True),
     ):
-        result = main()
+        result = main([])
     assert result == 1
     mock_exec.assert_not_called()
 
@@ -176,7 +176,7 @@ def test_main_calls_execvp(tmp_path: Path) -> None:
         patch("vergil_tooling.bin.vrg_container_test.os.execvp") as mock_exec,
         patch.dict("os.environ", {}, clear=True),
     ):
-        main()
+        main([])
     mock_exec.assert_called_once()
     call_args = mock_exec.call_args
     assert call_args[0][0] == "docker"
@@ -192,7 +192,7 @@ def test_main_calls_execvp_nerdctl(tmp_path: Path) -> None:
         patch("vergil_tooling.bin.vrg_container_test.os.execvp") as mock_exec,
         patch.dict("os.environ", {}, clear=True),
     ):
-        main()
+        main([])
     mock_exec.assert_called_once()
     assert mock_exec.call_args[0][0] == "nerdctl"
 

--- a/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
+++ b/tests/vergil_tooling/test_vrg_pr_issue_linkage.py
@@ -23,67 +23,67 @@ def _write_event(tmp_path: Path, body: str) -> str:
 
 def test_missing_env_var() -> None:
     with patch.dict("os.environ", {}, clear=True):
-        assert main() == 2
+        assert main([]) == 2
 
 
 def test_missing_event_file() -> None:
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": "/nonexistent/event.json"}):
-        assert main() == 2
+        assert main([]) == 2
 
 
 def test_empty_body(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 1
+        assert main([]) == 1
 
 
 def test_null_body(tmp_path: Path) -> None:
     event_file = tmp_path / "event.json"
     event_file.write_text(json.dumps({"pull_request": {"body": None}}))
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": str(event_file)}):
-        assert main() == 1
+        assert main([]) == 1
 
 
 def test_no_linkage(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "This PR does something nice.")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 1
+        assert main([]) == 1
 
 
 def test_ref_linkage(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "Ref #123\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 def test_ref_cross_repo_linkage(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "Ref owner/repo#123\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 def test_ref_bullet_linkage(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "- Ref #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 def test_ref_star_bullet_linkage(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "* Ref #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 def test_ref_with_colon(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "Ref: #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 def test_ref_indented(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "  Ref #42\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 # -- auto-close keyword rejection -------------------------------------------
@@ -106,7 +106,7 @@ def test_ref_indented(tmp_path: Path) -> None:
 def test_rejects_banned_autoclose_keywords(tmp_path: Path, body: str) -> None:
     event_path = _write_event(tmp_path, body)
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 1
+        assert main([]) == 1
 
 
 @pytest.mark.parametrize(
@@ -125,14 +125,14 @@ def test_accepts_closes_keyword(tmp_path: Path, body: str) -> None:
     """Closes is the sanctioned auto-close keyword (epic .github#75)."""
     event_path = _write_event(tmp_path, body)
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 0
+        assert main([]) == 0
 
 
 def test_no_pull_request_key(tmp_path: Path) -> None:
     event_file = tmp_path / "event.json"
     event_file.write_text(json.dumps({}))
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": str(event_file)}):
-        assert main() == 1
+        assert main([]) == 1
 
 
 # -- output module integration ------------------------------------------------
@@ -146,7 +146,7 @@ def test_emit_error_on_missing_env() -> None:
         patch.dict("os.environ", {}, clear=True),
         patch(f"{_MOD}.emit_error") as mock_err,
     ):
-        main()
+        main([])
         mock_err.assert_called_once_with("GITHUB_EVENT_PATH is not set.")
 
 
@@ -157,7 +157,7 @@ def test_emit_error_on_empty_body(tmp_path: Path) -> None:
         patch(f"{_MOD}.emit_error") as mock_err,
         patch(f"{_MOD}.write_summary") as mock_sum,
     ):
-        main()
+        main([])
         mock_err.assert_called_once()
         assert "empty" in mock_err.call_args[0][0]
         mock_sum.assert_called_once()
@@ -171,7 +171,7 @@ def test_emit_error_on_autoclose(tmp_path: Path) -> None:
         patch(f"{_MOD}.emit_error") as mock_err,
         patch(f"{_MOD}.write_summary") as mock_sum,
     ):
-        main()
+        main([])
         mock_err.assert_called_once()
         assert "auto-close" in mock_err.call_args[0][0]
         mock_sum.assert_called_once()
@@ -184,7 +184,7 @@ def test_emit_error_on_missing_linkage(tmp_path: Path) -> None:
         patch(f"{_MOD}.emit_error") as mock_err,
         patch(f"{_MOD}.write_summary") as mock_sum,
     ):
-        main()
+        main([])
         mock_err.assert_called_once()
         assert "issue linkage" in mock_err.call_args[0][0]
         mock_sum.assert_called_once()
@@ -196,7 +196,7 @@ def test_no_summary_on_env_error() -> None:
         patch(f"{_MOD}.emit_error"),
         patch(f"{_MOD}.write_summary") as mock_sum,
     ):
-        main()
+        main([])
         mock_sum.assert_not_called()
 
 
@@ -207,7 +207,7 @@ def test_no_summary_on_success(tmp_path: Path) -> None:
         patch(f"{_MOD}.emit_error") as mock_err,
         patch(f"{_MOD}.write_summary") as mock_sum,
     ):
-        main()
+        main([])
         mock_err.assert_not_called()
         mock_sum.assert_not_called()
 
@@ -218,4 +218,4 @@ def test_no_summary_on_success(tmp_path: Path) -> None:
 def test_multiple_refs_rejected(tmp_path: Path) -> None:
     event_path = _write_event(tmp_path, "Ref #1\nRef #2\n")
     with patch.dict("os.environ", {"GITHUB_EVENT_PATH": event_path}):
-        assert main() == 1
+        assert main([]) == 1

--- a/tests/vergil_tooling/test_vrg_repo_profile.py
+++ b/tests/vergil_tooling/test_vrg_repo_profile.py
@@ -38,40 +38,40 @@ def _write_toml(tmp_path: Path, content: str) -> None:
 def test_valid_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     _write_toml(tmp_path, _VALID_TOML)
-    assert main() == 0
+    assert main([]) == 0
 
 
 def test_missing_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
-    assert main() == 2
+    assert main([]) == 2
 
 
 def test_missing_field(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     toml = _VALID_TOML.replace('release-model = "tagged-release"\n', "")
     _write_toml(tmp_path, toml)
-    assert main() == 1
+    assert main([]) == 1
 
 
 def test_optional_primary_language(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     toml = _VALID_TOML.replace('primary-language = "python"\n', "")
     _write_toml(tmp_path, toml)
-    assert main() == 0
+    assert main([]) == 0
 
 
 def test_invalid_enum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     toml = _VALID_TOML.replace('"library"', '"banana"')
     _write_toml(tmp_path, toml)
-    assert main() == 1
+    assert main([]) == 1
 
 
 def test_missing_dependencies_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     toml = _VALID_TOML.replace('vergil = "v2.0"', 'other = "v1.0"')
     _write_toml(tmp_path, toml)
-    assert main() == 1
+    assert main([]) == 1
 
 
 # -- _structural_check -------------------------------------------------------
@@ -126,17 +126,17 @@ def test_main_readme_structural_fails(tmp_path: Path, monkeypatch: pytest.Monkey
     monkeypatch.chdir(tmp_path)
     _write_toml(tmp_path, _VALID_TOML)
     (tmp_path / "README.md").write_text("## No H1\n")
-    assert main() == 1
+    assert main([]) == 1
 
 
 def test_main_readme_structural_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     _write_toml(tmp_path, _VALID_TOML)
     (tmp_path / "README.md").write_text("# Title\n\n## Table of Contents\n\n## Section\n")
-    assert main() == 0
+    assert main([]) == 0
 
 
 def test_main_no_readme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     _write_toml(tmp_path, _VALID_TOML)
-    assert main() == 0
+    assert main([]) == 0


### PR DESCRIPTION
# Pull Request

## Summary

- Gives the three remaining standalone help-gap tools argparse parsers so --help explains each tool's purpose, scope, and exit codes; behavior is otherwise unchanged and they take no flags.

## Issue Linkage

- Ref #2059

## Notes

- Task 3 of epic vergil-project/.github#72. Because main() now parses argv, the internal caller (validate_common -> vrg_repo_profile.main([])) and all three test suites pass an explicit []. Removes the three from the KNOWN_GAPS ratchet — only the wrappers (vrg-git/vrg-gh) and vrg-container-docs remain, which is Task 4. vrg-validate green.