### PR TITLE
feat(epics): add ad-hoc epic model in .github, deprecate standing

### DIFF
--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -11,7 +11,8 @@
     {"name": "rtfm", "color": "f9d0c4", "description": "Resolved by reading existing docs"},
     {"name": "observability", "color": "1d76db", "description": "Monitoring, reporting, health checks"},
     {"name": "epic", "color": "6f42c1", "description": "Umbrella issue; finite epics close when all sub-issues close"},
-    {"name": "standing", "color": "5319e7", "description": "Perpetual umbrella for ad-hoc work; never auto-closes"},
+    {"name": "standing", "color": "5319e7", "description": "Deprecated alias for ad-hoc; retired after the ad-hoc migration (epic #85)"},
+    {"name": "ad-hoc", "color": "5319e7", "description": "Perpetual umbrella for ad-hoc work; never auto-closes"},
     {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
     {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"}

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -227,67 +227,85 @@ def is_epic(ref: IssueRef) -> bool:
 
 
 def resolve_epic_ref(ref: str, *, repo: str) -> IssueRef:
-    """Resolve an epic ref, accepting the ``"standing"`` sentinel.
+    """Resolve an epic ref, accepting the ``"adhoc"`` sentinel.
 
-    ``"standing"`` ensures *repo*'s standing epic exists — creating it if absent
-    and reusing it otherwise — via :func:`ensure_standing_epic`. Any other ref is
-    parsed with :func:`parse_issue_ref` and validated to carry the ``epic`` label.
+    ``"adhoc"`` (and the deprecated alias ``"standing"``) ensures *repo*'s ad-hoc
+    epic exists in ``<org>/.github`` — creating it if absent and reusing it
+    otherwise — via :func:`ensure_adhoc_epic`. Any other ref is parsed with
+    :func:`parse_issue_ref` and validated to carry the ``epic`` label.
     """
-    if ref == "standing":
-        return ensure_standing_epic(repo)
+    if ref in ("adhoc", "standing"):
+        return ensure_adhoc_epic(repo)
     epic = parse_issue_ref(ref, default_repo=repo)
     if not is_epic(epic):
         raise ValueError(f"{epic.slug} is not an epic (missing the 'epic' label)")
     return epic
 
 
-_STANDING_EPIC_TITLE = "Epic (standing): Ad-hoc maintenance"
-_STANDING_EPIC_LABELS = ("epic", "standing")
-_STANDING_EPIC_BODY = (
-    "Standing umbrella for ad-hoc maintenance in this repo. Created and reused "
-    "idempotently; tasks routed to the standing epic are linked here.\n"
+_ADHOC_EPIC_TITLE_PREFIX = "Epic (ad hoc): "
+_ADHOC_EPIC_LABELS = ("epic", "ad-hoc")
+_ADHOC_EPIC_BODY = (
+    "Perpetual umbrella for ad-hoc work in {repo}. Created and reused "
+    "idempotently; tasks routed to the ad-hoc epic are linked here.\n"
 )
 
 
-def ensure_standing_epic(repo: str) -> IssueRef:
-    """Return *repo*'s standing epic, creating it if absent (idempotent).
+def ensure_adhoc_epic(target_repo: str) -> IssueRef:
+    """Return *target_repo*'s ad-hoc epic in ``<org>/.github``, creating it if absent.
 
-    A standing epic is the per-repo ``Epic (standing): Ad-hoc maintenance``
-    umbrella, labelled ``epic`` + ``standing``. Exactly one is expected: none
-    means create it; several is ambiguous and an error names an explicit ref
-    instead of guessing. Applies to member repos and ``.github`` alike.
+    All ad-hoc epics live in the org's ``.github`` repo, one per repo, each
+    disambiguated by the title ``Epic (ad hoc): <bare repo name>`` and labelled
+    ``epic`` + ``ad-hoc``. Idempotent: an existing epic with that title is
+    reused; none means create it; two sharing the title is ambiguous and an
+    error names an explicit ref instead of guessing. Applies to member repos and
+    ``.github`` itself alike.
     """
-    if "/" not in repo:
-        raise ValueError(f"cannot resolve repo for standing epic (repo={repo!r})")
-    owner, name = repo.split("/", 1)
+    if "/" not in target_repo:
+        raise ValueError(f"cannot resolve repo for ad-hoc epic (repo={target_repo!r})")
+    owner, bare = target_repo.split("/", 1)
+    dotgithub = f"{owner}/.github"
+    title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}"
     raw: Any = github.read_json(
         "issue",
         "list",
         "--repo",
-        repo,
+        dotgithub,
         "--label",
         "epic",
         "--label",
-        "standing",
+        "ad-hoc",
         "--state",
         "open",
         "--json",
-        "number",
+        "number,title",
     )
-    rows = [r for r in raw if isinstance(r, dict)] if isinstance(raw, list) else []
+    rows = (
+        [r for r in raw if isinstance(r, dict) and r.get("title") == title]
+        if isinstance(raw, list)
+        else []
+    )
     if len(rows) > 1:
         nums = ", ".join(f"#{r['number']}" for r in rows)
-        raise ValueError(f"multiple standing epics in {repo} ({nums}) — pass an explicit --epic")
+        raise ValueError(
+            f"multiple ad-hoc epics titled {title!r} in {dotgithub} ({nums}) — "
+            "pass an explicit --epic"
+        )
     if rows:
-        return IssueRef(owner=owner, repo=name, number=int(rows[0]["number"]))
+        return IssueRef(owner=owner, repo=".github", number=int(rows[0]["number"]))
     url = github.create_issue(
-        repo=repo,
-        title=_STANDING_EPIC_TITLE,
-        body=_STANDING_EPIC_BODY,
-        labels=list(_STANDING_EPIC_LABELS),
+        repo=dotgithub,
+        title=title,
+        body=_ADHOC_EPIC_BODY.format(repo=target_repo),
+        labels=list(_ADHOC_EPIC_LABELS),
     )
     number = int(url.rstrip("/").rsplit("/", 1)[-1])
-    return IssueRef(owner=owner, repo=name, number=number)
+    return IssueRef(owner=owner, repo=".github", number=number)
+
+
+# Deprecated alias kept for the ad-hoc rollout window (epic #85); callers still
+# importing ``ensure_standing_epic`` keep working. Removed in the retire-standing
+# task once the migration is complete.
+ensure_standing_epic = ensure_adhoc_epic
 
 
 def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
@@ -309,13 +327,14 @@ def rollup(task: IssueRef) -> None:
     """Close *task*'s parent epic if the epic is finite and all children closed.
 
     A no-op unless the task has an ``epic``-labeled parent (the transition gate):
-    legacy issues have no epic parent, so finalize never rolls them up. A
-    ``standing`` epic is perpetual and never auto-closes.
+    legacy issues have no epic parent, so finalize never rolls them up. An
+    ``ad-hoc`` epic (or its deprecated ``standing`` alias) is perpetual and never
+    auto-closes.
     """
     parent = parent_of(task)
     if parent is None or not is_epic(parent):
         return
-    if "standing" in _labels(parent):
+    if _labels(parent) & {"ad-hoc", "standing"}:
         return
     if all_children_closed(parent):
         print(f"Rolling up epic {parent.slug} — all child tasks closed.")

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -244,7 +244,20 @@ def test_rollup_closes_finite_epic_when_all_children_closed() -> None:
     assert "40" in mock_run.call_args.args
 
 
-def test_rollup_skips_standing_epic() -> None:
+def test_rollup_skips_adhoc_epic() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
+        patch("vergil_tooling.lib.epics.all_children_closed", return_value=True),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_not_called()
+
+
+def test_rollup_skips_standing_epic_alias() -> None:
+    # 'standing' remains perpetual during the rollout window (deprecated alias).
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
         patch("vergil_tooling.lib.epics.is_epic", return_value=True),
@@ -323,49 +336,82 @@ def test_remove_child_issues_removesubissue_mutation() -> None:
     assert mock_graphql.call_args.kwargs == {"parent": "EPIC_ID", "child": "TASK_ID"}
 
 
-# -- resolve_epic_ref --------------------------------------------------------
+# -- resolve_epic_ref / ensure_adhoc_epic ------------------------------------
 
 
-def test_resolve_epic_ref_standing_discovers_single_epic() -> None:
-    with patch("vergil_tooling.lib.github.read_json", return_value=[{"number": 1972}]) as mock_list:
-        assert epics.resolve_epic_ref("standing", repo="org/tooling") == IssueRef(
-            "org", "tooling", 1972
+def _adhoc_row(number: int, repo_bare: str = "tooling") -> dict:
+    """A .github issue-list row for an ad-hoc epic titled for *repo_bare*."""
+    return {"number": number, "title": f"Epic (ad hoc): {repo_bare}"}
+
+
+def test_resolve_epic_ref_adhoc_discovers_single_epic() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]) as mock_list:
+        assert epics.resolve_epic_ref("adhoc", repo="org/tooling") == IssueRef(
+            "org", ".github", 1972
         )
