### PR TITLE
feat(linkage): enforce single-task linkage at PR-body construction

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -14,7 +14,11 @@ import sys
 from datetime import UTC, datetime
 
 from vergil_tooling.lib import epics, git, github
-from vergil_tooling.lib.linkage import normalize_linkage
+from vergil_tooling.lib.linkage import (
+    find_linkage_keyword,
+    freetext_linkage_error,
+    normalize_linkage,
+)
 from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
 from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
@@ -54,6 +58,10 @@ def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) ->
         linkage, linkage_warning = normalize_linkage(args.linkage)
     except ValueError as exc:
         raise WorkflowError(f"report-ready: {exc}") from exc
+    for value in (args.notes, args.summary):
+        found = find_linkage_keyword(value)
+        if found:
+            raise WorkflowError(freetext_linkage_error(found, str(args.issue)))
     state = transport.read()
     if state is None:
         state = engine.init_state(

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -84,6 +84,48 @@ def normalize_linkage(value: str) -> tuple[str, str | None]:
     return keyword, warning
 
 
+# Any issue-linkage keyword (Ref, or the close/fix/resolve family) followed by an
+# issue reference, matched mid-line (not anchored) so a smuggled "... this also
+# Closes #999" is caught. A bare "#200" does NOT match, so a lightweight
+# cross-reference in free text is still allowed. This is the guard for the
+# free-text PR fields (--notes/--summary): broader than LINKAGE_RE (anchored,
+# Ref/Close only) and commit_message.AUTOCLOSE_RE (close family only).
+_FREETEXT_LINKAGE_RE = re.compile(
+    r"\b(?:ref|close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+"
+    r"(?:[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+",
+    re.IGNORECASE,
+)
+
+
+def find_linkage_keyword(text: str) -> str | None:
+    """Return the first issue-linkage keyword+ref in *text*, or None.
+
+    Matches Ref / Close[sd] / Fix(es|ed) / Resolve[sd] followed by an issue
+    reference (#N or owner/repo#N), anywhere in the line. A bare "#200" does not
+    match. The returned substring (e.g. "Ref #157") names the offending text in
+    the guard's error message.
+    """
+    match = _FREETEXT_LINKAGE_RE.search(text)
+    return match.group(0) if match else None
+
+
+def freetext_linkage_error(found: str, primary_issue: str) -> str:
+    """User-ready error for a linkage keyword smuggled into --notes/--summary.
+
+    Rejects rather than strips: a keyword the agent typed is a signal that a real
+    relationship exists, so the message redirects that reasoning to a lossless
+    home — a comment on the primary issue — instead of discarding it.
+    """
+    return (
+        f"notes/summary must not contain an issue-linkage keyword (found {found!r}). "
+        "A PR links exactly one task, and that link is added for you automatically. "
+        "If this change genuinely relates to another issue, record it — and why — "
+        "as a comment on the primary issue: "
+        f'vrg-gh issue comment {primary_issue} --body "Related to #N — <the reason>". '
+        "Don't encode it as a bare linkage in notes, where the reasoning is lost."
+    )
+
+
 def extract_tracking_issue(text: str) -> int | None:
     """Return the tracking issue number from a ``Ref #N`` / ``Closes #N`` match.
 

--- a/src/vergil_tooling/lib/pr_body.py
+++ b/src/vergil_tooling/lib/pr_body.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import re
 
+from vergil_tooling.lib.linkage import find_linkage_keyword, freetext_linkage_error
+
 _ISSUE_PLAIN_RE = re.compile(r"^[1-9]\d*$")
 _ISSUE_CROSS_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[1-9]\d*$")
 
@@ -26,6 +28,10 @@ def resolve_issue_ref(issue: str) -> str:
 
 def build_pr_body(*, summary: str, linkage: str, issue_ref: str, notes: str) -> str:
     """Render the canonical PR body from validated fields."""
+    for value in (summary, notes):
+        found = find_linkage_keyword(value)
+        if found:
+            raise SystemExit(freetext_linkage_error(found, issue_ref.lstrip("#")))
     notes_section = notes or "-"
     return (
         f"# Pull Request\n\n"

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -297,8 +297,19 @@ def test_report_ready_rejects_linkage_keyword_in_notes(
         patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
     ):
         rc = vrg_pr_workflow.main(
-            ["--base", "develop", "report-ready",
-             "--issue", "42", "--title", "t", "--summary", "s", "--notes", "Ref #157"]
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "Ref #157",
+            ]
         )
     assert rc == 1
     assert "Ref #157" in capsys.readouterr().err

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -287,3 +287,18 @@ def test_report_ready_strips_issue_number_from_linkage_and_warns(
     out = json.loads(capsys.readouterr().out)
     assert out["ok"] is True
     assert "warning" in out
+
+
+def test_report_ready_rejects_linkage_keyword_in_notes(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
+    ):
+        rc = vrg_pr_workflow.main(
+            ["--base", "develop", "report-ready",
+             "--issue", "42", "--title", "t", "--summary", "s", "--notes", "Ref #157"]
+        )
+    assert rc == 1
+    assert "Ref #157" in capsys.readouterr().err

--- a/tests/vergil_tooling/test_linkage.py
+++ b/tests/vergil_tooling/test_linkage.py
@@ -145,3 +145,46 @@ def test_extract_tracking_ref_none() -> None:
 def test_extract_tracking_ref_multiple_raises() -> None:
     with pytest.raises(ValueError, match="multiple"):
         extract_tracking_ref("Ref #1\nRef #2")
+
+
+from vergil_tooling.lib.linkage import find_linkage_keyword
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Ref #157", "Ref #157"),
+        ("Ref: #157", "Ref: #157"),
+        ("Closes #42", "Closes #42"),
+        ("- Fixes #9", "Fixes #9"),
+        ("this also Resolves #9 in passing", "Resolves #9"),
+        ("Ref owner/repo#3", "Ref owner/repo#3"),
+        ("Closes vergil-project/.github#82", "Closes vergil-project/.github#82"),
+    ],
+)
+def test_find_linkage_keyword_matches(text: str, expected: str) -> None:
+    assert find_linkage_keyword(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "See #200 for background",
+        "Part of epic vergil-project/.github#82",
+        "referenced the earlier work",
+        "no linkage here",
+        "",
+    ],
+)
+def test_find_linkage_keyword_ignores_bare_and_plain(text: str) -> None:
+    assert find_linkage_keyword(text) is None
+
+
+from vergil_tooling.lib.linkage import freetext_linkage_error
+
+
+def test_freetext_linkage_error_names_offender_and_redirects() -> None:
+    msg = freetext_linkage_error("Ref #157", "83")
+    assert "Ref #157" in msg
+    assert "vrg-gh issue comment 83" in msg
+    assert "added for you" in msg

--- a/tests/vergil_tooling/test_pr_body.py
+++ b/tests/vergil_tooling/test_pr_body.py
@@ -46,3 +46,22 @@ def test_resolve_issue_ref_invalid() -> None:
 def test_resolve_issue_ref_zero() -> None:
     with pytest.raises(SystemExit, match="must be a number"):
         pr_body.resolve_issue_ref("0")
+
+
+def test_build_pr_body_rejects_linkage_keyword_in_notes() -> None:
+    with pytest.raises(SystemExit) as exc:
+        pr_body.build_pr_body(summary="s", linkage="Closes", issue_ref="#42", notes="Ref #99")
+    assert "Ref #99" in str(exc.value)
+
+
+def test_build_pr_body_rejects_linkage_keyword_in_summary() -> None:
+    with pytest.raises(SystemExit) as exc:
+        pr_body.build_pr_body(summary="Closes #7", linkage="Closes", issue_ref="#42", notes="")
+    assert "Closes #7" in str(exc.value)
+
+
+def test_build_pr_body_allows_bare_reference_in_notes() -> None:
+    body = pr_body.build_pr_body(
+        summary="s", linkage="Closes", issue_ref="#42", notes="See #99 for background"
+    )
+    assert "See #99 for background" in body


### PR DESCRIPTION
# Pull Request

## Summary

- Add find_linkage_keyword and reject issue-linkage keywords in report-ready and build_pr_body free-text fields, so the builder's Issue Linkage line is the PR body's only keyworded linkage by construction.

## Issue Linkage

- Closes #2117

## Notes

- Task A of epic vergil-project/.github#82. Adds a shared guard at both construction points (report-ready for agent feedback, build_pr_body as the chokepoint) that rejects linkage keywords in the notes/summary free-text fields and redirects related-issue reasoning to a comment on the primary issue. Extractors, vrg-resolve-tracking-issue, and epic_audit are untouched. Follow-ups B (vergil-actions#746) and C (vergil-tooling#2116) remove the now-redundant CI gate after this releases.