### PR TITLE
fix(off-platform): retry transient IAP/SSH transport-connect failures

### DIFF
--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -13,10 +13,90 @@ import os
 import shlex
 import subprocess
 import sys
-from typing import NoReturn, Protocol, runtime_checkable
+import time
+from typing import TYPE_CHECKING, NoReturn, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _DEFAULT_WORKDIR = "/tmp"  # noqa: S108
 _TERMINAL_ENV_VARS = "COLORTERM,TERM_PROGRAM,TERM_PROGRAM_VERSION"
+
+# Transient-transport retry for the off-platform transports (IAP tunnel, plain
+# ssh). Both ``gcloud compute ssh`` and ``ssh`` exit 255 when the *transport
+# itself* fails to connect — the IAP "4003: failed to connect to backend" /
+# "Failed to connect to port 22" blip, or ssh's "Connection refused" /
+# "Connection closed" — as opposed to a remote command that ran and returned its
+# own nonzero exit. A burst of short-lived IAP tunnels (readiness + credentials +
+# tooling) can trip a Google-side backend blip that clears in seconds, and a
+# single such blip must not discard a multi-minute rebuild (#1992).
+#
+# Keying the retry on exit 255 alone is safe here: none of the guest-side
+# commands the off-platform pipeline runs return 255, so a 255 is unambiguously a
+# transport failure, never a real remote-command result. Any other nonzero exit
+# is a genuine command failure and is re-raised immediately — retrying it would
+# mask a real fault (no-silent-failures).
+_CONNECT_FAILURE_RETURNCODE = 255
+_CONNECT_RETRIES = 3  # extra attempts after the first (4 total)
+_CONNECT_BACKOFF_BASE_SECS = 2.0  # 2s, 4s, 8s — bounded, ~14s worst case
+
+
+def _run_checked(
+    cmd: list[str],
+    *,
+    quiet: bool,
+    input_data: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run *cmd* under the shared off-platform retry/reporting policy.
+
+    A transient transport-connect failure (exit 255) is retried with bounded
+    exponential backoff; every other nonzero exit is a real remote-command
+    failure and is raised on the first attempt. On the final failure the child's
+    stderr is echoed unless *quiet*.
+
+    ``quiet`` probe callers (the readiness gate's ``_wait_for_ssh`` /
+    ``_poll_cloud_init_status``) own their own poll loop and expect the connect
+    failure back, so they are never retried here — an internal retry would blow
+    out their cadence during the boot race. They also suppress the stderr echo,
+    for which raw IAP 4003 noise would be misleading.
+    """
+
+    def _call() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            input=input_data,
+        )
+
+    return _with_connect_retry(_call, quiet=quiet)
+
+
+def _with_connect_retry(
+    call: Callable[[], subprocess.CompletedProcess[str]],
+    *,
+    quiet: bool,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke *call*, retrying only a transport-connect failure (exit 255)."""
+    for attempt in range(_CONNECT_RETRIES + 1):
+        try:
+            return call()
+        except subprocess.CalledProcessError as exc:
+            transient = exc.returncode == _CONNECT_FAILURE_RETURNCODE
+            last = attempt == _CONNECT_RETRIES
+            if quiet or not transient or last:
+                if exc.stderr and not quiet:
+                    print(exc.stderr, end="", file=sys.stderr)
+                raise
+            delay = _CONNECT_BACKOFF_BASE_SECS * (2**attempt)
+            print(
+                f"  transient transport failure (exit {exc.returncode}); retrying "
+                f"in {delay:.0f}s ({attempt + 1}/{_CONNECT_RETRIES})...",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 @runtime_checkable
@@ -145,32 +225,11 @@ class IapTransport:
         self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
     ) -> subprocess.CompletedProcess[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
-        try:
-            return subprocess.run(  # noqa: S603
-                [*self._base(), f"--command={remote}"],  # noqa: S607
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            if exc.stderr and not quiet:
-                print(exc.stderr, end="", file=sys.stderr)
-            raise
+        return _run_checked([*self._base(), f"--command={remote}"], quiet=quiet)
 
     def pipe(self, cmd: str, input_data: str, *, workdir: str = _DEFAULT_WORKDIR) -> None:
         remote = f"cd {shlex.quote(workdir)} && {cmd}"
-        try:
-            subprocess.run(  # noqa: S603
-                [*self._base(), f"--command={remote}"],  # noqa: S607
-                check=True,
-                input=input_data,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            if exc.stderr:
-                print(exc.stderr, end="", file=sys.stderr)
-            raise
+        _run_checked([*self._base(), f"--command={remote}"], quiet=False, input_data=input_data)
 
     def popen(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.Popen[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
@@ -224,32 +283,11 @@ class SshTransport:
         self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
     ) -> subprocess.CompletedProcess[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
-        try:
-            return subprocess.run(  # noqa: S603
-                [*self._base(), remote],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            if exc.stderr and not quiet:
-                print(exc.stderr, end="", file=sys.stderr)
-            raise
+        return _run_checked([*self._base(), remote], quiet=quiet)
 
     def pipe(self, cmd: str, input_data: str, *, workdir: str = _DEFAULT_WORKDIR) -> None:
         remote = f"cd {shlex.quote(workdir)} && {cmd}"
-        try:
-            subprocess.run(  # noqa: S603
-                [*self._base(), remote],
-                check=True,
-                input=input_data,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            if exc.stderr:
-                print(exc.stderr, end="", file=sys.stderr)
-            raise
+        _run_checked([*self._base(), remote], quiet=False, input_data=input_data)
 
     def popen(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.Popen[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vergil_tooling.lib.vm_transport import IapTransport, LimaTransport, SshTransport
+from vergil_tooling.lib.vm_transport import (
+    _CONNECT_RETRIES,
+    IapTransport,
+    LimaTransport,
+    SshTransport,
+)
 
 
 class TestLimaTransport:
@@ -212,6 +217,84 @@ class TestIapTransport:
             raise AssertionError("expected CalledProcessError")
         assert capsys.readouterr().err == ""
 
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_retries_transient_connect_failure_then_succeeds(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        # A transient IAP tunnel blip (exit 255 / "4003: failed to connect") is
+        # retried rather than aborting a multi-minute rebuild (#1992).
+        blip = subprocess.CalledProcessError(255, "gcloud")
+        blip.stderr = "ERROR: 4003: failed to connect to port 22"
+        mock_run.side_effect = [
+            blip,
+            subprocess.CompletedProcess([], 0, stdout="ok", stderr=""),
+        ]
+        result = IapTransport("inst", "z", "p", "vergil").run("true")
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 2
+        assert mock_sleep.called
+
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_does_not_retry_real_command_failure(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        # A remote command that ran and returned nonzero (exit 1) is a real
+        # failure — retrying would mask it (no-silent-failures).
+        err = subprocess.CalledProcessError(1, "gcloud")
+        err.stderr = "test: /x: No such file or directory"
+        mock_run.side_effect = err
+        with pytest.raises(subprocess.CalledProcessError):
+            IapTransport("inst", "z", "p", "vergil").run("test", "-d", "/x")
+        assert mock_run.call_count == 1
+        assert not mock_sleep.called
+
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_gives_up_after_bounded_retries(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        # A persistently unreachable box still fails the stage — the retries are
+        # bounded, not infinite.
+        blip = subprocess.CalledProcessError(255, "gcloud")
+        blip.stderr = "ERROR: 4003: failed to connect to port 22"
+        mock_run.side_effect = blip
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            IapTransport("inst", "z", "p", "vergil").run("true")
+        assert excinfo.value.returncode == 255
+        assert mock_run.call_count == _CONNECT_RETRIES + 1
+
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_quiet_probe_is_not_retried(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        # quiet=True callers (the readiness gate) own their own poll loop, so a
+        # connect failure passes straight back — an internal retry here would
+        # blow out their cadence.
+        blip = subprocess.CalledProcessError(255, "gcloud")
+        blip.stderr = "ERROR: 4003"
+        mock_run.side_effect = blip
+        with pytest.raises(subprocess.CalledProcessError):
+            IapTransport("inst", "z", "p", "vergil").run("true", quiet=True)
+        assert mock_run.call_count == 1
+        assert not mock_sleep.called
+
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_pipe_retries_transient_connect_failure(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        blip = subprocess.CalledProcessError(255, "gcloud")
+        blip.stderr = "ERROR: 4003"
+        mock_run.side_effect = [
+            blip,
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+        IapTransport("inst", "z", "p", "vergil").pipe("cat > f", "data")
+        assert mock_run.call_count == 2
+
     @patch("vergil_tooling.lib.vm_transport.os.execvp")
     def test_exec_session_tunnels_interactively(self, mock_execvp: MagicMock) -> None:
         IapTransport("inst", "z", "p", "vergil").exec_session("/work", "exec bash")
@@ -334,6 +417,39 @@ class TestSshTransport:
         else:  # pragma: no cover
             raise AssertionError("expected CalledProcessError")
         assert capsys.readouterr().err == ""
+
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_retries_transient_connect_failure_then_succeeds(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        # plain ssh also exits 255 when the transport fails to connect
+        # ("Connection refused" / "Connection closed") — same retriable class as
+        # the IAP tunnel (#1992).
+        blip = subprocess.CalledProcessError(255, "ssh")
+        blip.stderr = "ssh: connect to host 1.2.3.4 port 22: Connection refused"
+        mock_run.side_effect = [
+            blip,
+            subprocess.CompletedProcess([], 0, stdout="ok", stderr=""),
+        ]
+        result = SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key").run("true")
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 2
+        assert mock_sleep.called
+
+    @patch("vergil_tooling.lib.vm_transport.time.sleep")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_does_not_retry_real_command_failure(
+        self, mock_run: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        err = subprocess.CalledProcessError(1, "ssh")
+        err.stderr = "test: /x: No such file or directory"
+        mock_run.side_effect = err
+        transport = SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key")
+        with pytest.raises(subprocess.CalledProcessError):
+            transport.run("test", "-d", "/x")
+        assert mock_run.call_count == 1
+        assert not mock_sleep.called
 
     @patch("vergil_tooling.lib.vm_transport.subprocess.Popen")
     def test_popen_streams_via_ssh(self, mock_popen: MagicMock) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Post-readiness off-platform stages (credentials, tooling, bootstrap-volume) called the IAP/SSH transport with no retry, so a single transient IAP backend blip ('4003: failed to connect to backend', ssh exit 255) aborted a whole multi-minute rebuild. Adds bounded exponential-backoff retry (keyed on exit 255) shared by IapTransport and SshTransport; quiet readiness probes opt out since they own their own poll loop; real remote-command failures (non-255) are never retried.

## Issue Linkage

- Closes #1992

## Notes

- Root cause confirmed live: firing 16 parallel IAP tunnels at a healthy box (sshd NRestarts=0, no SYN-flood, no listen-drops) reproduced ~2/16 failing with the exact 4003/255 error — the failure is the IAP tunnel layer, not the guest. TDD: 8 new transport tests (retry-then-succeed, no-retry-on-real-failure, bounded give-up, quiet opt-out, pipe retry; IAP + SSH). Full vrg-validate green. Complements #2028 (fingerprint-read messaging on persistent failure). Deferred follow-up: SSH ControlMaster/ControlPersist to collapse the connection burst at the source.