### PR TITLE
feat(epic-audit): make rollup/audit validation-aware

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -105,6 +105,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     epics_outside = epic_audit.epic_outside_dotgithub(org)
     stray = epic_audit.stray_dotgithub_issue(org)
+    pending_validation = epic_audit.validation_pending(org)
+    closed_validation_no_pass = epic_audit.closed_validation_without_pass(org)
     print(
         epic_audit.render(
             tasks,
@@ -113,6 +115,8 @@ def main(argv: list[str] | None = None) -> int:
             window_days=args.window_days,
             epics_outside=epics_outside,
             stray=stray,
+            pending_validation=pending_validation,
+            closed_validation_no_pass=closed_validation_no_pass,
         )
     )
     return 0

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -9,6 +9,7 @@ by the caller.
 
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass
 from typing import Any
@@ -96,6 +97,97 @@ def epic_drift() -> list[roadmap.EpicSummary]:
     return [epic for epic in roadmap.gather() if epic.total > 0 and epic.closed == epic.total]
 
 
+@dataclass(frozen=True)
+class ValidationStatus:
+    """An epic's outstanding (open) validation children, split runnable vs blocked."""
+
+    epic: epics.IssueRef
+    runnable: tuple[epics.IssueRef, ...]  # open validation children, all blockers closed
+    blocked: tuple[epics.IssueRef, ...]  # open validation children, a blocker still open
+
+    @property
+    def pending(self) -> tuple[epics.IssueRef, ...]:
+        """All outstanding validation children (runnable + blocked)."""
+        return self.runnable + self.blocked
+
+
+def validation_status(epic: epics.IssueRef) -> ValidationStatus:
+    """Classify *epic*'s open validation children as runnable vs blocked.
+
+    A validation child is runnable when every task it is ``Blocked-by`` is
+    closed; otherwise it is blocked. This runnable-vs-blocked split is the honest
+    "what still has to be validated" signal — and the seed of a future automator
+    that runs validations as their dependencies land.
+    """
+    runnable: list[epics.IssueRef] = []
+    blocked: list[epics.IssueRef] = []
+    for child in epics.child_states(epic):
+        if child.state != "OPEN" or not epics.is_validation(child.ref):
+            continue
+        target = runnable if epics.all_blockers_closed(child.ref) else blocked
+        target.append(child.ref)
+    return ValidationStatus(epic=epic, runnable=tuple(runnable), blocked=tuple(blocked))
+
+
+def validation_pending(org: str) -> list[ValidationStatus]:
+    """Open finite epics with outstanding validation children.
+
+    Reports the "code-complete, validation-pending" state that keeps an epic
+    honestly not-done: its code tasks may all be merged, but until its
+    validations run the epic is not finished. Only epics with at least one open
+    validation child appear.
+    """
+    pending: list[ValidationStatus] = []
+    for summary in roadmap.gather(org):
+        status = validation_status(epics.IssueRef(org, ".github", summary.number))
+        if status.pending:
+            pending.append(status)
+    return pending
+
+
+# A validation task records its result as a comment; a PASS is an ``Outcome: PASS``
+# line (bulleting optional). This is the contract the ``issue-validate`` skill
+# writes and this invariant reads — kept narrow so the scaffold's unresolved
+# "Outcome: PASS / FAIL" template line does not read as a pass.
+_VALIDATION_PASS_RE = re.compile(r"^\s*[-*]?\s*Outcome:\s*PASS\s*$", re.MULTILINE | re.IGNORECASE)
+
+
+def closed_validation_without_pass(org: str) -> list[str]:
+    """Closed validation tasks with no recorded PASS result comment (invariant).
+
+    A validation task must close only after its checklist runs and *passes*,
+    recorded as a comment. A closed ``validation``-labelled issue whose comments
+    carry no ``Outcome: PASS`` line is drift — most likely closed by hand — and
+    is flagged. Report-only: like the other invariants, this is never auto-acted.
+    """
+    raw: Any = github.read_json(
+        "search",
+        "issues",
+        "--owner",
+        org,
+        "--label",
+        "validation",
+        "--state",
+        "closed",
+        "--json",
+        "number,repository",
+    )
+    violations: list[str] = []
+    for item in raw if isinstance(raw, list) else []:
+        name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
+        if "/" not in name_with_owner:
+            continue
+        number = int(item["number"])
+        detail: Any = github.read_json(
+            "issue", "view", str(number), "--repo", name_with_owner, "--json", "comments"
+        )
+        comments = (detail.get("comments") or []) if isinstance(detail, dict) else []
+        bodies = "\n".join(str((c or {}).get("body", "")) for c in comments)
+        if not _VALIDATION_PASS_RE.search(bodies):
+            violations.append(f"{name_with_owner}#{number}")
+    return violations
+
+
 _INTAKE_LABELS = frozenset({"triage", "idea", "research"})
 
 
