### PR TITLE
refactor(finalize-pr): remove the command-triggered task close path

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -46,10 +46,8 @@ from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import (
     config,
-    epics,
     git,
     github,
-    linkage,
     pr_merge,
     pr_provenance,
     progress,
@@ -135,18 +133,7 @@ def _run_finalize_batch(
         if result.returncode != 0:
             raise batch.BatchAbortError(f"{' '.join(cmd)} exited {result.returncode}")
 
-    def _close_tasks() -> None:
-        # Close each merged PR's task after post-checks pass. The single-PR path
-        # closes in main(); the batch defers post-checks (--skip-post-checks per
-        # item, --cleanup-only at the end), so neither sub-invocation hits that
-        # close — do it here, after validation, before release.
-        for pr in prs:
-            _close_managed_task(pr)
-
-    post_steps = [
-        batch.PostStep("validation", _validate),
-        batch.PostStep("close-tasks", _close_tasks),
-    ]
+    post_steps = [batch.PostStep("validation", _validate)]
     if release:
         post_steps.append(batch.PostStep("release", _release))
 
@@ -730,37 +717,6 @@ def _chain_release(root: Path, *, install: bool = False) -> int:
     return result.returncode
 
 
-def _close_managed_task(pr: str) -> None:
-    """Close the PR's tracking task + roll up its epic, gated to the model.
-
-    ``vrg-finalize-pr`` is shared tooling: this runs in every repo on deploy
-    while most issues are still legacy (spec §5). It acts only when the Ref'd
-    issue has an ``epic``-labeled parent; legacy issues (no epic parent) are
-    left open for manual close, with a visible note. The caller invokes this
-    only after the pipeline fully succeeded, so the close follows merge +
-    post-checks.
-    """
-    body = github.read_output("pr", "view", pr, "--json", "body", "--jq", ".body")
-    try:
-        issue_number = linkage.extract_tracking_issue(body)
-    except ValueError:
-        return
-    if issue_number is None:
-        return
-    repo = github.current_repo()
-    owner, name = repo.split("/", 1)
-    task = epics.IssueRef(owner=owner, repo=name, number=issue_number)
-    parent = epics.parent_of(task)
-    if parent is None or not epics.is_epic(parent):
-        print(
-            f"#{issue_number} has no epic parent — left open for manual close (transition policy)."
-        )
-        return
-    print(f"Auto-closing task #{issue_number} (finalized).")
-    github.run("issue", "close", str(issue_number), "--repo", repo)
-    epics.rollup(task)
-
-
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -825,18 +781,10 @@ def main(argv: list[str] | None = None) -> int:
         repo_root=root,
     )
 
-    # Auto-close the tracking task + roll up its epic once the pipeline fully
-    # succeeded (gated on an epic parent — spec §5 transition gate). Skipped on
-    # dry-run, cleanup-only (no merge), and skip-post-checks (post-checks
-    # deferred, so success is not yet verified).
-    if (
-        rc == 0
-        and args.pr is not None
-        and not args.dry_run
-        and not args.cleanup_only
-        and not args.skip_post_checks
-    ):
-        _close_managed_task(args.pr)
+    # Task closure and epic rollup are event-driven now (epic
+    # vergil-project/.github#75): the PR's `Closes #N` linkage closes the task on
+    # merge, and the on: issues.closed rollup Action closes the parent epic. The
+    # old post-pipeline `_close_managed_task` call was removed here in T4.
 
     # --release cascade (issue #1634): chain into vrg-release only after a
     # clean finalize. A non-zero pipeline must not trigger a release, and the

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -16,7 +16,6 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     FinalizeContext,
     FinalizeError,
     _check_cd_workflow_status,
-    _close_managed_task,
     _parse_pr_list,
     _resolve_open_prs,
     _resolve_strategy,
@@ -30,7 +29,6 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     main,
     parse_args,
 )
-from vergil_tooling.lib import epics
 from vergil_tooling.lib.pr_merge import MergeAbortError
 from vergil_tooling.lib.pr_provenance import Action, ProvenanceResult, Role
 from vergil_tooling.lib.worktrees import Worktree, WorktreeState, WorktreeStatus
@@ -39,19 +37,6 @@ _MOD = "vergil_tooling.bin.vrg_finalize_pr"
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-
-@pytest.fixture(autouse=True)
-def _no_managed_close() -> Iterator[None]:
-    """Default: neutralize the post-pipeline task close+rollup.
-
-    main() now calls ``_close_managed_task`` after a successful pipeline; the
-    broad main() tests don't exercise it (and would hit a real ``gh pr view``).
-    The dedicated ``_close_managed_task`` tests call the imported function
-    directly, so this module-attr patch doesn't shadow them.
-    """
-    with patch(_MOD + "._close_managed_task"):
-        yield
 
 
 @pytest.fixture(autouse=True)
@@ -1904,25 +1889,6 @@ def test_finalize_batch_stops_on_item_failure_no_release() -> None:
     assert rc == 1
 
 
