### PR TITLE
feat(epic-audit): add invariant-enforcement checks (report-only)

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -40,10 +40,12 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="vrg-epic-audit",
         description=(
-            "Report epic/task drift for the current repo's GitHub org: merged "
-            "PRs whose Ref'd task issue is still open, and open non-standing "
-            "epics whose children are all closed. Read-only by default; pass "
-            "--close (as a human) to actually close what it finds."
+            "Report epic/task drift and invariant violations for the current "
+            "repo's GitHub org: merged PRs whose Ref'd task is still open, open "
+            "non-perpetual epics whose children are all closed, and issues in "
+            "the wrong place (epics outside .github; stray .github issues). "
+            "Read-only by default; pass --close (as a human) to close the drift "
+            "it finds (invariant violations are report-only)."
         ),
         epilog=(
             "Scope: the org is auto-detected from this repo's 'origin' remote, "
@@ -101,7 +103,18 @@ def main(argv: list[str] | None = None) -> int:
         closed = epic_audit.close_drift(tasks, epics, org=org)
         print(epic_audit.render_closed(closed, org=org, window_days=args.window_days))
         return 0
-    print(epic_audit.render(tasks, epics, org=org, window_days=args.window_days))
+    epics_outside = epic_audit.epic_outside_dotgithub(org)
+    stray = epic_audit.stray_dotgithub_issue(org)
+    print(
+        epic_audit.render(
+            tasks,
+            epics,
+            org=org,
+            window_days=args.window_days,
+            epics_outside=epics_outside,
+            stray=stray,
+        )
+    )
     return 0
 
 

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
-from vergil_tooling.lib import github, linkage, release, roadmap
+from vergil_tooling.lib import epics, github, linkage, release, roadmap
 
 
 @dataclass(frozen=True)
@@ -96,26 +96,104 @@ def epic_drift() -> list[roadmap.EpicSummary]:
     return [epic for epic in roadmap.gather() if epic.total > 0 and epic.closed == epic.total]
 
 
+_INTAKE_LABELS = frozenset({"triage", "idea", "research"})
+
+
+def epic_outside_dotgithub(org: str) -> list[str]:
+    """Open ``epic``-labelled issues living outside ``<org>/.github`` (invariant 1).
+
+    Invariant 1 (epic #85): all epics live in the org's ``.github``. Any open
+    epic-labelled issue in another repo is a violation; returns their
+    ``owner/repo#n`` slugs.
+    """
+    raw: Any = github.read_json(
+        "search",
+        "issues",
+        "--owner",
+        org,
+        "--label",
+        "epic",
+        "--state",
+        "open",
+        "--json",
+        "number,repository",
+    )
+    dotgithub = f"{org}/.github"
+    violations: list[str] = []
+    for item in raw if isinstance(raw, list) else []:
+        if not isinstance(item, dict):
+            continue
+        name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
+        if not name_with_owner or name_with_owner == dotgithub:
+            continue
+        violations.append(f"{name_with_owner}#{item['number']}")
+    return violations
+
+
+def stray_dotgithub_issue(org: str) -> list[str]:
+    """Open ``<org>/.github`` issues that violate invariant 2 (epic #85).
+
+    ``.github`` holds only epics, intake (``triage``/``idea``/``research``), and
+    managed tasks whose closing PR lands in ``.github`` (a task linked under an
+    epic). An open ``.github`` issue that is none of these — an unlinked,
+    non-epic, non-intake issue — is a stray; returns their slugs. When a
+    candidate's parent cannot be confirmed as an epic it is reported (fail-loud,
+    the human decides).
+    """
+    dotgithub = f"{org}/.github"
+    raw: Any = github.read_json(
+        "issue",
+        "list",
+        "--repo",
+        dotgithub,
+        "--state",
+        "open",
+        "--limit",
+        "500",
+        "--json",
+        "number,labels",
+    )
+    strays: list[str] = []
+    for item in raw if isinstance(raw, list) else []:
+        if not isinstance(item, dict):
+            continue
+        labels = {str((label or {}).get("name", "")) for label in (item.get("labels") or [])}
+        if "epic" in labels or (labels & _INTAKE_LABELS):
+            continue
+        number = int(item["number"])
+        parent = epics.parent_of(epics.IssueRef(org, ".github", number))
+        if parent is not None and epics.is_epic(parent):
+            continue
+        strays.append(f"{dotgithub}#{number}")
+    return strays
+
+
 def render(
     tasks: list[TaskDrift],
-    epics: list[roadmap.EpicSummary],
+    epic_summaries: list[roadmap.EpicSummary],
     *,
     org: str,
     window_days: int,
+    epics_outside: list[str] | None = None,
+    stray: list[str] | None = None,
 ) -> str:
-    """Format the drift report; a clean state says so explicitly.
+    """Format the drift + invariant report; a clean state says so explicitly.
 
     The report opens with a banner naming the audited org and window and
     stating the run is read-only, so the output is never mistaken for a list of
-    actions the tool took.
+    actions the tool took. ``epics_outside`` and ``stray`` are the invariant
+    violations (epic #85); their section appears only when there is something to
+    report.
     """
+    epics_outside = epics_outside or []
+    stray = stray or []
     banner = (
         f"_Read-only audit of the **{org}** org (merged PRs from the last "
         f"{window_days} days) — this report changes nothing; run `--close` (as "
         "a human) to close what it lists._"
     )
     header = ["# Epic/task drift audit", "", banner, ""]
-    if not tasks and not epics:
+    if not tasks and not epic_summaries and not epics_outside and not stray:
         return "\n".join([*header, "_No drift — everything that should be closed is closed._", ""])
     lines = [*header, "## Task drift (merged PR, task still open)", ""]
     if tasks:
@@ -126,13 +204,21 @@ def render(
     else:
         lines.append("- _none_")
     lines += ["", "## Epic drift (all children closed, epic still open)", ""]
-    if epics:
-        for epic in sorted(epics, key=lambda e: e.number):
+    if epic_summaries:
+        for epic in sorted(epic_summaries, key=lambda e: e.number):
             lines.append(
                 f"- [#{epic.number}]({epic.url}) {epic.title} — {epic.closed}/{epic.total} done"
             )
     else:
         lines.append("- _none_")
+    if epics_outside or stray:
+        lines += ["", "## Invariant violations (issues in the wrong place)", ""]
+        if epics_outside:
+            lines.append("**Epics outside `.github`** — move each to the org's `.github`:")
+            lines += [f"- {slug}" for slug in sorted(epics_outside)]
+        if stray:
+            lines.append("**Stray `.github` issues** — not an epic, intake, or linked task:")
+            lines += [f"- {slug}" for slug in sorted(stray)]
     lines.append("")
     return "\n".join(lines)
 

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -121,8 +121,6 @@ def epic_outside_dotgithub(org: str) -> list[str]:
     dotgithub = f"{org}/.github"
     violations: list[str] = []
     for item in raw if isinstance(raw, list) else []:
-        if not isinstance(item, dict):
-            continue
         name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
         if not name_with_owner or name_with_owner == dotgithub:
             continue
@@ -155,8 +153,6 @@ def stray_dotgithub_issue(org: str) -> list[str]:
     )
     strays: list[str] = []
     for item in raw if isinstance(raw, list) else []:
-        if not isinstance(item, dict):
-            continue
         labels = {str((label or {}).get("name", "")) for label in (item.get("labels") or [])}
         if "epic" in labels or (labels & _INTAKE_LABELS):
             continue

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -212,6 +212,32 @@ def test_render_shows_invariant_violations() -> None:
     assert "vergil-project/.github#7" in out
 
 
+def test_render_invariant_only_epics_outside() -> None:
+    out = epic_audit.render(
+        [],
+        [],
+        org="vergil-project",
+        window_days=30,
+        epics_outside=["vergil-project/vergil-tooling#99"],
+    )
+    assert "Epics outside" in out
+    assert "vergil-project/vergil-tooling#99" in out
+    assert "Stray" not in out
+
+
+def test_render_invariant_only_stray() -> None:
+    out = epic_audit.render(
+        [],
+        [],
+        org="vergil-project",
+        window_days=30,
+        stray=["vergil-project/.github#7"],
+    )
+    assert "Stray" in out
+    assert "vergil-project/.github#7" in out
+    assert "Epics outside" not in out
+
+
 def test_render_clean() -> None:
     out = epic_audit.render([], [], org="vergil-project", window_days=30)
     assert "No drift" in out

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-from vergil_tooling.lib import epic_audit, github, roadmap
+from vergil_tooling.lib import epic_audit, epics, github, roadmap
 from vergil_tooling.lib.epic_audit import TaskDrift
 
 if TYPE_CHECKING:
@@ -160,6 +160,56 @@ def test_epic_drift_flags_all_done_open_epics() -> None:
     with patch("vergil_tooling.lib.epic_audit.roadmap.gather", return_value=summaries):
         result = epic_audit.epic_drift()
     assert [e.number for e in result] == [40]
+
+
+def test_epic_outside_dotgithub_flags_non_dotgithub_epics() -> None:
+    issues = [
+        {"number": 99, "repository": {"nameWithOwner": "vergil-project/vergil-tooling"}},
+        {"number": 40, "repository": {"nameWithOwner": "vergil-project/.github"}},  # ok
+        {"number": 5, "repository": {}},  # no repo -> skipped
+    ]
+    with patch("vergil_tooling.lib.github.read_json", return_value=issues) as mock_search:
+        result = epic_audit.epic_outside_dotgithub("vergil-project")
+    assert result == ["vergil-project/vergil-tooling#99"]
+    args = mock_search.call_args.args
+    assert "search" in args and "issues" in args and "epic" in args
+
+
+def test_stray_dotgithub_issue_flags_unlinked_non_epic_non_intake() -> None:
+    issues = [
+        {"number": 40, "labels": [{"name": "epic"}]},  # epic -> ok
+        {"number": 50, "labels": [{"name": "idea"}]},  # intake -> ok
+        {"number": 86, "labels": [{"name": "documentation"}]},  # managed task -> ok
+        {"number": 7, "labels": []},  # unlinked, non-epic, non-intake -> STRAY
+    ]
+
+    def fake_parent_of(ref: epics.IssueRef) -> epics.IssueRef | None:
+        # #86 is a managed task under an epic; #7 has no parent.
+        if ref.number == 86:
+            return epics.IssueRef("vergil-project", ".github", 85)
+        return None
+
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=issues),
+        patch("vergil_tooling.lib.epics.parent_of", side_effect=fake_parent_of),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+    ):
+        result = epic_audit.stray_dotgithub_issue("vergil-project")
+    assert result == ["vergil-project/.github#7"]
+
+
+def test_render_shows_invariant_violations() -> None:
+    out = epic_audit.render(
+        [],
+        [],
+        org="vergil-project",
+        window_days=30,
+        epics_outside=["vergil-project/vergil-tooling#99"],
+        stray=["vergil-project/.github#7"],
+    )
+    assert "Invariant violations" in out
+    assert "vergil-project/vergil-tooling#99" in out
+    assert "vergil-project/.github#7" in out
 
 
 def test_render_clean() -> None:

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -17,6 +17,8 @@ def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
+        patch(f"{_MOD}.epic_audit.stray_dotgithub_issue", return_value=[]),
     ):
         rc = main([])
     out = capsys.readouterr().out
@@ -25,6 +27,28 @@ def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
     # The read-only banner names the auto-detected org and states nothing changed.
     assert "Read-only audit" in out
     assert "**vergil-project**" in out
+
+
+def test_main_reports_invariant_violations(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
+        patch(
+            f"{_MOD}.epic_audit.epic_outside_dotgithub",
+            return_value=["vergil-project/vergil-tooling#99"],
+        ),
+        patch(
+            f"{_MOD}.epic_audit.stray_dotgithub_issue",
+            return_value=["vergil-project/.github#7"],
+        ),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Invariant violations" in out
+    assert "vergil-project/vergil-tooling#99" in out
+    assert "vergil-project/.github#7" in out
 
 
 def test_main_errors_when_org_undetectable(capsys: pytest.CaptureFixture[str]) -> None:
@@ -40,6 +64,8 @@ def test_window_days_controls_since() -> None:
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
         patch(f"{_MOD}.epic_audit.task_drift", task_drift),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
+        patch(f"{_MOD}.epic_audit.stray_dotgithub_issue", return_value=[]),
     ):
         rc = main(["--window-days", "7"])
     assert rc == 0


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-epic-audit gains two report-only checks: epic_outside_dotgithub (open epic-labelled issues living outside <org>/.github) and stray_dotgithub_issue (open .github issues that aren't an epic, intake, or a managed task linked under an epic); render() shows an 'Invariant violations' section only when non-empty.

## Issue Linkage

- Closes #2127

## Notes

- Phase 1 of epic vergil-project/.github#85; the enforcement guard that keeps the model from drifting. Read-only path only — invariant violations are never auto-closed (they need human judgment). Unresolvable parents are reported (fail-loud). TDD: new lib + CLI tests (23 pass); the render invariant sections are suppressed when empty to preserve existing output. Full vrg-validate green.