### PR TITLE
feat(off-platform): reuse one IAP/SSH connection via ControlMaster/ControlPersist

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -848,6 +848,24 @@ def _cloud_create_stages() -> list[Stage]:
     ]
 
 
+def _teardown_ssh_master(state: _CloudState) -> None:
+    """Best-effort: kill the shared SSH control master the pipeline opened.
+
+    The whole off-platform pipeline rides one multiplexed connection (see
+    ``vm_transport`` mux helpers); this shuts its master down immediately on exit,
+    success or failure, so no background master survives the run (``ControlPersist``
+    is only the backstop). Building the transport needs the persisted box state
+    (e.g. the zone); if the pipeline failed before that was written there is simply
+    no master to close, so a construction failure is the expected nothing-to-do
+    case — the ``close()`` itself already swallows its own transport errors.
+    """
+    try:
+        transport = state.backend.transport()
+    except Exception:  # noqa: BLE001 — no persisted box yet ⇒ no master to tear down
+        return
+    transport.close()
+
+
 def _run_cloud_lifecycle(
     verb: str, state: _CloudState, stages: list[Stage], args: argparse.Namespace
 ) -> int:
@@ -862,6 +880,7 @@ def _run_cloud_lifecycle(
             repo_root=_log_root(),
         )
     finally:
+        _teardown_ssh_master(state)
         if state.modules_root is not None:
             shutil.rmtree(state.modules_root.parent, ignore_errors=True)
 

