### PR TITLE
feat(epic-audit): tag operational-pending audit items by kind

### DIFF
--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -104,6 +104,7 @@ class OperationalStatus:
     epic: epics.IssueRef
     runnable: tuple[epics.IssueRef, ...]  # open operational children, all blockers closed
     blocked: tuple[epics.IssueRef, ...]  # open operational children, a blocker still open
+    by_kind: dict[epics.IssueRef, str]  # each pending child -> its kind (validation/deployment)
 
     @property
     def pending(self) -> tuple[epics.IssueRef, ...]:
@@ -112,22 +113,29 @@ class OperationalStatus:
 
 
 def operational_status(epic: epics.IssueRef) -> OperationalStatus:
-    """Classify *epic*'s open operational children as runnable vs blocked.
+    """Classify *epic*'s open operational children as runnable vs blocked, by kind.
 
     An operational child (validation, deployment, …) is runnable when every task
     it is ``Blocked-by`` is closed; otherwise it is blocked. This
-    runnable-vs-blocked split is the honest "what still has to run" signal — and
-    the seed of a future automator that runs operational tasks as their
-    dependencies land.
+    runnable-vs-blocked split, tagged by kind, is the honest "what still has to
+    run" signal — and the seed of a future automator that runs operational tasks
+    as their dependencies land.
     """
     runnable: list[epics.IssueRef] = []
     blocked: list[epics.IssueRef] = []
+    by_kind: dict[epics.IssueRef, str] = {}
     for child in epics.child_states(epic):
-        if child.state != "OPEN" or not epics.is_operational(child.ref):
+        if child.state != "OPEN":
             continue
+        kind = epics.operational_kind(child.ref)
+        if kind is None:
+            continue
+        by_kind[child.ref] = kind
         target = runnable if epics.all_blockers_closed(child.ref) else blocked
         target.append(child.ref)
-    return OperationalStatus(epic=epic, runnable=tuple(runnable), blocked=tuple(blocked))
+    return OperationalStatus(
+        epic=epic, runnable=tuple(runnable), blocked=tuple(blocked), by_kind=by_kind
+    )
 
 
 def operational_pending(org: str) -> list[OperationalStatus]:
@@ -324,8 +332,14 @@ def render(
     if pending_operational:
         lines += ["", "## Operational tasks pending (epic not done until they run)", ""]
         for status in sorted(pending_operational, key=lambda s: s.epic.number):
-            runnable = ", ".join(ref.slug for ref in status.runnable) or "none"
-            blocked = ", ".join(ref.slug for ref in status.blocked) or "none"
+            runnable = (
+                ", ".join(f"{ref.slug} ({status.by_kind.get(ref, '?')})" for ref in status.runnable)
+                or "none"
+            )
+            blocked = (
+                ", ".join(f"{ref.slug} ({status.by_kind.get(ref, '?')})" for ref in status.blocked)
+                or "none"
+            )
             lines.append(f"- {status.epic.slug} — runnable: {runnable}; blocked: {blocked}")
     if epics_outside or stray or closed_operational_no_success:
         lines += ["", "## Invariant violations (issues in the wrong place)", ""]

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -326,15 +326,15 @@ def test_operational_status_classifies_runnable_vs_blocked() -> None:
         epics.ChildState(epics.IssueRef("org", "repo", 9), "CLOSED"),  # closed -> ignored
     ]
 
-    def is_operational(ref: epics.IssueRef) -> bool:
-        return ref.number in (7, 8, 9)
+    def kind(ref: epics.IssueRef) -> str | None:
+        return "validation" if ref.number in (7, 8, 9) else None
 
     def all_blockers_closed(ref: epics.IssueRef) -> bool:
         return ref.number == 7  # #7 runnable, #8 still blocked
 
     with (
         patch("vergil_tooling.lib.epics.child_states", return_value=children),
-        patch("vergil_tooling.lib.epics.is_operational", side_effect=is_operational),
+        patch("vergil_tooling.lib.epics.operational_kind", side_effect=kind),
         patch("vergil_tooling.lib.epics.all_blockers_closed", side_effect=all_blockers_closed),
     ):
         status = epic_audit.operational_status(epic)
@@ -343,13 +343,33 @@ def test_operational_status_classifies_runnable_vs_blocked() -> None:
     assert status.pending == (val_runnable, val_blocked)
 
 
+def test_operational_status_tags_kind() -> None:
+    epic = epics.IssueRef("org", ".github", 124)
+    val = epics.IssueRef("org", "repo", 7)
+    dep = epics.IssueRef("org", "repo", 8)
+    children = [epics.ChildState(val, "OPEN"), epics.ChildState(dep, "OPEN")]
+
+    def kind(ref: epics.IssueRef) -> str | None:
+        return "validation" if ref.number == 7 else "deployment"
+
+    with (
+        patch("vergil_tooling.lib.epics.child_states", return_value=children),
+        patch("vergil_tooling.lib.epics.operational_kind", side_effect=kind),
+        patch("vergil_tooling.lib.epics.all_blockers_closed", return_value=True),
+    ):
+        status = epic_audit.operational_status(epic)
+    # keyed by IssueRef (cross-repo safe), not bare number
+    assert status.by_kind[val] == "validation"
+    assert status.by_kind[dep] == "deployment"
+
+
 def test_operational_pending_collects_only_epics_with_open_validations() -> None:
     val = epics.IssueRef("org", "repo", 7)
 
     def fake_status(epic: epics.IssueRef) -> epic_audit.OperationalStatus:
         if epic.number == 115:
-            return epic_audit.OperationalStatus(epic, (val,), ())
-        return epic_audit.OperationalStatus(epic, (), ())  # nothing pending
+            return epic_audit.OperationalStatus(epic, (val,), (), {val: "validation"})
+        return epic_audit.OperationalStatus(epic, (), (), {})  # nothing pending
 
     with (
         patch(
@@ -416,15 +436,18 @@ def test_success_marker_accepts_success_and_legacy_pass() -> None:
 
 
 def test_render_includes_operational_pending_section() -> None:
+    val = epics.IssueRef("org", "repo", 7)
+    dep = epics.IssueRef("org", "repo", 8)
     status = epic_audit.OperationalStatus(
         epics.IssueRef("org", ".github", 115),
-        (epics.IssueRef("org", "repo", 7),),
-        (epics.IssueRef("org", "repo", 8),),
+        (val,),
+        (dep,),
+        {val: "validation", dep: "deployment"},
     )
     out = epic_audit.render([], [], org="org", window_days=30, pending_operational=[status])
     assert "Operational tasks pending" in out
-    assert "org/repo#7" in out  # runnable
-    assert "org/repo#8" in out  # blocked
+    assert "org/repo#7 (validation)" in out  # runnable, kind-tagged
+    assert "org/repo#8 (deployment)" in out  # blocked, kind-tagged
 
 
 def test_render_flags_closed_operational_without_success() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Tag each pending operational task with its kind (validation/deployment) in OperationalStatus.by_kind (ref-keyed, cross-repo safe) and annotate the audit's 'Operational tasks pending' section, so the report distinguishes what still needs deploying from what still needs validating.

## Issue Linkage

- Closes #2219

## Notes

- Classifier now uses the public operational_kind (one gh lookup per child vs two). Completes the six tooling tasks of epic #124; only the four skills (#598-601) and the dogfood (#129) remain. Full validation green.