### PR TITLE
fix(github-repo-config): strip GitHub-injected dismissal_restriction from ruleset comparison

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -374,7 +374,12 @@ def _fetch_vulnerability_alerts(repo: str) -> bool:
     return "204" in result.stdout.split("\n")[0]
 
 
-_STRIP_RULE_PARAMS = frozenset({"do_not_enforce_on_create"})
+# API-default fields GitHub injects into rule parameters that the desired state
+# never sets. They must be stripped before comparison, else audit reports
+# phantom drift that apply can never resolve (GitHub re-injects the default on
+# every write). ``dismissal_restriction`` was added when GitHub began emitting
+# it as a default on the ``pull_request`` rule (issue #2179).
+_STRIP_RULE_PARAMS = frozenset({"do_not_enforce_on_create", "dismissal_restriction"})
 
 
 def _normalize_rules(rules: Sequence[object]) -> list[dict[str, object]]:

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -1429,6 +1429,28 @@ def test_normalize_rules_strips_default_params() -> None:
     assert params["strict_required_status_checks_policy"] is True
 
 
+def test_normalize_rules_strips_dismissal_restriction() -> None:
+    # GitHub's rulesets API injects ``dismissal_restriction`` as a server-side
+    # default on the ``pull_request`` rule; the desired state never sets it, so
+    # it must be stripped to avoid phantom drift (issue #2179).
+    rules: list[object] = [
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 0,
+                "dismissal_restriction": {"enabled": False, "allowed_actors": []},
+                "allowed_merge_methods": ["merge", "squash", "rebase"],
+            },
+        },
+    ]
+    result = _normalize_rules(rules)
+    assert len(result) == 1
+    params = cast("dict[str, object]", result[0]["parameters"])
+    assert "dismissal_restriction" not in params
+    assert params["required_approving_review_count"] == 0
+    assert params["allowed_merge_methods"] == ["merge", "squash", "rebase"]
+
+
 def test_normalize_rules_skips_non_dict_entries() -> None:
     rules: list[object] = [
         "not-a-dict",


### PR DESCRIPTION
# Pull Request

## Summary

- Add dismissal_restriction to _STRIP_RULE_PARAMS so GitHub's server-injected default on the pull_request rule no longer registers as phantom drift, fixing the unwinnable audit/apply loop that failed the vrg-release audit gate.

## Issue Linkage

- Closes #2179

## Notes

- Root cause: GitHub's rulesets API now returns dismissal_restriction as a default the desired state never sets; _normalize_rules only stripped do_not_enforce_on_create, so the field survived into compute_diff and apply could never clear it. One-token addition to the existing strip-set, exactly parallel to do_not_enforce_on_create. TDD: added test_normalize_rules_strips_dismissal_restriction (red before, green after). Full vrg-validate green.