### PR TITLE
fix(cli): accept adhoc sentinel in issue-create/epic-move cross-org guard

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_move.py
+++ b/src/vergil_tooling/bin/vrg_epic_move.py
@@ -2,8 +2,8 @@
 
 GitHub sub-issues allow only one parent, so re-parenting is unlink-then-link.
 The target epic is resolved via :func:`epics.resolve_epic_ref` (accepting the
-``standing`` sentinel and validating epic-ness); moving a task already under the
-target epic is a no-op.
+``adhoc`` sentinel and its deprecated ``standing`` alias, and validating
+epic-ness); moving a task already under the target epic is a no-op.
 """
 
 from __future__ import annotations
@@ -30,10 +30,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         task = epics.parse_issue_ref(args.task, default_repo=default_repo)
         # Scope the App token to the task's owner (#2070). The epic must live in
-        # the same org — 'standing' resolves within the task's repo, so only an
-        # explicit ref can diverge; guard that before any network call so a
-        # cross-org mistake is a clear message, not a cwd-scoped 403.
-        if args.epic != "standing":
+        # the same org — the 'adhoc' sentinel (and its deprecated 'standing'
+        # alias) resolves within the task's org (.github), so only an explicit
+        # ref can diverge; guard that before any network call so a cross-org
+        # mistake is a clear message, not a cwd-scoped 403.
+        if args.epic not in ("standing", "adhoc"):
             epic_owner = epics.parse_issue_ref(args.epic, default_repo=default_repo).owner
             if epic_owner != task.owner:
                 raise ValueError(

--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -2,8 +2,9 @@
 
 Every issue must be born linked to an epic (a native sub-issue), so this is the
 only sanctioned issue-creation path: ``vrg-gh`` denies raw ``gh issue create``
-and redirects here. ``--epic`` is required — pass ``--epic standing`` to target
-the repo's standing epic, or an explicit ``owner/repo#N`` / ``#N`` epic ref.
+and redirects here. ``--epic`` is required — pass ``--epic adhoc`` (or the
+deprecated alias ``standing``) to target the repo's ad-hoc epic in ``.github``,
+or an explicit ``owner/repo#N`` / ``#N`` epic ref.
 
 If the issue is created but the link fails, the created issue's URL is reported
 so it is never a silent orphan; recover with ``vrg-epic-move``.
@@ -41,9 +42,10 @@ def main(argv: list[str] | None = None) -> int:
     repo = args.repo or github.current_repo()
     owner, name = repo.split("/", 1)
     # Pre-network cross-org guard: the issue and its epic must share an owner so
-    # one App-installation token reaches both (#2070). 'standing' resolves
-    # within *repo*, so only an explicit epic ref can diverge.
-    if args.epic != "standing":
+    # one App-installation token reaches both (#2070). The 'adhoc' sentinel (and
+    # its deprecated 'standing' alias) resolves within *repo*'s org (.github), so
+    # only an explicit epic ref can diverge.
+    if args.epic not in ("standing", "adhoc"):
         try:
             epic_owner = epics.parse_issue_ref(args.epic, default_repo=repo).owner
         except ValueError as exc:

--- a/tests/vergil_tooling/test_vrg_epic_move.py
+++ b/tests/vergil_tooling/test_vrg_epic_move.py
@@ -87,6 +87,19 @@ def test_main_accepts_standing_epic() -> None:
     mock_add.assert_called_once_with(NEW, TASK)
 
 
+def test_main_accepts_adhoc_epic() -> None:
+    """The 'adhoc' sentinel skips the cross-org guard (it resolves in .github)."""
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=NEW),
+        patch(f"{_MOD}.epics.parent_of", return_value=None),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--task", "#42", "--epic", "adhoc"])
+    assert rc == 0
+    mock_add.assert_called_once_with(NEW, TASK)
+
+
 def test_main_scopes_token_to_task_owner() -> None:
     """The re-parent runs under the task's owner installation, not cwd (#2070)."""
     with (

--- a/tests/vergil_tooling/test_vrg_issue_create.py
+++ b/tests/vergil_tooling/test_vrg_issue_create.py
@@ -40,6 +40,21 @@ def test_main_creates_issue_and_links_under_epic() -> None:
     mock_add.assert_called_once_with(EPIC, epics.IssueRef("org", "repo", 123))
 
 
+def test_main_adhoc_sentinel_skips_cross_org_guard() -> None:
+    # 'adhoc' (like the deprecated 'standing') resolves within the repo's org
+    # (.github), so it must skip the explicit-ref cross-org guard and link.
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC) as mock_resolve,
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--epic", "adhoc", "--title", "T"])
+    assert rc == 0
+    mock_resolve.assert_called_once_with("adhoc", repo="org/repo")
+    mock_add.assert_called_once_with(EPIC, epics.IssueRef("org", "repo", 123))
+
+
 def test_main_epic_resolution_failure_creates_nothing() -> None:
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),


### PR DESCRIPTION
# Pull Request

## Summary

- Extends the cross-org guard in vrg-issue-create and vrg-epic-move to skip the 'adhoc' sentinel (not just the deprecated 'standing' alias), since both resolve within the repo's org (.github); without this, --epic adhoc was parsed as a literal ref and rejected.

## Issue Linkage

- Closes #2124

## Notes

- Phase 1 of epic vergil-project/.github#85, builds on #2122/#2123. Guard predicate is now 'not in (standing, adhoc)'; existing 'standing' behavior is unchanged. TDD: added adhoc-sentinel tests to both CLIs (21 pass). Full vrg-validate green.