### PR TITLE
refactor(reporting): treat ad-hoc epics as perpetual in roadmap/audit

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_create.py
+++ b/src/vergil_tooling/bin/vrg_epic_create.py
@@ -25,7 +25,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
         epilog=(
             "Run from inside a repo in the target org. Extra --label values are "
-            "added alongside 'epic' (e.g. --label standing for a standing epic)."
+            "added alongside 'epic' (e.g. --label ad-hoc for an ad-hoc epic)."
         ),
     )
     parser.add_argument("--title", required=True, help="Epic title")

--- a/src/vergil_tooling/bin/vrg_epic_rollup.py
+++ b/src/vergil_tooling/bin/vrg_epic_rollup.py
@@ -6,7 +6,8 @@ Thin CLI over ``epics.rollup`` for the ``on: issues.closed`` Action (issue
 tasks are now closed.
 
 ``epics.rollup`` is a no-op unless the closed issue is a managed task with an
-``epic``-labeled, non-``standing`` parent, so this is safe to fire on *every*
+``epic``-labeled, non-perpetual parent (an ``ad-hoc`` epic, or its deprecated
+``standing`` alias, never auto-closes), so this is safe to fire on *every*
 issue close. Moving rollup here makes it event-driven — it no longer depends on
 ``vrg-finalize-pr`` running.
 

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -1,7 +1,7 @@
 """Audit for epic/task drift — work that slipped through auto-close.
 
 ``task_drift`` finds merged PRs whose ``Ref``'d task is still open;
-``epic_drift`` finds open, non-standing epics whose children are all closed
+``epic_drift`` finds open, non-perpetual epics whose children are all closed
 (should have rolled up). ``render`` formats both sections for review;
 ``close_drift`` closes them with an explanatory comment — a human action, gated
 by the caller.
@@ -92,7 +92,7 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
 
 
 def epic_drift() -> list[roadmap.EpicSummary]:
-    """Open, non-standing epics whose children are all closed (should roll up)."""
+    """Open, non-perpetual epics whose children are all closed (should roll up)."""
     return [epic for epic in roadmap.gather() if epic.total > 0 and epic.closed == epic.total]
 
 

--- a/src/vergil_tooling/lib/roadmap.py
+++ b/src/vergil_tooling/lib/roadmap.py
@@ -1,7 +1,7 @@
 """Generate the project roadmap from open finite epics in the org ``.github`` repo.
 
 "Where we're going", derived mechanically from epic metadata — no hand editing.
-``gather`` reads the open ``epic``-labelled issues (skipping ``standing`` buckets)
+``gather`` reads the open ``epic``-labelled issues (skipping perpetual ``ad-hoc`` buckets)
 and rolls up each one's children via :mod:`vergil_tooling.lib.epics`; ``render``
 turns the summaries into markdown grouped by milestone.
 """
@@ -46,12 +46,15 @@ def _open_epics(org: str) -> list[Any]:
     return raw if isinstance(raw, list) else []
 
 
-def _is_standing(epic: Any) -> bool:
-    return any((label or {}).get("name") == "standing" for label in (epic.get("labels") or []))
+def _is_perpetual(epic: Any) -> bool:
+    """True if the epic is a perpetual ad-hoc bucket (``ad-hoc``, or its
+    deprecated ``standing`` alias) — excluded from the strategic roadmap."""
+    names = {(label or {}).get("name") for label in (epic.get("labels") or [])}
+    return bool(names & {"ad-hoc", "standing"})
 
 
 def gather(org: str | None = None) -> list[EpicSummary]:
-    """Summarize every open finite (non-standing) epic in *org*'s ``.github``.
+    """Summarize every open finite (non-perpetual) epic in *org*'s ``.github``.
 
     *org* defaults to the owner of the current repo's git remote, so the same
     command reports each org's own roadmap.
@@ -60,7 +63,7 @@ def gather(org: str | None = None) -> list[EpicSummary]:
         org = github.current_org()
     summaries: list[EpicSummary] = []
     for epic in _open_epics(org):
-        if _is_standing(epic):
+        if _is_perpetual(epic):
             continue
         # Defense in depth: a release tracking issue is never epic-labelled, so
         # it should not reach here — but skip it explicitly so a stray label can

--- a/tests/vergil_tooling/test_roadmap.py
+++ b/tests/vergil_tooling/test_roadmap.py
@@ -52,6 +52,35 @@ def test_gather_summarizes_open_epics_and_skips_standing() -> None:
     assert (summary.total, summary.closed) == (2, 1)
 
 
+def test_gather_skips_adhoc_epic() -> None:
+    # The ad-hoc bucket is perpetual and excluded from the strategic roadmap,
+    # just like the deprecated 'standing' alias (epic #85).
+    epic_list = [
+        {
+            "number": 40,
+            "title": "Convention",
+            "createdAt": "2026-06-28T10:00:00Z",
+            "milestone": None,
+            "labels": [{"name": "epic"}],
+            "url": "u40",
+        },
+        {
+            "number": 6,
+            "title": "Epic (ad hoc): vergil-tooling",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "milestone": None,
+            "labels": [{"name": "epic"}, {"name": "ad-hoc"}],  # ad-hoc -> skipped
+            "url": "u6",
+        },
+    ]
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=epic_list),
+        patch("vergil_tooling.lib.epics.child_states", return_value=[]),
+    ):
+        result = roadmap.gather("vergil-project")
+    assert [s.number for s in result] == [40]
+
+
 def test_gather_handles_no_milestone_and_no_children() -> None:
     epic_list = [
         {


### PR DESCRIPTION
# Pull Request

## Summary

- roadmap's perpetual-bucket check now matches 'ad-hoc' as well as the deprecated 'standing' alias, so ad-hoc epics are excluded from the strategic roadmap and epic-drift; epic_audit/rollup/epic-create wording updated to ad-hoc.

## Issue Linkage

- Closes #2126

## Notes

- Phase 1 of epic vergil-project/.github#85. Preserves the canonical 'epic AND NOT ad-hoc' strategic view; standing behavior unchanged during the rollout. epic_drift delegates to roadmap.gather so no separate logic change was needed there. TDD: added an ad-hoc-skip roadmap test (29 reporting tests pass). Full vrg-validate green.