### PR TITLE
docs(cli): point --epic help at the adhoc sentinel

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_move.py
+++ b/src/vergil_tooling/bin/vrg_epic_move.py
@@ -18,9 +18,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Move a task under a different epic.")
     parser.add_argument("--task", required=True, help="Task ref: owner/repo#N or #N")
-    parser.add_argument(
-        "--epic", required=True, help="Target epic: 'standing', #N, or owner/repo#N"
-    )
+    parser.add_argument("--epic", required=True, help="Target epic: 'adhoc', #N, or owner/repo#N")
     return parser.parse_args(argv)
 
 

--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -23,7 +23,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Create an issue linked under an epic (native sub-issue)."
     )
-    parser.add_argument("--epic", required=True, help="Epic ref: 'standing', #N, or owner/repo#N")
+    parser.add_argument("--epic", required=True, help="Epic ref: 'adhoc', #N, or owner/repo#N")
     parser.add_argument("--title", required=True, help="Issue title")
     parser.add_argument("--body", default="", help="Issue body text")
     parser.add_argument("--body-file", help="Read the issue body from a file")


### PR DESCRIPTION
# Pull Request

## Summary

- Updates the --epic --help text in vrg-issue-create and vrg-epic-move to show 'adhoc' as the sentinel instead of the deprecated 'standing' (which still works as the silent alias).

## Issue Linkage

- Closes #2130

## Notes

- Epic vergil-project/.github#85, Task 12. The planned living-doc standing->ad-hoc sweep found nothing to rename — the epic/task model was never documented in living docs (only in the epic specs), and CLAUDE.md's 'standing' is the unrelated no-direct-commits policy. That gap is now its own task, #2168 (author the issue-management site-docs guide), feeding the doc-review gate #2139. Full vrg-validate green.