### PR TITLE
refactor(cli): rename vrg-standing-epic to vrg-adhoc-epic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = ["rich>=13.0", "pyyaml>=6.0"]
 
 [project.scripts]
 vrg-activity-log = "vergil_tooling.bin.vrg_activity_log:main"
+vrg-adhoc-epic = "vergil_tooling.bin.vrg_adhoc_epic:main"
 vrg-audit-approve = "vergil_tooling.bin.vrg_audit_approve:main"
 vrg-await = "vergil_tooling.bin.vrg_await:main"
 vrg-changelog = "vergil_tooling.bin.vrg_changelog:main"
@@ -55,7 +56,8 @@ vrg-roadmap = "vergil_tooling.bin.vrg_roadmap:main"
 vrg-sarif-evaluate = "vergil_tooling.bin.vrg_sarif_evaluate:main"
 vrg-scorecard = "vergil_tooling.bin.vrg_scorecard:main"
 vrg-semgrep-scan = "vergil_tooling.bin.vrg_semgrep_scan:main"
-vrg-standing-epic = "vergil_tooling.bin.vrg_standing_epic:main"
+# Deprecated alias for vrg-adhoc-epic during the ad-hoc rollout (epic #85); removed in Task 11.
+vrg-standing-epic = "vergil_tooling.bin.vrg_adhoc_epic:main"
 vrg-submit-pr = "vergil_tooling.bin.vrg_submit_pr:main"
 vrg-triage-create = "vergil_tooling.bin.vrg_triage_create:main"
 vrg-update-deps = "vergil_tooling.bin.vrg_update_deps:main"

--- a/src/vergil_tooling/bin/vrg_adhoc_epic.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_epic.py
@@ -1,11 +1,15 @@
-"""Ensure a repo's standing epic exists (create-if-missing), idempotently.
+"""Ensure a repo's ad-hoc epic exists (create-if-missing), idempotently.
 
-Standing epics are per-repo: the ``Epic (standing): Ad-hoc maintenance`` umbrella
-(labelled ``epic`` + ``standing``) in each member repo and in ``.github``. This
+Ad-hoc epics are centralized: the ``Epic (ad hoc): <repo>`` umbrella (labelled
+``epic`` + ``ad-hoc``) lives in the org's ``.github`` repo, one per repo. This
 provisions it before linking pre-existing issues — e.g. ``migrate-repo`` step 1,
-which must ensure the epic exists before it can link standing tasks to it.
-Routing work to ``standing`` (``vrg-issue-create``/``vrg-epic-move --epic
-standing``) also ensures it via the same path.
+which must ensure the epic exists before it can link ad-hoc tasks to it. Routing
+work to ``adhoc`` (``vrg-issue-create``/``vrg-epic-move --epic adhoc``) also
+ensures it via the same path.
+
+``vrg-standing-epic`` remains as a deprecated alias for this command during the
+ad-hoc rollout (epic vergil-project/.github#85); it is removed once the
+migration is complete.
 """
 
 from __future__ import annotations
@@ -18,24 +22,24 @@ from vergil_tooling.lib import epics, github
 
 def cmd_ensure(args: argparse.Namespace) -> int:
     repo = args.repo or github.current_repo()
-    epic = epics.ensure_standing_epic(repo)
-    print(f"Standing epic: {epic.slug}")
+    epic = epics.ensure_adhoc_epic(repo)
+    print(f"Ad-hoc epic: {epic.slug}")
     return 0
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
-        prog="vrg-standing-epic",
+        prog="vrg-adhoc-epic",
         description=(
-            "Manage a repo's standing epic (Epic (standing): Ad-hoc "
-            "maintenance, labelled epic + standing)."
+            "Manage a repo's ad-hoc epic (Epic (ad hoc): <repo>, labelled "
+            "epic + ad-hoc, located in the org's .github)."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
     p_ensure = sub.add_parser(
         "ensure",
-        help="Ensure the repo's standing epic exists (create-if-missing, idempotent).",
+        help="Ensure the repo's ad-hoc epic exists (create-if-missing, idempotent).",
     )
     p_ensure.add_argument("--repo", help="Target repo owner/name (defaults to the current repo)")
     p_ensure.set_defaults(func=cmd_ensure)

--- a/tests/vergil_tooling/test_vrg_adhoc_epic.py
+++ b/tests/vergil_tooling/test_vrg_adhoc_epic.py
@@ -1,4 +1,4 @@
-"""Tests for vergil_tooling.bin.vrg_standing_epic."""
+"""Tests for vergil_tooling.bin.vrg_adhoc_epic."""
 
 from __future__ import annotations
 
@@ -6,10 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
-from vergil_tooling.bin.vrg_standing_epic import main, parse_args
+from vergil_tooling.bin.vrg_adhoc_epic import main, parse_args
 from vergil_tooling.lib import epics
 
-_MOD = "vergil_tooling.bin.vrg_standing_epic"
+_MOD = "vergil_tooling.bin.vrg_adhoc_epic"
 
 
 def test_parse_args_requires_subcommand() -> None:
@@ -18,29 +18,32 @@ def test_parse_args_requires_subcommand() -> None:
 
 
 def test_ensure_current_repo(capsys: pytest.CaptureFixture[str]) -> None:
+    # The ad-hoc epic for org/repo lives in org/.github (title-disambiguated).
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
         patch(
-            f"{_MOD}.epics.ensure_standing_epic",
-            return_value=epics.IssueRef("org", "repo", 5),
+            f"{_MOD}.epics.ensure_adhoc_epic",
+            return_value=epics.IssueRef("org", ".github", 5),
         ) as mock_ensure,
     ):
         rc = main(["ensure"])
     assert rc == 0
     mock_ensure.assert_called_once_with("org/repo")
-    assert "org/repo#5" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "Ad-hoc epic:" in out
+    assert "org/.github#5" in out
 
 
 def test_ensure_repo_override(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.current_repo") as mock_cur,
         patch(
-            f"{_MOD}.epics.ensure_standing_epic",
+            f"{_MOD}.epics.ensure_adhoc_epic",
             return_value=epics.IssueRef("org", ".github", 9),
         ) as mock_ensure,
     ):
-        rc = main(["ensure", "--repo", "org/.github"])
+        rc = main(["ensure", "--repo", "org/actions"])
     assert rc == 0
-    mock_ensure.assert_called_once_with("org/.github")
+    mock_ensure.assert_called_once_with("org/actions")
     mock_cur.assert_not_called()
     assert "org/.github#9" in capsys.readouterr().out


### PR DESCRIPTION
# Pull Request

## Summary

- Renames the standing-epic CLI to vrg-adhoc-epic (git mv of bin + test), calling epics.ensure_adhoc_epic to ensure the repo's ad-hoc epic in <org>/.github; vrg-standing-epic is kept as a deprecated console-script alias to the same module during the rollout.

## Issue Linkage

- Closes #2123

## Notes

- Phase 1 of epic vergil-project/.github#85, builds on the ad-hoc model from #2122. Both console scripts (vrg-adhoc-epic and the deprecated vrg-standing-epic alias) resolve during the rollout; the alias is removed in Task 11. Full vrg-validate green.