### PR TITLE
fix(epic-audit): honor cross-repo Refs and skip unresolvable tasks in task_drift

### DIFF
--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -9,6 +9,7 @@ by the caller.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Any
 
@@ -41,18 +42,36 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
     )
     drift: list[TaskDrift] = []
     for entry in raw if isinstance(raw, list) else []:
-        repo = str((entry.get("repository") or {}).get("nameWithOwner", ""))
-        if not repo:
+        pr_repo = str((entry.get("repository") or {}).get("nameWithOwner", ""))
+        if not pr_repo:
             continue
         try:
-            task = linkage.extract_tracking_issue(str(entry.get("body") or ""))
+            ref = linkage.extract_tracking_ref(str(entry.get("body") or ""))
         except ValueError:
             continue
-        if task is None:
+        if ref is None:
             continue
-        issue = github.read_json(
-            "issue", "view", str(task), "--repo", repo, "--json", "state,title,body"
-        )
+        # ``ref`` is ``"#N"`` (same-repo) or ``"owner/repo#N"`` (cross-repo).
+        # Resolve the repo the task actually lives in — honor a cross-repo ref
+        # instead of assuming the PR's own repo (issue #2111).
+        repo_part, _, num = ref.rpartition("#")
+        task = int(num)
+        task_repo = repo_part or pr_repo
+        try:
+            issue = github.read_json(
+                "issue", "view", str(task), "--repo", task_repo, "--json", "state,title,body"
+            )
+        except github.GitHubAPIError:
+            # The task is in a repo this run can't see (cross-org, private, or
+            # deleted). Not this org's drift to close — warn and skip rather than
+            # abort the whole sweep.
+            print(
+                f"vrg-epic-audit: skipping {task_repo}#{task} (referenced by "
+                f"{pr_repo} PR #{entry.get('number')}) — not found or not "
+                "accessible from this run.",
+                file=sys.stderr,
+            )
+            continue
         if not isinstance(issue, dict):
             continue
         if str(issue.get("state") or "").upper() != "OPEN":
@@ -66,7 +85,7 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
             continue
         drift.append(
             TaskDrift(
-                repo=repo, task=task, pr_number=int(entry["number"]), pr_url=str(entry["url"])
+                repo=task_repo, task=task, pr_number=int(entry["number"]), pr_url=str(entry["url"])
             )
         )
     return drift

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-from vergil_tooling.lib import epic_audit, roadmap
+from vergil_tooling.lib import epic_audit, github, roadmap
 from vergil_tooling.lib.epic_audit import TaskDrift
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_task_drift_flags_open_task_behind_merged_pr() -> None:
@@ -73,6 +77,54 @@ def test_task_drift_skips_release_tracking_issue() -> None:
     with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
         result = epic_audit.task_drift("2026-06-01", org="vergil-project")
     assert result == []
+
+
+def test_task_drift_resolves_cross_repo_ref() -> None:
+    # A cross-repo Ref (owner/repo#N) must be looked up in the ref's repo, not
+    # the PR's own repo (issue #2111).
+    prs = [
+        {
+            "number": 7,
+            "repository": {"nameWithOwner": "vergil-project/.github"},
+            "url": "u7",
+            "body": "Ref vergil-project/vergil-tooling#42",
+        },
+    ]
+    looked_up: dict[str, str] = {}
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        looked_up["repo"] = args[args.index("--repo") + 1]
+        return {"state": "open", "title": "feat: t", "body": "b"}
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        result = epic_audit.task_drift("2026-06-01", org="vergil-project")
+    assert looked_up["repo"] == "vergil-project/vergil-tooling"
+    assert result == [TaskDrift("vergil-project/vergil-tooling", 42, 7, "u7")]
+
+
+def test_task_drift_skips_unresolvable_task(capsys: pytest.CaptureFixture[str]) -> None:
+    # A ref to a task this run can't see (cross-org, private, deleted) must be
+    # skipped with a warning, not crash the sweep (issue #2111).
+    prs = [
+        {
+            "number": 8,
+            "repository": {"nameWithOwner": "logical-minds-foundry/.github"},
+            "url": "u8",
+            "body": "Ref vergil-project/vergil-tooling#2105",
+        },
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        raise github.GitHubAPIError(1, ["gh"], "", "GraphQL: Could not resolve to an issue")
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        result = epic_audit.task_drift("2026-06-01", org="logical-minds-foundry")
+    assert result == []
+    assert "skipping vergil-project/vergil-tooling#2105" in capsys.readouterr().err
 
 
 def test_task_drift_returns_empty_on_non_list() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Make vrg-epic-audit's task_drift resolve a cross-repo Ref to the task's real repo and skip (with a warning) any task it can't access, instead of looking it up in the PR's own repo and crashing the whole sweep on the resulting 404.

## Issue Linkage

- Closes #2111

## Notes

- Task under epic vergil-project/.github#80. Root-caused from the scheduled sweep crashing in logical-minds-foundry/.github over a PR that cross-org-Ref'd vergil-tooling#2105 (my T3 deployment linkage). Uses extract_tracking_ref; wraps the issue lookup in GitHubAPIError->skip+warn; TaskDrift/close_drift now target the task's actual repo. 2 new tests (cross-repo resolution, skip-on-unresolvable). Full vrg-validate green, 3996 passed, 100% coverage. Needs merge + release before the scheduled sweep runs clean.