### PR TITLE
docs(standards): document Closes-based task closure and event-driven rollup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,15 @@ finalization are human actions. The PR handoff is:
 1. The agent records the PR metadata with `vrg-pr-workflow report-ready
    --issue <N> --title --summary --notes` (optional `--linkage`), which writes
    it to `.vergil/pr-workflow.json`. `title`, `summary`, and `notes` are
-   required and non-empty. `linkage` defaults to `Ref` and must stay `Ref`:
-   GitHub auto-close keywords (`Closes`/`Fixes`/`Resolves`) are banned repo-wide
-   because issues stay open until post-merge workflows succeed, and
-   `vrg-submit-pr` rejects any non-`Ref` value before building the PR body.
+   required and non-empty. `linkage` defaults to `Ref`; leave it there.
+   `vrg-submit-pr` auto-selects the keyword at submit time — a **managed task**
+   (an issue with an `epic`-labeled parent) links with `Closes` so it
+   auto-closes on merge, and its parent epic rolls up via the `on: issues.closed`
+   Action; a legacy issue (no epic parent) keeps `Ref` and stays open for manual
+   close. `Fixes`/`Resolves` remain banned so `Closes` is the one close keyword.
+   This is safe because a task is exactly one PR: once it is in develop it is
+   done, and any later change is a new follow-up issue, never a reopening (epic
+   vergil-project/.github#75).
 2. The human runs `vrg-submit-pr` with no arguments, which reads the
    state file, previews the PR, and submits after confirmation.
 3. The human merges and runs post-merge cleanup (`vrg-finalize-pr`).

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -62,8 +62,10 @@ vrg-submit-pr \
 
 - `--issue` (required): GitHub issue number (just the number)
 - `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Ref`): `Ref` (only `Ref` is accepted;
-  auto-close keywords are rejected)
+- `--linkage` (optional, default: `Ref`): `Ref` or `Closes`. `vrg-submit-pr`
+  auto-selects `Closes` for a managed task (an issue with an `epic`-labeled
+  parent) so it auto-closes on merge; legacy issues keep `Ref`. `Fixes`/
+  `Resolves` are rejected — `Closes` is the one sanctioned close keyword
 - `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
 - `--dry-run` (optional): print generated PR without executing

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -294,9 +294,8 @@ jobs:
 What the composite action runs inside the `dev-base` container:
 
 - `vrg-repo-profile` — validates `docs/repository-standards.md`
-- `vrg-pr-issue-linkage` — validates PR body uses `Ref` for issue
-  linkage and rejects auto-close keywords (`Fixes`, `Closes`,
-  `Resolves`)
+- `vrg-pr-issue-linkage` — validates the PR body links one task with
+  `Ref` or `Closes`, and rejects `Fixes`/`Resolves`
 
 The `dev-base` container already has vergil-tooling on PATH, so
 no further setup is needed in the workflow.

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -139,9 +139,10 @@ vrg-submit-pr \
 `vrg-submit-pr`:
 
 - Pushes the current branch to `origin`.
-- Constructs a standards-compliant PR body with issue linkage
-  (`Ref #42`). Auto-close keywords (`Fixes`, `Closes`,
-  `Resolves`) are not accepted.
+- Constructs a standards-compliant PR body with issue linkage,
+  auto-selecting `Closes #42` for a managed task (so it closes on
+  merge) or `Ref #42` for a legacy issue. `Fixes`/`Resolves` are
+  not accepted.
 - Creates the PR via `gh pr create` under the hood.
 
 !!! note "Auto-merge is disabled"

--- a/docs/site/docs/guides/validation-matrix.md
+++ b/docs/site/docs/guides/validation-matrix.md
@@ -48,10 +48,10 @@ reference for config details and file scope.
 
 **Trigger:** PR opened or updated
 
-Validates the PR body uses `Ref #N` for issue linkage.
-Rejects auto-close keywords (`Fixes`, `Closes`, `Resolves`
-and variants) to keep issues open until post-merge workflows
-succeed.
+Validates the PR body links exactly one task with `Ref #N` or
+`Closes #N`. `Closes` auto-closes a task on merge (a task is one
+PR); `Fixes`/`Resolves` and variants are rejected so there is
+one sanctioned close keyword.
 
 ## Exit Code Reference
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -240,9 +240,9 @@ placeholder values.
 
 ### vrg-pr-issue-linkage
 
