### PR TITLE
fix(github): scope App token to the target owner, not the cwd org (#2070)

### DIFF
--- a/src/vergil_tooling/bin/vrg_activity_log.py
+++ b/src/vergil_tooling/bin/vrg_activity_log.py
@@ -24,7 +24,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     org = args.org or github.current_org()
     since = (datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)).date().isoformat()
-    print(activity_log.render(activity_log.gather(since, org=org)))
+    # Scope the App token to the org being listed so a cross-org --org selects
+    # that org's installation, not the cwd repo's (#2070).
+    try:
+        with github.target_org(org):
+            print(activity_log.render(activity_log.gather(since, org=org)))
+    except github.NoInstallationError as exc:
+        print(f"vrg-activity-log: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/vergil_tooling/bin/vrg_ensure_label.py
+++ b/src/vergil_tooling/bin/vrg_ensure_label.py
@@ -87,18 +87,28 @@ def sync_repo(repo: str) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
-    if args.owner and args.project:
-        # Project mode: discover repos, sync each
-        repos = list_project_repos(args.owner, args.project)
-        print(f"Found {len(repos)} repos in project {args.project}")
-        for repo in repos:
-            sync_repo(repo)
-    elif args.sync:
-        # Sync mode: single repo
-        sync_repo(args.repo)
-    else:
-        # Single-label mode
-        _ensure_single(args.repo, args.label, args.color, args.description)
+    # Scope the App token to the owner named by the target argument — the
+    # project owner in project mode, else the --repo owner — so labelling a
+    # repo outside the cwd org selects the right installation (#2070).
+    owner = args.owner if (args.owner and args.project) else args.repo.split("/", 1)[0]
+
+    try:
+        with github.target_org(owner):
+            if args.owner and args.project:
+                # Project mode: discover repos, sync each
+                repos = list_project_repos(args.owner, args.project)
+                print(f"Found {len(repos)} repos in project {args.project}")
+                for repo in repos:
+                    sync_repo(repo)
+            elif args.sync:
+                # Sync mode: single repo
+                sync_repo(args.repo)
+            else:
+                # Single-label mode
+                _ensure_single(args.repo, args.label, args.color, args.description)
+    except github.NoInstallationError as exc:
+        print(f"vrg-ensure-label: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
 
     return 0
 

--- a/src/vergil_tooling/bin/vrg_epic_link.py
+++ b/src/vergil_tooling/bin/vrg_epic_link.py
@@ -34,10 +34,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         epic = epics.parse_issue_ref(args.epic, default_repo=default_repo)
         task = epics.parse_issue_ref(args.task, default_repo=default_repo)
+        owner = epics.single_target_org(epic, task)
     except ValueError as exc:
         print(f"vrg-epic-link: {exc}", file=sys.stderr)
         return 1
-    epics.add_child(epic, task)
+    try:
+        with github.target_org(owner):
+            epics.add_child(epic, task)
+    except github.NoInstallationError as exc:
+        print(f"vrg-epic-link: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
     print(f"Linked {task.slug} under epic {epic.slug}.")
     return 0
 

--- a/src/vergil_tooling/bin/vrg_epic_move.py
+++ b/src/vergil_tooling/bin/vrg_epic_move.py
@@ -29,18 +29,38 @@ def main(argv: list[str] | None = None) -> int:
     default_repo = github.current_repo()
     try:
         task = epics.parse_issue_ref(args.task, default_repo=default_repo)
-        epic = epics.resolve_epic_ref(args.epic, repo=default_repo)
+        # Scope the App token to the task's owner (#2070). The epic must live in
+        # the same org — 'standing' resolves within the task's repo, so only an
+        # explicit ref can diverge; guard that before any network call so a
+        # cross-org mistake is a clear message, not a cwd-scoped 403.
+        if args.epic != "standing":
+            epic_owner = epics.parse_issue_ref(args.epic, default_repo=default_repo).owner
+            if epic_owner != task.owner:
+                raise ValueError(
+                    "cross-org operation is out of scope: task owner "
+                    f"{task.owner!r} != epic owner {epic_owner!r}"
+                )
     except ValueError as exc:
         print(f"vrg-epic-move: {exc}", file=sys.stderr)
         return 1
 
-    current = epics.parent_of(task)
-    if current == epic:
-        print(f"{task.slug} is already under epic {epic.slug}; nothing to do.")
-        return 0
-    if current is not None:
-        epics.remove_child(current, task)
-    epics.add_child(epic, task)
+    try:
+        with github.target_org(task.owner):
+            try:
+                epic = epics.resolve_epic_ref(args.epic, repo=default_repo)
+            except ValueError as exc:
+                print(f"vrg-epic-move: {exc}", file=sys.stderr)
+                return 1
+            current = epics.parent_of(task)
+            if current == epic:
+                print(f"{task.slug} is already under epic {epic.slug}; nothing to do.")
+                return 0
+            if current is not None:
+                epics.remove_child(current, task)
+            epics.add_child(epic, task)
+    except github.NoInstallationError as exc:
+        print(f"vrg-epic-move: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
     print(f"Moved {task.slug} under epic {epic.slug}.")
     return 0
 

--- a/src/vergil_tooling/bin/vrg_epic_rollup.py
+++ b/src/vergil_tooling/bin/vrg_epic_rollup.py
@@ -38,7 +38,14 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"vrg-epic-rollup: {exc}", file=sys.stderr)
         return 1
-    epics.rollup(task)
+    # Scope the App token to the task's owner so the rollup's parent/children
+    # queries and epic close hit the right installation, not the cwd org (#2070).
+    try:
+        with github.target_org(task.owner):
+            epics.rollup(task)
+    except github.NoInstallationError as exc:
+        print(f"vrg-epic-rollup: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
     print(f"Epic rollup check complete for {task.slug}.")
     return 0
 

--- a/src/vergil_tooling/bin/vrg_epic_unlink.py
+++ b/src/vergil_tooling/bin/vrg_epic_unlink.py
@@ -28,11 +28,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"vrg-epic-unlink: {exc}", file=sys.stderr)
         return 1
 
-    current = epics.parent_of(task)
-    if current is None:
-        print(f"{task.slug} is not linked to any epic; nothing to do.")
-        return 0
-    epics.remove_child(current, task)
+    # Scope the App token to the task's owner so the parent lookup and unlink
+    # hit the right installation, not the cwd org's (#2070).
+    try:
+        with github.target_org(task.owner):
+            current = epics.parent_of(task)
+            if current is None:
+                print(f"{task.slug} is not linked to any epic; nothing to do.")
+                return 0
+            epics.remove_child(current, task)
+    except github.NoInstallationError as exc:
+        print(f"vrg-epic-unlink: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
     print(f"Unlinked {task.slug} from epic {current.slug}.")
     return 0
 

--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -39,32 +39,55 @@ def _issue_number_from_url(url: str) -> int:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo = args.repo or github.current_repo()
-    try:
-        epic = epics.resolve_epic_ref(args.epic, repo=repo)
-    except ValueError as exc:
-        print(f"vrg-issue-create: {exc}", file=sys.stderr)
-        return 1
-
-    url = github.create_issue(
-        repo=repo,
-        title=args.title,
-        body=args.body,
-        body_file=args.body_file,
-        labels=args.label,
-        assignees=args.assignee,
-    )
     owner, name = repo.split("/", 1)
-    task = epics.IssueRef(owner=owner, repo=name, number=_issue_number_from_url(url))
+    # Pre-network cross-org guard: the issue and its epic must share an owner so
+    # one App-installation token reaches both (#2070). 'standing' resolves
+    # within *repo*, so only an explicit epic ref can diverge.
+    if args.epic != "standing":
+        try:
+            epic_owner = epics.parse_issue_ref(args.epic, default_repo=repo).owner
+        except ValueError as exc:
+            print(f"vrg-issue-create: {exc}", file=sys.stderr)
+            return 1
+        if epic_owner != owner:
+            print(
+                "vrg-issue-create: cross-org operation is out of scope: issue owner "
+                f"{owner!r} != epic owner {epic_owner!r}",
+                file=sys.stderr,
+            )
+            return 1
 
+    # Scope every App-token call below to the issue's owner, not the cwd org.
     try:
-        epics.add_child(epic, task)
-    except Exception as exc:  # noqa: BLE001 - orphan-safe: never lose the created issue
-        print(
-            f"vrg-issue-create: created {url} but failed to link it under epic "
-            f"{epic.slug}: {exc}. Link it with: vrg-epic-move --task #{task.number} "
-            f"--epic {epic.slug}",
-            file=sys.stderr,
-        )
+        with github.target_org(owner):
+            try:
+                epic = epics.resolve_epic_ref(args.epic, repo=repo)
+            except ValueError as exc:
+                print(f"vrg-issue-create: {exc}", file=sys.stderr)
+                return 1
+
+            url = github.create_issue(
+                repo=repo,
+                title=args.title,
+                body=args.body,
+                body_file=args.body_file,
+                labels=args.label,
+                assignees=args.assignee,
+            )
+            task = epics.IssueRef(owner=owner, repo=name, number=_issue_number_from_url(url))
+
+            try:
+                epics.add_child(epic, task)
+            except Exception as exc:  # noqa: BLE001 - orphan-safe: never lose the created issue
+                print(
+                    f"vrg-issue-create: created {url} but failed to link it under epic "
+                    f"{epic.slug}: {exc}. Link it with: vrg-epic-move --task #{task.number} "
+                    f"--epic {epic.slug}",
+                    file=sys.stderr,
+                )
+                return 1
+    except github.NoInstallationError as exc:
+        print(f"vrg-issue-create: {github.no_installation_message(exc)}", file=sys.stderr)
         return 1
 
     print(f"Created {url}, linked under epic {epic.slug}.")

--- a/src/vergil_tooling/bin/vrg_roadmap.py
+++ b/src/vergil_tooling/bin/vrg_roadmap.py
@@ -20,7 +20,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     org = args.org or github.current_org()
-    print(roadmap.render(roadmap.gather(org), org))
+    # Scope the App token to the org being read so a cross-org --org selects
+    # that org's installation, not the cwd repo's (#2070).
+    try:
+        with github.target_org(org):
+            print(roadmap.render(roadmap.gather(org), org))
+    except github.NoInstallationError as exc:
+        print(f"vrg-roadmap: {github.no_installation_message(exc)}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -67,6 +67,24 @@ def parse_issue_ref(ref: str, *, default_repo: str) -> IssueRef:
     return IssueRef(owner=owner, repo=name, number=int(number))
 
 
+def single_target_org(*refs: IssueRef) -> str:
+    """Return the single owner shared by *refs*, or raise on a cross-org span.
+
+    Commands that mint a GitHub App token for an explicit target select the
+    installation by owner, and one token cannot reach two owners. When an
+    operation names refs under different owners (e.g. an epic and a task in
+    different orgs) that is out of scope: fail clearly here rather than mint a
+    token for one owner and hit a cryptic ``403`` on the other (issue #2070).
+    """
+    owners = {ref.owner for ref in refs}
+    if len(owners) != 1:
+        joined = ", ".join(sorted(owners))
+        raise ValueError(
+            f"cross-org operation is out of scope: refs span multiple owners ({joined})"
+        )
+    return next(iter(owners))
+
+
 _SUBISSUES_QUERY = """
 query($id: ID!) {
   node(id: $id) {

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -8,6 +8,8 @@ refused, DNS lookup failures, and EOF) with exponential backoff.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import json
 import logging
 import os
@@ -23,12 +25,22 @@ from typing import TYPE_CHECKING, Any, cast
 from vergil_tooling.lib import retry
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
 log = logging.getLogger(__name__)
 
 _token_cache: dict[str, tuple[str, float]] = {}
 _installation_cache: dict[str, str] | None = None
+
+# The owner whose App installation should mint tokens for lib calls made in
+# the current context. Set by commands that act on an EXPLICIT cross-org
+# target (a --repo/--owner/--org/--epic/--task argument) via target_org();
+# read by _gh_env() at call time so it propagates through any call depth
+# (epics, roadmap, …) without re-plumbing each function. Unset (None) keeps
+# the historical behavior: resolve the org from the cwd git remote. See #2070.
+_target_org: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "vrg_target_org", default=None
+)
 
 
 class NoInstallationError(Exception):
@@ -254,9 +266,50 @@ def is_app_mode() -> bool:
     return token.startswith("ghs_")
 
 
+@contextlib.contextmanager
+def target_org(org: str | None) -> Iterator[None]:
+    """Scope App-token minting to an explicit target *org* for the block.
+
+    Within the context, every lib call that mints an App installation token
+    (everything through :func:`_gh_env` / :func:`_run_with_retry`) selects the
+    installation for *org* instead of resolving the org from the cwd git
+    remote — the fix for cross-org commands minting a cwd-scoped token and
+    getting a cryptic ``403`` (#2070). A missing installation fails loudly
+    with :class:`NoInstallationError` rather than silently falling back to a
+    wrong-org token, exactly as ``vrg-gh`` already does (#1413).
+
+    A *None* org is a no-op (cwd detection, the pre-existing behavior), so a
+    caller can pass a possibly-unset owner uniformly. The context is restored
+    on exit, so nesting and reuse are safe.
+    """
+    handle = _target_org.set(org)
+    try:
+        yield
+    finally:
+        _target_org.reset(handle)
+
+
+def no_installation_message(exc: NoInstallationError) -> str:
+    """A consistent, actionable message for a missing App installation.
+
+    Shared by every command that scopes work to an explicit target owner so
+    the "no installation for owner X" failure reads the same everywhere.
+    """
+    known = ", ".join(exc.known) if exc.known else "none"
+    return (
+        f"the GitHub App has no installation for owner '{exc.org}'. Known installations: {known}."
+    )
+
+
 def _gh_env() -> dict[str, str] | None:
-    """Return env dict with App installation token, or ``None`` for ambient auth."""
-    token = get_installation_token()
+    """Return env dict with App installation token, or ``None`` for ambient auth.
+
+    When a :func:`target_org` context is active, the token is minted for that
+    owner and a missing installation raises :class:`NoInstallationError`;
+    otherwise the org is resolved from the cwd git remote (the default).
+    """
+    org = _target_org.get()
+    token = get_installation_token(org=org, require_installation=org is not None)
     if token is None:
         return None
     return {**os.environ, "GH_TOKEN": token}

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -17,6 +17,29 @@ def _repo_node(login: str, name: str) -> dict[str, object]:
     return {"name": name, "owner": {"login": login}}
 
 
+# -- single_target_org (issue #2070) -----------------------------------------
+
+
+def test_single_target_org_returns_common_owner() -> None:
+    owner = epics.single_target_org(
+        IssueRef("org", ".github", 40),
+        IssueRef("org", "repo-a", 101),
+    )
+    assert owner == "org"
+
+
+def test_single_target_org_single_ref() -> None:
+    assert epics.single_target_org(IssueRef("org", "repo-a", 101)) == "org"
+
+
+def test_single_target_org_rejects_cross_org() -> None:
+    with pytest.raises(ValueError, match="cross-org"):
+        epics.single_target_org(
+            IssueRef("org-a", ".github", 40),
+            IssueRef("org-b", "repo", 101),
+        )
+
+
 # -- child_states ------------------------------------------------------------
 
 

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -857,6 +857,102 @@ class TestGhEnvNew:
             assert github._gh_env() is None
 
 
+# --- target_org token scoping (issue #2070) ---
+
+
+class TestTargetOrgScoping:
+    def test_gh_env_mints_for_target_org_ignoring_cwd(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Inside target_org, the token is minted for the named owner, and
+        the cwd git remote (detect_org) is never consulted — the acceptance
+        criterion "minting for an explicit target owner ignores the cwd org"."""
+        monkeypatch.setattr("vergil_tooling.lib.github._gh_env", _real_gh_env)
+        detect = MagicMock(return_value="cwd-org")
+        with (
+            patch("vergil_tooling.lib.github.detect_org", detect),
+            patch(
+                "vergil_tooling.lib.github.get_installation_token",
+                return_value="ghs_token",
+            ) as mint,
+            github.target_org("target-org"),
+        ):
+            env = github._gh_env()
+        assert env is not None
+        assert env["GH_TOKEN"] == "ghs_token"  # noqa: S105
+        mint.assert_called_once_with(org="target-org", require_installation=True)
+        detect.assert_not_called()
+
+    def test_gh_env_falls_back_to_cwd_when_no_target(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Outside any target_org, behavior is unchanged: no explicit org and
+        no required installation, so cwd detection still drives minting."""
+        monkeypatch.setattr("vergil_tooling.lib.github._gh_env", _real_gh_env)
+        with patch(
+            "vergil_tooling.lib.github.get_installation_token",
+            return_value="ghs_token",
+        ) as mint:
+            github._gh_env()
+        mint.assert_called_once_with(org=None, require_installation=False)
+
+    def test_gh_env_propagates_no_installation_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A targeted owner with no App installation fails loudly rather than
+        silently falling back to a cwd-scoped (wrong) token."""
+        monkeypatch.setattr("vergil_tooling.lib.github._gh_env", _real_gh_env)
+        with (
+            patch(
+                "vergil_tooling.lib.github.get_installation_token",
+                side_effect=github.NoInstallationError("target-org", ["cwd-org"]),
+            ),
+            pytest.raises(github.NoInstallationError),
+            github.target_org("target-org"),
+        ):
+            github._gh_env()
+
+    def test_target_org_none_is_a_noop(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Passing None (an unset owner) is a no-op: callers can pass a
+        possibly-unset owner uniformly and get the cwd-detection default."""
+        monkeypatch.setattr("vergil_tooling.lib.github._gh_env", _real_gh_env)
+        with (
+            patch(
+                "vergil_tooling.lib.github.get_installation_token",
+                return_value="ghs_token",
+            ) as mint,
+            github.target_org(None),
+        ):
+            github._gh_env()
+        mint.assert_called_once_with(org=None, require_installation=False)
+
+    def test_target_org_restores_previous_on_exit(self) -> None:
+        """The context is scoped: nesting restores the outer target on exit."""
+        assert github._target_org.get() is None
+        with github.target_org("outer"):
+            assert github._target_org.get() == "outer"
+            with github.target_org("inner"):
+                assert github._target_org.get() == "inner"
+            assert github._target_org.get() == "outer"
+        assert github._target_org.get() is None
+
+    def test_no_installation_message_lists_known(self) -> None:
+        exc = github.NoInstallationError("target-org", ["a-org", "b-org"])
+        msg = github.no_installation_message(exc)
+        assert "target-org" in msg
+        assert "a-org, b-org" in msg
+
+    def test_no_installation_message_handles_empty(self) -> None:
+        exc = github.NoInstallationError("target-org", [])
+        assert "none" in github.no_installation_message(exc)
+
+
 # --- App token exchange ---
 
 

--- a/tests/vergil_tooling/test_vrg_activity_log.py
+++ b/tests/vergil_tooling/test_vrg_activity_log.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_activity_log import main
+from vergil_tooling.lib import github
+
+_MOD = "vergil_tooling.bin.vrg_activity_log"
 
 if TYPE_CHECKING:
     import pytest
@@ -37,3 +40,23 @@ def test_main_defaults_org_to_current_repo() -> None:
     assert rc == 0
     mock_org.assert_called_once()
     assert mock_gather.call_args.kwargs["org"] == "acme"
+
+
+def test_main_scopes_token_to_org() -> None:
+    """Listing a cross-org activity log mints for that org's installation (#2070)."""
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.activity_log.gather", return_value=[]),
+    ):
+        rc = main(["--org", "other-org"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_reports_missing_installation() -> None:
+    with patch(
+        f"{_MOD}.activity_log.gather",
+        side_effect=github.NoInstallationError("other-org", []),
+    ):
+        rc = main(["--org", "other-org"])
+    assert rc == 1

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -7,6 +7,9 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_ensure_label import main, parse_args
+from vergil_tooling.lib import github
+
+_MOD = "vergil_tooling.bin.vrg_ensure_label"
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -173,3 +176,39 @@ def test_main_project_mode_discovers_and_syncs() -> None:
         result = main(["--owner", "myorg", "--project", "3", "--sync"])
     assert result == 0
     mock_discover.assert_called_once_with("myorg", "3")
+
+
+# ---------------------------------------------------------------------------
+# Token scoping (issue #2070)
+# ---------------------------------------------------------------------------
+
+
+def test_main_single_label_scopes_token_to_repo_owner() -> None:
+    """Labelling a repo outside the cwd org mints for the --repo owner (#2070)."""
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.github.run"),
+    ):
+        result = main(["--repo", "other-org/repo", "--label", "bug"])
+    assert result == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_project_mode_scopes_token_to_owner() -> None:
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.list_project_repos", return_value=[]),
+        patch(f"{_MOD}.github.run"),
+    ):
+        result = main(["--owner", "myorg", "--project", "3", "--sync"])
+    assert result == 0
+    mock_scope.assert_called_once_with("myorg")
+
+
+def test_main_reports_missing_installation() -> None:
+    with patch(
+        f"{_MOD}.github.run",
+        side_effect=github.NoInstallationError("other-org", []),
+    ):
+        result = main(["--repo", "other-org/repo", "--label", "bug"])
+    assert result == 1

--- a/tests/vergil_tooling/test_vrg_epic_link.py
+++ b/tests/vergil_tooling/test_vrg_epic_link.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_epic_link import main, parse_args
-from vergil_tooling.lib import epics
+from vergil_tooling.lib import epics, github
 
 _MOD = "vergil_tooling.bin.vrg_epic_link"
 
@@ -38,3 +38,38 @@ def test_main_rejects_bad_ref() -> None:
         rc = main(["--epic", "not-a-ref", "--task", "#42"])
     assert rc == 1
     mock_add.assert_not_called()
+
+
+def test_main_scopes_token_to_target_owner() -> None:
+    """The link runs under the epic/task owner's App installation, not the
+    cwd org's (#2070)."""
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="cwd-org/repo"),
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--epic", "other-org/.github#40", "--task", "other-org/repo#42"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_rejects_cross_org_refs() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--epic", "org-a/.github#40", "--task", "org-b/repo#42"])
+    assert rc == 1
+    mock_add.assert_not_called()
+
+
+def test_main_reports_missing_installation() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.epics.add_child",
+            side_effect=github.NoInstallationError("org", []),
+        ),
+    ):
+        rc = main(["--epic", "org/.github#40", "--task", "#42"])
+    assert rc == 1

--- a/tests/vergil_tooling/test_vrg_epic_move.py
+++ b/tests/vergil_tooling/test_vrg_epic_move.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_epic_move import main, parse_args
-from vergil_tooling.lib import epics
+from vergil_tooling.lib import epics, github
 
 _MOD = "vergil_tooling.bin.vrg_epic_move"
 
@@ -72,3 +72,56 @@ def test_main_rejects_non_epic_target() -> None:
         rc = main(["--task", "#42", "--epic", "#999"])
     assert rc == 1
     mock_add.assert_not_called()
+
+
+def test_main_accepts_standing_epic() -> None:
+    """The 'standing' sentinel skips the cross-org guard (it resolves in-repo)."""
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=NEW),
+        patch(f"{_MOD}.epics.parent_of", return_value=None),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--task", "#42", "--epic", "standing"])
+    assert rc == 0
+    mock_add.assert_called_once_with(NEW, TASK)
+
+
+def test_main_scopes_token_to_task_owner() -> None:
+    """The re-parent runs under the task's owner installation, not cwd (#2070)."""
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="cwd-org/repo"),
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=NEW),
+        patch(f"{_MOD}.epics.parent_of", return_value=None),
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--task", "other-org/repo#42", "--epic", "other-org/repo#200"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_rejects_cross_org_task_and_epic() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref") as mock_resolve,
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--task", "org-a/repo#42", "--epic", "org-b/repo#200"])
+    assert rc == 1
+    mock_resolve.assert_not_called()
+    mock_add.assert_not_called()
+
+
+def test_main_reports_missing_installation() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=NEW),
+        patch(f"{_MOD}.epics.parent_of", return_value=None),
+        patch(
+            f"{_MOD}.epics.add_child",
+            side_effect=github.NoInstallationError("org", []),
+        ),
+    ):
+        rc = main(["--task", "#42", "--epic", "org/repo#200"])
+    assert rc == 1