@@ -172,24 +264,32 @@ def render(
     window_days: int,
     epics_outside: list[str] | None = None,
     stray: list[str] | None = None,
+    pending_validation: list[ValidationStatus] | None = None,
+    closed_validation_no_pass: list[str] | None = None,
 ) -> str:
     """Format the drift + invariant report; a clean state says so explicitly.
 
     The report opens with a banner naming the audited org and window and
     stating the run is read-only, so the output is never mistaken for a list of
     actions the tool took. ``epics_outside`` and ``stray`` are the invariant
-    violations (epic #85); their section appears only when there is something to
-    report.
+    violations (epic #85). ``pending_validation`` lists epics still gated on
+    post-merge validation (runnable vs blocked); ``closed_validation_no_pass`` is
+    the validation invariant (a validation task closed without a PASS comment).
+    Each section appears only when it has something to report.
     """
     epics_outside = epics_outside or []
     stray = stray or []
+    pending_validation = pending_validation or []
+    closed_validation_no_pass = closed_validation_no_pass or []
     banner = (
         f"_Read-only audit of the **{org}** org (merged PRs from the last "
         f"{window_days} days) — this report changes nothing; run `--close` (as "
         "a human) to close what it lists._"
     )
     header = ["# Epic/task drift audit", "", banner, ""]
-    if not tasks and not epic_summaries and not epics_outside and not stray:
+    if not any(
+        [tasks, epic_summaries, epics_outside, stray, pending_validation, closed_validation_no_pass]
+    ):
         return "\n".join([*header, "_No drift — everything that should be closed is closed._", ""])
     lines = [*header, "## Task drift (merged PR, task still open)", ""]
     if tasks:
@@ -207,7 +307,13 @@ def render(
             )
     else:
         lines.append("- _none_")
-    if epics_outside or stray:
+    if pending_validation:
+        lines += ["", "## Validation pending (epic not done until validations run)", ""]
+        for status in sorted(pending_validation, key=lambda s: s.epic.number):
+            runnable = ", ".join(ref.slug for ref in status.runnable) or "none"
+            blocked = ", ".join(ref.slug for ref in status.blocked) or "none"
+            lines.append(f"- {status.epic.slug} — runnable: {runnable}; blocked: {blocked}")
+    if epics_outside or stray or closed_validation_no_pass:
         lines += ["", "## Invariant violations (issues in the wrong place)", ""]
         if epics_outside:
             lines.append("**Epics outside `.github`** — move each to the org's `.github`:")
