### PR TITLE
fix(labels): keep label descriptions within GitHub's 100-char limit

### DIFF
--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -16,7 +16,7 @@
     {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
     {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"},
-    {"name": "validation", "color": "006b75", "description": "Post-merge validation task: run the checklist, record PASS/FAIL as a comment; never PR-workable, never auto-closed"}
+    {"name": "validation", "color": "006b75", "description": "Post-merge validation: run the checklist, record PASS/FAIL as a comment; never auto-closed"}
   ],
   "delete": ["enhancement"]
 }

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -83,6 +83,15 @@ def test_registry_includes_validation_label() -> None:
     assert entry["description"], "validation label needs a description"
 
 
+def test_label_descriptions_within_github_limit() -> None:
+    # GitHub caps a label's description at 100 chars; a longer one fails
+    # provisioning with HTTP 422 so vrg-ensure-label --sync cannot deploy it.
+    # (Found by the post-merge-validation dogfood, epic vergil-project/.github#115.)
+    for label in load_labels()["labels"]:
+        length = len(label["description"])
+        assert length <= 100, f"{label['name']} description is {length} chars (max 100)"
+
+
 def test_label_change_is_additive_only() -> None:
     # Convention labels are added additively; retiring default cruft is deferred
     # to the per-repo migration pass (epic #40, Task 9). This task must not


### PR DESCRIPTION
# Pull Request

## Summary

- Shorten the validation label's description from 114 to 90 chars (GitHub caps label descriptions at 100, so it could not be provisioned via vrg-ensure-label) and add a registry test asserting every label description is <=100 chars so the class of bug cannot recur.

## Issue Linkage

- Closes #2203

## Notes

- Found by the post-merge-validation dogfood (#120) — the framework caught its own deployment defect before epic #115 could roll up. After this merges, the label provisions via --sync and #120 is re-set-up as a validation task and re-run. Full validation green.