--- a/tests/vergil_tooling/test_vrg_epic_rollup.py
+++ b/tests/vergil_tooling/test_vrg_epic_rollup.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_epic_rollup import main, parse_args
-from vergil_tooling.lib import epics
+from vergil_tooling.lib import epics, github
 
 _MOD = "vergil_tooling.bin.vrg_epic_rollup"
 
@@ -45,3 +45,27 @@ def test_main_rejects_bad_ref() -> None:
         rc = main(["--task", "not-a-ref"])
     assert rc == 1
     mock_rollup.assert_not_called()
+
+
+def test_main_scopes_token_to_task_owner() -> None:
+    """The rollup queries + epic close run under the task's owner (#2070)."""
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="cwd-org/repo"),
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.rollup"),
+    ):
+        rc = main(["--task", "other-org/other#7"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_reports_missing_installation() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.epics.rollup",
+            side_effect=github.NoInstallationError("org", []),
+        ),
+    ):
+        rc = main(["--task", "#42"])
+    assert rc == 1

--- a/tests/vergil_tooling/test_vrg_epic_unlink.py
+++ b/tests/vergil_tooling/test_vrg_epic_unlink.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_epic_unlink import main, parse_args
-from vergil_tooling.lib import epics
+from vergil_tooling.lib import epics, github
 
 _MOD = "vergil_tooling.bin.vrg_epic_unlink"
 
