### PR TITLE
refactor(epic-audit): generalize the validation-aware audit to operational tasks

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -105,8 +105,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     epics_outside = epic_audit.epic_outside_dotgithub(org)
     stray = epic_audit.stray_dotgithub_issue(org)
-    pending_validation = epic_audit.validation_pending(org)
-    closed_validation_no_pass = epic_audit.closed_validation_without_pass(org)
+    pending_operational = epic_audit.operational_pending(org)
+    closed_operational_no_success = epic_audit.closed_operational_without_success(org)
     print(
         epic_audit.render(
             tasks,
@@ -115,8 +115,8 @@ def main(argv: list[str] | None = None) -> int:
             window_days=args.window_days,
             epics_outside=epics_outside,
             stray=stray,
-            pending_validation=pending_validation,
-            closed_validation_no_pass=closed_validation_no_pass,
+            pending_operational=pending_operational,
+            closed_operational_no_success=closed_operational_no_success,
         )
     )
     return 0

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -98,26 +98,27 @@ def epic_drift() -> list[roadmap.EpicSummary]:
 
 
 @dataclass(frozen=True)
-class ValidationStatus:
-    """An epic's outstanding (open) validation children, split runnable vs blocked."""
+class OperationalStatus:
+    """An epic's outstanding (open) operational children, split runnable vs blocked."""
 
     epic: epics.IssueRef
-    runnable: tuple[epics.IssueRef, ...]  # open validation children, all blockers closed
-    blocked: tuple[epics.IssueRef, ...]  # open validation children, a blocker still open
+    runnable: tuple[epics.IssueRef, ...]  # open operational children, all blockers closed
+    blocked: tuple[epics.IssueRef, ...]  # open operational children, a blocker still open
 
     @property
     def pending(self) -> tuple[epics.IssueRef, ...]:
-        """All outstanding validation children (runnable + blocked)."""
+        """All outstanding operational children (runnable + blocked)."""
         return self.runnable + self.blocked
 
 
-def validation_status(epic: epics.IssueRef) -> ValidationStatus:
-    """Classify *epic*'s open validation children as runnable vs blocked.
+def operational_status(epic: epics.IssueRef) -> OperationalStatus:
+    """Classify *epic*'s open operational children as runnable vs blocked.
 
-    A validation child is runnable when every task it is ``Blocked-by`` is
-    closed; otherwise it is blocked. This runnable-vs-blocked split is the honest
-    "what still has to be validated" signal — and the seed of a future automator
-    that runs validations as their dependencies land.
+    An operational child (validation, deployment, …) is runnable when every task
+    it is ``Blocked-by`` is closed; otherwise it is blocked. This
+    runnable-vs-blocked split is the honest "what still has to run" signal — and
+    the seed of a future automator that runs operational tasks as their
+    dependencies land.
     """
     runnable: list[epics.IssueRef] = []
     blocked: list[epics.IssueRef] = []
@@ -126,65 +127,69 @@ def validation_status(epic: epics.IssueRef) -> ValidationStatus:
             continue
         target = runnable if epics.all_blockers_closed(child.ref) else blocked
         target.append(child.ref)
-    return ValidationStatus(epic=epic, runnable=tuple(runnable), blocked=tuple(blocked))
+    return OperationalStatus(epic=epic, runnable=tuple(runnable), blocked=tuple(blocked))
 
 
-def validation_pending(org: str) -> list[ValidationStatus]:
-    """Open finite epics with outstanding validation children.
+def operational_pending(org: str) -> list[OperationalStatus]:
+    """Open finite epics with outstanding operational children.
 
-    Reports the "code-complete, validation-pending" state that keeps an epic
+    Reports the "code-complete, operation-pending" state that keeps an epic
     honestly not-done: its code tasks may all be merged, but until its
-    validations run the epic is not finished. Only epics with at least one open
-    validation child appear.
+    operational tasks (validations, deployments, …) run the epic is not finished.
+    Only epics with at least one open operational child appear.
     """
-    pending: list[ValidationStatus] = []
+    pending: list[OperationalStatus] = []
     for summary in roadmap.gather(org):
-        status = validation_status(epics.IssueRef(org, ".github", summary.number))
+        status = operational_status(epics.IssueRef(org, ".github", summary.number))
         if status.pending:
             pending.append(status)
     return pending
 
 
