### PR TITLE
fix(freeze-refs): also freeze relative workflow refs

### DIFF
--- a/src/vergil_tooling/lib/freeze_refs.py
+++ b/src/vergil_tooling/lib/freeze_refs.py
@@ -36,9 +36,14 @@ def collect_yaml_files(dirs: list[Path]) -> list[Path]:
 def freeze_references(content: str, owner_repo: str, tag: str) -> str:
     """Apply reference freezing transformations to file content.
 
-    Two transformations, applied only to lines containing ``uses:``:
+    Three transformations, applied only to lines containing ``uses:``:
     1. ``./actions/<path>`` → ``<owner_repo>/actions/<path>@<tag>``
-    2. ``<owner_repo>/<path>@develop`` → ``<owner_repo>/<path>@<tag>``
+    2. ``./.github/workflows/<path>`` → ``<owner_repo>/.github/workflows/<path>@<tag>``
+    3. ``<owner_repo>/<path>@develop`` → ``<owner_repo>/<path>@<tag>``
+
+    Transformation 2 matters for a reusable workflow that nests another reusable
+    workflow: a relative ``./`` ref does not resolve when the workflow is called
+    from another repository, so it must be fully-qualified and pinned.
     """
     escaped_owner = re.escape(owner_repo)
     lines: list[str] = []
@@ -47,6 +52,11 @@ def freeze_references(content: str, owner_repo: str, tag: str) -> str:
             line = re.sub(
                 r"\./actions/(\S+)",
                 rf"{owner_repo}/actions/\1@{tag}",
+                line,
+            )
+            line = re.sub(
+                r"\./\.github/workflows/(\S+)",
+                rf"{owner_repo}/.github/workflows/\1@{tag}",
                 line,
             )
             line = re.sub(
@@ -65,8 +75,10 @@ def validate_no_unfrozen(content: str, filename: str, owner_repo: str) -> list[F
     for i, line in enumerate(content.splitlines(), 1):
         if "uses:" not in line:
             continue
-        if re.search(r"uses:\s+\./actions/", line) or re.search(
-            rf"{escaped_owner}/\S+@develop", line
+        if (
+            re.search(r"uses:\s+\./actions/", line)
+            or re.search(r"uses:\s+\./\.github/workflows/", line)
+            or re.search(rf"{escaped_owner}/\S+@develop", line)
         ):
             findings.append(Finding(file=filename, line=i, text=line.strip()))
     return findings

--- a/tests/vergil_tooling/test_freeze_refs.py
+++ b/tests/vergil_tooling/test_freeze_refs.py
@@ -56,6 +56,13 @@ class TestFreezeReferences:
         result = freeze_references(content, _OWNER, _TAG)
         assert result == f"    uses: {_OWNER}/actions/local/setup/action.yml@{_TAG}"
 
+    def test_freezes_relative_workflow_ref(self) -> None:
+        # A relative nested-reusable-workflow ref must also be fully-qualified so
+        # it resolves when the reusable workflow is called cross-repo.
+        content = "    uses: ./.github/workflows/cd-docs.yml"
+        result = freeze_references(content, _OWNER, _TAG)
+        assert result == f"    uses: {_OWNER}/.github/workflows/cd-docs.yml@{_TAG}"
+
     def test_freezes_develop_ref(self) -> None:
         content = f"    uses: {_OWNER}/.github/workflows/ci.yml@develop"
         result = freeze_references(content, _OWNER, _TAG)
@@ -106,6 +113,12 @@ class TestValidateNoUnfrozen:
         findings = validate_no_unfrozen(content, "ci.yml", _OWNER)
         assert len(findings) == 1
         assert findings[0] == Finding(file="ci.yml", line=1, text="uses: ./actions/setup")
+
+    def test_detects_relative_workflow_ref(self) -> None:
+        content = "    uses: ./.github/workflows/cd-docs.yml"
+        findings = validate_no_unfrozen(content, "cd-docs-refresh.yml", _OWNER)
+        assert len(findings) == 1
+        assert findings[0].line == 1
 
     def test_detects_develop_ref(self) -> None:
         content = f"    uses: {_OWNER}/actions/setup@develop"


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-freeze-refs now rewrites relative nested-workflow refs (./.github/workflows/X -> <owner>/.github/workflows/X@<tag>) and flags unfrozen ones in validation — closing the gap that let the cross-repo cd-docs-refresh bug ship unfrozen.

## Issue Linkage

- Closes #2177

## Notes

- Under the vergil-tooling ad-hoc epic (vergil-project/.github#99); systemic companion to vergil-actions#751. TDD (2 new tests), freeze_refs.py at 100% branch coverage; full vrg-validate green.