--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -9,11 +9,14 @@ and tooling logic does not.
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import os
 import shlex
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -99,6 +102,102 @@ def _with_connect_retry(
     raise AssertionError("unreachable")  # pragma: no cover
 
 
+# ---------------------------------------------------------------------------
+# SSH connection multiplexing (ControlMaster/ControlPath/ControlPersist).
+#
+# Off-platform pipelines run ~18-20 guest commands back-to-back, each of which
+# would otherwise open a fresh IAP tunnel + SSH handshake + auth. That burst is
+# the *trigger* behind the IAP "4003: failed to connect to backend" blip (#1992
+# retries the residual; this removes most of them) and leaves ~25 half-open
+# sessions lingering until sshd's ClientAlive reaps them. Multiplexing makes a
+# whole pipeline ride one underlying connection: the first command opens the
+# master, the rest reuse it over its control socket, and the master self-reaps
+# ``_CONTROL_PERSIST`` after the last client disconnects.
+#
+# The socket is a filesystem path keyed by (host, workdir), so every per-step
+# transport object the pipeline builds for the same box shares one master
+# automatically — no need to thread a single transport through the pipeline.
+# ---------------------------------------------------------------------------
+
+# Idle lifetime of the background master after the last channel closes. Explicit
+# teardown (``close()``) kills it immediately on pipeline exit; this is the
+# backstop that reaps a master a crashed run failed to close.
+_CONTROL_PERSIST = "60s"
+
+# 16 hex chars of a sha256 keeps the socket filename short so the full path stays
+# well under the Unix domain-socket ``sun_path`` cap (104 on macOS, 108 on Linux)
+# even for long home directories — a real failure mode for naive temp/state paths.
+_SOCKET_HASH_LEN = 16
+
+# Kill-switch: multiplexing is on by default; set this env truthy to disable all
+# injection so the transports behave exactly as they did pre-#2088. Cheap insurance
+# for the off-platform path, which cannot be validated on a real box pre-merge.
+_MUX_DISABLE_ENV = "VERGIL_VM_DISABLE_SSH_MUX"
+_MUX_DISABLE_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _mux_disabled() -> bool:
+    return os.environ.get(_MUX_DISABLE_ENV, "").strip().lower() in _MUX_DISABLE_TRUTHY
+
+
+def _control_dir() -> Path:
+    """Directory holding the per-box control sockets.
+
+    Under ``~/.config/vergil`` to match the existing off-platform state (e.g.
+    ``SshTransport``'s ``UserKnownHostsFile``) and to stay short enough for the
+    socket-path length cap.
+    """
+    return Path.home() / ".config" / "vergil" / "cm"
+
+
+def control_socket_path(host: str, workdir: str) -> Path:
+    """Deterministic control-socket path for a (host, workdir) pair.
+
+    ``host`` is already globally unique per box (a hash of identity/org/repo/name);
+    ``workdir`` adds worktree isolation so two worktrees reaching the same box get
+    distinct sockets and never clobber each other's master. Within one pipeline the
+    cwd is constant, so every step resolves to the same socket and shares the master.
+    """
+    digest = hashlib.sha256(f"{host}\0{workdir}".encode()).hexdigest()[:_SOCKET_HASH_LEN]
+    return _control_dir() / digest
+
+
+def ssh_mux_options(host: str, workdir: str) -> list[tuple[str, str]]:
+    """SSH multiplexing ``-o`` options for a box, or ``[]`` when disabled.
+
+    Creating the control dir (0700) is a side effect here because ssh requires the
+    socket's parent to exist before it opens the master.
+    """
+    if _mux_disabled():
+        return []
+    socket = control_socket_path(host, workdir)
+    socket.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return [
+        ("ControlMaster", "auto"),
+        ("ControlPath", str(socket)),
+        ("ControlPersist", _CONTROL_PERSIST),
+    ]
+
+
+def _shutdown_master(dest: str, control_path: Path) -> None:
+    """Best-effort teardown of a shared SSH control master.
+
+    ``ssh -O exit`` signals the background master over its control socket to exit
+    now; with no socket it fails fast without opening a connection, so the error is
+    swallowed. The socket file is then removed. ``ControlPersist`` is the final
+    backstop for any master this could not reach.
+    """
+    with contextlib.suppress(OSError, subprocess.SubprocessError):
+        subprocess.run(  # noqa: S603
+            ["ssh", "-o", f"ControlPath={control_path}", "-O", "exit", dest],  # noqa: S607
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    with contextlib.suppress(OSError):
+        control_path.unlink(missing_ok=True)
+
+
 @runtime_checkable
 class Transport(Protocol):
     """Execute commands inside a guest, regardless of how we reach it."""
@@ -124,6 +223,10 @@ class Transport(Protocol):
     ) -> subprocess.Popen[str]: ...  # pragma: no cover
 
     def exec_session(self, workdir: str, inner: str) -> NoReturn: ...  # pragma: no cover
+
+    def close(self) -> None:
+        """Tear down any shared connection state (no-op for connectionless backends)."""
+        ...  # pragma: no cover
 
 
 class LimaTransport:
@@ -194,6 +297,10 @@ class LimaTransport:
         ]
         os.execvp(cmd[0], cmd)  # noqa: S606, S607
 
+    def close(self) -> None:
+        """No persistent connection to tear down — limactl has no control master."""
+        return
+
 
 class IapTransport:
     """Transport over a GCP IAP SSH tunnel (no public IP, IAM-authed).
@@ -211,6 +318,11 @@ class IapTransport:
         self.ssh_user = ssh_user
 
     def _base(self) -> list[str]:
+        # Multiplexing options ride the underlying ssh via ``--ssh-flag``. The
+        # glued ``-oKey=Val`` form (no space) is used deliberately: gcloud splits a
+        # ``--ssh-flag`` value on spaces, so ``-o ControlPath=…`` would arrive as
+        # two mangled tokens — the glued form passes through intact.
+        mux = [f"--ssh-flag=-o{key}={value}" for key, value in ssh_mux_options(self.host, os.getcwd())]
         return [
             "gcloud",
             "compute",
@@ -219,6 +331,7 @@ class IapTransport:
             "--tunnel-through-iap",
             f"--zone={self.zone}",
             f"--project={self.project}",
+            *mux,
         ]
 
     def run(
@@ -249,6 +362,14 @@ class IapTransport:
         cmd = [*self._base(), "--", "-t", remote]
         os.execvp(cmd[0], cmd)  # noqa: S606, S607
 
+    def close(self) -> None:
+        """Tear down the shared IAP/SSH control master for this box (best effort)."""
+        if _mux_disabled():
+            return
+        _shutdown_master(
+            f"{self.ssh_user}@{self.host}", control_socket_path(self.host, os.getcwd())
+        )
+
 
 class SshTransport:
     """Transport over plain ``ssh`` to a public-IP host (Azure off-platform).