-Check that a pull request body uses `Ref` for issue linkage and
-does not contain auto-close keywords (`Fixes`, `Closes`, `Resolves`
-and variants). Reads the GitHub event payload from
+Check that a pull request body links exactly one task with `Ref`
+or `Closes`, and does not contain the banned `Fixes`/`Resolves`
+auto-close keywords. Reads the GitHub event payload from
 `GITHUB_EVENT_PATH`.
 
 | Attribute | Value |
@@ -250,7 +250,7 @@ and variants). Reads the GitHub event payload from
 | Source | `vergil_tooling.bin.vrg_pr_issue_linkage` |
 | Args | None |
 | Preconditions | `GITHUB_EVENT_PATH` set and pointing to a valid JSON file |
-| Failure mode | Exit 2 for missing env var or file; exit 1 for auto-close keyword or missing linkage |
+| Failure mode | Exit 2 for missing env var or file; exit 1 for a banned keyword (`Fixes`/`Resolves`), multiple, or missing linkage |
 | Exit codes | 0 valid, 1 rejected linkage or missing linkage, 2 infrastructure error |
 | Status | Active |
 

--- a/docs/site/docs/reference/lint/pr-issue-linkage.md
+++ b/docs/site/docs/reference/lint/pr-issue-linkage.md
@@ -2,9 +2,9 @@
 
 **Installed as:** `vrg-pr-issue-linkage` (Python console script)
 
-Validates that a pull request body uses `Ref` for issue linkage
-and rejects auto-close keywords. Runs in CI using the GitHub event
-payload.
+Validates that a pull request body links exactly one task with
+`Ref` or `Closes`, and rejects the `Fixes`/`Resolves` auto-close
+keywords. Runs in CI using the GitHub event payload.
 
 ## Usage
 
@@ -13,21 +13,22 @@ reads the PR body from `$GITHUB_EVENT_PATH`.
 
 ## Validation Rules
 
-The PR body must contain at least one line matching:
+The PR body must contain exactly one line matching:
 
 ```text
-Ref #123
-Ref owner/repo#123
+Ref #123          Closes #123
+Ref owner/repo#123 Closes owner/repo#123
 ```
 
 The pattern allows optional leading whitespace, list markers
 (`-` or `*`), and an optional colon after the keyword.
 
-Auto-close keywords (`Fixes`, `Closes`, `Resolves` and all
-variants like `Fix`, `Fixed`, `Close`, `Closed`, `Resolve`,
-`Resolved`) are rejected. Issues must remain open until
-post-merge workflows succeed; premature closure loses tracking
-for multi-PR and multi-repo work.
+`Closes` is the sanctioned auto-close keyword: a task is exactly
+one PR, so it closes on merge (`vrg-submit-pr` selects `Closes`
+for managed tasks; legacy issues keep `Ref`). `Fixes`/`Resolves`
+and their variants remain rejected so there is one close keyword.
+This gate is a dependency-free syntax/uniqueness check; the
+epic-vs-task policy lives in `vrg-submit-pr`.
 
 ## Environment
 
@@ -39,6 +40,6 @@ for multi-PR and multi-repo work.
 
 | Code | Meaning |
 | ---- | ------- |
-| 0 | Valid `Ref` linkage found |
-| 1 | Auto-close keyword used, no linkage, or empty PR body |
+| 0 | Valid `Ref` or `Closes` linkage found |
+| 1 | Banned keyword (`Fixes`/`Resolves`), multiple/no linkage, or empty PR body |
 | 2 | `GITHUB_EVENT_PATH` not set or file not found |


### PR DESCRIPTION
# Pull Request

## Summary

- Update CLAUDE.md, repository-standards, and the site docs to describe the event-driven closure model — Closes for managed tasks (auto-close on merge), Ref for legacy/epic, Fixes/Resolves banned, rollup via the issues.closed Action — and record the merged-to-develop-is-done rationale.

## Issue Linkage

- Closes #2046

## Notes

- Task T5 of epic vergil-project/.github#75. Current docs only; dated docs/specs/* left as historical snapshots. markdownlint/vrg-validate green. Merge after T4 (#2045) so docs match the code once _close_managed_task is gone.