### PR TITLE
feat(epics): add vrg-adhoc-migrate to relocate standing epics into .github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = ["rich>=13.0", "pyyaml>=6.0"]
 [project.scripts]
 vrg-activity-log = "vergil_tooling.bin.vrg_activity_log:main"
 vrg-adhoc-epic = "vergil_tooling.bin.vrg_adhoc_epic:main"
+vrg-adhoc-migrate = "vergil_tooling.bin.vrg_adhoc_migrate:main"
 vrg-audit-approve = "vergil_tooling.bin.vrg_audit_approve:main"
 vrg-await = "vergil_tooling.bin.vrg_await:main"
 vrg-changelog = "vergil_tooling.bin.vrg_changelog:main"

--- a/src/vergil_tooling/bin/vrg_adhoc_migrate.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_migrate.py
@@ -1,0 +1,72 @@
+"""Relocate per-repo standing epics into the org ``.github`` (one-shot, epic #85).
+
+Dry-run by default: prints the planned relocations, changing nothing. ``--apply``
+executes them (reparent each standing epic's open children under the new
+``.github`` ad-hoc epic, then close the standing epic) — a human action, refused
+in agent sessions, mirroring ``vrg-epic-audit --close``.
+
+See :mod:`vergil_tooling.lib.adhoc_migrate`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from vergil_tooling.lib import adhoc_migrate, github, identity_mode
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="vrg-adhoc-migrate",
+        description=(
+            "Relocate per-repo standing epics into the org .github (the ad-hoc "
+            "model, epic #85): re-link open children under the new .github ad-hoc "
+            "epic and close the old standing epic. Dry-run by default; pass "
+            "--apply (as a human) to execute. The org is auto-detected from this "
+            "repo's 'origin' remote."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Execute the relocations (a human action — refused in agent "
+            "sessions). Default: read-only dry-run preview."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    # Gate the write path before any network work, mirroring vrg-epic-audit
+    # --close: relocating and closing epics is a human action.
+    if args.apply and not identity_mode.is_human():
+        print(
+            "vrg-adhoc-migrate: --apply is a human action and was refused in an "
+            "agent session; run without --apply to preview the migration, or run "
+            "as a human to apply it.",
+            file=sys.stderr,
+        )
+        return 1
+    org = github.detect_org()
+    if org is None:
+        print(
+            "vrg-adhoc-migrate: could not determine the GitHub org from this "
+            "repo's 'origin' remote; run it from inside a repo in the org to "
+            "migrate.",
+            file=sys.stderr,
+        )
+        return 1
+    relocations = adhoc_migrate.plan(org)
+    if not args.apply:
+        print(adhoc_migrate.render_plan(relocations, org=org))
+        return 0
+    summaries = [adhoc_migrate.apply_one(reloc) for reloc in relocations]
+    print(adhoc_migrate.render_applied(summaries, org=org))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vergil_tooling/lib/adhoc_migrate.py
+++ b/src/vergil_tooling/lib/adhoc_migrate.py
@@ -1,0 +1,132 @@
+"""One-shot migration: relocate per-repo standing epics into the org ``.github``.
+
+Standing epics used to live per-repo as ``Epic (standing): Ad-hoc maintenance``.
+The ad-hoc model (epic vergil-project/.github#85) centralizes them: one
+``Epic (ad hoc): <repo>`` per repo, in ``<org>/.github``. This module finds the
+old standing epics, re-links their **open** child tasks under the new ``.github``
+ad-hoc epic, and closes the old standing epic. Closed children stay with the
+retired epic for history.
+
+Idempotent and safe to re-run: a closed standing epic drops out of the
+open-epic search, so a second pass reprocesses nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vergil_tooling.lib import epics, github
+
+
+@dataclass(frozen=True)
+class Relocation:
+    """A standing epic and the open children to move under its ad-hoc replacement."""
+
+    standing: epics.IssueRef
+    open_children: tuple[epics.IssueRef, ...]
+
+    @property
+    def target_repo(self) -> str:
+        """The repo whose ad-hoc epic (in ``.github``) replaces this standing epic."""
+        return f"{self.standing.owner}/{self.standing.repo}"
+
+
+def find_standing_epics(org: str) -> list[epics.IssueRef]:
+    """Open ``epic``+``standing`` issues across *org* — the epics to relocate."""
+    raw: Any = github.read_json(
+        "search",
+        "issues",
+        "--owner",
+        org,
+        "--label",
+        "epic",
+        "--label",
+        "standing",
+        "--state",
+        "open",
+        "--json",
+        "number,repository",
+    )
+    refs: list[epics.IssueRef] = []
+    for item in raw if isinstance(raw, list) else []:
+        name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
+        if "/" not in name_with_owner:
+            continue
+        owner, name = name_with_owner.split("/", 1)
+        refs.append(epics.IssueRef(owner=owner, repo=name, number=int(item["number"])))
+    return refs
+
+
+def plan(org: str) -> list[Relocation]:
+    """Build the relocation plan: each standing epic paired with its OPEN children."""
+    relocations: list[Relocation] = []
+    for standing in find_standing_epics(org):
+        open_children = tuple(
+            child.ref for child in epics.child_states(standing) if child.state == "OPEN"
+        )
+        relocations.append(Relocation(standing=standing, open_children=open_children))
+    return relocations
+
+
+_CLOSE_COMMENT = (
+    "Migrated to {adhoc} — ad-hoc epics now live in the org `.github` (epic "
+    "vergil-project/.github#85). Open children were re-linked there; closed "
+    "children stay here for history."
+)
+
+
+def apply_one(reloc: Relocation) -> str:
+    """Execute one relocation and return a summary line.
+
+    Ensures the target ad-hoc epic in ``.github``, reparents each open child under
+    it (unlink from the standing epic, link to the ad-hoc epic), then closes the
+    standing epic with a pointer comment.
+    """
+    adhoc = epics.ensure_adhoc_epic(reloc.target_repo)
+    for child in reloc.open_children:
+        epics.remove_child(reloc.standing, child)
+        epics.add_child(adhoc, child)
+    github.run(
+        "issue",
+        "close",
+        str(reloc.standing.number),
+        "--repo",
+        reloc.target_repo,
+        "--comment",
+        _CLOSE_COMMENT.format(adhoc=adhoc.slug),
+    )
+    moved = len(reloc.open_children)
+    return f"{reloc.standing.slug} → {adhoc.slug} ({moved} open child(ren) moved)"
+
+
+def render_plan(relocations: list[Relocation], *, org: str) -> str:
+    """Dry-run report: what ``--apply`` would do, changing nothing."""
+    header = [
+        f"# Ad-hoc migration — dry run (**{org}**)",
+        "",
+        "_Preview only; nothing changed. Run `--apply` (as a human) to execute._",
+        "",
+    ]
+    if not relocations:
+        return "\n".join([*header, "_No standing epics found — nothing to migrate._", ""])
+    lines = [*header, "## Planned relocations", ""]
+    for reloc in sorted(relocations, key=lambda r: r.standing.slug):
+        adhoc_title = f"Epic (ad hoc): {reloc.standing.repo}"
+        lines.append(
+            f"- {reloc.standing.slug} → `{reloc.standing.owner}/.github` "
+            f"«{adhoc_title}» — move {len(reloc.open_children)} open child(ren), "
+            "then close the standing epic"
+        )
+        lines += [f"    - {child.slug}" for child in reloc.open_children]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_applied(summaries: list[str], *, org: str) -> str:
+    """Summary of an ``--apply`` run: what was actually relocated."""
+    header = [f"# Ad-hoc migration — applied (**{org}**)", ""]
+    if not summaries:
+        return "\n".join([*header, "_No standing epics found — nothing migrated._", ""])
+    lines = [*header, "## Relocated", "", *(f"- {summary}" for summary in summaries), ""]
+    return "\n".join(lines)

--- a/tests/vergil_tooling/test_adhoc_migrate.py
+++ b/tests/vergil_tooling/test_adhoc_migrate.py
@@ -1,0 +1,113 @@
+"""Tests for vergil_tooling.lib.adhoc_migrate."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from vergil_tooling.lib import adhoc_migrate
+from vergil_tooling.lib.adhoc_migrate import Relocation
+from vergil_tooling.lib.epics import ChildState, IssueRef
+
+_STANDING = IssueRef("org", "tooling", 100)
+
+
+def test_find_standing_epics_returns_refs() -> None:
+    issues = [
+        {"number": 100, "repository": {"nameWithOwner": "org/tooling"}},
+        {"number": 5, "repository": {"nameWithOwner": "org/.github"}},
+        {"number": 9, "repository": {}},  # no repo -> skipped
+    ]
+    with patch("vergil_tooling.lib.github.read_json", return_value=issues) as mock_search:
+        result = adhoc_migrate.find_standing_epics("org")
+    assert result == [IssueRef("org", "tooling", 100), IssueRef("org", ".github", 5)]
+    args = mock_search.call_args.args
+    assert "search" in args and "standing" in args and "epic" in args
+
+
+def test_find_standing_epics_non_list_is_empty() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value={"x": 1}):
+        assert adhoc_migrate.find_standing_epics("org") == []
+
+
+def test_plan_pairs_standing_with_open_children_only() -> None:
+    children = [
+        ChildState(IssueRef("org", "tooling", 101), "OPEN"),
+        ChildState(IssueRef("org", "tooling", 102), "CLOSED"),  # excluded
+    ]
+    with (
+        patch(
+            "vergil_tooling.lib.adhoc_migrate.find_standing_epics",
+            return_value=[_STANDING],
+        ),
+        patch("vergil_tooling.lib.epics.child_states", return_value=children),
+    ):
+        result = adhoc_migrate.plan("org")
+    assert result == [
+        Relocation(standing=_STANDING, open_children=(IssueRef("org", "tooling", 101),))
+    ]
+    assert result[0].target_repo == "org/tooling"
+
+
+def test_apply_one_reparents_open_children_and_closes() -> None:
+    adhoc = IssueRef("org", ".github", 40)
+    child = IssueRef("org", "tooling", 101)
+    reloc = Relocation(standing=_STANDING, open_children=(child,))
+    with (
+        patch("vergil_tooling.lib.epics.ensure_adhoc_epic", return_value=adhoc) as mock_ensure,
+        patch("vergil_tooling.lib.epics.remove_child") as mock_remove,
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        summary = adhoc_migrate.apply_one(reloc)
+    mock_ensure.assert_called_once_with("org/tooling")
+    mock_remove.assert_called_once_with(_STANDING, child)
+    mock_add.assert_called_once_with(adhoc, child)
+    assert mock_run.call_args.args[:5] == ("issue", "close", "100", "--repo", "org/tooling")
+    assert "org/.github#40" in mock_run.call_args.args[-1]
+    assert summary == "org/tooling#100 → org/.github#40 (1 open child(ren) moved)"
+
+
+def test_apply_one_no_children_still_closes() -> None:
+    adhoc = IssueRef("org", ".github", 40)
+    reloc = Relocation(standing=_STANDING, open_children=())
+    with (
+        patch("vergil_tooling.lib.epics.ensure_adhoc_epic", return_value=adhoc),
+        patch("vergil_tooling.lib.epics.remove_child") as mock_remove,
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        summary = adhoc_migrate.apply_one(reloc)
+    mock_remove.assert_not_called()
+    mock_add.assert_not_called()
+    mock_run.assert_called_once()
+    assert "0 open child(ren) moved" in summary
+
+
+def test_render_plan_empty() -> None:
+    out = adhoc_migrate.render_plan([], org="org")
+    assert "dry run" in out
+    assert "nothing to migrate" in out
+
+
+def test_render_plan_lists_relocations_and_children() -> None:
+    reloc = Relocation(
+        standing=IssueRef("org", "tooling", 100),
+        open_children=(IssueRef("org", "tooling", 101),),
+    )
+    out = adhoc_migrate.render_plan([reloc], org="org")
+    assert "Planned relocations" in out
+    assert "org/tooling#100" in out
+    assert "Epic (ad hoc): tooling" in out
+    assert "org/tooling#101" in out
+
+
+def test_render_applied_empty() -> None:
+    assert "nothing migrated" in adhoc_migrate.render_applied([], org="org")
+
+
+def test_render_applied_lists_summaries() -> None:
+    out = adhoc_migrate.render_applied(
+        ["org/tooling#100 → org/.github#40 (1 open child(ren) moved)"], org="org"
+    )
+    assert "Relocated" in out
+    assert "org/tooling#100 → org/.github#40" in out

--- a/tests/vergil_tooling/test_vrg_adhoc_migrate.py
+++ b/tests/vergil_tooling/test_vrg_adhoc_migrate.py
@@ -1,0 +1,62 @@
+"""Tests for vergil_tooling.bin.vrg_adhoc_migrate."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from vergil_tooling.bin.vrg_adhoc_migrate import main
+from vergil_tooling.lib.adhoc_migrate import Relocation
+from vergil_tooling.lib.epics import IssueRef
+
+if TYPE_CHECKING:
+    import pytest
+
+_MOD = "vergil_tooling.bin.vrg_adhoc_migrate"
+
+
+def test_dry_run_prints_plan(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=False),
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.adhoc_migrate.plan", return_value=[]),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "dry run" in out
+    assert "nothing to migrate" in out
+
+
+def test_apply_refused_for_agent(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.identity_mode.is_human", return_value=False):
+        rc = main(["--apply"])
+    assert rc == 1
+    assert "human action" in capsys.readouterr().err
+
+
+def test_apply_as_human_executes(capsys: pytest.CaptureFixture[str]) -> None:
+    reloc = Relocation(standing=IssueRef("org", "tooling", 100), open_children=())
+    apply_one = MagicMock(return_value="org/tooling#100 → org/.github#40 (0 open child(ren) moved)")
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=True),
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.adhoc_migrate.plan", return_value=[reloc]),
+        patch(f"{_MOD}.adhoc_migrate.apply_one", apply_one),
+    ):
+        rc = main(["--apply"])
+    assert rc == 0
+    apply_one.assert_called_once_with(reloc)
+    out = capsys.readouterr().out
+    assert "applied" in out
+    assert "org/tooling#100 → org/.github#40" in out
+
+
+def test_errors_when_org_undetectable(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=False),
+        patch(f"{_MOD}.github.detect_org", return_value=None),
+    ):
+        rc = main([])
+    assert rc == 1
+    assert "could not determine the GitHub org" in capsys.readouterr().err


### PR DESCRIPTION
# Pull Request

## Summary

- One-shot migration tool: finds open epic+standing issues across the org and, for each, ensures its Epic (ad hoc): <repo> in .github, re-links the standing epic's open children under it, and closes the standing epic; dry-run by default, --apply human-gated.

## Issue Linkage

- Closes #2128

## Notes

- Phase 2 of epic vergil-project/.github#85 — the data migration; unblocked now that .github carries the ad-hoc label. Ships the tool; the actual run is a human step: 'vrg-adhoc-migrate' (dry-run) to preview, then 'vrg-adhoc-migrate --apply' as a human to execute. Idempotent (closed standing epics drop out of the search). New lib adhoc_migrate + CLI, 100% branch coverage; full vrg-validate green.