### PR TITLE
feat(epic-audit): unify operational success marker (SUCCESS, legacy PASS)

### DIFF
--- a/src/vergil_tooling/data/validation_task_body.md
+++ b/src/vergil_tooling/data/validation_task_body.md
@@ -28,8 +28,8 @@ If any precondition is unmet: comment "blocked: preconditions not met —
 
 ## Results
 
-Post the outcome as a comment on this issue, then close only on PASS.
+Post the outcome as a comment on this issue, then close only on SUCCESS.
 
-- Outcome: PASS / FAIL
+- Outcome: SUCCESS / FAILURE
 - Evidence: \<command output / observations\>
-- On FAIL: file follow-on fix task(s); leave this task and the epic open.
+- On FAILURE: file follow-on fix task(s); leave this task and the epic open.

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -146,12 +146,13 @@ def operational_pending(org: str) -> list[OperationalStatus]:
     return pending
 
 
-# An operational task records its result as a comment; the current success marker
-# is ``Outcome: PASS`` (unified to SUCCESS in a later task). Kept narrow so the
-# scaffold's unresolved ``Outcome: PASS / FAIL`` template line does not read as a
+# An operational task records its result as a comment; the unified success marker
+# is ``Outcome: SUCCESS`` (``Outcome: PASS`` is recognized as a legacy alias, so
+# validations closed before the unification are not falsely flagged). Kept narrow
+# so an unresolved ``Outcome: SUCCESS / FAILURE`` template line does not read as a
 # success.
 _OPERATIONAL_SUCCESS_RE = re.compile(
-    r"^\s*[-*]?\s*Outcome:\s*PASS\s*$", re.MULTILINE | re.IGNORECASE
+    r"^\s*[-*]?\s*Outcome:\s*(?:SUCCESS|PASS)\s*$", re.MULTILINE | re.IGNORECASE
 )
 
 

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -395,6 +395,23 @@ def test_closed_validation_pass_marker_excludes_unresolved_template() -> None:
         assert epic_audit.closed_operational_without_success("org") == ["org/repo#1"]
 
 
+def test_success_marker_accepts_success_and_legacy_pass() -> None:
+    search = [
+        {"number": 1, "repository": {"nameWithOwner": "org/repo"}},  # SUCCESS -> ok
+        {"number": 2, "repository": {"nameWithOwner": "org/repo"}},  # legacy PASS -> ok
+        {"number": 3, "repository": {"nameWithOwner": "org/repo"}},  # neither -> flagged
+    ]
+    bodies = {"1": "- Outcome: SUCCESS", "2": "- Outcome: PASS", "3": "closed early"}
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return search
+        return {"comments": [{"body": bodies[args[2]]}]}
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        assert epic_audit.closed_operational_without_success("org") == ["org/repo#3"]
+
+
 def test_render_includes_operational_pending_section() -> None:
     status = epic_audit.OperationalStatus(
         epics.IssueRef("org", ".github", 115),


### PR DESCRIPTION
# Pull Request

## Summary

- Unify the operational-task success marker to Outcome: SUCCESS across all kinds (recognizing legacy Outcome: PASS so pre-unification validations aren't falsely flagged), and update the validation scaffold results template to SUCCESS / FAILURE.

## Issue Linkage

- Closes #2216

## Notes

- Tooling side of the marker unification; the issue-validate skill records SUCCESS in a separate plugin task (#598). Unresolved 'SUCCESS / FAILURE' template line still correctly reads as not-success. Full validation green.