### PR TITLE
fix(github-config): drop 'security / standards' required check from CI-gates ruleset

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -274,7 +274,6 @@ def desired_ci_gates_ruleset(
     checks.append(_make_check("quality / common"))
     checks.append(_make_check("security / trivy"))
     checks.append(_make_check("security / semgrep"))
-    checks.append(_make_check("security / standards"))
 
     # GHAS check runs — created by GitHub Advanced Security (app 57789)
     # when workflows upload SARIF via codeql-action/upload-sarif.  These

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -232,7 +232,7 @@ def test_ci_gates_always_includes_common_and_security() -> None:
     assert "quality / common" in check_names
     assert "security / trivy" in check_names
     assert "security / semgrep" in check_names
-    assert "security / standards" in check_names
+    assert "security / standards" not in check_names
     assert "Trivy" in check_names
     assert "Semgrep OSS" in check_names
 
@@ -268,7 +268,7 @@ def test_ci_gates_without_ghas_drops_alert_checks() -> None:
     assert "CodeQL" not in names
     assert "security / trivy" in names
     assert "security / semgrep" in names
-    assert "security / standards" in names
+    assert "security / standards" not in names
     assert "quality / common" in names
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the security-slash-standards required status check from the code-managed CI-gates ruleset so retiring the standards CI job does not leave a required check that never reports.

## Issue Linkage

- Closes #2140

## Notes

- Prerequisite for Task B of epic vergil-project/.github#82, surfaced when vergil-actions PR #747 could not merge. Branch protection is managed as code (desired_ci_gates_ruleset); a human runs vrg-github-repo-config apply to reconcile live rulesets across the fleet after this releases, which unblocks merges everywhere. Sequencing: this releases and is applied, then Task B (#746) merges and releases, then Task C (#2116).