-    # discovery filters open issues carrying both the epic and standing labels
+    # discovery targets <org>/.github, filtering issues carrying epic + ad-hoc
     args = mock_list.call_args.args
-    assert "epic" in args and "standing" in args
+    assert "org/.github" in args and "epic" in args and "ad-hoc" in args
 
 
-def test_resolve_epic_ref_standing_zero_creates() -> None:
-    # When no standing epic exists, resolving "standing" creates it idempotently.
-    created = "https://github.com/org/tooling/issues/77"
+def test_resolve_epic_ref_standing_is_deprecated_alias_for_adhoc() -> None:
+    # 'standing' still resolves during the rollout window, routing to .github.
+    with patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]):
+        assert epics.resolve_epic_ref("standing", repo="org/tooling") == IssueRef(
+            "org", ".github", 1972
+        )
+
+
+def test_ensure_adhoc_epic_zero_creates_in_dotgithub() -> None:
+    # When no ad-hoc epic exists, ensure creates it in <org>/.github, by title.
+    created = "https://github.com/org/.github/issues/77"
     with (
         patch("vergil_tooling.lib.github.read_json", return_value=[]),
         patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
     ):
-        result = epics.resolve_epic_ref("standing", repo="org/tooling")
-    assert result == IssueRef("org", "tooling", 77)
-    assert mock_create.call_args.kwargs["repo"] == "org/tooling"
-    assert mock_create.call_args.kwargs["labels"] == ["epic", "standing"]
-    assert mock_create.call_args.kwargs["title"] == "Epic (standing): Ad-hoc maintenance"
+        result = epics.ensure_adhoc_epic("org/tooling")
+    assert result == IssueRef("org", ".github", 77)
+    assert mock_create.call_args.kwargs["repo"] == "org/.github"
+    assert mock_create.call_args.kwargs["labels"] == ["epic", "ad-hoc"]
+    assert mock_create.call_args.kwargs["title"] == "Epic (ad hoc): tooling"
 
 
-def test_ensure_standing_epic_reuses_existing() -> None:
-    # Idempotent: an existing standing epic is returned without creating another.
+def test_ensure_adhoc_epic_for_dotgithub_itself() -> None:
+    created = "https://github.com/org/.github/issues/5"
     with (
-        patch("vergil_tooling.lib.github.read_json", return_value=[{"number": 1972}]),
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
+    ):
+        assert epics.ensure_adhoc_epic("org/.github") == IssueRef("org", ".github", 5)
+    assert mock_create.call_args.kwargs["title"] == "Epic (ad hoc): .github"
+
+
+def test_ensure_adhoc_epic_reuses_existing_by_title() -> None:
+    # Idempotent and title-disambiguated: the same-title epic is reused; a
+    # different repo's ad-hoc epic in the same .github list is ignored.
+    rows = [_adhoc_row(1972), {"number": 40, "title": "Epic (ad hoc): actions"}]
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=rows),
         patch("vergil_tooling.lib.github.create_issue") as mock_create,
     ):
