### PR TITLE
feat(epics): add visibility-based epic-home resolver

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -282,6 +282,24 @@ def resolve_epic_ref(ref: str, *, repo: str) -> IssueRef:
     return epic
 
 
+def resolve_epic_home(org: str, target_repo: str) -> str:
+    """Map an explicit *target_repo* (bare name) to its epic home ``"owner/repo"``.
+
+    A public target homes centrally in ``<org>/.github`` (today's behavior). A
+    private target with a public ``.github`` homes its epics in itself
+    (self-contained). A private ``.github`` means the whole org is private, so
+    everything routes to ``.github``. Fail-loud: visibility errors propagate
+    (see :func:`github.repo_visibility`).
+    """
+    if target_repo == ".github":
+        return f"{org}/.github"
+    if github.is_public(f"{org}/{target_repo}"):
+        return f"{org}/.github"
+    if github.is_public(f"{org}/.github"):
+        return f"{org}/{target_repo}"
+    return f"{org}/.github"
+
+
 _ADHOC_EPIC_TITLE_PREFIX = "Epic (ad hoc): "
 _ADHOC_EPIC_LABELS = ("epic", "ad-hoc")
 _ADHOC_EPIC_BODY = (

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import functools
 import json
 import logging
 import os
@@ -104,6 +105,30 @@ def detect_org() -> str | None:
             if org:
                 return org
     return None
+
+
+@functools.cache
+def repo_visibility(name_with_owner: str) -> str:
+    """Return *name_with_owner*'s GitHub visibility (``PUBLIC``/``PRIVATE``/``INTERNAL``).
+
+    Fail-loud: a ``gh`` error (missing repo, auth, network) propagates as
+    :class:`GitHubAPIError` from :func:`read_output`; an empty result is also an
+    error. Memoized per process so audit/roadmap sweeps probe each repo once.
+    """
+    data = read_json("repo", "view", name_with_owner, "--json", "visibility")
+    visibility = data.get("visibility") if isinstance(data, dict) else None
+    if not isinstance(visibility, str) or not visibility:
+        raise GitHubAPIError(
+            1,
+            f"gh repo view {name_with_owner} --json visibility",
+            "empty or missing visibility",
+        )
+    return visibility
+
+
+def is_public(name_with_owner: str) -> bool:
+    """True only when *name_with_owner* is ``PUBLIC`` (``INTERNAL`` and ``PRIVATE`` are not)."""
+    return repo_visibility(name_with_owner) == "PUBLIC"
 
 
 def _jwt_api_request(endpoint: str, jwt_token: str, *, method: str = "GET") -> Any:

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from vergil_tooling.lib import epics
+from vergil_tooling.lib import epics, github
 from vergil_tooling.lib.epics import ChildState, IssueRef
 
 EPIC = IssueRef("org", ".github", 40)
@@ -542,3 +542,43 @@ def test_resolve_epic_ref_explicit_non_epic_raises() -> None:
 def test_ensure_adhoc_epic_repo_without_owner_raises() -> None:
     with pytest.raises(ValueError, match="cannot resolve repo for ad-hoc epic"):
         epics.ensure_adhoc_epic("tooling")
+
+
+# -- resolve_epic_home (epic #130) -------------------------------------------
+def test_resolve_epic_home_dotgithub_short_circuits() -> None:
+    # A ".github" target never probes visibility.
+    with patch("vergil_tooling.lib.epics.github.is_public") as pub:
+        assert epics.resolve_epic_home("org", ".github") == "org/.github"
+        pub.assert_not_called()
+
+
+def test_resolve_epic_home_public_target_is_central() -> None:
+    with patch("vergil_tooling.lib.epics.github.is_public", return_value=True):
+        assert epics.resolve_epic_home("org", "tooling") == "org/.github"
+
+
+def test_resolve_epic_home_private_target_public_dotgithub_is_self() -> None:
+    def pub(nwo: str) -> bool:
+        return {"org/lab": False, "org/.github": True}[nwo]
+
+    with patch("vergil_tooling.lib.epics.github.is_public", side_effect=pub):
+        assert epics.resolve_epic_home("org", "lab") == "org/lab"
+
+
+def test_resolve_epic_home_private_org_is_central() -> None:
+    def pub(nwo: str) -> bool:
+        return {"org/lab": False, "org/.github": False}[nwo]
+
+    with patch("vergil_tooling.lib.epics.github.is_public", side_effect=pub):
+        assert epics.resolve_epic_home("org", "lab") == "org/.github"
+
+
+def test_resolve_epic_home_fails_loud() -> None:
+    with (
+        patch(
+            "vergil_tooling.lib.epics.github.is_public",
+            side_effect=github.GitHubAPIError(1, "cmd", "boom"),
+        ),
+        pytest.raises(github.GitHubAPIError),
+    ):
+        epics.resolve_epic_home("org", "missing")

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -1656,3 +1656,36 @@ def test_closed_pr_for_branch_none_when_no_closed_pr() -> None:
 def test_closed_pr_for_branch_none_when_payload_not_dict() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value=["nope"]):
         assert github.closed_pr_for_branch("feature/1445-finalize-cleanup-race") is None
+
+
+# -- repo_visibility / is_public (epic #130) ---------------------------------
+def test_is_public_true_for_public_repo() -> None:
+    github.repo_visibility.cache_clear()
+    with patch("vergil_tooling.lib.github.read_json", return_value={"visibility": "PUBLIC"}):
+        assert github.is_public("org/repo") is True
+
+
+def test_is_public_false_for_private_and_internal() -> None:
+    github.repo_visibility.cache_clear()
+    with patch("vergil_tooling.lib.github.read_json", return_value={"visibility": "PRIVATE"}):
+        assert github.is_public("org/priv") is False
+    github.repo_visibility.cache_clear()
+    with patch("vergil_tooling.lib.github.read_json", return_value={"visibility": "INTERNAL"}):
+        assert github.is_public("org/intern") is False
+
+
+def test_repo_visibility_memoizes_one_probe_per_repo() -> None:
+    github.repo_visibility.cache_clear()
+    with patch("vergil_tooling.lib.github.read_json", return_value={"visibility": "PUBLIC"}) as rj:
+        github.repo_visibility("org/repo")
+        github.repo_visibility("org/repo")
+    assert rj.call_count == 1
+
+
+def test_repo_visibility_fails_loud_on_empty() -> None:
+    github.repo_visibility.cache_clear()
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value={}),
+        pytest.raises(github.GitHubAPIError),
+    ):
+        github.repo_visibility("org/repo")


### PR DESCRIPTION
# Pull Request

## Summary

- Add resolve_epic_home(org, target_repo) plus a memoized, fail-loud repo_visibility/is_public so a private target repo homes its epics in itself instead of the public .github.

## Issue Linkage

- Closes #2231

## Notes

- Foundational task of epic #130. Pure additions — no existing behavior changes (public targets and private orgs still resolve to <org>/.github). Visibility is binary (INTERNAL treated as private); probe failures raise GitHubAPIError rather than silently defaulting to .github. Tasks #2232-#2235 and #2236 consume this. 197 tests pass; validation green.