### PR TITLE
refactor(pr-guard): generalize the PR-workability guard to operational tasks

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -52,29 +52,29 @@ def _reject_epic_issue(issue: str) -> None:
         )
 
 
-def _reject_validation_issue(issue: str) -> None:
-    """Refuse a validation-task linkage at report time — it is not PR-workable.
+def _reject_operational_issue(issue: str) -> None:
+    """Refuse an operational-task linkage at report time — it is not PR-workable.
 
     Mirrors vrg-submit-pr's guard so the error surfaces where the value is
-    entered. Best-effort: if validation-ness cannot be determined (no remote, no
+    entered. Best-effort: if operational-ness cannot be determined (no remote, no
     gh auth — e.g. an offline run), defer silently to vrg-submit-pr's
     authoritative check rather than blocking report-ready.
     """
     try:
-        is_validation = epics.is_validation_task(issue, default_repo=github.current_repo())
+        is_operational = epics.is_operational_task(issue, default_repo=github.current_repo())
     except (subprocess.CalledProcessError, OSError):
         return
-    if is_validation:
+    if is_operational:
         raise WorkflowError(
-            f"--issue (#{issue}) is a validation task, which is not PR-workable; "
-            "record the result as a comment (issue-validate skill) instead of "
-            "preparing a PR."
+            f"--issue (#{issue}) is an operational task (validation/deployment), which "
+            "is not PR-workable; record the Outcome as a comment (issue-validate / "
+            "issue-deploy) instead of preparing a PR."
         )
 
 
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
     _reject_epic_issue(str(args.issue))
-    _reject_validation_issue(str(args.issue))
+    _reject_operational_issue(str(args.issue))
     try:
         linkage, linkage_warning = normalize_linkage(args.linkage)
     except ValueError as exc:

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -245,21 +245,21 @@ def _reject_if_epic_link(issue_ref: str) -> None:
         )
 
 
-def _reject_if_validation_task(issue_ref: str) -> None:
-    """Abort if the linkage is a validation task — it is not PR-workable.
+def _reject_if_operational_task(issue_ref: str) -> None:
+    """Abort if the linkage is an operational task — it is not PR-workable.
 
-    A validation task is proven by running its checklist and recording PASS/FAIL
-    as a comment; it has no code PR. Refuse PR construction here so the guard
-    matches the skill boundary (issue-implement redirects to issue-validate).
-    Deciding validation-ness needs the same authenticated ``gh`` call as the epic
-    guard. Self-scoping: plain/legacy tasks are never validation tasks, so they
-    pass.
+    An operational task (validation, deployment, …) is proven by *running* it and
+    recording an ``Outcome:`` comment; it has no code PR. Refuse PR construction
+    here so the guard matches the skill boundary (issue-implement redirects to the
+    task's run skill). Deciding operational-ness needs the same authenticated
+    ``gh`` call as the epic guard. Self-scoping: plain/legacy tasks are never
+    operational, so they pass.
     """
-    if epics.is_validation_task(issue_ref, default_repo=github.current_repo()):
+    if epics.is_operational_task(issue_ref, default_repo=github.current_repo()):
         raise SystemExit(
-            "vrg-submit-pr: --issue is a validation task, which is not "
-            "PR-workable; run the validation and record PASS/FAIL as a comment "
-            "(see the issue-validate skill) instead of opening a PR."
+            "vrg-submit-pr: --issue is an operational task (validation/deployment), "
+            "which is not PR-workable; run it with its run skill (issue-validate / "
+            "issue-deploy) and record the Outcome as a comment instead of opening a PR."
         )
 
 
@@ -313,7 +313,7 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
 
     issue_ref = resolve_issue_ref(args.issue)
     _reject_if_epic_link(issue_ref)
-    _reject_if_validation_task(issue_ref)
+    _reject_if_operational_task(issue_ref)
     linkage = _resolve_linkage(issue_ref, args.linkage)
     branch = git.current_branch()
     target = _target_branch(args.base)
@@ -553,7 +553,7 @@ def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: b
     fields = submission.read_pr_fields(worktree_root)
     issue_ref = resolve_issue_ref(fields["issue"])
     _reject_if_epic_link(issue_ref)
-    _reject_if_validation_task(issue_ref)
+    _reject_if_operational_task(issue_ref)
     branch = git.current_branch()
     target = _target_branch(base_override, fields.get("base"))
     try:

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -122,7 +122,7 @@ def validation_status(epic: epics.IssueRef) -> ValidationStatus:
     runnable: list[epics.IssueRef] = []
     blocked: list[epics.IssueRef] = []
     for child in epics.child_states(epic):
-        if child.state != "OPEN" or not epics.is_validation(child.ref):
+        if child.state != "OPEN" or not epics.is_operational(child.ref):
             continue
         target = runnable if epics.all_blockers_closed(child.ref) else blocked
         target.append(child.ref)

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -363,26 +363,38 @@ def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
     return is_epic(issue)
 
 
-def is_validation(ref: IssueRef) -> bool:
-    """True if *ref* carries the ``validation`` label (a validation task)."""
-    return "validation" in _labels(ref)
+# Labels marking a not-PR-workable *operational task* — one that is run and whose
+# acceptance is a recorded ``Outcome:`` comment, not a merged PR. Extended as new
+# operational kinds are added (e.g. ``deployment``).
+_OPERATIONAL_LABELS: set[str] = {"validation"}
 
 
-def is_validation_task(ref: str, *, default_repo: str) -> bool:
-    """True if *ref* is a validation task, so PR tooling must refuse it.
+def is_operational(ref: IssueRef) -> bool:
+    """True if *ref* carries any operational label (validation, deployment, …)."""
+    return bool(_labels(ref) & _OPERATIONAL_LABELS)
 
-    Single source of truth for "is this a validation task?", shared by
-    ``vrg-submit-pr`` and ``vrg-pr-workflow report-ready``. A validation task is
-    proven by running its checklist and recording PASS/FAIL as a comment — it has
-    no code PR — so the PR path is refused before any work begins. Self-scoping:
-    an unparseable ref (e.g. a legacy issue with no resolvable repo) is never a
-    validation task and returns False.
+
+def operational_kind(ref: IssueRef) -> str | None:
+    """The operational label on *ref* (``"validation"`` / ``"deployment"``), or None."""
+    kinds = _labels(ref) & _OPERATIONAL_LABELS
+    return next(iter(kinds)) if kinds else None
+
+
+def is_operational_task(ref: str, *, default_repo: str) -> bool:
+    """True if *ref* is an operational task, so PR tooling must refuse it.
+
+    Single source of truth for "is this an operational task?", shared by
+    ``vrg-submit-pr`` and ``vrg-pr-workflow report-ready``. An operational task
+    (validation, deployment, …) is proven by *running* it and recording an
+    ``Outcome:`` comment — it has no code PR — so the PR path is refused before
+    any work begins. Self-scoping: an unparseable ref (e.g. a legacy issue with
+    no resolvable repo) is never operational and returns False.
     """
     try:
         issue = parse_issue_ref(ref, default_repo=default_repo)
     except ValueError:
         return False
-    return is_validation(issue)
+    return is_operational(issue)
 
 
 def rollup(task: IssueRef) -> None:

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -101,15 +101,15 @@ def test_report_ready_rejects_epic(in_git_repo: Path, capsys: pytest.CaptureFixt
     assert "epic" in capsys.readouterr().err.lower()
 
 
-def test_report_ready_rejects_validation_task(
+def test_report_ready_rejects_operational_task(
     in_git_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # Guard parity with vrg-submit-pr: report-ready refuses a validation task —
+    # Guard parity with vrg-submit-pr: report-ready refuses an operational task —
     # it is not PR-workable (its result is a comment, not a PR).
     with (
         patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
         patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
-        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_validation_task", return_value=True),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_operational_task", return_value=True),
     ):
         rc = vrg_pr_workflow.main(
             [
@@ -127,7 +127,7 @@ def test_report_ready_rejects_validation_task(
             ]
         )
     assert rc == 1
-    assert "validation task" in capsys.readouterr().err.lower()
+    assert "operational task" in capsys.readouterr().err.lower()
 
 
 def test_report_ready_allows_non_epic_task(

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -322,11 +322,11 @@ def test_validation_status_classifies_runnable_vs_blocked() -> None:
     children = [
         epics.ChildState(val_runnable, "OPEN"),
         epics.ChildState(val_blocked, "OPEN"),
-        epics.ChildState(epics.IssueRef("org", "repo", 5), "OPEN"),  # not a validation task
+        epics.ChildState(epics.IssueRef("org", "repo", 5), "OPEN"),  # not an operational task
         epics.ChildState(epics.IssueRef("org", "repo", 9), "CLOSED"),  # closed -> ignored
     ]
 
-    def is_validation(ref: epics.IssueRef) -> bool:
+    def is_operational(ref: epics.IssueRef) -> bool:
         return ref.number in (7, 8, 9)
 
     def all_blockers_closed(ref: epics.IssueRef) -> bool:
@@ -334,7 +334,7 @@ def test_validation_status_classifies_runnable_vs_blocked() -> None:
 
     with (
         patch("vergil_tooling.lib.epics.child_states", return_value=children),
-        patch("vergil_tooling.lib.epics.is_validation", side_effect=is_validation),
+        patch("vergil_tooling.lib.epics.is_operational", side_effect=is_operational),
         patch("vergil_tooling.lib.epics.all_blockers_closed", side_effect=all_blockers_closed),
     ):
         status = epic_audit.validation_status(epic)

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -230,32 +230,43 @@ def test_is_epic_linkage_false_for_unparseable_ref() -> None:
     mock.assert_not_called()
 
 
-def test_is_validation_true_when_labeled() -> None:
+def test_is_operational_true_when_labeled() -> None:
     labels = {"labels": [{"name": "validation"}, {"name": "task"}]}
     with patch("vergil_tooling.lib.github.read_json", return_value=labels):
-        assert epics.is_validation(TASK) is True
+        assert epics.is_operational(TASK) is True
 
 
-def test_is_validation_false_without_label() -> None:
+def test_is_operational_false_without_label() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"labels": [{"name": "task"}]}):
-        assert epics.is_validation(TASK) is False
+        assert epics.is_operational(TASK) is False
 
 
-def test_is_validation_task_true_for_validation() -> None:
-    with patch("vergil_tooling.lib.epics.is_validation", return_value=True) as mock:
-        assert epics.is_validation_task("org/repo#7", default_repo="org/repo") is True
+def test_operational_kind_returns_the_label() -> None:
+    labels = {"labels": [{"name": "validation"}, {"name": "task"}]}
+    with patch("vergil_tooling.lib.github.read_json", return_value=labels):
+        assert epics.operational_kind(TASK) == "validation"
+
+
+def test_operational_kind_none_without_label() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value={"labels": [{"name": "task"}]}):
+        assert epics.operational_kind(TASK) is None
+
+
+def test_is_operational_task_true_for_operational() -> None:
+    with patch("vergil_tooling.lib.epics.is_operational", return_value=True) as mock:
+        assert epics.is_operational_task("org/repo#7", default_repo="org/repo") is True
     mock.assert_called_once_with(IssueRef("org", "repo", 7))
 
 
-def test_is_validation_task_false_for_plain_task() -> None:
-    with patch("vergil_tooling.lib.epics.is_validation", return_value=False):
-        assert epics.is_validation_task("#42", default_repo="org/repo") is False
+def test_is_operational_task_false_for_plain_task() -> None:
+    with patch("vergil_tooling.lib.epics.is_operational", return_value=False):
+        assert epics.is_operational_task("#42", default_repo="org/repo") is False
 
 
-def test_is_validation_task_false_for_unparseable_ref() -> None:
-    # No resolvable default repo -> parse fails -> never a validation task.
-    with patch("vergil_tooling.lib.epics.is_validation") as mock:
-        assert epics.is_validation_task("#42", default_repo="") is False
+def test_is_operational_task_false_for_unparseable_ref() -> None:
+    # No resolvable default repo -> parse fails -> never an operational task.
+    with patch("vergil_tooling.lib.epics.is_operational") as mock:
+        assert epics.is_operational_task("#42", default_repo="") is False
     mock.assert_not_called()
 
 

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -12,7 +12,7 @@ import pytest
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
     _reject_if_epic_link,
-    _reject_if_validation_task,
+    _reject_if_operational_task,
     _resolve_linkage,
     _run_submit_batch,
     _select_batch_worktrees,
@@ -42,7 +42,7 @@ def _no_epic_link_check() -> Iterator[None]:
     """
     with (
         patch(_MOD + "._reject_if_epic_link"),
-        patch(_MOD + "._reject_if_validation_task"),
+        patch(_MOD + "._reject_if_operational_task"),
         patch(_MOD + "._task_linkage", side_effect=lambda _ref, requested: (requested, None)),
     ):
         yield
@@ -1675,25 +1675,25 @@ def test_reject_if_epic_link_passes_for_task() -> None:
     mock_is_epic.assert_called_once_with(epics.IssueRef("org", "repo", 42))
 
 
-# -- _reject_if_validation_task (validation tasks are not PR-workable) --------
+# -- _reject_if_operational_task (operational tasks are not PR-workable) -------
 
 
-def test_reject_if_validation_task_raises_for_validation() -> None:
+def test_reject_if_operational_task_raises_for_operational() -> None:
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
-        patch(f"{_MOD}.epics.is_validation", return_value=True),
-        pytest.raises(SystemExit, match="validation task"),
+        patch(f"{_MOD}.epics.is_operational", return_value=True),
+        pytest.raises(SystemExit, match="operational task"),
     ):