@@ -215,6 +321,9 @@ def render(
         if stray:
             lines.append("**Stray `.github` issues** — not an epic, intake, or linked task:")
             lines += [f"- {slug}" for slug in sorted(stray)]
+        if closed_validation_no_pass:
+            lines.append("**Validation tasks closed without a PASS comment** — re-open and run:")
+            lines += [f"- {slug}" for slug in sorted(closed_validation_no_pass)]
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -310,3 +310,106 @@ def test_render_closed_lists_what_closed() -> None:
 def test_render_closed_empty_says_nothing_to_close() -> None:
     out = epic_audit.render_closed([], org="vergil-project", window_days=30)
     assert "nothing to close" in out
+
+
+# -- validation-aware rollup/audit (epic vergil-project/.github#115) ----------
+
+
+def test_validation_status_classifies_runnable_vs_blocked() -> None:
+    epic = epics.IssueRef("org", ".github", 115)
+    val_runnable = epics.IssueRef("org", "repo", 7)
+    val_blocked = epics.IssueRef("org", "repo", 8)
+    children = [
+        epics.ChildState(val_runnable, "OPEN"),
+        epics.ChildState(val_blocked, "OPEN"),
+        epics.ChildState(epics.IssueRef("org", "repo", 5), "OPEN"),  # not a validation task
+        epics.ChildState(epics.IssueRef("org", "repo", 9), "CLOSED"),  # closed -> ignored
+    ]
+
+    def is_validation(ref: epics.IssueRef) -> bool:
+        return ref.number in (7, 8, 9)
+
+    def all_blockers_closed(ref: epics.IssueRef) -> bool:
+        return ref.number == 7  # #7 runnable, #8 still blocked
+
+    with (
+        patch("vergil_tooling.lib.epics.child_states", return_value=children),
+        patch("vergil_tooling.lib.epics.is_validation", side_effect=is_validation),
+        patch("vergil_tooling.lib.epics.all_blockers_closed", side_effect=all_blockers_closed),
+    ):
+        status = epic_audit.validation_status(epic)
+    assert status.runnable == (val_runnable,)
+    assert status.blocked == (val_blocked,)
+    assert status.pending == (val_runnable, val_blocked)
+
+
+def test_validation_pending_collects_only_epics_with_open_validations() -> None:
+    val = epics.IssueRef("org", "repo", 7)
+
+    def fake_status(epic: epics.IssueRef) -> epic_audit.ValidationStatus:
+        if epic.number == 115:
+            return epic_audit.ValidationStatus(epic, (val,), ())
+        return epic_audit.ValidationStatus(epic, (), ())  # nothing pending
+
+    with (
+        patch(
+            "vergil_tooling.lib.epic_audit.roadmap.gather",
+            return_value=[MagicMock(number=115), MagicMock(number=200)],
+        ),
+        patch("vergil_tooling.lib.epic_audit.validation_status", side_effect=fake_status),
+    ):
+        pending = epic_audit.validation_pending("org")
+    assert [s.epic.number for s in pending] == [115]
+
+
+def test_closed_validation_without_pass_flags_missing_pass() -> None:
+    search = [
+        {"number": 120, "repository": {"nameWithOwner": "org/.github"}},  # has PASS -> ok
+        {"number": 55, "repository": {"nameWithOwner": "org/repo"}},  # no PASS -> flagged
+        {"number": 77, "repository": {}},  # no repo -> skipped
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return search
+        number = args[2]
+        if number == "120":
+            return {"comments": [{"body": "ran it\n- Outcome: PASS"}]}
+        return {"comments": [{"body": "closed early; no result recorded"}]}
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        result = epic_audit.closed_validation_without_pass("org")
+    assert result == ["org/repo#55"]
+
+
+def test_closed_validation_pass_marker_excludes_unresolved_template() -> None:
+    # The scaffold's unresolved "Outcome: PASS / FAIL" line must NOT read as a pass.
+    search = [{"number": 1, "repository": {"nameWithOwner": "org/repo"}}]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return search
+        return {"comments": [{"body": "- Outcome: PASS / FAIL"}]}
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        assert epic_audit.closed_validation_without_pass("org") == ["org/repo#1"]
+
+
+def test_render_includes_validation_pending_section() -> None:
+    status = epic_audit.ValidationStatus(
+        epics.IssueRef("org", ".github", 115),
+        (epics.IssueRef("org", "repo", 7),),
+        (epics.IssueRef("org", "repo", 8),),
+    )
+    out = epic_audit.render([], [], org="org", window_days=30, pending_validation=[status])
+    assert "Validation pending" in out
+    assert "org/repo#7" in out  # runnable
+    assert "org/repo#8" in out  # blocked
+
+
+def test_render_flags_closed_validation_without_pass() -> None:
+    out = epic_audit.render(
+        [], [], org="org", window_days=30, closed_validation_no_pass=["org/repo#55"]
+    )
+    assert "PASS comment" in out
+    assert "org/repo#55" in out

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -320,6 +320,21 @@ def test_rollup_closes_finite_epic_when_all_children_closed() -> None:
     assert "40" in mock_run.call_args.args
 
 
+def test_rollup_holds_epic_open_while_validation_child_open() -> None:
+    # A validation task is a normal open child; the rollup must not close the epic
+    # while it is open. This locks in the "validation gates epic closure" guarantee
+    # that the whole post-merge-validation framework depends on.
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic"}),
+        patch("vergil_tooling.lib.epics.all_children_closed", return_value=False),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.rollup(TASK)
+    mock_run.assert_not_called()  # epic stays open — a validation child is still open
+
+
 def test_rollup_skips_adhoc_epic() -> None:
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -15,6 +15,8 @@ _MOD = "vergil_tooling.bin.vrg_epic_audit"
 def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
@@ -32,6 +34,8 @@ def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
 def test_main_reports_invariant_violations(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(
@@ -62,6 +66,8 @@ def test_window_days_controls_since() -> None:
     task_drift = MagicMock(return_value=[])
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", task_drift),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
@@ -106,6 +112,8 @@ def test_close_allowed_for_scheduled_sweep(capsys: pytest.CaptureFixture[str]) -
         patch(f"{_MOD}.identity_mode.is_human", return_value=False),
         patch.dict("os.environ", {"VRG_EPIC_SWEEP": "1"}),
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
         patch(f"{_MOD}.epic_audit.close_drift", close_drift),
@@ -121,6 +129,8 @@ def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]
     with (
         patch(f"{_MOD}.identity_mode.is_human", return_value=True),
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
         patch(f"{_MOD}.epic_audit.close_drift", close_drift),


### PR DESCRIPTION
# Pull Request

## Summary

- Add validation-aware reporting to vrg-epic-audit: classify each epic's open validation children runnable-vs-blocked, surface the code-complete/validation-pending state, and flag (report-only) any validation task closed without a recorded PASS comment — plus a regression test that the rollup holds an epic open while a validation child is open.

## Issue Linkage

- Closes #2189

## Notes

- Runnable-vs-blocked is the future automator's worklist; the closed-without-PASS invariant is the #114 belt-and-suspenders (PASS marker is an 'Outcome: PASS' comment line, the contract issue-validate will write). Completes the tooling core of epic #115. Full validation green (4039+ tests).