### PR TITLE
feat(cli): add intake --kind and default vrg-triage-create to org .github

### DIFF
--- a/src/vergil_tooling/bin/vrg_triage_create.py
+++ b/src/vergil_tooling/bin/vrg_triage_create.py
@@ -1,9 +1,15 @@
-"""Create an unlinked triage issue.
+"""Create an unlinked intake issue (triage / idea / research).
 
-Triage issues are standalone (no parent epic) and labelled ``triage``; they are
-routed to an epic later during triage-review. This is the sanctioned path for
-creating them — ``vrg-gh`` denies raw ``gh issue create`` — used by the
-``triage-capture`` skill.
+Intake issues are standalone (no parent epic) and carry one of three ``--kind``
+labels — ``triage`` (a problem not yet understood), ``idea`` (a spark), or
+``research`` (a reproducible investigation). They are folded into the epic/task
+model later during triage-review. This is the sanctioned path for creating them
+— ``vrg-gh`` denies raw ``gh issue create`` — used by the ``triage-capture``
+skill.
+
+Intake is routed to the org's ``.github`` by default so the whole org-wide
+intake queue lives in one place (epic vergil-project/.github#85); this
+supersedes the earlier current-repo default (#2075).
 """
 
 from __future__ import annotations
@@ -13,36 +19,56 @@ import sys
 
 from vergil_tooling.lib import github
 
+_KINDS = ("triage", "idea", "research")
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         prog="vrg-triage-create",
         description=(
-            "Create an unlinked triage issue (labelled 'triage', no parent "
-            "epic). Defaults to the current repo; use --repo for another repo "
-            "(e.g. the org .github for a project-level seed)."
+            "Create an unlinked intake issue (triage/idea/research, no parent "
+            "epic). Routed to the org's .github by default; use --repo to "
+            "override (e.g. a task whose PR lands in .github itself)."
         ),
-        epilog=("The issue is intentionally unlinked; triage-review routes it to an epic later."),
+        epilog=("The issue is intentionally unlinked; triage-review folds it into an epic later."),
     )
     parser.add_argument("--title", required=True, help="Issue title")
+    parser.add_argument(
+        "--kind",
+        choices=_KINDS,
+        default="triage",
+        help="Intake kind; sets the primary label (default: triage)",
+    )
     parser.add_argument("--body", default="", help="Issue body text")
     parser.add_argument("--body-file", help="Read the issue body from a file")
     parser.add_argument(
         "--label",
         action="append",
         default=[],
-        help="Extra label (repeatable); 'triage' is always added",
+        help="Extra label (repeatable); the --kind label is always added",
     )
     parser.add_argument("--assignee", action="append", default=[], help="Assignee (repeatable)")
-    parser.add_argument("--repo", help="Target repo owner/name (defaults to the current repo)")
+    parser.add_argument("--repo", help="Target repo owner/name (defaults to the org's .github)")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    repo = args.repo or github.current_repo()
-    labels = list(dict.fromkeys(["triage", *args.label]))
+    if args.repo:
+        repo = args.repo
+    else:
+        org = github.detect_org()
+        if org is None:
+            print(
+                "vrg-triage-create: could not determine the GitHub org from this "
+                "repo's 'origin' remote; run it from inside a repo in the target "
+                "org, or pass --repo.",
+                file=sys.stderr,
+            )
+            return 1
+        repo = f"{org}/.github"
+    labels = list(dict.fromkeys([args.kind, *args.label]))
     url = github.create_issue(
         repo=repo,
         title=args.title,
@@ -51,7 +77,7 @@ def main(argv: list[str] | None = None) -> int:
         labels=labels,
         assignees=args.assignee,
     )
-    print(f"Created {url} (triage).")
+    print(f"Created {url} ({args.kind}).")
     return 0
 
 

--- a/tests/vergil_tooling/test_vrg_triage_create.py
+++ b/tests/vergil_tooling/test_vrg_triage_create.py
@@ -9,7 +9,7 @@ import pytest
 from vergil_tooling.bin.vrg_triage_create import main, parse_args
 
 _MOD = "vergil_tooling.bin.vrg_triage_create"
-_URL = "https://github.com/org/repo/issues/321"
+_URL = "https://github.com/org/.github/issues/321"
 
 
 def test_parse_args_requires_title() -> None:
@@ -17,31 +17,72 @@ def test_parse_args_requires_title() -> None:
         parse_args([])
 
 
-def test_main_creates_unlinked_triage_in_current_repo() -> None:
+def test_main_defaults_to_org_dotgithub() -> None:
+    # Intake defaults to <org>/.github (supersedes the old current-repo default,
+    # #2075) so the whole org-wide intake queue lives in one place.
     with (
-        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
     ):
         rc = main(["--title", "T", "--body", "B"])
     assert rc == 0
-    assert mock_create.call_args.kwargs["repo"] == "org/repo"
+    assert mock_create.call_args.kwargs["repo"] == "org/.github"
     assert mock_create.call_args.kwargs["labels"] == ["triage"]
 
 
-def test_main_repo_override_skips_current_repo() -> None:
+def test_main_kind_research() -> None:
     with (
-        patch(f"{_MOD}.github.current_repo", return_value="org/repo") as mock_cur,
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
     ):
-        main(["--title", "T", "--repo", "org/.github"])
+        rc = main(["--title", "T", "--kind", "research"])
+    assert rc == 0
     assert mock_create.call_args.kwargs["repo"] == "org/.github"
-    mock_cur.assert_not_called()
+    assert mock_create.call_args.kwargs["labels"] == ["research"]
+
+
+def test_main_kind_idea() -> None:
+    with (
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+    ):
+        main(["--title", "T", "--kind", "idea"])
+    assert mock_create.call_args.kwargs["labels"] == ["idea"]
+
+
+def test_main_repo_override_skips_detect_org() -> None:
+    with (
+        patch(f"{_MOD}.github.detect_org") as mock_detect,
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+    ):
+        main(["--title", "T", "--repo", "org/tooling"])
+    assert mock_create.call_args.kwargs["repo"] == "org/tooling"
+    mock_detect.assert_not_called()
 
 
 def test_main_adds_extra_labels() -> None:
     with (
-        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
     ):
         main(["--title", "T", "--label", "bug"])
     assert mock_create.call_args.kwargs["labels"] == ["triage", "bug"]
+
+
+def test_main_kind_dedupes_with_extra_label() -> None:
+    with (
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+    ):
+        main(["--title", "T", "--kind", "research", "--label", "research"])
+    assert mock_create.call_args.kwargs["labels"] == ["research"]
+
+
+def test_main_undetectable_org_errors() -> None:
+    with (
+        patch(f"{_MOD}.github.detect_org", return_value=None),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(["--title", "T"])
+    assert rc == 1
+    mock_create.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-triage-create gains --kind {triage,idea,research} (default triage) which sets the primary label, and now defaults its target to <org>/.github (auto-detected, clear error if undetectable) so the org-wide intake queue lives in one place; --repo still overrides.

## Issue Linkage

- Closes #2125

## Notes

- Phase 1 of epic vergil-project/.github#85; independent of the ad-hoc rename. Supersedes the #2075 current-repo default. idea/research labels already exist in labels.json. Unblocks the T8 plugin-skill routing update. TDD rewrite of the tool's tests (8 pass); full vrg-validate green.