-        _reject_if_validation_task("org/repo#7")
+        _reject_if_operational_task("org/repo#7")
 
 
-def test_reject_if_validation_task_passes_for_plain_task() -> None:
+def test_reject_if_operational_task_passes_for_plain_task() -> None:
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
-        patch(f"{_MOD}.epics.is_validation", return_value=False) as mock_is_validation,
+        patch(f"{_MOD}.epics.is_operational", return_value=False) as mock_is_operational,
     ):
-        _reject_if_validation_task("#42")
-    mock_is_validation.assert_called_once_with(epics.IssueRef("org", "repo", 42))
+        _reject_if_operational_task("#42")
+    mock_is_operational.assert_called_once_with(epics.IssueRef("org", "repo", 42))
 
 
 # -- _task_linkage (managed tasks auto-close via Closes) ----------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Behavior-preserving rename of the not-PR-workable guard from validation-specific to the operational-task family (is_operational / is_operational_task over a label set, plus public operational_kind), so a deployment kind can join without duplicating the guard — no behavior change and no back-compat aliases.

## Issue Linkage

- Closes #2214

## Notes

- First of epic #124's two behavior-preserving renames. All existing validation tests pass unchanged (renamed only); the epic_audit is_operational reference is updated so the audit still works before its own rename (#2215). Full validation green (4030+ tests).