### PR TITLE
feat(epic-audit): authorize --close for the scheduled reconciliation sweep

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -7,12 +7,25 @@ auto-close so a human can close it.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from datetime import UTC, datetime, timedelta
 
 from vergil_tooling.lib import epic_audit, github, identity_mode
 
 _DEFAULT_WINDOW_DAYS = 30
+
+# Set by the scheduled reconciliation workflow (ops-epic-sweep) to authorize the
+# automated ``--close``. The sweep only closes provably-complete drift (epics
+# whose children are all closed, tasks whose PR merged), so it is a trusted,
+# deterministic automation — allowed to close even though it is not a human. An
+# interactive agent session never sets this, so the human/agent gate stands.
+_SWEEP_ENV = "VRG_EPIC_SWEEP"
+
+
+def _automated_sweep() -> bool:
+    """True when running as the trusted scheduled reconciliation sweep."""
+    return os.environ.get(_SWEEP_ENV) == "1"
 
 
 def _positive_int(raw: str) -> int:
@@ -51,7 +64,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help=(
             "Close the drifted task issues and rolled-up epics (with an "
             "explanatory comment on each) instead of only reporting them. A "
-            "human action — refused in agent sessions. Default: read-only."
+            "human action (or the scheduled reconciliation sweep) — refused in "
+            "interactive agent sessions. Default: read-only."
         ),
     )
     return parser.parse_args(argv)
@@ -60,12 +74,14 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     # Gate the write path before any network work so a rejected agent run is
-    # cheap and unambiguous.
-    if args.close and not identity_mode.is_human():
+    # cheap and unambiguous. A human may close interactively; the scheduled
+    # reconciliation sweep (ops-epic-sweep) closes via the _SWEEP_ENV signal.
+    if args.close and not (identity_mode.is_human() or _automated_sweep()):
         print(
             "vrg-epic-audit: --close is a human action and was refused in an "
-            "agent session; run without --close to preview the drift, or run as "
-            "a human to apply the closes.",
+            "interactive agent session; run without --close to preview the "
+            "drift, or run as a human to apply the closes. (The scheduled sweep "
+            f"authorizes automated closes via ${_SWEEP_ENV}.)",
             file=sys.stderr,
         )
         return 1

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -63,10 +63,31 @@ def test_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_close_refused_for_agent(capsys: pytest.CaptureFixture[str]) -> None:
     # Refusal happens before any network work, so nothing else needs mocking.
-    with patch(f"{_MOD}.identity_mode.is_human", return_value=False):
+    # Pin the sweep signal off so the refusal is deterministic regardless of env.
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=False),
+        patch.dict("os.environ", {"VRG_EPIC_SWEEP": ""}),
+    ):
         rc = main(["--close"])
     assert rc == 1
     assert "human action" in capsys.readouterr().err
+
+
+def test_close_allowed_for_scheduled_sweep(capsys: pytest.CaptureFixture[str]) -> None:
+    """The scheduled sweep (VRG_EPIC_SWEEP=1) may --close even though it is not human."""
+    close_drift = MagicMock(return_value=["o/r#1"])
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=False),
+        patch.dict("os.environ", {"VRG_EPIC_SWEEP": "1"}),
+        patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
+        patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
+        patch(f"{_MOD}.epic_audit.close_drift", close_drift),
+    ):
+        rc = main(["--close"])
+    assert rc == 0
+    close_drift.assert_called_once_with(["T"], ["E"], org="vergil-project")
+    assert "o/r#1" in capsys.readouterr().out
 
 
 def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Allow vrg-epic-audit --close under the trusted scheduled sweep (VRG_EPIC_SWEEP=1) in addition to a human, so the automated reconciliation sweep can close provably-complete drift while interactive agent sessions still cannot.

## Issue Linkage

- Closes #2104

## Notes

- Task T1 of epic vergil-project/.github#80. The sweep workflow (T2, ops-epic-sweep in vergil-actions) sets VRG_EPIC_SWEEP=1; the gate now passes for human OR that signal. Refusal test pinned deterministic; new test covers the sweep-authorized path. Full vrg-validate green, 3994 passed, 100% coverage. Unblocks T2 (reusable workflow) and T3 (per-org deployment).