-# A validation task records its result as a comment; a PASS is an ``Outcome: PASS``
-# line (bulleting optional). This is the contract the ``issue-validate`` skill
-# writes and this invariant reads — kept narrow so the scaffold's unresolved
-# "Outcome: PASS / FAIL" template line does not read as a pass.
-_VALIDATION_PASS_RE = re.compile(r"^\s*[-*]?\s*Outcome:\s*PASS\s*$", re.MULTILINE | re.IGNORECASE)
+# An operational task records its result as a comment; the current success marker
+# is ``Outcome: PASS`` (unified to SUCCESS in a later task). Kept narrow so the
+# scaffold's unresolved ``Outcome: PASS / FAIL`` template line does not read as a
+# success.
+_OPERATIONAL_SUCCESS_RE = re.compile(
+    r"^\s*[-*]?\s*Outcome:\s*PASS\s*$", re.MULTILINE | re.IGNORECASE
+)
 
 
-def closed_validation_without_pass(org: str) -> list[str]:
-    """Closed validation tasks with no recorded PASS result comment (invariant).
+def closed_operational_without_success(org: str) -> list[str]:
+    """Closed operational tasks with no recorded success comment (invariant).
 
-    A validation task must close only after its checklist runs and *passes*,
-    recorded as a comment. A closed ``validation``-labelled issue whose comments
-    carry no ``Outcome: PASS`` line is drift — most likely closed by hand — and
-    is flagged. Report-only: like the other invariants, this is never auto-acted.
+    An operational task must close only after it runs and *succeeds*, recorded as
+    a comment. A closed operational-labelled issue whose comments carry no success
+    ``Outcome:`` line is drift — most likely closed by hand — and is flagged.
+    Searches every operational label. Report-only: like the other invariants, this
+    is never auto-acted.
     """
-    raw: Any = github.read_json(
-        "search",
-        "issues",
-        "--owner",
-        org,
-        "--label",
-        "validation",
-        "--state",
-        "closed",
-        "--json",
-        "number,repository",
-    )
     violations: list[str] = []
-    for item in raw if isinstance(raw, list) else []:
-        name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
-        if "/" not in name_with_owner:
-            continue
-        number = int(item["number"])
-        detail: Any = github.read_json(
-            "issue", "view", str(number), "--repo", name_with_owner, "--json", "comments"
+    for label in sorted(epics.operational_labels()):
+        raw: Any = github.read_json(
+            "search",
+            "issues",
+            "--owner",
+            org,
+            "--label",
+            label,
+            "--state",
+            "closed",
+            "--json",
+            "number,repository",
         )
-        comments = (detail.get("comments") or []) if isinstance(detail, dict) else []
-        bodies = "\n".join(str((c or {}).get("body", "")) for c in comments)
-        if not _VALIDATION_PASS_RE.search(bodies):
-            violations.append(f"{name_with_owner}#{number}")
+        for item in raw if isinstance(raw, list) else []:
+            name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
+            if "/" not in name_with_owner:
+                continue
+            number = int(item["number"])
+            detail: Any = github.read_json(
+                "issue", "view", str(number), "--repo", name_with_owner, "--json", "comments"
+            )
+            comments = (detail.get("comments") or []) if isinstance(detail, dict) else []
+            bodies = "\n".join(str((c or {}).get("body", "")) for c in comments)
+            if not _OPERATIONAL_SUCCESS_RE.search(bodies):
+                violations.append(f"{name_with_owner}#{number}")
     return violations
 
 
@@ -264,23 +269,24 @@ def render(
     window_days: int,
     epics_outside: list[str] | None = None,
     stray: list[str] | None = None,
-    pending_validation: list[ValidationStatus] | None = None,
-    closed_validation_no_pass: list[str] | None = None,
+    pending_operational: list[OperationalStatus] | None = None,
+    closed_operational_no_success: list[str] | None = None,
 ) -> str:
     """Format the drift + invariant report; a clean state says so explicitly.
 
     The report opens with a banner naming the audited org and window and
     stating the run is read-only, so the output is never mistaken for a list of
     actions the tool took. ``epics_outside`` and ``stray`` are the invariant