-        assert epics.ensure_standing_epic("org/tooling") == IssueRef("org", "tooling", 1972)
+        assert epics.ensure_adhoc_epic("org/tooling") == IssueRef("org", ".github", 1972)
     mock_create.assert_not_called()
 
 
-def test_resolve_epic_ref_standing_multiple_raises() -> None:
+def test_ensure_standing_epic_is_backward_compatible_alias() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]):
+        assert epics.ensure_standing_epic("org/tooling") == IssueRef("org", ".github", 1972)
+
+
+def test_ensure_adhoc_epic_multiple_same_title_raises() -> None:
     with (
-        patch("vergil_tooling.lib.github.read_json", return_value=[{"number": 1}, {"number": 2}]),
-        pytest.raises(ValueError, match="multiple standing epics"),
+        patch(
+            "vergil_tooling.lib.github.read_json",
+            return_value=[_adhoc_row(1), _adhoc_row(2)],
+        ),
+        pytest.raises(ValueError, match="multiple ad-hoc epics"),
     ):
-        epics.resolve_epic_ref("standing", repo="org/tooling")
+        epics.ensure_adhoc_epic("org/tooling")
 
 
 def test_resolve_epic_ref_explicit_validates_epic() -> None:
@@ -383,6 +429,6 @@ def test_resolve_epic_ref_explicit_non_epic_raises() -> None:
         epics.resolve_epic_ref("#123", repo="org/repo")
 
 
