### PR TITLE
feat(submit-pr): emit Closes for managed tasks so they auto-close on merge

### DIFF
--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -250,6 +250,47 @@ def _reject_if_epic_link(issue_ref: str) -> None:
         )
 
 
+def _task_linkage(issue_ref: str, requested: str) -> tuple[str, str | None]:
+    """Choose the PR-body linkage keyword for *issue_ref*.
+
+    A managed task — an issue with an ``epic``-labeled parent — is closed by its
+    single PR, so it links with ``Closes`` to auto-close on merge to the default
+    branch (epic vergil-project/.github#75). Legacy issues (no epic parent) keep
+    *requested* (default ``Ref``) and stay open for manual close. Assumes the
+    epic-target case was already rejected by :func:`_reject_if_epic_link`.
+
+    Deciding task-ness needs the same authenticated cross-repo ``gh`` call as the
+    epic rejection — a parent epic may live in ``.github``. Returns
+    ``(linkage, note)`` where *note* explains the automatic upgrade to ``Closes``
+    (for the caller to surface), or ``None``.
+    """
+    try:
+        task = epics.parse_issue_ref(issue_ref, default_repo=github.current_repo())
+    except ValueError:
+        return requested, None
+    parent = epics.parent_of(task)
+    if parent is not None and epics.is_epic(parent):
+        note = (
+            f"{task.slug} is a task under epic {parent.slug}; "
+            "linking with 'Closes' to auto-close it on merge."
+        )
+        return "Closes", note
+    return requested, None
+
+
+def _resolve_linkage(issue_ref: str, requested: str) -> str:
+    """Effective PR-body linkage for *issue_ref*, announcing a ``Closes`` upgrade.
+
+    Thin wrapper over :func:`_task_linkage` used at every PR-body build site: it
+    prints the upgrade note (when a managed task is auto-linked with ``Closes``)
+    and returns the linkage keyword.
+    """
+    linkage, note = _task_linkage(issue_ref, requested)
+    if note:
+        print(f"vrg-submit-pr: {note}")
+    return linkage
+
+
 def _run_cli_mode(args: argparse.Namespace) -> int:
     # main() only routes here when all three are present; narrow for the
     # type checker without relying on an assert (ruff S101).
@@ -259,11 +300,12 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
 
     issue_ref = resolve_issue_ref(args.issue)
     _reject_if_epic_link(issue_ref)
+    linkage = _resolve_linkage(issue_ref, args.linkage)
     branch = git.current_branch()
     target = _target_branch(args.base)
     pr_body = build_pr_body(
         summary=args.summary,
-        linkage=args.linkage,
+        linkage=linkage,
         issue_ref=issue_ref,
         notes=args.notes,
     )
@@ -505,6 +547,7 @@ def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: b
         raise SystemExit(f"vrg-submit-pr: {exc}") from exc
     if linkage_warning:
         print(f"vrg-submit-pr: {linkage_warning}", file=sys.stderr)
