### PR TITLE
fix(pr-workflow): reject an epic issue in report-ready (guard parity with vrg-submit-pr)

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from datetime import UTC, datetime
 
-from vergil_tooling.lib import git
+from vergil_tooling.lib import epics, git, github
 from vergil_tooling.lib.linkage import normalize_linkage
 from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
@@ -27,7 +28,28 @@ def _emit(payload: dict[str, object]) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def _reject_epic_issue(issue: str) -> None:
+    """Refuse an epic linkage at report time — a PR links a task, not an epic.
+
+    Mirrors vrg-submit-pr's guard so the error surfaces where the value is
+    entered (report time) rather than later at submit time. Best-effort: if
+    epic-ness cannot be determined (no remote, no gh auth — e.g. an offline
+    run), it defers silently to vrg-submit-pr's authoritative check rather than
+    blocking report-ready.
+    """
+    try:
+        links_epic = epics.is_epic_linkage(issue, default_repo=github.current_repo())
+    except (subprocess.CalledProcessError, OSError):
+        return
+    if links_epic:
+        raise WorkflowError(
+            f"--issue links an epic (#{issue}); link a task, not an epic "
+            "(epics are closed by rollup when their tasks complete)."
+        )
+
+
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
+    _reject_epic_issue(str(args.issue))
     try:
         linkage, linkage_warning = normalize_linkage(args.linkage)
     except ValueError as exc:

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -239,11 +239,7 @@ def _reject_if_epic_link(issue_ref: str) -> None:
     CI gate (a dependency-free body regex) does not. Self-scoping: legacy issues
     are never epics, so they pass.
     """
-    try:
-        issue = epics.parse_issue_ref(issue_ref, default_repo=github.current_repo())
-    except ValueError:
-        return
-    if epics.is_epic(issue):
+    if epics.is_epic_linkage(issue_ref, default_repo=github.current_repo()):
         raise SystemExit(
             "vrg-submit-pr: --issue links an epic; link a task, not an epic "
             "(epics are closed by rollup when their tasks complete)."

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -254,6 +254,21 @@ def _resolve_standing_epic(repo: str) -> IssueRef:
     return IssueRef(owner=owner, repo=name, number=int(rows[0]["number"]))
 
 
+def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
+    """True if *ref* points at an epic, so it must not be linked as a PR's task.
+
+    Single source of truth for "is this linkage an epic?", shared by
+    ``vrg-submit-pr`` and ``vrg-pr-workflow report-ready``. Self-scoping: an
+    unparseable ref (e.g. a legacy issue with no resolvable repo) is never an
+    epic and returns False.
+    """
+    try:
+        issue = parse_issue_ref(ref, default_repo=default_repo)
+    except ValueError:
+        return False
+    return is_epic(issue)
+
+
 def rollup(task: IssueRef) -> None:
     """Close *task*'s parent epic if the epic is finite and all children closed.
 

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -72,6 +73,87 @@ def test_report_ready_initializes_and_records(
     assert state["issue"] == "42"
     assert state["status"] == "ready"
     assert state["pr_metadata"]["title"] == "t"
+
+
+def test_report_ready_rejects_epic(in_git_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # Guard parity with vrg-submit-pr: report-ready refuses an epic linkage at
+    # the point the value is entered, instead of only failing later at submit.
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=True),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "72",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 1
+    assert "epic" in capsys.readouterr().err.lower()
+
+
+def test_report_ready_allows_non_epic_task(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The guard resolves the repo and finds a task (not an epic): proceeds.
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "ready"}
+
+
+def test_report_ready_defers_when_epicness_unresolvable(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # If GitHub is unreachable, the guard defers (does not block report-ready);
+    # vrg-submit-pr's authoritative check still catches a real epic later.
+    with patch(
+        "vergil_tooling.bin.vrg_pr_workflow.github.current_repo",
+        side_effect=subprocess.CalledProcessError(1, "gh"),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "ready"}
 
 
 def test_report_ready_rerun_overwrites(

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -189,6 +189,24 @@ def test_is_epic_false_without_label() -> None:
         assert epics.is_epic(TASK) is False
 
 
+def test_is_epic_linkage_true_for_epic() -> None:
+    with patch("vergil_tooling.lib.epics.is_epic", return_value=True) as mock:
+        assert epics.is_epic_linkage("org/.github#40", default_repo="org/repo") is True
+    mock.assert_called_once_with(IssueRef("org", ".github", 40))
+
+
+def test_is_epic_linkage_false_for_task() -> None:
+    with patch("vergil_tooling.lib.epics.is_epic", return_value=False):
+        assert epics.is_epic_linkage("#42", default_repo="org/repo") is False
+
+
+def test_is_epic_linkage_false_for_unparseable_ref() -> None:
+    # No resolvable default repo -> parse fails -> never an epic (is_epic unused).
+    with patch("vergil_tooling.lib.epics.is_epic") as mock:
+        assert epics.is_epic_linkage("#42", default_repo="") is False
+    mock.assert_not_called()
+
+
 def test_rollup_closes_finite_epic_when_all_children_closed() -> None:
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),


### PR DESCRIPTION
# Pull Request

## Summary

- report-ready now refuses --issue pointing at an epic (via a shared epics.is_epic_linkage that vrg-submit-pr also uses), so the mistake surfaces at report time instead of only later at submit; the guard is best-effort and defers to vrg-submit-pr's authoritative check when GitHub is unreachable.

## Issue Linkage

- Ref #2026

## Notes

- Implements #2026 — the bug found earlier this session when report-ready silently accepted epic #72 and vrg-submit-pr rejected it downstream. Single source of truth: epics.is_epic_linkage (parse + label check, self-scoping). vrg-validate green (100% coverage, including the defer path).