### PR TITLE
fix(vm): refuse meta-only ~/.lima sidecar dirs that poison limactl

### DIFF
--- a/src/vergil_tooling/lib/lima.py
+++ b/src/vergil_tooling/lib/lima.py
@@ -288,9 +288,21 @@ def write_instance_meta(
 
     Lives in ``~/.lima/<instance>/``, removed when ``limactl delete --force`` deletes
     that dir. ``name`` is the optional fourth handle segment (empty for the default).
+
+    The instance dir must already exist — ``limactl create`` makes it before this is
+    called. We refuse to create it ourselves: a dir under ``~/.lima`` without a
+    ``lima.yaml`` makes ``limactl`` fatally abort on *every* command, so conjuring a
+    meta-only dir would poison the whole Lima home. Failing loudly turns a caller
+    mistake (e.g. an un-stubbed unit test) into a test failure instead of a
+    developer-host outage.
     """
     meta_dir = _serial_dir(instance)
-    meta_dir.mkdir(parents=True, exist_ok=True)
+    if not meta_dir.is_dir():
+        raise FileNotFoundError(
+            f"Lima instance dir {meta_dir} does not exist; refusing to write a "
+            "meta-only sidecar that would poison limactl (limactl create must run "
+            "first)."
+        )
     payload = {
         "schema": 2,
         "identity": identity,

--- a/tests/vergil_tooling/test_lima_meta.py
+++ b/tests/vergil_tooling/test_lima_meta.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 def test_write_then_read_round_trips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    (tmp_path / ".lima" / "u.org.repo").mkdir(parents=True)  # limactl create made this
     lima.write_instance_meta("u.org.repo", "vergil-user", "org", "repo")
     assert lima.read_instance_meta("u.org.repo") == {
         "schema": 2,
@@ -23,6 +24,17 @@ def test_write_then_read_round_trips(tmp_path: Path, monkeypatch: pytest.MonkeyP
         "repo": "repo",
         "name": "",
     }
+
+
+def test_write_refuses_when_instance_dir_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A meta-only dir with no ``lima.yaml`` poisons every ``limactl`` command, so
+    the sidecar must never conjure an instance dir — it fails loudly instead."""
+    monkeypatch.setattr(lima.Path, "home", classmethod(lambda cls: tmp_path))
+    with pytest.raises(FileNotFoundError):
+        lima.write_instance_meta("u.org.repo", "vergil-user", "org", "repo")
+    assert not (tmp_path / ".lima" / "u.org.repo").exists()
 
 
 def test_read_returns_none_when_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -202,6 +202,7 @@ def test_recover_handle_roundtrips_named_instance(
     from vergil_tooling.lib.lima import write_instance_meta
 
     inst = "vergil-user.lmf.mq.cloud-x86"
+    (tmp_path / ".lima" / inst).mkdir(parents=True)  # limactl create made this
     write_instance_meta(inst, "vergil-user", "lmf", "mq", "cloud-x86")
     assert recover_handle(inst) == ("vergil-user", "lmf", "mq", "cloud-x86")
 
@@ -214,6 +215,7 @@ def test_recover_handle_default_instance_name_none(
     from vergil_tooling.lib.lima import write_instance_meta
 
     inst = "vergil-user.lmf.mq"
+    (tmp_path / ".lima" / inst).mkdir(parents=True)  # limactl create made this
     write_instance_meta(inst, "vergil-user", "lmf", "mq")
     assert recover_handle(inst) == ("vergil-user", "lmf", "mq", None)
 
@@ -2637,6 +2639,15 @@ class TestOffPlatformDispatch:
 
 
 class TestCreateDedicated:
+    @pytest.fixture(autouse=True)
+    def _stub_instance_meta(self) -> Iterator[None]:
+        """The dedicated create/rebuild path writes a real ``~/.lima`` sidecar via
+        ``write_instance_meta``. With ``create_vm`` mocked the instance dir never
+        exists, so the real writer now refuses (and, before that guard, silently
+        poisoned the host's Lima home). Stub it so these unit tests stay hermetic."""
+        with patch("vergil_tooling.bin.vrg_vm.write_instance_meta"):
+            yield
+
     @patch("vergil_tooling.bin.vrg_vm.stop_vm")
     @patch("vergil_tooling.bin.vrg_vm.install_tooling")
     @patch("vergil_tooling.bin.vrg_vm.inject_credentials")


### PR DESCRIPTION
# Pull Request

## Summary

- write_instance_meta now fails loudly instead of creating a meta-only ~/.lima dir (which lacks lima.yaml and fatally breaks every limactl command); the two full-pipeline TestCreateDedicated tests that leaked such dirs into the real ~/.lima are made hermetic.

## Issue Linkage

- Closes #2097

## Notes

- Root cause: regression from #1837, which added the sidecar write to the create path (vrg_vm.py:634) but did not stub it in the pre-existing full-pipeline create/rebuild tests, so on a short-home dev host running the suite poisoned ~/.lima and bricked vrg-vm. Fix is three parts: (1) production guard in lib/lima.py refuses to write when the instance dir is absent; (2) TestCreateDedicated autouse-stubs write_instance_meta and the recover_handle tests pre-create the instance dir; (3) new test_lima_meta regression covers the guard. Full vrg-validate green; verified the fixed create tests leave ~/.lima clean. Pre-existing test_recorded_state_* long-home failures are unrelated (env-only, pass in-container).