@@ -50,3 +50,28 @@ def test_main_rejects_bad_ref() -> None:
         rc = main(["--task", "not-a-ref"])
     assert rc == 1
     mock_remove.assert_not_called()
+
+
+def test_main_scopes_token_to_task_owner() -> None:
+    """Parent lookup + unlink run under the task's owner installation (#2070)."""
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="cwd-org/repo"),
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.parent_of", return_value=PARENT),
+        patch(f"{_MOD}.epics.remove_child"),
+    ):
+        rc = main(["--task", "other-org/repo#42"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_reports_missing_installation() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.epics.parent_of",
+            side_effect=github.NoInstallationError("org", []),
+        ),
+    ):
+        rc = main(["--task", "#42"])
+    assert rc == 1

--- a/tests/vergil_tooling/test_vrg_issue_create.py
+++ b/tests/vergil_tooling/test_vrg_issue_create.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_issue_create import main, parse_args
-from vergil_tooling.lib import epics
+from vergil_tooling.lib import epics, github
 
 _MOD = "vergil_tooling.bin.vrg_issue_create"
 
@@ -62,3 +62,63 @@ def test_main_link_failure_reports_created_issue(capsys: pytest.CaptureFixture[s
     assert rc == 1
     err = capsys.readouterr().err
     assert "123" in err  # orphan-safe: the created issue is surfaced
+
+
+def test_main_scopes_token_to_repo_owner() -> None:
+    """Issue creation + linking run under the --repo owner installation (#2070)."""
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--repo", "other-org/repo", "--epic", "standing", "--title", "T"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_explicit_same_org_epic_proceeds() -> None:
+    """An explicit epic ref in the issue's own org passes the guard and links."""
+    with (
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--repo", "org/repo", "--epic", "org/.github#5", "--title", "T"])
+    assert rc == 0
+    mock_add.assert_called_once_with(EPIC, epics.IssueRef("org", "repo", 123))
+
+
+def test_main_rejects_bad_epic_ref() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(["--epic", "not-a-ref", "--title", "T"])
+    assert rc == 1
+    mock_create.assert_not_called()
+
+
+def test_main_rejects_cross_org_epic() -> None:
+    with (
+        patch(f"{_MOD}.epics.resolve_epic_ref") as mock_resolve,
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(["--repo", "org-a/repo", "--epic", "org-b/repo#5", "--title", "T"])
+    assert rc == 1
+    mock_resolve.assert_not_called()
+    mock_create.assert_not_called()
+
+
+def test_main_reports_missing_installation() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(
+            f"{_MOD}.epics.resolve_epic_ref",
+            side_effect=github.NoInstallationError("org", []),
+        ),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(["--epic", "standing", "--title", "T"])
+    assert rc == 1
+    mock_create.assert_not_called()

--- a/tests/vergil_tooling/test_vrg_roadmap.py
+++ b/tests/vergil_tooling/test_vrg_roadmap.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_roadmap import main
+from vergil_tooling.lib import github
+
+_MOD = "vergil_tooling.bin.vrg_roadmap"
 
 if TYPE_CHECKING:
     import pytest
@@ -27,3 +30,23 @@ def test_main_defaults_org_to_current_repo() -> None:
     assert rc == 0
     mock_org.assert_called_once()
     assert mock_gather.call_args.args[0] == "acme"
+
+
+def test_main_scopes_token_to_org() -> None:
+    """Reading a cross-org roadmap mints for that org's installation (#2070)."""
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.roadmap.gather", return_value=[]),
+    ):
+        rc = main(["--org", "other-org"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_reports_missing_installation() -> None:
+    with patch(
+        f"{_MOD}.roadmap.gather",
+        side_effect=github.NoInstallationError("other-org", []),
+    ):
+        rc = main(["--org", "other-org"])
+    assert rc == 1


### PR DESCRIPTION
# Pull Request

## Summary

- Cross-org commands minted the GitHub App installation token from the cwd org instead of the explicit target owner, causing a cryptic HTTP 403; a ContextVar-backed github.target_org() context now scopes token minting to the target owner and fails loudly on a missing installation.

## Issue Linkage

- Closes #2070

## Notes

- Approach: Option 2 from the issue — a lib-level target-org context read in _gh_env(), so the fix propagates through any call depth without re-plumbing epics/roadmap/etc. Eight genuine cross-org offenders are wrapped (epic-link/move/unlink/rollup, issue-create, ensure-label, roadmap, activity-log); epics.single_target_org() and pre-network guards reject cross-org spans with a clear message.

Scope note for reviewers: the audit initially flagged 10 offenders, but vrg-epic-audit and vrg-finalize-pr are cwd-scoped by construction (no explicit cross-org target) — wrapping them would convert their working ambient-auth fallback into a hard NoInstallationError for repos whose org lacks an App installation, a regression for zero benefit, so they are deliberately left unchanged.

Behavior change: with a target set, a missing App installation now raises NoInstallationError (fail-loud) instead of silently falling back to a cwd-scoped token — matching vrg-gh (#1413). Unset target keeps the historical cwd-detection default. New regression test asserts minting for an explicit target owner ignores the cwd org. Full vrg-validate green (100% coverage).