### PR TITLE
fix(reporting): exclude release-tracking issues from roadmap/activity-log/audit

### DIFF
--- a/src/vergil_tooling/lib/activity_log.py
+++ b/src/vergil_tooling/lib/activity_log.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from vergil_tooling.lib import github
+from vergil_tooling.lib import github, release
 
 
 @dataclass(frozen=True)
@@ -44,13 +44,19 @@ def gather(since: str, *, org: str | None = None) -> list[ActivityItem]:
         "--limit",
         "100",
         "--json",
-        "number,title,repository,url,closedAt",
+        "number,title,repository,url,closedAt,body",
     )
     items: list[ActivityItem] = []
     for entry in raw if isinstance(raw, list) else []:
         repo = str((entry.get("repository") or {}).get("nameWithOwner", ""))
         closed = str(entry.get("closedAt") or "")
         if not repo or not closed:
+            continue
+        # Release tracking issues (release: X.Y.Z) are vrg-release bookkeeping,
+        # not epic/task work — keep them out of the ledger. See issue #1984.
+        if release.is_release_tracking_issue(
+            title=str(entry.get("title") or ""), body=str(entry.get("body") or "")
+        ):
             continue
         items.append(
             ActivityItem(

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -65,7 +65,9 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
         ):
             continue
         drift.append(
-            TaskDrift(repo=repo, task=task, pr_number=int(entry["number"]), pr_url=str(entry["url"]))
+            TaskDrift(
+                repo=repo, task=task, pr_number=int(entry["number"]), pr_url=str(entry["url"])
+            )
         )
     return drift
 

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from vergil_tooling.lib import github, linkage, roadmap
+from vergil_tooling.lib import github, linkage, release, roadmap
 
 
 @dataclass(frozen=True)
@@ -50,15 +50,23 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
             continue
         if task is None:
             continue
-        state = github.read_output(
-            "issue", "view", str(task), "--repo", repo, "--json", "state", "--jq", ".state"
-        ).upper()
-        if state == "OPEN":
-            drift.append(
-                TaskDrift(
-                    repo=repo, task=task, pr_number=int(entry["number"]), pr_url=str(entry["url"])
-                )
-            )
+        issue = github.read_json(
+            "issue", "view", str(task), "--repo", repo, "--json", "state,title,body"
+        )
+        if not isinstance(issue, dict):
+            continue
+        if str(issue.get("state") or "").upper() != "OPEN":
+            continue
+        # A merged release PR Refs its release: X.Y.Z tracking issue, which stays
+        # open as vrg-release bookkeeping — not drift. Skip it so the audit does
+        # not flag release issues as slipped tasks. See issue #1984.
+        if release.is_release_tracking_issue(
+            title=str(issue.get("title") or ""), body=str(issue.get("body") or "")
+        ):
+            continue
+        drift.append(
+            TaskDrift(repo=repo, task=task, pr_number=int(entry["number"]), pr_url=str(entry["url"]))
+        )
     return drift
 
 

--- a/src/vergil_tooling/lib/release/__init__.py
+++ b/src/vergil_tooling/lib/release/__init__.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 import re
 
+from vergil_tooling.lib.release.checklist import BEGIN as _PROGRESS_MARKER
+
 _LEGACY_CHORE_RE = re.compile(r"^chore/(bump-version-|\d+-next-cycle-deps-)")
+
+# A release tracking issue's title is exactly ``release: X.Y.Z`` (see
+# release.tracking / release.resume). Matching the version form — not a bare
+# ``release:`` prefix — keeps a legitimately-titled epic (e.g. one about the
+# release pipeline) from being mistaken for release bookkeeping.
+_RELEASE_TITLE_RE = re.compile(r"^release:\s+\d+\.\d+\.\d+\s*$")
 
 
 def is_release_branch(branch: str) -> bool:
@@ -17,3 +25,18 @@ def is_release_branch(branch: str) -> bool:
     are updated to use ``release/``.
     """
     return branch.startswith("release/") or bool(_LEGACY_CHORE_RE.match(branch))
+
+
+def is_release_tracking_issue(title: str | None = None, body: str | None = None) -> bool:
+    """Return True if an issue is a vrg-release tracking issue, not epic/task work.
+
+    Release-tracking issues (``release: X.Y.Z``) are release bookkeeping and must
+    never appear in the epic/task observability outputs (roadmap, activity log,
+    drift audit) — they are not tasks (issue #1984). The authoritative signal is
+    the ``<!-- vrg-release:progress -->`` checklist marker vrg-release writes into
+    the body; the ``release: X.Y.Z`` title is a secondary signal for callers that
+    only have the title, or for an issue whose body marker was hand-removed.
+    """
+    if body and _PROGRESS_MARKER in body:
+        return True
+    return bool(title and _RELEASE_TITLE_RE.match(title))

--- a/src/vergil_tooling/lib/roadmap.py
+++ b/src/vergil_tooling/lib/roadmap.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from vergil_tooling.lib import epics, github
+from vergil_tooling.lib import epics, github, release
 
 
 @dataclass(frozen=True)
@@ -41,7 +41,7 @@ def _open_epics(org: str) -> list[Any]:
         "--limit",
         "200",
         "--json",
-        "number,title,createdAt,milestone,labels,url",
+        "number,title,createdAt,milestone,labels,url,body",
     )
     return raw if isinstance(raw, list) else []
 
@@ -61,6 +61,14 @@ def gather(org: str | None = None) -> list[EpicSummary]:
     summaries: list[EpicSummary] = []
     for epic in _open_epics(org):
         if _is_standing(epic):
+            continue
+        # Defense in depth: a release tracking issue is never epic-labelled, so
+        # it should not reach here — but skip it explicitly so a stray label can
+        # never leak release bookkeeping into the roadmap (or epic-drift, which
+        # reads this same gather). See issue #1984.
+        if release.is_release_tracking_issue(
+            title=str(epic.get("title") or ""), body=str(epic.get("body") or "")
+        ):
             continue
         number = int(epic["number"])
         children = epics.child_states(epics.IssueRef(org, ".github", number))

--- a/tests/vergil_tooling/test_activity_log.py
+++ b/tests/vergil_tooling/test_activity_log.py
@@ -36,6 +36,42 @@ def test_gather_parses_and_skips_incomplete() -> None:
     assert ">=2026-06-01" in args
 
 
+def test_gather_skips_release_tracking_issues() -> None:
+    # A closed ``release: X.Y.Z`` issue is vrg-release bookkeeping, not work —
+    # keep it out of the ledger, whether detected by body marker or by title.
+    results = [
+        {
+            "number": 1912,
+            "title": "labels",
+            "repository": {"nameWithOwner": "vergil-project/vergil-tooling"},
+            "url": "u1912",
+            "closedAt": "2026-06-29T10:00:00Z",
+            "body": "real work",
+        },
+        {  # release issue by body marker -> skipped
+            "number": 373,
+            "title": "release: 2.1.4",
+            "repository": {"nameWithOwner": "vergil-project/vergil-containers"},
+            "url": "u373",
+            "closedAt": "2026-06-30T09:00:00Z",
+            "body": "<!-- vrg-release:progress -->\n- [x] tag\n",
+        },
+        {  # release issue by title only (body marker hand-removed) -> skipped
+            "number": 400,
+            "title": "release: 2.1.5",
+            "repository": {"nameWithOwner": "vergil-project/vergil-containers"},
+            "url": "u400",
+            "closedAt": "2026-06-30T10:00:00Z",
+            "body": "",
+        },
+    ]
+    with patch("vergil_tooling.lib.github.read_json", return_value=results):
+        items = activity_log.gather("2026-06-01", org="vergil-project")
+    assert items == [
+        ActivityItem("vergil-project/vergil-tooling", 1912, "labels", "u1912", "2026-06-29")
+    ]
+
+
 def test_gather_returns_empty_on_non_list() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"x": 1}):
         assert activity_log.gather("2026-06-01", org="vergil-project") == []

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -37,15 +37,42 @@ def test_task_drift_flags_open_task_behind_merged_pr() -> None:
         },
     ]
 
-    def fake_state(*args: str) -> str:
-        return "open" if args[2] == "1947" else "closed"
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        # issue view: args = ("issue", "view", "<number>", ...)
+        state = "open" if args[2] == "1947" else "closed"
+        return {"state": state, "title": f"feat: task {args[2]}", "body": "task body"}
 
-    with (
-        patch("vergil_tooling.lib.github.read_json", return_value=prs),
-        patch("vergil_tooling.lib.github.read_output", side_effect=fake_state),
-    ):
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
         result = epic_audit.task_drift("2026-06-01", org="vergil-project")
     assert result == [TaskDrift("vergil-project/vergil-tooling", 1947, 1948, "u1948")]
+
+
+def test_task_drift_skips_release_tracking_issue() -> None:
+    # A merged release PR Refs its open ``release: X.Y.Z`` tracking issue, which
+    # is vrg-release bookkeeping — not a slipped task. It must not be flagged.
+    prs = [
+        {
+            "number": 500,
+            "repository": {"nameWithOwner": "vergil-project/vergil-containers"},
+            "url": "u500",
+            "body": "Ref #373",
+        },
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        return {
+            "state": "open",
+            "title": "release: 2.1.4",
+            "body": "<!-- vrg-release:progress -->\n- [x] tag\n",
+        }
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        result = epic_audit.task_drift("2026-06-01", org="vergil-project")
+    assert result == []
 
 
 def test_task_drift_returns_empty_on_non_list() -> None:

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -80,6 +80,25 @@ def test_task_drift_returns_empty_on_non_list() -> None:
         assert epic_audit.task_drift("2026-06-01", org="vergil-project") == []
 
 
+def test_task_drift_skips_when_issue_view_is_not_an_object() -> None:
+    # Defensive: gh issue view --json returns a JSON object, but if the response
+    # is ever shaped unexpectedly (a list), skip the entry rather than crash.
+    prs = [
+        {
+            "number": 1948,
+            "repository": {"nameWithOwner": "vergil-project/vergil-tooling"},
+            "url": "u1948",
+            "body": "Ref #1947",
+        },
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        return prs if args[0] == "search" else ["unexpected"]
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        assert epic_audit.task_drift("2026-06-01", org="vergil-project") == []
+
+
 def test_epic_drift_flags_all_done_open_epics() -> None:
     summaries = [
         roadmap.EpicSummary(40, "Convention", "2026-06-28", None, (), 9, 9, "u40"),  # all done

--- a/tests/vergil_tooling/test_release.py
+++ b/tests/vergil_tooling/test_release.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from vergil_tooling.lib.release import is_release_branch
+from vergil_tooling.lib.release import is_release_branch, is_release_tracking_issue
 
 
 @pytest.mark.parametrize(
@@ -42,3 +42,36 @@ def test_release_branch_allowed(branch: str) -> None:
 )
 def test_non_release_branch_denied(branch: str) -> None:
     assert is_release_branch(branch) is False
+
+
+_MARKER = "<!-- vrg-release:progress -->"
+
+
+def test_release_issue_detected_by_body_marker() -> None:
+    # The checklist marker is authoritative even if the title was hand-edited.
+    assert is_release_tracking_issue(title="anything at all", body=f"intro\n{_MARKER}\n- [ ] x")
+
+
+def test_release_issue_detected_by_title_when_body_absent() -> None:
+    # Secondary signal: a caller with only the title still classifies it.
+    assert is_release_tracking_issue(title="release: 2.1.4", body=None)
+    assert is_release_tracking_issue(title="release:   0.10.0", body="")
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "feat(release): overhaul the release pipeline",
+        "release: overhaul the pipeline",  # no version -> not a tracking issue
+        "chore: release notes",
+        "fix(reporting): exclude release-tracking issues",
+        "",
+    ],
+)
+def test_non_release_titles_are_not_tracking_issues(title: str) -> None:
+    assert is_release_tracking_issue(title=title, body="") is False
+
+
+def test_no_signals_is_false() -> None:
+    assert is_release_tracking_issue() is False
+    assert is_release_tracking_issue(title=None, body=None) is False

--- a/tests/vergil_tooling/test_roadmap.py
+++ b/tests/vergil_tooling/test_roadmap.py
@@ -72,6 +72,36 @@ def test_gather_handles_no_milestone_and_no_children() -> None:
     assert result[0].repos == ()
 
 
+def test_gather_skips_release_tracking_issue() -> None:
+    # Defense in depth: a release tracking issue is never epic-labelled, but if a
+    # stray ``epic`` label ever lands on one it must not leak into the roadmap.
+    epic_list = [
+        {
+            "number": 40,
+            "title": "Convention",
+            "createdAt": "2026-06-28T10:00:00Z",
+            "milestone": None,
+            "labels": [{"name": "epic"}],
+            "url": "u40",
+        },
+        {
+            "number": 373,
+            "title": "release: 2.1.4",
+            "createdAt": "2026-06-30T00:00:00Z",
+            "milestone": None,
+            "labels": [{"name": "epic"}],
+            "url": "u373",
+            "body": "<!-- vrg-release:progress -->\n- [x] tag\n",
+        },
+    ]
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=epic_list),
+        patch("vergil_tooling.lib.epics.child_states", return_value=[]),
+    ):
+        result = roadmap.gather("vergil-project")
+    assert [e.number for e in result] == [40]
+
+
 def test_gather_returns_empty_on_non_list() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"unexpected": True}):
         assert roadmap.gather("vergil-project") == []


### PR DESCRIPTION
# Pull Request

## Summary

- Add is_release_tracking_issue(title, body) to lib/release (body checklist marker primary, release: X.Y.Z title secondary) and filter release-tracking issues out of activity_log.gather, epic_audit.task_drift, and roadmap.gather so vrg-release bookkeeping never surfaces in epic/task observability outputs.

## Issue Linkage

- Closes #1984

## Notes

- Fixes the reported symptom where vrg-epic-audit flagged an open release issue behind a merged release PR (e.g. vergil-containers#373) as task-drift. task_drift now fetches state+title+body via read_json (was state-only via read_output) to classify the tracking issue. roadmap is defense-in-depth (release issues are never epic-labelled) and also covers epic_drift, which reads the same gather. New tests: detector unit tests in test_release.py, plus exclusion cases in test_roadmap/test_activity_log/test_epic_audit. Note: an unrelated pre-existing host-only test failure (test_help_coverage[vrg-update-deps], which refuses to run under the user agent identity) does not occur in the container validation, which is fully green.