-def test_resolve_epic_ref_standing_repo_without_owner_raises() -> None:
-    with pytest.raises(ValueError, match="cannot resolve repo"):
-        epics.resolve_epic_ref("standing", repo="tooling")
+def test_ensure_adhoc_epic_repo_without_owner_raises() -> None:
+    with pytest.raises(ValueError, match="cannot resolve repo for ad-hoc epic"):
+        epics.ensure_adhoc_epic("tooling")

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -62,11 +62,12 @@ def test_delete_list_is_strings() -> None:
 
 
 def test_registry_includes_convention_labels() -> None:
-    # epic/task convention (epic #40): Role (epic, standing), Stage (triage),
-    # Kind (idea), Exception (hotfix). The remaining Kind axis reuses the
-    # existing conventional-commit labels already in the registry.
+    # epic/task convention (epic #40, #85): Role (epic, ad-hoc), Stage (triage),
+    # Kind (idea, research), Exception (hotfix). "standing" is retained during the
+    # ad-hoc rollout window as a deprecated alias (removed in epic #85, Task 11).
+    # The remaining Kind axis reuses the existing conventional-commit labels.
     names = {label["name"] for label in load_labels()["labels"]}
-    for required in {"epic", "standing", "triage", "idea", "hotfix"}:
+    for required in {"epic", "ad-hoc", "standing", "triage", "idea", "research", "hotfix"}:
         assert required in names, f"convention label missing: {required}"
 
 

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -127,7 +127,7 @@ def test_main_sync_provisions_all_labels() -> None:
     assert result == 0
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
-    assert len(label_calls) == 15  # 10 base + 5 epic/task convention labels
+    assert len(label_calls) == 16  # 10 base + 6 convention labels (incl. ad-hoc, epic #85)
 
 
 def test_main_sync_uses_force_with_color_description() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Introduces ensure_adhoc_epic (locates/creates a repo's ad-hoc epic in <org>/.github, titled 'Epic (ad hoc): <repo>', labelled epic+ad-hoc, disambiguated by title), the 'adhoc' sentinel with 'standing' as a deprecated alias, and a perpetual-guard update so ad-hoc/standing epics never auto-close.

## Issue Linkage

- Closes #2122

## Notes

- Phase 1 foundational task of epic vergil-project/.github#85 — backward-compatible: the 'standing' sentinel and ensure_standing_epic alias keep working but now resolve to the .github ad-hoc epic; the standing label is retained (retired in Task 11) and existing per-repo standing epics are relocated by the Phase 2 migration. TDD in test_epics.py/test_labels.py; label-count assertion bumped to 16. Full vrg-validate green.