### PR TITLE
feat(repo-init): scaffold the epic-rollup caller in every new repo

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -548,6 +548,37 @@ def render_cd_workflow(ctx: RepoInitContext) -> str:
     return "".join(lines)
 
 
+def render_epic_rollup_workflow() -> str:
+    """Render .github/workflows/epic-rollup.yml — the event-driven rollup caller.
+
+    Thin caller (epic vergil-project/.github#75): on any issue close it hands off
+    to the reusable ops-epic-rollup workflow, which closes the parent epic once
+    all its sibling tasks are closed. Static across repos and orgs — the reusable
+    workflow reads the event and resolves the epic repo (``.github``) within the
+    caller's own org, so managed tasks auto-close on merge and their epics roll
+    up with no per-command step.
+    """
+    return (
+        "name: Epic Rollup\n"
+        "\n"
+        "on:\n"
+        "  issues:\n"
+        "    types: [closed]\n"
+        "\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "\n"
+        "jobs:\n"
+        "  epic-rollup:\n"
+        "    uses: vergil-project/vergil-actions/.github/workflows/ops-epic-rollup.yml@v2.1\n"
+        "    permissions:\n"
+        "      contents: read\n"
+        "    secrets:\n"
+        "      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}\n"
+        "      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}\n"
+    )
+
+
 def render_mkdocs_yml(ctx: RepoInitContext) -> str:
     """Render docs/site/mkdocs.yml."""
     return (
@@ -833,6 +864,11 @@ def step_ci_cd_workflows(ctx: RepoInitContext) -> None:
 
     ci_content = render_ci_workflow(ctx)
     (workflows_dir / "ci.yml").write_text(ci_content)
+
+    # Event-driven epic rollup ships in every managed repo (epic
+    # vergil-project/.github#75) so a merged task closes and its epic rolls up
+    # with no per-command step.
+    (workflows_dir / "epic-rollup.yml").write_text(render_epic_rollup_workflow())
 
     if ctx.publish_docs or ctx.publish_release:
         cd_content = render_cd_workflow(ctx)

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -28,6 +28,7 @@ from vergil_tooling.lib.repo_init import (
     render_ci_workflow,
     render_claude_md,
     render_claude_settings,
+    render_epic_rollup_workflow,
     render_gitignore,
     render_mkdocs_yml,
     render_readme,
@@ -892,6 +893,17 @@ class TestStepCiCdWorkflows:
 
         assert (tmp_path / ".github" / "workflows" / "ci.yml").exists()
         assert not (tmp_path / ".github" / "workflows" / "cd.yml").exists()
+        # Event-driven rollup ships in every repo, even without docs/release.
+        assert (tmp_path / ".github" / "workflows" / "epic-rollup.yml").exists()
+
+
+class TestRenderEpicRollupWorkflow:
+    def test_is_a_thin_caller_to_the_reusable_workflow(self) -> None:
+        content = render_epic_rollup_workflow()
+        assert "on:\n  issues:\n    types: [closed]" in content
+        assert "ops-epic-rollup.yml@v2.1" in content
+        assert "APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}" in content
+        assert "APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}" in content
 
 
 class TestStepDocsSite:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-github-repo-init now provisions the on: issues.closed epic-rollup caller workflow for every managed repo, making event-driven task closure and epic rollup the default for newly initialized repos.

## Issue Linkage

- Closes #2047

## Notes

- Task T7 of epic vergil-project/.github#75, the 'make it the standard' step. render_epic_rollup_workflow returns the static thin caller (references the reusable ops-epic-rollup.yml@v2.1, passes APP_* secrets); step_ci_cd_workflows writes it unconditionally alongside ci.yml. Tests cover the render output and that the workflow ships even in the minimal no-docs/no-release case. Full vrg-validate green, 3904 passed, 100% coverage. Convention docs were updated in T5; Phase 3 (rolling this out to existing repos across the three orgs) is the follow-on.