-    violations (epic #85). ``pending_validation`` lists epics still gated on
-    post-merge validation (runnable vs blocked); ``closed_validation_no_pass`` is
-    the validation invariant (a validation task closed without a PASS comment).
-    Each section appears only when it has something to report.
+    violations (epic #85). ``pending_operational`` lists epics still gated on
+    operational tasks (validations/deployments, runnable vs blocked);
+    ``closed_operational_no_success`` is the operational invariant (a closed
+    operational task with no recorded success comment). Each section appears only
+    when it has something to report.
     """
     epics_outside = epics_outside or []
     stray = stray or []
-    pending_validation = pending_validation or []
-    closed_validation_no_pass = closed_validation_no_pass or []
+    pending_operational = pending_operational or []
+    closed_operational_no_success = closed_operational_no_success or []
     banner = (
         f"_Read-only audit of the **{org}** org (merged PRs from the last "
         f"{window_days} days) — this report changes nothing; run `--close` (as "
@@ -288,7 +294,14 @@ def render(
     )
     header = ["# Epic/task drift audit", "", banner, ""]
     if not any(
-        [tasks, epic_summaries, epics_outside, stray, pending_validation, closed_validation_no_pass]
+        [
+            tasks,
+            epic_summaries,
+            epics_outside,
+            stray,
+            pending_operational,
+            closed_operational_no_success,
+        ]
     ):
         return "\n".join([*header, "_No drift — everything that should be closed is closed._", ""])
     lines = [*header, "## Task drift (merged PR, task still open)", ""]
@@ -307,13 +320,13 @@ def render(
             )
     else:
         lines.append("- _none_")
-    if pending_validation:
-        lines += ["", "## Validation pending (epic not done until validations run)", ""]
-        for status in sorted(pending_validation, key=lambda s: s.epic.number):
+    if pending_operational:
+        lines += ["", "## Operational tasks pending (epic not done until they run)", ""]
+        for status in sorted(pending_operational, key=lambda s: s.epic.number):
             runnable = ", ".join(ref.slug for ref in status.runnable) or "none"
             blocked = ", ".join(ref.slug for ref in status.blocked) or "none"
             lines.append(f"- {status.epic.slug} — runnable: {runnable}; blocked: {blocked}")
-    if epics_outside or stray or closed_validation_no_pass:
+    if epics_outside or stray or closed_operational_no_success:
         lines += ["", "## Invariant violations (issues in the wrong place)", ""]
         if epics_outside:
             lines.append("**Epics outside `.github`** — move each to the org's `.github`:")
@@ -321,9 +334,9 @@ def render(
         if stray:
             lines.append("**Stray `.github` issues** — not an epic, intake, or linked task:")
             lines += [f"- {slug}" for slug in sorted(stray)]
-        if closed_validation_no_pass:
+        if closed_operational_no_success:
             lines.append("**Validation tasks closed without a PASS comment** — re-open and run:")
-            lines += [f"- {slug}" for slug in sorted(closed_validation_no_pass)]
+            lines += [f"- {slug}" for slug in sorted(closed_operational_no_success)]
     lines.append("")
     return "\n".join(lines)
 

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -380,6 +380,11 @@ def operational_kind(ref: IssueRef) -> str | None:
     return next(iter(kinds)) if kinds else None
 
 
+def operational_labels() -> frozenset[str]:
+    """The operational label set (validation, deployment, …) — the public view."""
+    return frozenset(_OPERATIONAL_LABELS)
+
+
 def is_operational_task(ref: str, *, default_repo: str) -> bool:
     """True if *ref* is an operational task, so PR tooling must refuse it.
 

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -315,7 +315,7 @@ def test_render_closed_empty_says_nothing_to_close() -> None:
 # -- validation-aware rollup/audit (epic vergil-project/.github#115) ----------
 
 
-def test_validation_status_classifies_runnable_vs_blocked() -> None:
+def test_operational_status_classifies_runnable_vs_blocked() -> None:
     epic = epics.IssueRef("org", ".github", 115)
     val_runnable = epics.IssueRef("org", "repo", 7)
     val_blocked = epics.IssueRef("org", "repo", 8)
@@ -337,32 +337,32 @@ def test_validation_status_classifies_runnable_vs_blocked() -> None:
         patch("vergil_tooling.lib.epics.is_operational", side_effect=is_operational),
         patch("vergil_tooling.lib.epics.all_blockers_closed", side_effect=all_blockers_closed),
     ):
-        status = epic_audit.validation_status(epic)
+        status = epic_audit.operational_status(epic)
     assert status.runnable == (val_runnable,)
     assert status.blocked == (val_blocked,)
     assert status.pending == (val_runnable, val_blocked)
 
 
-def test_validation_pending_collects_only_epics_with_open_validations() -> None:
+def test_operational_pending_collects_only_epics_with_open_validations() -> None:
     val = epics.IssueRef("org", "repo", 7)
 
-    def fake_status(epic: epics.IssueRef) -> epic_audit.ValidationStatus:
+    def fake_status(epic: epics.IssueRef) -> epic_audit.OperationalStatus:
         if epic.number == 115:
-            return epic_audit.ValidationStatus(epic, (val,), ())
-        return epic_audit.ValidationStatus(epic, (), ())  # nothing pending
+            return epic_audit.OperationalStatus(epic, (val,), ())
+        return epic_audit.OperationalStatus(epic, (), ())  # nothing pending
 
     with (
         patch(
             "vergil_tooling.lib.epic_audit.roadmap.gather",
             return_value=[MagicMock(number=115), MagicMock(number=200)],
         ),
-        patch("vergil_tooling.lib.epic_audit.validation_status", side_effect=fake_status),
+        patch("vergil_tooling.lib.epic_audit.operational_status", side_effect=fake_status),
     ):
-        pending = epic_audit.validation_pending("org")
+        pending = epic_audit.operational_pending("org")
     assert [s.epic.number for s in pending] == [115]
 
 
-def test_closed_validation_without_pass_flags_missing_pass() -> None:
+def test_closed_operational_without_success_flags_missing_pass() -> None:
     search = [
         {"number": 120, "repository": {"nameWithOwner": "org/.github"}},  # has PASS -> ok
         {"number": 55, "repository": {"nameWithOwner": "org/repo"}},  # no PASS -> flagged
@@ -378,7 +378,7 @@ def test_closed_validation_without_pass_flags_missing_pass() -> None:
         return {"comments": [{"body": "closed early; no result recorded"}]}
 
     with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
-        result = epic_audit.closed_validation_without_pass("org")
+        result = epic_audit.closed_operational_without_success("org")
     assert result == ["org/repo#55"]
 
 
@@ -392,24 +392,24 @@ def test_closed_validation_pass_marker_excludes_unresolved_template() -> None:
         return {"comments": [{"body": "- Outcome: PASS / FAIL"}]}
 
     with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
-        assert epic_audit.closed_validation_without_pass("org") == ["org/repo#1"]
+        assert epic_audit.closed_operational_without_success("org") == ["org/repo#1"]
 
 
-def test_render_includes_validation_pending_section() -> None:
-    status = epic_audit.ValidationStatus(
+def test_render_includes_operational_pending_section() -> None:
+    status = epic_audit.OperationalStatus(
         epics.IssueRef("org", ".github", 115),
         (epics.IssueRef("org", "repo", 7),),
         (epics.IssueRef("org", "repo", 8),),
     )
-    out = epic_audit.render([], [], org="org", window_days=30, pending_validation=[status])
-    assert "Validation pending" in out
+    out = epic_audit.render([], [], org="org", window_days=30, pending_operational=[status])
+    assert "Operational tasks pending" in out
     assert "org/repo#7" in out  # runnable
     assert "org/repo#8" in out  # blocked
 
 
-def test_render_flags_closed_validation_without_pass() -> None:
+def test_render_flags_closed_operational_without_success() -> None:
     out = epic_audit.render(
-        [], [], org="org", window_days=30, closed_validation_no_pass=["org/repo#55"]
+        [], [], org="org", window_days=30, closed_operational_no_success=["org/repo#55"]
     )
     assert "PASS comment" in out
     assert "org/repo#55" in out

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -15,8 +15,8 @@ _MOD = "vergil_tooling.bin.vrg_epic_audit"
 def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
-        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
-        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
+        patch(f"{_MOD}.epic_audit.operational_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
@@ -34,8 +34,8 @@ def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
 def test_main_reports_invariant_violations(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
-        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
-        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
+        patch(f"{_MOD}.epic_audit.operational_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(
@@ -66,8 +66,8 @@ def test_window_days_controls_since() -> None:
     task_drift = MagicMock(return_value=[])
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
-        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
-        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
+        patch(f"{_MOD}.epic_audit.operational_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", task_drift),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
@@ -112,8 +112,8 @@ def test_close_allowed_for_scheduled_sweep(capsys: pytest.CaptureFixture[str]) -
         patch(f"{_MOD}.identity_mode.is_human", return_value=False),
         patch.dict("os.environ", {"VRG_EPIC_SWEEP": "1"}),
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
-        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
-        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
+        patch(f"{_MOD}.epic_audit.operational_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
         patch(f"{_MOD}.epic_audit.close_drift", close_drift),
@@ -129,8 +129,8 @@ def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]
     with (
         patch(f"{_MOD}.identity_mode.is_human", return_value=True),
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
-        patch(f"{_MOD}.epic_audit.validation_pending", return_value=[]),
-        patch(f"{_MOD}.epic_audit.closed_validation_without_pass", return_value=[]),
+        patch(f"{_MOD}.epic_audit.operational_pending", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
         patch(f"{_MOD}.epic_audit.close_drift", close_drift),


### PR DESCRIPTION
# Pull Request

## Summary

- Behavior-preserving rename of the audit's validation-aware reporting to the operational-task family (OperationalStatus, operational_status/operational_pending/closed_operational_without_success), searching the operational label set via a new public epics.operational_labels() — completing the generalized base so the deployment kind can be added without duplication.

## Issue Linkage

- Closes #2215

## Notes

- Second and last of epic #124's behavior-preserving renames. Regex still matches Outcome: PASS (SUCCESS unification is #2216). All audit tests pass unchanged (renamed only). Full validation green.