### PR TITLE
feat(cli): wrapper-specific --help for vrg-git/vrg-gh + vrg-container-docs help

### DIFF
--- a/src/vergil_tooling/bin/vrg_container_docs.py
+++ b/src/vergil_tooling/bin/vrg_container_docs.py
@@ -46,6 +46,10 @@ def main(argv: list[str] | None = None) -> int:
     config = os.environ.get("MKDOCS_CONFIG", "docs/site/mkdocs.yml")
     port = os.environ.get("DOCS_PORT", "8000")
 
+    if {"-h", "--help"} & set(args):
+        _usage(port)
+        return 0
+
     prefix = "prod"
     if "--prefix" in args:
         pi = args.index("--prefix")

--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -206,6 +206,31 @@ def _exec_gh(argv: list[str]) -> int:
     return 0
 
 
+def _print_help() -> None:
+    """Print vrg-gh's own help — what the wrapper enforces before forwarding."""
+    allowed = ", ".join(
+        f"{top} ({'/'.join(sorted(subs))})" for top, subs in sorted(_ALLOWED.items())
+    )
+    print(
+        "usage: vrg-gh <subcommand> <action> [args...]\n"
+        "\n"
+        "A safe, identity-aware gh wrapper for agent sessions: it forwards to gh\n"
+        "only after enforcing policy, injecting the GitHub App installation token\n"
+        "for the target owner.\n"
+        "\n"
+        "What it enforces:\n"
+        f"  - Allowed (human/user): {allowed}.\n"
+        "    The audit identity is narrower (read-only pr actions); agents are\n"
+        "    barred from pr create/edit/merge and issue reopen.\n"
+        "  - Denied outright: gh auth, pr close, repo edit/create/delete.\n"
+        "  - gh api is gated by identity: human full, audit read-only GET, user\n"
+        "    denied.\n"
+        "\n"
+        "Identity mode is resolved via vrg-whoami. Per-subcommand gh help still\n"
+        "forwards, e.g. 'vrg-gh pr view --help'."
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -213,6 +238,10 @@ def main(argv: list[str] | None = None) -> int:
     if not argv:
         print("usage: vrg-gh <subcommand> <action> [args...]", file=sys.stderr)
         return 2
+
+    if argv[0] in ("-h", "--help"):
+        _print_help()
+        return 0
 
     top = argv[0]
 
@@ -300,3 +329,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     return _exec_gh(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -378,6 +378,32 @@ def _print_workflow_push_guidance() -> None:
     )
 
 
+def _print_help() -> None:
+    """Print vrg-git's own help — what the wrapper enforces before forwarding."""
+    denied = ", ".join(sorted(_DENIED))
+    print(
+        "usage: vrg-git <subcommand> [args...]\n"
+        "\n"
+        "A safe git wrapper for agent sessions: it forwards to git only after\n"
+        "enforcing policy, so it is not a drop-in replacement for git.\n"
+        "\n"
+        "What it enforces:\n"
+        "  - Subcommand allowlist: read-only inspection commands plus a vetted\n"
+        "    set of mutating ones (add, push, fetch, pull, clone, checkout,\n"
+        "    switch, stash, merge, cherry-pick, rebase, worktree add/list/remove).\n"
+        f"  - Denied subcommands: {denied} (use vrg-commit for commits).\n"
+        "  - Flag deny-list: push -f/--force, branch -D/--force, rebase -i,\n"
+        "    checkout -- . ; --force-with-lease is blocked on protected branches\n"
+        "    (develop, main, release/*).\n"
+        "  - Worktree convention: branch switches in the main worktree and\n"
+        "    'worktree add' targets outside .worktrees/ are refused.\n"
+        "  - Identity: remote ops run with the GitHub App installation token for\n"
+        "    the resolved identity mode (see vrg-whoami).\n"
+        "\n"
+        "Per-subcommand git help still forwards, e.g. 'vrg-git log --help'."
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
@@ -385,6 +411,10 @@ def main(argv: list[str] | None = None) -> int:
     if not argv:
         print("usage: vrg-git <subcommand> [args...]", file=sys.stderr)
         return 2
+
+    if argv[0] in ("-h", "--help"):
+        _print_help()
+        return 0
 
     subcmd = argv[0]
 
@@ -477,3 +507,7 @@ def main(argv: list[str] | None = None) -> int:
 
     result = subprocess.run(["git", *argv], check=False, env=env)  # noqa: S603, S607
     return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vergil_tooling/test_help_coverage.py
+++ b/tests/vergil_tooling/test_help_coverage.py
@@ -33,13 +33,7 @@ EXEMPT = frozenset({"vrg-hook-guard"})
 # vergil-project/.github#72; removing a tool from this set is part of its fix.
 # When the set is empty the gate is fully enforcing. Do NOT add a new tool here
 # to silence the gate — give the tool a --help instead.
-KNOWN_GAPS = frozenset(
-    {
-        "vrg-container-docs",
-        "vrg-gh",
-        "vrg-git",
-    }
-)
+KNOWN_GAPS: frozenset[str] = frozenset()
 
 
 def _scripts() -> dict[str, str]:

--- a/tests/vergil_tooling/test_vrg_container_docs.py
+++ b/tests/vergil_tooling/test_vrg_container_docs.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_container_docs import main
 
+if TYPE_CHECKING:
+    import pytest
+
 
 def test_no_args() -> None:
     assert main([]) == 1
+
+
+def test_help_prints_usage(capsys: pytest.CaptureFixture[str]) -> None:
+    for flag in ("-h", "--help"):
+        assert main([flag]) == 0
+        assert "Usage: vrg-container-docs" in capsys.readouterr().out
 
 
 def test_unknown_command() -> None:

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -25,6 +25,14 @@ def test_no_args_exits_nonzero(capsys: pytest.CaptureFixture[str]) -> None:
     assert "usage" in capsys.readouterr().err.lower()
 
 
+def test_help_prints_wrapper_help(capsys: pytest.CaptureFixture[str]) -> None:
+    for flag in ("-h", "--help"):
+        assert main([flag]) == 0
+        out = capsys.readouterr().out
+        assert "gh wrapper" in out.lower()
+        assert "denied outright" in out.lower()
+
+
 def test_none_argv_reads_sys_argv(capsys: pytest.CaptureFixture[str]) -> None:
     with patch("vergil_tooling.bin.vrg_gh.sys.argv", ["vrg-gh"]):
         assert main(None) != 0

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -28,6 +28,14 @@ def test_no_args_exits_nonzero(capsys: pytest.CaptureFixture[str]) -> None:
     assert "usage" in capsys.readouterr().err.lower()
 
 
+def test_help_prints_wrapper_help(capsys: pytest.CaptureFixture[str]) -> None:
+    for flag in ("-h", "--help"):
+        assert main([flag]) == 0
+        out = capsys.readouterr().out
+        assert "safe git wrapper" in out.lower()
+        assert "denied subcommands" in out.lower()
+
+
 def test_none_argv_reads_sys_argv(capsys: pytest.CaptureFixture[str]) -> None:
     with patch("vergil_tooling.bin.vrg_git.sys.argv", ["vrg-git"]):
         assert main(None) != 0


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-git and vrg-gh gain a top-level -h/--help that explains their allowlist, denied commands, flag deny-list, worktree convention, and identity-based credential selection before forwarding; vrg-container-docs recognizes -h/--help explicitly. Completes the help-coverage epic.

## Issue Linkage

- Ref #2061

## Notes

- Task 4 (final) of epic vergil-project/.github#72. Also adds the missing __main__ guard to both wrappers so they run as module entrypoints (the gate invokes tools via python -m; without the guard --help produced no output — the gate caught this). Parallel-merge note: #2059 also shrinks KNOWN_GAPS from different entries, so whichever of #2059/#2061 merges second reconciles that set to empty; test_gap_set_matches_reality fails CI if the reconciliation is wrong, so there is no silent-wrong risk. vrg-validate green.