### PR TITLE
chore(repo-init): default new-repo license to MIT

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -41,7 +41,7 @@ class RepoInitContext:
     publish_release: bool = False
     publish_docs: bool = True
     vergil_version: str = "v2.1"
-    license_type: str = "GPL-3.0"
+    license_type: str = "MIT"
     initial_version: str = "0.1.0"
 
     @property
@@ -785,8 +785,8 @@ def step_generate_config(ctx: RepoInitContext) -> None:
         default=deps.get("vergil", "v2.1"),
     )
 
-    license_options = ["GPL-3.0", "MIT", "Apache-2.0", "none"]
-    ctx.license_type = prompt_choice("License", license_options, default="GPL-3.0")
+    license_options = ["MIT", "GPL-3.0", "Apache-2.0", "none"]
+    ctx.license_type = prompt_choice("License", license_options, default="MIT")
 
     ctx.initial_version = prompt_free_text("Initial version", default="0.1.0")
 

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -141,6 +141,11 @@ class TestRepoInitContext:
         assert ctx.repo == "vergil-project/vergil-vm"
         assert ctx.completed_steps == set()
 
+    def test_default_license_is_mit(self) -> None:
+        # Standing decision (2026-06-30): new repos default to MIT, not GPL-3.0.
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        assert ctx.license_type == "MIT"
+
     def test_adopt_mode(self) -> None:
         ctx = RepoInitContext(
             org="vergil-project",
@@ -651,7 +656,7 @@ class TestStepGenerateConfig:
                 "y",  # publish releases
                 "y",  # publish docs
                 "",  # vergil version (default v2.0)
-                "1",  # license: GPL-3.0
+                "1",  # license: MIT (option 1)
                 "",  # initial version (default 0.1.0)
             ]
         )
@@ -690,7 +695,7 @@ class TestStepGenerateConfig:
                 "n",  # publish releases
                 "y",  # publish docs
                 "",  # vergil version
-                "1",  # license: GPL-3.0
+                "1",  # license: MIT (option 1)
                 "",  # initial version
             ]
         )


### PR DESCRIPTION
# Pull Request

## Summary

- Flips the vrg-github-repo-init wizard default license from GPL-3.0 to MIT (field default, prompt default, and options order) per the 2026-06-30 standing decision; existing repos are not retroactively relicensed.

## Issue Linkage

- Closes #1990

## Notes

- No repo-config audit checks a repo's own license, so nothing to reconcile there (the remaining GPL-3.0 references are dependency-license allowlists in languages.py / license_finder.yml). Added a test locking RepoInitContext's default to MIT; both GPL and MIT license templates remain covered. vrg-validate green.