### PR TITLE
feat(issue-create): add --kind validation path

### DIFF
--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from importlib import resources
 
 from vergil_tooling.lib import epics, github
 
@@ -30,11 +31,43 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--label", action="append", default=[], help="Label (repeatable)")
     parser.add_argument("--assignee", action="append", default=[], help="Assignee (repeatable)")
     parser.add_argument("--repo", help="Target repo owner/name (defaults to the current repo)")
+    parser.add_argument(
+        "--kind",
+        choices=("task", "validation"),
+        default="task",
+        help="Issue kind; 'validation' stamps the validation label and executable scaffold",
+    )
+    parser.add_argument(
+        "--blocked-by",
+        action="append",
+        default=[],
+        metavar="REF",
+        help="Dependency ref this validation task is blocked by (repeatable; validation only)",
+    )
     return parser.parse_args(argv)
 
 
 def _issue_number_from_url(url: str) -> int:
     return int(url.rstrip("/").rsplit("/", 1)[-1])
+
+
+def _render_validation_body(*, intro: str, deps: list[epics.IssueRef]) -> str:
+    """Build a validation-task body from the scaffold template.
+
+    The scaffold carries the generic precondition self-check, commands,
+    acceptance criteria, and PASS/FAIL results template. *deps* are rendered as
+    machine-parseable ``Blocked-by:`` reflinks under a Dependencies heading (or
+    omitted entirely when there are none).
+    """
+    template = (
+        resources.files("vergil_tooling.data")
+        .joinpath("validation_task_body.md")
+        .read_text(encoding="utf-8")
+    )
+    blocked_by = ""
+    if deps:
+        blocked_by = "## Dependencies (merge-first)\n\n" + epics.render_blocked_by(deps) + "\n"
+    return template.format(intro=intro or "Post-merge validation task.", blocked_by=blocked_by)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -59,6 +92,29 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
+    # Build the issue body/labels. A validation task stamps the executable
+    # scaffold + the ``validation`` label and renders its Blocked-by reflinks;
+    # a plain task passes the caller's body/labels through unchanged.
+    labels = list(args.label)
+    body = args.body
+    body_file = args.body_file
+    if args.kind == "validation":
+        if args.body_file:
+            print(
+                "vrg-issue-create: --body-file is not compatible with --kind validation "
+                "(the validation scaffold defines the body)",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            deps = [epics.parse_issue_ref(ref, default_repo=repo) for ref in args.blocked_by]
+        except ValueError as exc:
+            print(f"vrg-issue-create: invalid --blocked-by ref: {exc}", file=sys.stderr)
+            return 1
+        labels.append("validation")
+        body = _render_validation_body(intro=args.body, deps=deps)
+        body_file = None
+
     # Scope every App-token call below to the issue's owner, not the cwd org.
     try:
         with github.target_org(owner):
@@ -71,9 +127,9 @@ def main(argv: list[str] | None = None) -> int:
             url = github.create_issue(
                 repo=repo,
                 title=args.title,
-                body=args.body,
-                body_file=args.body_file,
-                labels=args.label,
+                body=body,
+                body_file=body_file,
+                labels=labels,
                 assignees=args.assignee,
             )
             task = epics.IssueRef(owner=owner, repo=name, number=_issue_number_from_url(url))

--- a/src/vergil_tooling/data/validation_task_body.md
+++ b/src/vergil_tooling/data/validation_task_body.md
@@ -1,0 +1,35 @@
+{intro}
+
+This is a **validation task**: run the checklist below and record PASS/FAIL as a
+comment. It is not PR-workable — it has no code PR and never auto-closes. Close
+it only on PASS; on FAIL, record the evidence, file follow-on fix task(s), and
+leave this task (and its epic) open.
+
+## Preconditions (self-check — run first, do not fabricate)
+
+Declare this task's preconditions here and check them before anything else. They
+are author-defined and generic — a machine-checkable probe (a health/status
+command, or a check that the dependency change is actually deployed) *or* a
+human-attested statement (e.g. "the target has been rebuilt to include the
+dependency below"). The framework prescribes no mechanism.
+
+- \<precondition — probe or human-attested\>
+
+If any precondition is unmet: comment "blocked: preconditions not met —
+\<which\>" and stop. Do not run the checklist. Never fabricate a result.
+
+{blocked_by}## Commands to run
+
+- \<concrete validation command(s)\>
+
+## Acceptance criteria
+
+- \<explicit pass/fail condition(s)\>
+
+## Results
+
+Post the outcome as a comment on this issue, then close only on PASS.
+
+- Outcome: PASS / FAIL
+- Evidence: \<command output / observations\>
+- On FAIL: file follow-on fix task(s); leave this task and the epic open.

--- a/tests/vergil_tooling/test_vrg_issue_create.py
+++ b/tests/vergil_tooling/test_vrg_issue_create.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_issue_create import main, parse_args
 from vergil_tooling.lib import epics, github
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _MOD = "vergil_tooling.bin.vrg_issue_create"
 
@@ -38,6 +42,96 @@ def test_main_creates_issue_and_links_under_epic() -> None:
     assert mock_create.call_args.kwargs["title"] == "T"
     assert mock_create.call_args.kwargs["labels"] == ["bug"]
     mock_add.assert_called_once_with(EPIC, epics.IssueRef("org", "repo", 123))
+
+
+def test_kind_validation_applies_label_and_scaffold() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--kind",
+                "validation",
+                "--title",
+                "Validate the thing",
+                "--blocked-by",
+                "org/repo#5",
+            ]
+        )
+    assert rc == 0
+    kwargs = mock_create.call_args.kwargs
+    assert "validation" in kwargs["labels"]
+    body = kwargs["body"]
+    assert "Blocked-by: org/repo#5" in body  # machine-parseable reflink present
+    assert "## Preconditions" in body
+    assert "## Results" in body
+    assert kwargs["body_file"] is None
+
+
+def test_kind_validation_without_blockers_has_no_dependency_reflink() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--epic", "adhoc", "--kind", "validation", "--title", "V"])
+    assert rc == 0
+    body = mock_create.call_args.kwargs["body"]
+    assert "Blocked-by:" not in body
+    assert "## Preconditions" in body
+
+
+def test_kind_validation_rejects_body_file(tmp_path: Path) -> None:
+    body_file = tmp_path / "b.md"
+    body_file.write_text("x")
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--kind",
+                "validation",
+                "--title",
+                "V",
+                "--body-file",
+                str(body_file),
+            ]
+        )
+    assert rc == 1
+    mock_create.assert_not_called()
+
+
+def test_kind_validation_rejects_invalid_blocked_by() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(
+            ["--epic", "adhoc", "--kind", "validation", "--title", "V", "--blocked-by", "not-a-ref"]
+        )
+    assert rc == 1
+    mock_create.assert_not_called()
+
+
+def test_kind_defaults_to_task_without_validation_label() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--epic", "adhoc", "--title", "T", "--label", "bug"])
+    assert rc == 0
+    assert mock_create.call_args.kwargs["labels"] == ["bug"]  # no validation label added
 
 
 def test_main_adhoc_sentinel_skips_cross_org_guard() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a --kind validation path to vrg-issue-create that stamps the validation label, an executable scaffold body (generic precondition self-check, commands, acceptance, PASS/FAIL results), and --blocked-by dependencies rendered as Blocked-by: reflinks — the single sanctioned way to create a post-merge validation task.

## Issue Linkage

- Closes #2188

## Notes

- New data/validation_task_body.md scaffold; rejects --body-file (scaffold owns the body) and invalid --blocked-by refs. Plain --kind task is unchanged. Unblocks the dogfood (#120) and pairs with the rollup (#2189). Full validation green.