@@ -265,6 +386,9 @@ class SshTransport:
         self.key_path = key_path
 
     def _base(self, *, pty: bool = False) -> list[str]:
+        mux: list[str] = []
+        for key, value in ssh_mux_options(self.host, os.getcwd()):
+            mux += ["-o", f"{key}={value}"]
         return [
             "ssh",
             *(["-t"] if pty else []),
@@ -276,6 +400,7 @@ class SshTransport:
             "StrictHostKeyChecking=accept-new",
             "-o",
             "UserKnownHostsFile=~/.config/vergil/known_hosts",
+            *mux,
             f"{self.ssh_user}@{self.host}",
         ]
 
@@ -302,3 +427,11 @@ class SshTransport:
         remote = f"cd {shlex.quote(workdir)} && {inner}"
         cmd = [*self._base(pty=True), remote]
         os.execvp(cmd[0], cmd)  # noqa: S606, S607
+
+    def close(self) -> None:
+        """Tear down the shared SSH control master for this box (best effort)."""
+        if _mux_disabled():
+            return
+        _shutdown_master(
+            f"{self.ssh_user}@{self.host}", control_socket_path(self.host, os.getcwd())
+        )

--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -140,6 +140,12 @@ def _mux_disabled() -> bool:
     return os.environ.get(_MUX_DISABLE_ENV, "").strip().lower() in _MUX_DISABLE_TRUTHY
 
 
+def _cwd() -> str:
+    """Current working directory as a string — the worktree discriminator for the
+    control socket. Isolated in a helper so callers stay short and testable."""
+    return str(Path.cwd())
+
+
 def _control_dir() -> Path:
     """Directory holding the per-box control sockets.
 
@@ -322,7 +328,7 @@ class IapTransport:
         # glued ``-oKey=Val`` form (no space) is used deliberately: gcloud splits a
         # ``--ssh-flag`` value on spaces, so ``-o ControlPath=…`` would arrive as
         # two mangled tokens — the glued form passes through intact.
-        mux = [f"--ssh-flag=-o{key}={value}" for key, value in ssh_mux_options(self.host, os.getcwd())]
+        mux = [f"--ssh-flag=-o{key}={value}" for key, value in ssh_mux_options(self.host, _cwd())]
         return [
             "gcloud",
             "compute",
@@ -366,9 +372,7 @@ class IapTransport:
         """Tear down the shared IAP/SSH control master for this box (best effort)."""
         if _mux_disabled():
             return
-        _shutdown_master(
-            f"{self.ssh_user}@{self.host}", control_socket_path(self.host, os.getcwd())
-        )
+        _shutdown_master(f"{self.ssh_user}@{self.host}", control_socket_path(self.host, _cwd()))
 
 
 class SshTransport:
@@ -387,7 +391,7 @@ class SshTransport:
 
     def _base(self, *, pty: bool = False) -> list[str]:
         mux: list[str] = []
-        for key, value in ssh_mux_options(self.host, os.getcwd()):
+        for key, value in ssh_mux_options(self.host, _cwd()):
             mux += ["-o", f"{key}={value}"]
         return [
             "ssh",
@@ -432,6 +436,4 @@ class SshTransport:
         """Tear down the shared SSH control master for this box (best effort)."""
         if _mux_disabled():
             return
-        _shutdown_master(
-            f"{self.ssh_user}@{self.host}", control_socket_path(self.host, os.getcwd())
-        )
+        _shutdown_master(f"{self.ssh_user}@{self.host}", control_socket_path(self.host, _cwd()))

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -1,14 +1,30 @@
+import os
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vergil_tooling.lib import vm_transport
 from vergil_tooling.lib.vm_transport import (
     _CONNECT_RETRIES,
     IapTransport,
     LimaTransport,
     SshTransport,
+    control_socket_path,
+    ssh_mux_options,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_control_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep multiplexing hermetic: sockets/dirs go under tmp, never the real home."""
+    monkeypatch.setattr(vm_transport, "_control_dir", lambda: tmp_path / "cm")
+
+
+@pytest.fixture
+def _disable_mux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(vm_transport._MUX_DISABLE_ENV, "1")
 
 
 class TestLimaTransport:
@@ -474,3 +490,121 @@ class TestSshTransport:
         # the remote command (the bug: -t after user@host → no PTY allocated).
         assert cmd.index("-t") < cmd.index("ubuntu@1.2.3.4")
         assert any("cd /work && exec bash" in a for a in cmd)
+
+
+_HEX16 = 16
+
+
+class TestControlSocketPath:
+    def test_deterministic_for_same_host_and_workdir(self) -> None:
+        a = control_socket_path("inst-abc", "/w/tree")
+        b = control_socket_path("inst-abc", "/w/tree")
+        assert a == b
+
+    def test_unique_per_host(self) -> None:
+        assert control_socket_path("inst-a", "/w") != control_socket_path("inst-b", "/w")
+
+    def test_unique_per_workdir(self) -> None:
+        # Two worktrees reaching the same box must not share a master socket.
+        assert control_socket_path("inst", "/w/one") != control_socket_path("inst", "/w/two")
+
+    def test_filename_is_short_hex(self) -> None:
+        name = control_socket_path("inst", "/w").name
+        assert len(name) == _HEX16
+        assert all(c in "0123456789abcdef" for c in name)
+
+    def test_full_path_stays_under_socket_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # sun_path cap is 104 (macOS) / 108 (Linux); a realistically long home must
+        # still fit. Point _control_dir at a long-username home and check the margin.
+        long_home = Path("/Users/a-rather-long-developer-username/.config/vergil/cm")
+        monkeypatch.setattr(vm_transport, "_control_dir", lambda: long_home)
+        assert len(str(control_socket_path("inst", "/some/deep/worktree/path"))) < 104  # noqa: PLR2004
+
+
+class TestSshMuxOptions:
+    def test_enabled_returns_three_options_and_creates_dir(self, tmp_path: Path) -> None:
+        opts = ssh_mux_options("inst", "/w")
+        keys = [k for k, _ in opts]
+        assert keys == ["ControlMaster", "ControlPath", "ControlPersist"]
+        assert dict(opts)["ControlMaster"] == "auto"
+        assert dict(opts)["ControlPersist"] == vm_transport._CONTROL_PERSIST
+        assert (tmp_path / "cm").is_dir()  # side effect: parent created for the socket
+
+    @pytest.mark.usefixtures("_disable_mux")
+    def test_disabled_returns_empty(self, tmp_path: Path) -> None:
+        assert ssh_mux_options("inst", "/w") == []
+        assert not (tmp_path / "cm").exists()  # nothing created when disabled
+
+
+class TestMultiplexInjection:
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_iap_injects_glued_ssh_flags(self, mock_run: MagicMock) -> None:
+        # gcloud splits --ssh-flag on spaces, so the glued -oKey=Val form is required.
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        IapTransport("inst", "z", "p", "vergil").run("true")
+        args = mock_run.call_args[0][0]
+        assert "--ssh-flag=-oControlMaster=auto" in args
+        assert "--ssh-flag=-oControlPersist=60s" in args
+        paths = [a for a in args if a.startswith("--ssh-flag=-oControlPath=")]
+        assert len(paths) == 1
+        socket = Path(paths[0].split("=", 2)[2])
+        assert len(socket.name) == _HEX16
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_ssh_injects_split_o_flags(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key").run("true")
+        argv = mock_run.call_args[0][0]
+        assert "ControlMaster=auto" in argv
+        # each option is a -o followed by Key=Val, inserted before the destination.
+        assert argv[argv.index("ControlMaster=auto") - 1] == "-o"
+        assert any(a.startswith("ControlPath=") for a in argv)
+        assert argv.index("ControlMaster=auto") < argv.index("ubuntu@1.2.3.4")
+
+    @pytest.mark.usefixtures("_disable_mux")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_kill_switch_removes_all_injection(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        IapTransport("inst", "z", "p", "vergil").run("true")
+        args = mock_run.call_args[0][0]
+        assert not any("Control" in a for a in args)
+
+
+class TestClose:
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_iap_close_exits_master_and_unlinks_socket(self, mock_run: MagicMock) -> None:
+        transport = IapTransport("inst", "z", "p", "vergil")
+        socket = control_socket_path("inst", os.getcwd())
+        socket.parent.mkdir(parents=True, exist_ok=True)
+        socket.write_text("")  # stand in for the live control socket
+        transport.close()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "ssh"
+        assert "-O" in cmd
+        assert "exit" in cmd
+        assert f"ControlPath={socket}" in cmd
+        assert "vergil@inst" in cmd
+        assert not socket.exists()  # removed after teardown
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_ssh_close_exits_master(self, mock_run: MagicMock) -> None:
+        SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key").close()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:1] == ["ssh"]
+        assert cmd[-3:] == ["-O", "exit", "ubuntu@1.2.3.4"]
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_close_swallows_teardown_errors(self, mock_run: MagicMock) -> None:
+        # A missing socket makes `ssh -O exit` fail; teardown is best-effort and
+        # must never raise (the pipeline is already exiting).
+        mock_run.side_effect = OSError("ssh not found")
+        SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key").close()  # no raise
+
+    @pytest.mark.usefixtures("_disable_mux")
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_close_is_noop_when_disabled(self, mock_run: MagicMock) -> None:
+        IapTransport("inst", "z", "p", "vergil").close()
+        mock_run.assert_not_called()
+
+    def test_lima_close_is_noop(self) -> None:
+        LimaTransport("vm-x").close()  # no raise, no connection to tear down

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -18,8 +17,10 @@ from vergil_tooling.lib.vm_transport import (
 
 @pytest.fixture(autouse=True)
 def _isolate_control_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep multiplexing hermetic: sockets/dirs go under tmp, never the real home."""
-    monkeypatch.setattr(vm_transport, "_control_dir", lambda: tmp_path / "cm")
+    """Keep multiplexing hermetic: point HOME at tmp so control sockets/dirs land
+    under the test's tmp_path, never the developer's real home. Setting HOME (rather
+    than patching _control_dir) exercises the real _control_dir() path logic too."""
+    monkeypatch.setenv("HOME", str(tmp_path))
 
 
 @pytest.fixture
@@ -528,12 +529,13 @@ class TestSshMuxOptions:
         assert keys == ["ControlMaster", "ControlPath", "ControlPersist"]
         assert dict(opts)["ControlMaster"] == "auto"
         assert dict(opts)["ControlPersist"] == vm_transport._CONTROL_PERSIST
-        assert (tmp_path / "cm").is_dir()  # side effect: parent created for the socket
+        # side effect: the socket's parent dir is created (HOME points at tmp_path)
+        assert (tmp_path / ".config" / "vergil" / "cm").is_dir()
 
     @pytest.mark.usefixtures("_disable_mux")
     def test_disabled_returns_empty(self, tmp_path: Path) -> None:
         assert ssh_mux_options("inst", "/w") == []
-        assert not (tmp_path / "cm").exists()  # nothing created when disabled
+        assert not (tmp_path / ".config" / "vergil" / "cm").exists()  # nothing created
 
 
 class TestMultiplexInjection:
@@ -574,7 +576,7 @@ class TestClose:
     @patch("vergil_tooling.lib.vm_transport.subprocess.run")
     def test_iap_close_exits_master_and_unlinks_socket(self, mock_run: MagicMock) -> None:
         transport = IapTransport("inst", "z", "p", "vergil")
-        socket = control_socket_path("inst", os.getcwd())
+        socket = control_socket_path("inst", str(Path.cwd()))
         socket.parent.mkdir(parents=True, exist_ok=True)
         socket.write_text("")  # stand in for the live control socket
         transport.close()
@@ -603,7 +605,10 @@ class TestClose:
     @pytest.mark.usefixtures("_disable_mux")
     @patch("vergil_tooling.lib.vm_transport.subprocess.run")
     def test_close_is_noop_when_disabled(self, mock_run: MagicMock) -> None:
+        # Both off-platform transports short-circuit teardown under the kill-switch
+        # (there is no master to close when injection was disabled).
         IapTransport("inst", "z", "p", "vergil").close()
+        SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key").close()
         mock_run.assert_not_called()
 
     def test_lima_close_is_noop(self) -> None:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -36,6 +36,7 @@ from vergil_tooling.bin.vrg_vm import (
     _resolve_target,
     _resolve_vm_verbose,
     _target_ref,
+    _teardown_ssh_master,
     _volume_rows,
     _warn_under,
     discover_dedicated,
@@ -3757,6 +3758,24 @@ class TestCloudStageGuards:
     def test_require_transport_raises(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="tofu-vm did not run"):
             _cs_credentials(self._state(tmp_path))
+
+
+class TestTeardownSshMaster:
+    def test_closes_the_shared_master(self) -> None:
+        # On pipeline exit the shared SSH/IAP control master is torn down.
+        state = MagicMock()
+        transport = MagicMock()
+        state.backend.transport.return_value = transport
+        _teardown_ssh_master(state)
+        transport.close.assert_called_once_with()
+
+    def test_absent_box_state_is_a_quiet_noop(self) -> None:
+        # A pipeline that failed before the box was applied has no master to close;
+        # building the transport raises, and teardown swallows it rather than
+        # masking the original failure with a cleanup error.
+        state = MagicMock()
+        state.backend.transport.side_effect = RuntimeError("zone not persisted")
+        _teardown_ssh_master(state)  # no raise
 
 
 class TestCloudLinkClaudeCopiesConfig:


### PR DESCRIPTION
# Pull Request

## Summary

- Inject SSH multiplexing (ControlMaster/ControlPath/ControlPersist) into IapTransport and SshTransport keyed by a per-(host,worktree) control socket under ~/.config/vergil/cm, so a whole off-platform pipeline rides one underlying connection instead of opening ~18-20 IAP tunnels, with an explicit best-effort teardown wired into the cloud lifecycle finally.

## Issue Linkage

- Closes #2088

## Notes

- REVIEWER: real-box GCP validation is NOT done in this PR and is a required pre-merge step. This session runs on the Mac/Lima and structurally cannot spin up a GCP IAP box, so the acceptance criterion 'validated on a real box' is deferred to a human or cloud smoke test: run 'vrg-vm rebuild' off-platform and confirm (a) one IAP tunnel/auth for the whole pipeline instead of one per command, and (b) the control socket under ~/.config/vergil/cm is removed on both a clean run and a killed run (no stale master). VERGIL_VM_DISABLE_SSH_MUX=1 is a kill-switch if the box test surfaces trouble — no revert needed.

Design decisions (brainstormed + approved): control socket is a filesystem path keyed by sha256(host + cwd)[:16] so every per-step transport shares one master automatically (no threading a single object through the pipeline); glued --ssh-flag=-oKey=Val form for gcloud (it space-splits --ssh-flag); native -o Key=Val for plain ssh; ControlPersist=60s as the teardown backstop; close() added to the Transport protocol (no-op for Lima). Azure SshTransport is supported and fully unit-tested but, consistent with Azure being an un-exercised strategic fallback, is not live-validated. Unit tests cover socket-path determinism/uniqueness/length-under-cap, glued-vs-split flag injection, kill-switch, and teardown (ssh -O exit + unlink); vm_transport at 100% coverage; vrg-validate green.