-def test_finalize_batch_closes_each_task_after_validation() -> None:
-    with (
-        patch(_FIN_MOD + ".subprocess.run", return_value=MagicMock(returncode=0)),
-        patch(_FIN_MOD + ".confirm", return_value=True),
-        patch(_FIN_MOD + "._close_managed_task") as mock_close,
-    ):
-        rc = _run_finalize_batch(
-            ["123", "124"],
-            root=Path("/repo"),
-            release=True,
-            install=False,
-            assume_yes=True,
-        )
-    assert rc == 0
-    assert mock_close.call_count == 2
-    mock_close.assert_any_call("123")
-    mock_close.assert_any_call("124")
-
-
 def test_resolve_open_prs_skips_worktrees_without_pr() -> None:
     wts = [
         Worktree(path=Path("/r/.worktrees/issue-2-b"), branch="feature/2-b"),
@@ -2004,68 +1970,7 @@ def test_main_comma_list_routes_to_batch() -> None:
     run_batch.assert_called_once()
 
 
-# -- _close_managed_task (transition gate, issue/epic auto-close) -------------
-
-
-def test_close_managed_task_skips_legacy_issue(capsys: pytest.CaptureFixture[str]) -> None:
-    with (
-        patch(_FIN_MOD + ".github.read_output", return_value="Ref #210"),
-        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=210),
-        patch(_FIN_MOD + ".github.current_repo", return_value="org/repo-a"),
-        patch(_FIN_MOD + ".epics.parent_of", return_value=None),
-        patch(_FIN_MOD + ".github.run") as mock_run,
-        patch(_FIN_MOD + ".epics.rollup") as mock_rollup,
-    ):
-        _close_managed_task("210")
-    mock_run.assert_not_called()
-    mock_rollup.assert_not_called()
-    assert "no epic parent" in capsys.readouterr().out
-
-
-def test_close_managed_task_skips_when_parent_not_epic() -> None:
-    with (
-        patch(_FIN_MOD + ".github.read_output", return_value="Ref #210"),
-        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=210),
-        patch(_FIN_MOD + ".github.current_repo", return_value="org/repo-a"),
-        patch(_FIN_MOD + ".epics.parent_of", return_value=epics.IssueRef("org", ".github", 40)),
-        patch(_FIN_MOD + ".epics.is_epic", return_value=False),
-        patch(_FIN_MOD + ".github.run") as mock_run,
-    ):
-        _close_managed_task("210")
-    mock_run.assert_not_called()
-
-
-def test_close_managed_task_closes_and_rolls_up() -> None:
-    with (
-        patch(_FIN_MOD + ".github.read_output", return_value="Ref #101"),
-        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=101),
-        patch(_FIN_MOD + ".github.current_repo", return_value="org/repo-a"),
-        patch(_FIN_MOD + ".epics.parent_of", return_value=epics.IssueRef("org", ".github", 40)),
-        patch(_FIN_MOD + ".epics.is_epic", return_value=True),
-        patch(_FIN_MOD + ".github.run") as mock_run,
-        patch(_FIN_MOD + ".epics.rollup") as mock_rollup,
-    ):
-        _close_managed_task("101")
-    assert mock_run.call_args.args[:2] == ("issue", "close")
-    assert "101" in mock_run.call_args.args
-    mock_rollup.assert_called_once()
-
-
-def test_close_managed_task_noop_without_tracking_issue() -> None:
-    with (
-        patch(_FIN_MOD + ".github.read_output", return_value="no ref"),
-        patch(_FIN_MOD + ".linkage.extract_tracking_issue", return_value=None),
-        patch(_FIN_MOD + ".github.run") as mock_run,
-    ):
-        _close_managed_task("101")
-    mock_run.assert_not_called()
-
-
-def test_close_managed_task_noop_on_multiple_refs() -> None:
-    with (
-        patch(_FIN_MOD + ".github.read_output", return_value="Ref #1\nRef #2"),
-        patch(_FIN_MOD + ".linkage.extract_tracking_issue", side_effect=ValueError("multiple")),
-        patch(_FIN_MOD + ".github.run") as mock_run,
-    ):
-        _close_managed_task("101")
-    mock_run.assert_not_called()
+# Task closure and epic rollup are event-driven now (epic
+# vergil-project/.github#75): vrg-finalize-pr no longer closes tasks. The
+# former _close_managed_task tests were removed in T4; the closing keyword is
+# covered by the linkage/submit-pr tests and rollup by test_vrg_epic_rollup.


### PR DESCRIPTION
# Pull Request

## Summary

- Delete _close_managed_task and its two call sites (single-PR post-pipeline close and the finalize-batch close-tasks step) now that task closure is via the Closes keyword and epic rollup is via the on: issues.closed Action — closing the vrg-submit-pr --all hole for good since closure lives in no command.

## Issue Linkage

- Closes #2045

## Notes

- Task T4 of epic vergil-project/.github#75. Verified prerequisites live on develop first: T3 (_task_linkage) and the caller workflow (epic-rollup.yml) are both present. Removed the now-unused epics/linkage imports from vrg-finalize-pr and the corresponding tests (fixture, batch close-tasks assertion, and the _close_managed_task test section). 156 deletions; full vrg-validate green, 3897 passed, 100% coverage on vrg_finalize_pr.py. epics.rollup remains in use via vrg-epic-rollup.