### PR TITLE
fix(vm): retry transient IAP connect failures on cloud spec-fingerprint read

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -450,6 +450,48 @@ def _wait_for_cloud_init(
             tail.stop()
 
 
+def _read_fingerprint(
+    transport: Transport,
+    *,
+    timeout_secs: float = _SSH_READY_TIMEOUT_SECS,
+    poll_secs: float = _SSH_PROBE_INTERVAL_SECS,
+) -> str:
+    """Read the stamped spec fingerprint, retrying transient connect failures.
+
+    The fingerprint read is a single SSH call that lands right as cloud-init
+    finishes — exactly when sshd may restart / regenerate host keys — so the IAP
+    tunnel can fail to connect (ssh exit 255 / IAP 4003) for that one command on
+    an otherwise-healthy box. Like ``_wait_for_ssh`` and ``_poll_cloud_init_status``,
+    we treat a connect failure as "not ready yet" and retry on the same bounded
+    cadence, emitting a heartbeat so the wait stays visible. A command that
+    actually ran and exited nonzero (exit != 255) is a genuinely missing or
+    unreadable marker and raises immediately; only an exhausted timeout of
+    connect failures is otherwise terminal. The probe runs ``quiet`` so the
+    expected transient 4003 noise does not spam the operator.
+    """
+    started = time.monotonic()
+    deadline = started + timeout_secs
+    while True:
+        try:
+            return transport.run("cat", _FINGERPRINT_PATH, quiet=True).stdout
+        except subprocess.CalledProcessError as exc:
+            if not _is_connection_failure(exc):
+                raise RuntimeError(
+                    f"could not read the spec fingerprint marker ({_FINGERPRINT_PATH}) "
+                    "on the cloud box — rebuild the VM"
+                ) from exc
+            now = time.monotonic()
+            if now >= deadline:
+                raise RuntimeError(
+                    f"could not read the spec fingerprint marker ({_FINGERPRINT_PATH}) "
+                    f"on the cloud box: SSH never became reachable within "
+                    f"{int(timeout_secs)}s (last exit {exc.returncode}) — rebuild the VM"
+                ) from exc
+            beat = _readiness_heartbeat(now - started, "", "reading spec fingerprint")
+            progress.emit(beat)
+            time.sleep(poll_secs)
+
+
 def await_readiness(transport: Transport, fingerprint: str, *, verbose: bool = False) -> None:
     """Synthesize a hard-fail readiness gate for a cloud box.
 
@@ -459,14 +501,8 @@ def await_readiness(transport: Transport, fingerprint: str, *, verbose: bool = F
     ``RuntimeError`` so the create pipeline aborts loudly (no half-ready box).
     """
     _wait_for_cloud_init(transport, verbose=verbose)
-    try:
-        result = transport.run("cat", _FINGERPRINT_PATH)
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"could not read the spec fingerprint marker ({_FINGERPRINT_PATH}) "
-            "on the cloud box — rebuild the VM"
-        ) from exc
-    if result.stdout.strip() != fingerprint:
+    stamped = _read_fingerprint(transport)
+    if stamped.strip() != fingerprint:
         raise RuntimeError("spec fingerprint mismatch on the cloud box — rebuild the VM")
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -673,9 +673,7 @@ class TestAwaitReadiness:
         monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
         monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", lambda _line: None)
         clock = iter([0.0, 0.0, 1000.0])
-        monkeypatch.setattr(
-            "vergil_tooling.lib.vm_cloud.time.monotonic", lambda: next(clock)
-        )
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.monotonic", lambda: next(clock))
         transport = MagicMock()
         transport.run.side_effect = [
             _done("status: done\n"),

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -633,12 +633,55 @@ class TestAwaitReadiness:
             await_readiness(transport, "fp123")
 
     def test_raises_when_marker_read_fails(self) -> None:
+        # A command that actually ran and exited nonzero (exit 1, not the 255
+        # transport-connect code) is a genuinely missing/unreadable marker and
+        # surfaces the "rebuild the VM" guidance immediately — no retry.
         transport = MagicMock()
         transport.run.side_effect = [
             _done("status: done\n"),
             subprocess.CalledProcessError(1, "cat"),
         ]
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="could not read the spec fingerprint marker"):
+            await_readiness(transport, "fp123")
+
+    def test_retries_transient_connect_failure_during_marker_read(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A transient exit-255 (IAP 4003) on the fingerprint read — sshd
+        # restarting right at cloud-init completion — must be retried, not
+        # misreported as an unreadable marker.
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
+        emitted: list[str] = []
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", emitted.append)
+        transport = MagicMock()
+        transport.run.side_effect = [
+            _done("status: done\n"),
+            subprocess.CalledProcessError(255, "ssh"),
+            subprocess.CalledProcessError(255, "ssh"),
+            _done("fp123\n"),
+        ]
+        await_readiness(transport, "fp123")  # no raise
+        beats = [line for line in emitted if "reading spec fingerprint" in line]
+        assert len(beats) == 2
+
+    def test_marker_read_raises_after_bounded_connect_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Persistent connect failures on the fingerprint read are terminal once
+        # the bounded timeout is exhausted — with a message that says SSH never
+        # became reachable, not that the marker file is missing.
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.time.sleep", lambda _s: None)
+        monkeypatch.setattr("vergil_tooling.lib.vm_cloud.progress.emit", lambda _line: None)
+        clock = iter([0.0, 0.0, 1000.0])
+        monkeypatch.setattr(
+            "vergil_tooling.lib.vm_cloud.time.monotonic", lambda: next(clock)
+        )
+        transport = MagicMock()
+        transport.run.side_effect = [
+            _done("status: done\n"),
+            subprocess.CalledProcessError(255, "ssh"),
+        ]
+        with pytest.raises(RuntimeError, match="SSH never became reachable"):
             await_readiness(transport, "fp123")
 
     def test_verbose_streams_log_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Extract await_readiness's fingerprint read into a bounded retry helper that tolerates exit-255 IAP connect blips (4003) the same way _wait_for_ssh does, so a transient tunnel hiccup on that single cat call is retried instead of misreported as an unreadable marker prompting a needless VM rebuild.

## Issue Linkage

- Ref #2028

## Notes

- The unreadable-marker 'rebuild the VM' error is now reserved for a command that actually ran and exited nonzero (exit != 255); a persistent connect timeout raises a distinct 'SSH never became reachable' message. The fingerprint-mismatch path is unchanged. Adds three tests (retry-through-transient-255, non-255 fails immediately, bounded connect timeout). Second commit is a ruff-format line-wrap normalization on the new test.