### PR TITLE
fix(vm-cloud): export ~/.local/bin PATH for bootstrap_volume vrg-git calls

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -224,12 +224,25 @@ def preflight(provider: str = "gcp") -> None:
     strategy_for(provider).preflight()
 
 
+# `uv tool install` puts vrg-git in ~/.local/bin, but a `gcloud compute ssh
+# --command=…` / `ssh <host> <cmd>` runs a non-login, non-interactive shell whose
+# PATH is the system default (no ~/.local/bin) and which sources no shell config.
+# So a bare `vrg-git` resolves to nothing → exit 127. Every other in-guest tool
+# call prepends ~/.local/bin for exactly this reason (see vm_guest's
+# _PLUGIN_PATH_EXPORT / _uv_tool_install); bootstrap_volume must too, or its
+# vrg-git clone/fetch 127s (#2145, a regression from the git→vrg-git switch #1791).
+_GIT_PATH_EXPORT = 'export PATH="$HOME/.local/bin:$PATH"'
+
+
 def bootstrap_volume(transport: Transport, identity: Identity, org: str, repo: str) -> None:
     """Clone the repo onto the persistent volume, reattach (fetch), or skip.
 
     - ``auth_type == "none"``: credential-less identity — skip checkout, logged.
     - existing ``/vergil/projects/<org>/<repo>``: reattached volume — fetch only.
     - absent: fresh volume — in-guest ``vrg-git clone`` + seed ``/vergil/claude``.
+
+    The ``vrg-git`` calls run through ``bash -c`` with ``_GIT_PATH_EXPORT`` so the
+    ~/.local/bin binary resolves over the non-login guest shell (#2145).
     """
     if identity.auth_type == "none":
         print("  Skipping checkout (credential-less identity)")
@@ -239,13 +252,18 @@ def bootstrap_volume(transport: Transport, identity: Identity, org: str, repo: s
         transport.run("test", "-d", path)
     except subprocess.CalledProcessError:
         print(f"  Cloning {org}/{repo} onto the volume...")
-        transport.run("vrg-git", "clone", f"https://github.com/{org}/{repo}.git", path)
+        url = f"https://github.com/{org}/{repo}.git"
+        transport.run(
+            "bash",
+            "-c",
+            f"{_GIT_PATH_EXPORT} && vrg-git clone {shlex.quote(url)} {shlex.quote(path)}",
+        )
         transport.run("mkdir", "-p", "/vergil/claude")
     else:
         print(f"  Reattaching existing checkout for {org}/{repo}...")
         # vrg-git (not raw git) so the installation token is injected, run inside the
         # repo so `fetch` resolves the org from its own remote (#1790).
-        transport.run("vrg-git", "fetch", "--all", workdir=path)
+        transport.run("bash", "-c", f"{_GIT_PATH_EXPORT} && vrg-git fetch --all", workdir=path)
 
 
 _FINGERPRINT_PATH = "/etc/vergil/vm-spec.fingerprint"

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -439,9 +439,48 @@ class TestBootstrap:
         identity.auth_type = "app"
         bootstrap_volume(transport, identity, "org", "repo")
         # reattach fetches via vrg-git (token injection), run inside the repo so the
-        # org resolves from its own remote.
+        # org resolves from its own remote, and inside the repo's checkout dir.
         fetch_call = transport.run.call_args_list[-1]
-        assert list(fetch_call.args) == ["vrg-git", "fetch", "--all"]
+        assert fetch_call.args[0] == "bash"
+        assert fetch_call.args[1] == "-c"
+        assert "vrg-git fetch --all" in fetch_call.args[2]
+        assert fetch_call.kwargs["workdir"] == "/vergil/projects/org/repo"
+
+    def test_clone_command_exports_local_bin_path(self) -> None:
+        # Regression (#2145): the fresh-volume clone runs vrg-git, which lives in
+        # ~/.local/bin — absent from the non-login guest shell's default PATH. Without
+        # the PATH export the guest command 127s (command not found).
+        transport = MagicMock()
+        transport.run.side_effect = [
+            subprocess.CalledProcessError(1, "test"),  # path absent
+            MagicMock(),  # clone
+            MagicMock(),  # mkdir
+        ]
+        identity = MagicMock()
+        identity.auth_type = "app"
+        bootstrap_volume(transport, identity, "org", "repo")
+        clone_call = transport.run.call_args_list[1]
+        assert clone_call.args[0] == "bash"
+        assert clone_call.args[1] == "-c"
+        assert "$HOME/.local/bin" in clone_call.args[2]
+        assert "vrg-git clone" in clone_call.args[2]
+
+    def test_fetch_command_exports_local_bin_path(self) -> None:
+        # Regression (#2145): the reattach fetch — the branch exercised on every
+        # rebuild of an existing volume — must export ~/.local/bin so vrg-git resolves
+        # over the non-login guest shell instead of exiting 127.
+        transport = MagicMock()
+        transport.run.side_effect = [
+            MagicMock(),  # test -d succeeds (present)
+            MagicMock(),  # fetch
+        ]
+        identity = MagicMock()
+        identity.auth_type = "app"
+        bootstrap_volume(transport, identity, "org", "repo")
+        fetch_call = transport.run.call_args_list[-1]
+        assert fetch_call.args[0] == "bash"
+        assert fetch_call.args[1] == "-c"
+        assert "$HOME/.local/bin" in fetch_call.args[2]
         assert fetch_call.kwargs["workdir"] == "/vergil/projects/org/repo"
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Route bootstrap_volume's vrg-git clone/fetch through 'bash -c' with a $HOME/.local/bin PATH export so they resolve over the non-login guest shell instead of exiting 127 on every cloud rebuild.

## Issue Linkage

- Closes #2145

## Notes

- Regression from the git->vrg-git switch (#1791/#1786/#1781): raw /usr/bin/git was on the default non-interactive PATH; vrg-git lives in ~/.local/bin and is not. The fix mirrors the established pattern used by every other in-guest tool call (vm_guest's _PLUGIN_PATH_EXPORT / _uv_tool_install). Both the fresh-volume clone branch and the reattach fetch branch are fixed. Two regression tests assert each branch's composed guest command carries the PATH export. Cannot be exercised on a real cloud box pre-merge (no Lima path); verified via unit tests + full vrg-validate (green, 100% coverage on vm_cloud.py).