### PR TITLE
feat(epics): add Blocked-by dependency reflink plumbing

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -47,6 +47,11 @@ _PARENT_RE = re.compile(
     re.MULTILINE,
 )
 
+_BLOCKED_BY_RE = re.compile(
+    r"^\s*Blocked-by:\s*([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)#(\d+)\s*$",
+    re.MULTILINE,
+)
+
 _REF_RE = re.compile(r"^(?:([A-Za-z0-9._-]+/[A-Za-z0-9._-]+))?#([0-9]+)$")
 
 
@@ -176,6 +181,41 @@ def child_states(epic: IssueRef) -> list[ChildState]:
     """All child tasks of *epic*: native sub-issues preferred, reflink fallback."""
     native = _native_child_states(epic)
     return native if native else _reflink_child_states(epic)
+
+
+def render_blocked_by(deps: list[IssueRef]) -> str:
+    """Render the ``Blocked-by:`` reflink lines for a validation task body.
+
+    One ``Blocked-by: owner/repo#N`` line per dependency — the portable mirror of
+    the ``Parent:`` sub-issue reflink. Empty *deps* yields the empty string.
+    """
+    return "".join(f"Blocked-by: {dep.slug}\n" for dep in deps)
+
+
+def blockers_of(task: IssueRef) -> list[IssueRef]:
+    """Deps *task* is blocked by, parsed from its ``Blocked-by:`` body reflinks.
+
+    Storage is the portable body reflink — the mirror of the ``Parent:``
+    sub-issue fallback — chosen by the storage spike (#2184) because GitHub's
+    native issue dependencies are REST-only and out of the sanctioned tooling's
+    reach. If native dependencies become reachable later, this is the one place
+    that would prefer them over the reflink.
+    """
+    body = github.read_output("api", _issue_endpoint(task), "--jq", ".body") or ""
+    return [
+        IssueRef(owner=match.group(1), repo=match.group(2), number=int(match.group(3)))
+        for match in _BLOCKED_BY_RE.finditer(body)
+    ]
+
+
+def all_blockers_closed(task: IssueRef) -> bool:
+    """True iff every blocker of *task* is CLOSED.
+
+    No blockers means nothing holds *task*, so it is runnable — the empty case is
+    vacuously True. Used by the validation-aware rollup to classify an open
+    validation task as runnable (blockers closed) vs blocked.
+    """
+    return all(_issue_state(dep) == "CLOSED" for dep in blockers_of(task))
 
 
 def parent_of(task: IssueRef) -> IssueRef | None:

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -259,6 +259,53 @@ def test_is_validation_task_false_for_unparseable_ref() -> None:
     mock.assert_not_called()
 
 
+def test_render_blocked_by_emits_one_line_per_dep() -> None:
+    out = epics.render_blocked_by([IssueRef("o", "r", 5), IssueRef("o", "r", 8)])
+    assert "Blocked-by: o/r#5" in out
+    assert "Blocked-by: o/r#8" in out
+
+
+def test_render_blocked_by_empty_is_empty_string() -> None:
+    assert epics.render_blocked_by([]) == ""
+
+
+def test_blockers_of_parses_reflink_body() -> None:
+    body = "Do the thing.\nBlocked-by: o/r#5\nBlocked-by: o/r#8\n"
+    with patch("vergil_tooling.lib.github.read_output", return_value=body):
+        refs = epics.blockers_of(IssueRef("o", "r", 42))
+    assert refs == [IssueRef("o", "r", 5), IssueRef("o", "r", 8)]
+
+
+def test_blockers_of_empty_when_no_reflinks() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value="no dependencies here"):
+        assert epics.blockers_of(IssueRef("o", "r", 42)) == []
+
+
+def test_all_blockers_closed_true_when_all_closed() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.blockers_of", return_value=[IssueRef("o", "r", 5)]),
+        patch("vergil_tooling.lib.epics._issue_state", return_value="CLOSED"),
+    ):
+        assert epics.all_blockers_closed(IssueRef("o", "r", 42)) is True
+
+
+def test_all_blockers_closed_false_when_any_open() -> None:
+    with (
+        patch(
+            "vergil_tooling.lib.epics.blockers_of",
+            return_value=[IssueRef("o", "r", 5), IssueRef("o", "r", 8)],
+        ),
+        patch("vergil_tooling.lib.epics._issue_state", side_effect=["CLOSED", "OPEN"]),
+    ):
+        assert epics.all_blockers_closed(IssueRef("o", "r", 42)) is False
+
+
+def test_all_blockers_closed_true_when_no_blockers() -> None:
+    # No blockers -> nothing holds it -> runnable (vacuously all-closed).
+    with patch("vergil_tooling.lib.epics.blockers_of", return_value=[]):
+        assert epics.all_blockers_closed(IssueRef("o", "r", 42)) is True
+
+
 def test_rollup_closes_finite_epic_when_all_children_closed() -> None:
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),


### PR DESCRIPTION
# Pull Request

## Summary

- Add render_blocked_by / blockers_of / all_blockers_closed to lib/epics.py so a validation task's dependencies are stored and read as portable Blocked-by: body reflinks (the storage the spike chose), providing the runnable-vs-blocked signal the validation-aware rollup needs.

## Issue Linkage

- Closes #2187

## Notes

- Reflink mirrors the existing Parent: sub-issue fallback; native GitHub dependencies were dropped as an unused stub (YAGNI) but noted as a future in blockers_of's docstring. Unblocks Tasks 5 (issue-create) and 6 (rollup/audit). Full validation green.