### PR TITLE
feat(pr-guard): refuse PR development against validation tasks

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -52,8 +52,29 @@ def _reject_epic_issue(issue: str) -> None:
         )
 
 
+def _reject_validation_issue(issue: str) -> None:
+    """Refuse a validation-task linkage at report time — it is not PR-workable.
+
+    Mirrors vrg-submit-pr's guard so the error surfaces where the value is
+    entered. Best-effort: if validation-ness cannot be determined (no remote, no
+    gh auth — e.g. an offline run), defer silently to vrg-submit-pr's
+    authoritative check rather than blocking report-ready.
+    """
+    try:
+        is_validation = epics.is_validation_task(issue, default_repo=github.current_repo())
+    except (subprocess.CalledProcessError, OSError):
+        return
+    if is_validation:
+        raise WorkflowError(
+            f"--issue (#{issue}) is a validation task, which is not PR-workable; "
+            "record the result as a comment (issue-validate skill) instead of "
+            "preparing a PR."
+        )
+
+
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
     _reject_epic_issue(str(args.issue))
+    _reject_validation_issue(str(args.issue))
     try:
         linkage, linkage_warning = normalize_linkage(args.linkage)
     except ValueError as exc:

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -245,6 +245,24 @@ def _reject_if_epic_link(issue_ref: str) -> None:
         )
 
 
