### PR TITLE
fix(vm): reap stale SSH masters + announce guest commands so cloud sessions can't silently hang (#2211)

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2372,6 +2372,14 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
     _warn_cloud_under(target)
 
     transport = backend.transport()
+    # #2202: a previous session can leave a network-dead SSH ControlMaster behind. A
+    # new session that attaches to it as a multiplex *client* hangs — the client has
+    # no connection of its own, so ConnectTimeout/ServerAlive don't apply. Reap any
+    # stale master up front (bounded, best-effort) so this session opens a fresh,
+    # self-healing connection instead of inheriting the wedge. Announced so a slow
+    # reap is never a silent stall.
+    print("  -> resetting any stale SSH connection to the box", file=sys.stderr, flush=True)
+    transport.close()
     # #1999 (Fix A): seed the operator's ~/.claude config (settings.json carries
     # permissions.defaultMode=bypassPermissions) and relink the volume history dirs
     # before the process-replacing exec_session, mirroring the Lima _cmd_session path.
@@ -2380,6 +2388,7 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
     claude_dir = Path.home() / ".claude"
     copy_claude_config(transport, claude_dir)
     vm_cloud.link_cloud_claude_dirs(transport)
+    print("  -> opening the session", file=sys.stderr, flush=True)
     workspace_abs = os.path.normpath(resolve_workspace(args.workspace, identity.projects_dir))
     rel_path = os.path.relpath(workspace_abs, identity.projects_dir)
     inner = _session_inner(

--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -83,6 +83,10 @@ def _ssh_keepalive_options() -> list[tuple[str, str]]:
 _GUEST_CMD_TIMEOUT_ENV = "VERGIL_VM_CMD_TIMEOUT"
 _GUEST_CMD_TIMEOUT_DEFAULT_SECS = 600.0
 
+# Bound on the best-effort control-master reap so tearing down a wedged master can
+# never itself hang (#2202).
+_REAP_TIMEOUT_SECS = 15.0
+
 
 def _guest_cmd_timeout() -> float | None:
     """Per-command wall-clock bound in seconds, or ``None`` when disabled."""
@@ -111,6 +115,18 @@ def _debug(msg: str) -> None:
     print(f"[vm-transport] {msg}", file=sys.stderr)
 
 
+def _announce(what: str) -> None:
+    """User-facing progress line printed *before* a guest command runs (#2202).
+
+    Always on, unlike :func:`_debug`: a guest command can block on a wedged
+    connection, so it must never run silently — we say what is about to happen and
+    how long we will wait, before the (possibly hanging) subprocess starts.
+    """
+    timeout = _guest_cmd_timeout()
+    bound = f"<={timeout:.0f}s" if timeout is not None else "unbounded"
+    print(f"  -> {what} ({bound})", file=sys.stderr, flush=True)
+
+
 class TransportTimeoutError(RuntimeError):
     """A guest command exceeded its wall-clock bound (#2202).
 
@@ -137,6 +153,7 @@ def _run_checked(
     *,
     quiet: bool,
     input_data: str | None = None,
+    announce: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run *cmd* under the shared off-platform retry/reporting policy.
 
@@ -156,6 +173,8 @@ def _run_checked(
     :class:`TransportTimeoutError` and is *not* retried — a timeout already burned its
     full budget, so another attempt would only burn more.
     """
+    if announce is not None and not quiet:
+        _announce(announce)
     if _debug_enabled():
         _debug(f"run (timeout={_guest_cmd_timeout()}): {shlex.join(cmd)}")
 
@@ -292,12 +311,15 @@ def _shutdown_master(dest: str, control_path: Path) -> None:
     swallowed. The socket file is then removed. ``ControlPersist`` is the final
     backstop for any master this could not reach.
     """
+    # timeout: TimeoutExpired is a SubprocessError, so a wedged master that won't
+    # even service `-O exit` is swallowed here — the reap can never itself hang (#2202).
     with contextlib.suppress(OSError, subprocess.SubprocessError):
         subprocess.run(  # noqa: S603
             ["ssh", "-o", f"ControlPath={control_path}", "-O", "exit", dest],  # noqa: S607
             check=False,
             capture_output=True,
             text=True,
+            timeout=_REAP_TIMEOUT_SECS,
         )
     with contextlib.suppress(OSError):
         control_path.unlink(missing_ok=True)
@@ -446,11 +468,20 @@ class IapTransport:
         self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
     ) -> subprocess.CompletedProcess[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
-        return _run_checked([*self._base(), f"--command={remote}"], quiet=quiet)
+        return _run_checked(
+            [*self._base(), f"--command={remote}"],
+            quiet=quiet,
+            announce=f"{self.host}: {shlex.join(args)}",
+        )
 
     def pipe(self, cmd: str, input_data: str, *, workdir: str = _DEFAULT_WORKDIR) -> None:
         remote = f"cd {shlex.quote(workdir)} && {cmd}"
-        _run_checked([*self._base(), f"--command={remote}"], quiet=False, input_data=input_data)
+        _run_checked(
+            [*self._base(), f"--command={remote}"],
+            quiet=False,
+            input_data=input_data,
+            announce=f"{self.host}: {cmd}",
+        )
 
     def popen(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.Popen[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
@@ -515,11 +546,18 @@ class SshTransport:
         self, *args: str, workdir: str = _DEFAULT_WORKDIR, quiet: bool = False
     ) -> subprocess.CompletedProcess[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"
-        return _run_checked([*self._base(), remote], quiet=quiet)
+        return _run_checked(
+            [*self._base(), remote], quiet=quiet, announce=f"{self.host}: {shlex.join(args)}"
+        )
 
     def pipe(self, cmd: str, input_data: str, *, workdir: str = _DEFAULT_WORKDIR) -> None:
         remote = f"cd {shlex.quote(workdir)} && {cmd}"
-        _run_checked([*self._base(), remote], quiet=False, input_data=input_data)
+        _run_checked(
+            [*self._base(), remote],
+            quiet=False,
+            input_data=input_data,
+            announce=f"{self.host}: {cmd}",
+        )
 
     def popen(self, *args: str, workdir: str = _DEFAULT_WORKDIR) -> subprocess.Popen[str]:
         remote = f"cd {shlex.quote(workdir)} && {shlex.join(args)}"

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -736,3 +736,58 @@ class TestDebugTracing:
         mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         IapTransport("inst", "z", "p", "vergil").run("true")
         assert "[vm-transport]" not in capsys.readouterr().err
+
+
+class TestAnnounce:
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_run_announces_by_default(
+        self, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #2202: a guest command must never run silently — announce it (host + what +
+        # the bound) BEFORE the potentially-hanging subprocess, with no opt-in flag.
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        IapTransport("inst", "z", "p", "vergil").run("systemctl", "is-active", "tlshd")
+        err = capsys.readouterr().err
+        assert "inst: systemctl is-active tlshd" in err
+        assert "<=600s" in err  # the default bound is shown
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_pipe_announces_by_default(
+        self, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        IapTransport("inst", "z", "p", "vergil").pipe("cat > f", "data")
+        assert "inst: cat > f" in capsys.readouterr().err
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_quiet_suppresses_announce(
+        self, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Probe callers (readiness gate) run quiet and own their cadence — no chatter.
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        IapTransport("inst", "z", "p", "vergil").run("true", quiet=True)
+        assert capsys.readouterr().err == ""
+
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_announce_shows_unbounded_when_timeout_disabled(
+        self,
+        mock_run: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv(vm_transport._GUEST_CMD_TIMEOUT_ENV, "0")
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        IapTransport("inst", "z", "p", "vergil").run("true")
+        assert "unbounded" in capsys.readouterr().err
+
+
+class TestReapIsBounded:
+    @patch("vergil_tooling.lib.vm_transport.subprocess.run")
+    def test_close_bounds_the_reap(self, mock_run: MagicMock) -> None:
+        # #2202: reaping a wedged master must never itself hang.
+        transport = IapTransport("inst", "z", "p", "vergil")
+        socket = control_socket_path("inst", str(Path.cwd()))
+        socket.parent.mkdir(parents=True, exist_ok=True)
+        socket.write_text("")
+        transport.close()
+        assert mock_run.call_args[1]["timeout"] == vm_transport._REAP_TIMEOUT_SECS


### PR DESCRIPTION
# Pull Request

## Summary

- Reap any stale/wedged SSH ControlMaster at cloud-session start (bounded) so the session opens a fresh self-healing connection instead of hanging as a mux client on a network-dead master, and announce every guest command on stderr before it runs so a hang is never silent.

## Issue Linkage

- Closes #2211

## Notes

- Follow-up to #2202, whose ConnectTimeout/ServerAlive are INERT for the real failure (a mux client reusing a network-dead master ignores them) — so it still hung to the 600s wall-clock, silently. Two changes: (1) always-on announce of each guest command before it runs + phase lines in _cloud_session; (2) reap any stale master at session start (bounded ssh -O exit + unlink, 15s cap) -> fresh, self-healing connection. LIVE-VALIDATED on a real GCP/IAP box (the miss last round): announce prints before the command; fresh connect works; close() reaps a live master in 0.01s; ssh -O check proved a network-dead master answers control-socket commands instantly, so the reap can't hang. vrg-validate green, 70 tests, coverage maintained. A real wedged-master reproduction on the mq-resiliency cloud box is kept LIVE (not cleared) to validate the deployed build end-to-end after merge. Branch feature/2211-chatty-reap; worktree dir still named issue-2202-* (cosmetic).