+    linkage = _resolve_linkage(issue_ref, linkage)
     pr_body = build_pr_body(
         summary=fields["summary"],
         linkage=linkage,
@@ -587,6 +630,7 @@ def _run_template_mode(args: argparse.Namespace) -> int:
         return 1
     if linkage_warning:
         print(f"vrg-submit-pr: {linkage_warning}", file=sys.stderr)
+    linkage = _resolve_linkage(issue_ref, linkage)
     pr_body = build_pr_body(
         summary=fields["summary"],
         linkage=linkage,

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -9,15 +9,13 @@ from __future__ import annotations
 import re
 
 # ``ALLOWED_LINKAGES`` is the keyword set accepted as a PR *submission-field*
-# value (the ``--linkage`` choices for vrg-submit-pr / vrg-pr-fix-body). It stays
-# Ref-only until vrg-submit-pr learns to emit ``Closes`` for managed tasks (epic
-# vergil-project/.github#75, task T3), where ``Closes`` is added alongside the
-# auto-selection logic and its tests.
-#
-# The *body* patterns below already recognize ``Closes`` as sanctioned linkage,
-# so the CI gate and the extract_* helpers accept a task PR that closes its issue
-# by keyword. ``Fixes``/``Resolves`` stay banned so there is one close keyword.
-ALLOWED_LINKAGES = ("Ref",)
+# value (the ``--linkage`` choices for vrg-submit-pr / vrg-pr-fix-body). ``Ref``
+# references without closing; ``Closes`` auto-closes the linked task on merge and
+# is selected automatically by vrg-submit-pr for managed tasks — a task with an
+# ``epic``-labeled parent (epic vergil-project/.github#75). ``Fixes``/``Resolves``
+# stay banned so there is exactly one close keyword; the body patterns below
+# recognize the close family so the gate and extract_* helpers read either keyword.
+ALLOWED_LINKAGES = ("Ref", "Closes")
 
 # Primary linkage in a PR body: ``Ref`` or the close family (canonical
 # ``Closes``; ``Close``/``Closed`` accepted as equivalents). The keyword is

--- a/tests/vergil_tooling/test_linkage.py
+++ b/tests/vergil_tooling/test_linkage.py
@@ -109,11 +109,15 @@ def test_normalize_rejects_wrong_keyword_with_number() -> None:
     assert "Ref" in str(exc.value)
 
 
-def test_normalize_rejects_non_ref_keyword() -> None:
-    # ALLOWED_LINKAGES stays Ref-only as a submit-field value until T3 adds
-    # Closes with the auto-selection logic; the body regex recognizes Closes.
+def test_normalize_accepts_closes() -> None:
+    # T3 added Closes to ALLOWED_LINKAGES; vrg-submit-pr auto-selects it for
+    # managed tasks so it closes the task on merge.
+    assert normalize_linkage("Closes") == ("Closes", None)
+
+
+def test_normalize_rejects_banned_autoclose_keyword() -> None:
     with pytest.raises(ValueError, match="bare keyword"):
-        normalize_linkage("Closes")
+        normalize_linkage("Fixes")
 
 
 def test_normalize_rejects_empty_string() -> None:

--- a/tests/vergil_tooling/test_vrg_pr_fix_body.py
+++ b/tests/vergil_tooling/test_vrg_pr_fix_body.py
@@ -59,9 +59,14 @@ def test_parse_args_defaults() -> None:
     assert args.no_retrigger is False
 
 
-def test_parse_args_rejects_autoclose_linkage() -> None:
+def test_parse_args_accepts_closes_linkage() -> None:
+    args = parse_args([*_ARGS, "--linkage", "Closes"])
+    assert args.linkage == "Closes"
+
+
+def test_parse_args_rejects_banned_autoclose_linkage() -> None:
     with pytest.raises(SystemExit):
-        parse_args([*_ARGS, "--linkage", "Closes"])
+        parse_args([*_ARGS, "--linkage", "Fixes"])
 
 
 # -- identity gating ----------------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -12,10 +12,12 @@ import pytest
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
     _reject_if_epic_link,
+    _resolve_linkage,
     _run_submit_batch,
     _select_batch_worktrees,
     _submit_one,
     _target_branch,
+    _task_linkage,
     main,
     parse_args,
 )
@@ -31,11 +33,16 @@ _MOD = "vergil_tooling.bin.vrg_submit_pr"
 
 @pytest.fixture(autouse=True)
 def _no_epic_link_check() -> Iterator[None]:
-    """Neutralize the epic-link guard for submit-flow tests (it would hit a real
-    gh call). The dedicated _reject_if_epic_link tests call the imported function
-    directly, so this module-attr patch doesn't shadow them.
+    """Neutralize the epic-link guard and the task-linkage lookup for submit-flow
+    tests (both would hit a real gh call). ``_task_linkage`` defaults to the
+    requested linkage with no ``Closes`` upgrade. The dedicated tests for these
+    functions call the imported functions directly, so these module-attr patches
+    don't shadow them.
     """
-    with patch(_MOD + "._reject_if_epic_link"):
+    with (
+        patch(_MOD + "._reject_if_epic_link"),
+        patch(_MOD + "._task_linkage", side_effect=lambda _ref, requested: (requested, None)),
+    ):
         yield
 
 
@@ -609,7 +616,7 @@ class TestTemplateMode:
     def test_template_rejects_forbidden_linkage(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        _write_workflow_state(tmp_path, title="fix", summary="Fix", linkage="Closes")
+        _write_workflow_state(tmp_path, title="fix", summary="Fix", linkage="Fixes")
         with (
             patch(_MOD + ".git.repo_root", return_value=tmp_path),
             patch(_MOD + ".git.current_branch", return_value="feature/x"),
@@ -624,7 +631,7 @@ class TestTemplateMode:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Even if the fields carry a bad linkage, template mode rejects it."""
-        fields = {"issue": "42", "title": "fix", "summary": "Fix", "linkage": "Closes"}
+        fields = {"issue": "42", "title": "fix", "summary": "Fix", "linkage": "Fixes"}
         with (
             patch(_MOD + ".git.repo_root", return_value=tmp_path),
             patch(_MOD + ".git.current_branch", return_value="feature/x"),
@@ -1515,7 +1522,7 @@ def test_select_batch_interactive_uses_multi_select() -> None:
 
 
 def test_submit_one_bad_linkage_exits() -> None:
-    fields = {"issue": "1", "title": "T", "summary": "s", "notes": "", "linkage": "Closes"}
+    fields = {"issue": "1", "title": "T", "summary": "s", "notes": "", "linkage": "Fixes"}
     with (
         patch(_MOD + ".submission.read_pr_fields", return_value=fields),
         patch(_MOD + ".resolve_issue_ref", return_value="#1"),
@@ -1664,6 +1671,58 @@ def test_reject_if_epic_link_passes_for_task() -> None:
     ):
         _reject_if_epic_link("#42")
     mock_is_epic.assert_called_once_with(epics.IssueRef("org", "repo", 42))
+
+
+# -- _task_linkage (managed tasks auto-close via Closes) ----------------------
+
+
+def test_task_linkage_upgrades_managed_task_to_closes() -> None:
+    parent = epics.IssueRef("org", ".github", 75)
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.parent_of", return_value=parent),
+        patch(f"{_MOD}.epics.is_epic", return_value=True),
+    ):
+        linkage, note = _task_linkage("#42", "Ref")
+    assert linkage == "Closes"
+    assert note is not None
+    assert "Closes" in note
+
+
+def test_task_linkage_keeps_ref_for_legacy_issue() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.parent_of", return_value=None),
+    ):
+        assert _task_linkage("#42", "Ref") == ("Ref", None)
+
+
+def test_task_linkage_keeps_ref_when_parent_not_epic() -> None:
+    parent = epics.IssueRef("org", "repo", 5)
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.parent_of", return_value=parent),
+        patch(f"{_MOD}.epics.is_epic", return_value=False),
+    ):
+        assert _task_linkage("#42", "Ref") == ("Ref", None)
+
+
+def test_task_linkage_noop_when_ref_unresolvable() -> None:
+    with patch(f"{_MOD}.github.current_repo", return_value=""):
+        assert _task_linkage("#42", "Ref") == ("Ref", None)
+
+
+def test_resolve_linkage_announces_closes_upgrade(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch(f"{_MOD}._task_linkage", return_value=("Closes", "note: upgraded")):
+        assert _resolve_linkage("#42", "Ref") == "Closes"
+    assert "note: upgraded" in capsys.readouterr().out
+
+
+def test_resolve_linkage_returns_requested_without_note() -> None:
+    with patch(f"{_MOD}._task_linkage", return_value=("Ref", None)):
+        assert _resolve_linkage("#42", "Ref") == "Ref"
 
 
 def test_reject_if_epic_link_noop_when_repo_unresolvable() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Teach vrg-submit-pr to link a managed task (an issue with an epic-labeled parent) with Closes instead of Ref, so its single PR auto-closes the task on merge and the rollup Action closes the parent epic when the last sibling lands.

## Issue Linkage

- Ref #2044

## Notes

- Task T3 of epic vergil-project/.github#75. Adds _task_linkage (epic-parent lookup) + _resolve_linkage (announce+apply) at all three PR-body build sites; legacy issues (no epic parent) keep Ref and stay open for manual close. ALLOWED_LINKAGES gains Closes; report-ready still stores Ref and the pr-workflow engine is untouched — the upgrade happens at submit time. Rebased onto current develop, full vrg-validate green (3867 passed, 100% coverage). Note: this PR itself predates its own logic being released, so #2044 links with Ref and won't self-close via keyword.