### PR TITLE
feat(labels): add validation label to the registry

### DIFF
--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -15,7 +15,8 @@
     {"name": "ad-hoc", "color": "5319e7", "description": "Perpetual umbrella for ad-hoc work; never auto-closes"},
     {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
-    {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"}
+    {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"},
+    {"name": "validation", "color": "006b75", "description": "Post-merge validation task: run the checklist, record PASS/FAIL as a comment; never PR-workable, never auto-closed"}
   ],
   "delete": ["enhancement"]
 }

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -71,6 +71,18 @@ def test_registry_includes_convention_labels() -> None:
         assert required in names, f"convention label missing: {required}"
 
 
+def test_registry_includes_validation_label() -> None:
+    # Post-merge validation task type (epic vergil-project/.github#115): a
+    # validation task is never PR-workable and never auto-closed — it closes only
+    # when its checklist runs and a PASS result is recorded as a comment.
+    entry = next(
+        (label for label in load_labels()["labels"] if label["name"] == "validation"),
+        None,
+    )
+    assert entry is not None, "validation label missing from the registry"
+    assert entry["description"], "validation label needs a description"
+
+
 def test_label_change_is_additive_only() -> None:
     # Convention labels are added additively; retiring default cruft is deferred
     # to the per-repo migration pass (epic #40, Task 9). This task must not

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -127,7 +127,7 @@ def test_main_sync_provisions_all_labels() -> None:
     assert result == 0
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
-    assert len(label_calls) == 16  # 10 base + 6 convention labels (incl. ad-hoc, epic #85)
+    assert len(label_calls) == 17  # 16 + validation (epic vergil-project/.github#115)
 
 
 def test_main_sync_uses_force_with_color_description() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a validation label to the canonical registry, marking post-merge validation tasks that are never PR-workable and never auto-closed — the first task of the post-merge validation framework (epic vergil-project/.github#115).

## Issue Linkage

- Closes #2185

## Notes

- Adds one registry entry (color 006b75, distinct from existing labels) plus a presence test; bumps the vrg-ensure-label sync count from 16 to 17. No behavior change beyond label provisioning. Full validation green.