### PR TITLE
feat(labels): add deployment label to the operational set

### DIFF
--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -16,7 +16,8 @@
     {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
     {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"},
-    {"name": "validation", "color": "006b75", "description": "Post-merge validation: run the checklist, record PASS/FAIL as a comment; never auto-closed"}
+    {"name": "validation", "color": "006b75", "description": "Post-merge validation: run the checklist, record PASS/FAIL as a comment; never auto-closed"},
+    {"name": "deployment", "color": "0052cc", "description": "Deployment task: install/sync merged changes so they are usable; never auto-closed"}
   ],
   "delete": ["enhancement"]
 }

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -366,7 +366,7 @@ def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
 # Labels marking a not-PR-workable *operational task* — one that is run and whose
 # acceptance is a recorded ``Outcome:`` comment, not a merged PR. Extended as new
 # operational kinds are added (e.g. ``deployment``).
-_OPERATIONAL_LABELS: set[str] = {"validation"}
+_OPERATIONAL_LABELS: set[str] = {"validation", "deployment"}
 
 
 def is_operational(ref: IssueRef) -> bool:

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -371,7 +371,8 @@ def test_closed_operational_without_success_flags_missing_pass() -> None:
 
     def fake_read_json(*args: str) -> object:
         if args[0] == "search":
-            return search
+            # invariant loops each operational label; return the fixture once
+            return search if args[5] == "validation" else []
         number = args[2]
         if number == "120":
             return {"comments": [{"body": "ran it\n- Outcome: PASS"}]}
@@ -388,7 +389,8 @@ def test_closed_validation_pass_marker_excludes_unresolved_template() -> None:
 
     def fake_read_json(*args: str) -> object:
         if args[0] == "search":
-            return search
+            # invariant loops each operational label; return the fixture once
+            return search if args[5] == "validation" else []
         return {"comments": [{"body": "- Outcome: PASS / FAIL"}]}
 
     with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
@@ -405,7 +407,8 @@ def test_success_marker_accepts_success_and_legacy_pass() -> None:
 
     def fake_read_json(*args: str) -> object:
         if args[0] == "search":
-            return search
+            # invariant loops each operational label; return the fixture once
+            return search if args[5] == "validation" else []
         return {"comments": [{"body": bodies[args[2]]}]}
 
     with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -270,6 +270,14 @@ def test_is_operational_task_false_for_unparseable_ref() -> None:
     mock.assert_not_called()
 
 
+def test_is_operational_true_for_deployment() -> None:
+    # The deployment label joins the operational set (epic #124).
+    labels = {"labels": [{"name": "deployment"}]}
+    with patch("vergil_tooling.lib.github.read_json", return_value=labels):
+        assert epics.is_operational(TASK) is True
+        assert epics.operational_kind(TASK) == "deployment"
+
+
 def test_render_blocked_by_emits_one_line_per_dep() -> None:
     out = epics.render_blocked_by([IssueRef("o", "r", 5), IssueRef("o", "r", 8)])
     assert "Blocked-by: o/r#5" in out

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -83,6 +83,18 @@ def test_registry_includes_validation_label() -> None:
     assert entry["description"], "validation label needs a description"
 
 
+def test_registry_includes_deployment_label() -> None:
+    # Deployment task type (epic vergil-project/.github#124): an operational task
+    # that installs/syncs merged changes so they are usable; never PR-workable,
+    # never auto-closed, closed only on a recorded SUCCESS comment.
+    entry = next(
+        (label for label in load_labels()["labels"] if label["name"] == "deployment"),
+        None,
+    )
+    assert entry is not None, "deployment label missing from the registry"
+    assert entry["description"], "deployment label needs a description"
+
+
 def test_label_descriptions_within_github_limit() -> None:
     # GitHub caps a label's description at 100 chars; a longer one fails
     # provisioning with HTTP 422 so vrg-ensure-label --sync cannot deploy it.

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -127,7 +127,7 @@ def test_main_sync_provisions_all_labels() -> None:
     assert result == 0
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
-    assert len(label_calls) == 17  # 16 + validation (epic vergil-project/.github#115)
+    assert len(label_calls) == 18  # 17 + deployment (epic vergil-project/.github#124)
 
 
 def test_main_sync_uses_force_with_color_description() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a deployment label and register it in epics._OPERATIONAL_LABELS, so deployment tasks are treated as operational everywhere — the PR-workability guard refuses them and the audit's runnable/blocked and closed-without-success reporting covers them.

## Issue Linkage

- Closes #2217

## Notes

- Description 82 chars (under the 100 cap the label-length test enforces). Sync count 17->18; audit invariant tests updated for the now-two-label loop. Full validation green. Unblocks --kind deployment (#2218) and kind-aware audit (#2219).