+def _reject_if_validation_task(issue_ref: str) -> None:
+    """Abort if the linkage is a validation task — it is not PR-workable.
+
+    A validation task is proven by running its checklist and recording PASS/FAIL
+    as a comment; it has no code PR. Refuse PR construction here so the guard
+    matches the skill boundary (issue-implement redirects to issue-validate).
+    Deciding validation-ness needs the same authenticated ``gh`` call as the epic
+    guard. Self-scoping: plain/legacy tasks are never validation tasks, so they
+    pass.
+    """
+    if epics.is_validation_task(issue_ref, default_repo=github.current_repo()):
+        raise SystemExit(
+            "vrg-submit-pr: --issue is a validation task, which is not "
+            "PR-workable; run the validation and record PASS/FAIL as a comment "
+            "(see the issue-validate skill) instead of opening a PR."
+        )
+
+
 def _task_linkage(issue_ref: str, requested: str) -> tuple[str, str | None]:
     """Choose the PR-body linkage keyword for *issue_ref*.
 
@@ -295,6 +313,7 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
 
     issue_ref = resolve_issue_ref(args.issue)
     _reject_if_epic_link(issue_ref)
+    _reject_if_validation_task(issue_ref)
     linkage = _resolve_linkage(issue_ref, args.linkage)
     branch = git.current_branch()
     target = _target_branch(args.base)
@@ -534,6 +553,7 @@ def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: b
     fields = submission.read_pr_fields(worktree_root)
     issue_ref = resolve_issue_ref(fields["issue"])
     _reject_if_epic_link(issue_ref)
+    _reject_if_validation_task(issue_ref)
     branch = git.current_branch()
     target = _target_branch(base_override, fields.get("base"))
     try:

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -323,6 +323,28 @@ def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
     return is_epic(issue)
 
 
+def is_validation(ref: IssueRef) -> bool:
+    """True if *ref* carries the ``validation`` label (a validation task)."""
+    return "validation" in _labels(ref)
+
+
+def is_validation_task(ref: str, *, default_repo: str) -> bool:
+    """True if *ref* is a validation task, so PR tooling must refuse it.
+
+    Single source of truth for "is this a validation task?", shared by
+    ``vrg-submit-pr`` and ``vrg-pr-workflow report-ready``. A validation task is
+    proven by running its checklist and recording PASS/FAIL as a comment — it has
+    no code PR — so the PR path is refused before any work begins. Self-scoping:
+    an unparseable ref (e.g. a legacy issue with no resolvable repo) is never a
+    validation task and returns False.
+    """
+    try:
+        issue = parse_issue_ref(ref, default_repo=default_repo)
+    except ValueError:
+        return False
+    return is_validation(issue)
+
+
 def rollup(task: IssueRef) -> None:
     """Close *task*'s parent epic if the epic is finite and all children closed.
 

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -101,6 +101,35 @@ def test_report_ready_rejects_epic(in_git_repo: Path, capsys: pytest.CaptureFixt
     assert "epic" in capsys.readouterr().err.lower()
 
 
+def test_report_ready_rejects_validation_task(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Guard parity with vrg-submit-pr: report-ready refuses a validation task —
+    # it is not PR-workable (its result is a comment, not a PR).
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_validation_task", return_value=True),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "120",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 1
+    assert "validation task" in capsys.readouterr().err.lower()
+
+
 def test_report_ready_allows_non_epic_task(
     in_git_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -230,6 +230,35 @@ def test_is_epic_linkage_false_for_unparseable_ref() -> None:
     mock.assert_not_called()
 
 
+def test_is_validation_true_when_labeled() -> None:
+    labels = {"labels": [{"name": "validation"}, {"name": "task"}]}
+    with patch("vergil_tooling.lib.github.read_json", return_value=labels):
+        assert epics.is_validation(TASK) is True
+
+
+def test_is_validation_false_without_label() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value={"labels": [{"name": "task"}]}):
+        assert epics.is_validation(TASK) is False
+
+
+def test_is_validation_task_true_for_validation() -> None:
+    with patch("vergil_tooling.lib.epics.is_validation", return_value=True) as mock:
+        assert epics.is_validation_task("org/repo#7", default_repo="org/repo") is True
+    mock.assert_called_once_with(IssueRef("org", "repo", 7))
+
+
+def test_is_validation_task_false_for_plain_task() -> None:
+    with patch("vergil_tooling.lib.epics.is_validation", return_value=False):
+        assert epics.is_validation_task("#42", default_repo="org/repo") is False
+
+
+def test_is_validation_task_false_for_unparseable_ref() -> None:
+    # No resolvable default repo -> parse fails -> never a validation task.
+    with patch("vergil_tooling.lib.epics.is_validation") as mock:
+        assert epics.is_validation_task("#42", default_repo="") is False
+    mock.assert_not_called()
+
+
 def test_rollup_closes_finite_epic_when_all_children_closed() -> None:
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -12,6 +12,7 @@ import pytest
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
     _reject_if_epic_link,
+    _reject_if_validation_task,
     _resolve_linkage,
     _run_submit_batch,
     _select_batch_worktrees,
@@ -41,6 +42,7 @@ def _no_epic_link_check() -> Iterator[None]:
     """
     with (
         patch(_MOD + "._reject_if_epic_link"),
+        patch(_MOD + "._reject_if_validation_task"),
         patch(_MOD + "._task_linkage", side_effect=lambda _ref, requested: (requested, None)),
     ):
         yield
@@ -1671,6 +1673,27 @@ def test_reject_if_epic_link_passes_for_task() -> None:
     ):
         _reject_if_epic_link("#42")
     mock_is_epic.assert_called_once_with(epics.IssueRef("org", "repo", 42))
+
+
+# -- _reject_if_validation_task (validation tasks are not PR-workable) --------
+
+
+def test_reject_if_validation_task_raises_for_validation() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.is_validation", return_value=True),
+        pytest.raises(SystemExit, match="validation task"),
+    ):
+        _reject_if_validation_task("org/repo#7")
+
+
+def test_reject_if_validation_task_passes_for_plain_task() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.is_validation", return_value=False) as mock_is_validation,
+    ):
+        _reject_if_validation_task("#42")
+    mock_is_validation.assert_called_once_with(epics.IssueRef("org", "repo", 42))
 
 
 # -- _task_linkage (managed tasks auto-close via Closes) ----------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Refuse a validation-labeled task in vrg-submit-pr and vrg-pr-workflow report-ready via a new epics.is_validation_task predicate (mirroring is_epic_linkage), so a validation task can never be given a code PR — the direct fix for the preemptive-close failure and the guard the rest of epic #115 relies on.

## Issue Linkage

- Closes #2186

## Notes

- Adds is_validation/is_validation_task to lib/epics.py and _reject_if_validation_task / _reject_validation_issue guards at both PR entry points; the report-ready guard defers silently when gh is unavailable, mirroring the epic guard. Full validation green (4014+ tests).