### PR TITLE
feat(epic-create): explicit --repo target, resolver-derived home

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_create.py
+++ b/src/vergil_tooling/bin/vrg_epic_create.py
@@ -1,9 +1,13 @@
-"""Create a top-level epic issue in the org's ``.github`` repo.
+"""Create a top-level epic issue in its resolved home repo.
 
-Epics are top-level (no parent) and live in ``<org>/.github`` with the ``epic``
-label. This is the sanctioned path for creating them — ``vrg-gh`` denies raw
-``gh issue create`` — used by the ``epic-create`` and ``migrate-repo`` skills.
-The org is auto-detected from the current repo's remote.
+Epics are top-level (no parent), labelled ``epic``. The *home* — the repo where
+the epic issue physically lives — is derived from the target repo's visibility
+by :func:`vergil_tooling.lib.epics.resolve_epic_home`: a public target homes
+centrally in ``<org>/.github``; a private target (with a public ``.github``)
+homes its epics in itself. The target defaults to the current repo but is named
+explicitly with ``--repo``. This is the sanctioned path for creating epics —
+``vrg-gh`` denies raw ``gh issue create`` — used by the ``epic-create`` and
+``migrate-repo`` skills.
 """
 
 from __future__ import annotations
@@ -11,7 +15,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from vergil_tooling.lib import github
+from vergil_tooling.lib import epics, github
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -19,18 +23,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="vrg-epic-create",
         description=(
-            "Create a top-level epic in the current repo's GitHub org: an issue "
-            "in <org>/.github labelled 'epic', with no parent. The org is "
-            "auto-detected from this repo's origin remote."
+            "Create a top-level epic labelled 'epic' with no parent. The epic "
+            "home is derived from the target repo's visibility: a public target "
+            "homes in <org>/.github, a private target homes in itself."
         ),
         epilog=(
-            "Run from inside a repo in the target org. Extra --label values are "
-            "added alongside 'epic' (e.g. --label ad-hoc for an ad-hoc epic)."
+            "Extra --label values are added alongside 'epic' (e.g. --label "
+            "ad-hoc for an ad-hoc epic)."
         ),
     )
     parser.add_argument("--title", required=True, help="Epic title")
     parser.add_argument("--body", default="", help="Epic body text")
     parser.add_argument("--body-file", help="Read the epic body from a file")
+    parser.add_argument(
+        "--repo",
+        help=(
+            "Target repo 'owner/repo' the epic is for (default: current repo). "
+            "The epic home is derived from the target's visibility."
+        ),
+    )
     parser.add_argument(
         "--label",
         action="append",
@@ -43,19 +54,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    org = github.detect_org()
-    if org is None:
+    target = args.repo or github.current_repo()  # "owner/repo"; raises if undeterminable
+    if "/" not in target:
         print(
-            "vrg-epic-create: could not determine the GitHub org from this "
-            "repo's 'origin' remote; run it from inside a repo in the org whose "
-            ".github should hold the epic.",
+            f"vrg-epic-create: --repo must be 'owner/repo' (got {target!r})",
             file=sys.stderr,
         )
         return 1
-    repo = f"{org}/.github"
+    owner, bare = target.split("/", 1)
+    home = epics.resolve_epic_home(owner, bare)
+    print(f"-> epic home: {home} [{github.repo_visibility(home)}]")
     labels = list(dict.fromkeys(["epic", *args.label]))
     url = github.create_issue(
-        repo=repo,
+        repo=home,
         title=args.title,
         body=args.body,
         body_file=args.body_file,

--- a/tests/vergil_tooling/test_vrg_epic_create.py
+++ b/tests/vergil_tooling/test_vrg_epic_create.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.bin.vrg_epic_create import main, parse_args
+from vergil_tooling.lib import github
 
 _MOD = "vergil_tooling.bin.vrg_epic_create"
 _URL = "https://github.com/org/.github/issues/50"
@@ -17,43 +18,81 @@ def test_parse_args_requires_title() -> None:
         parse_args([])
 
 
-def test_main_creates_epic_in_org_dot_github() -> None:
+def test_default_target_is_current_repo_public_goes_to_dotgithub() -> None:
     with (
-        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.github.current_repo", return_value="org/tooling"),
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/.github") as home,
+        patch(f"{_MOD}.github.repo_visibility", return_value="PUBLIC"),
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
     ):
         rc = main(["--title", "Epic: X", "--body", "B"])
     assert rc == 0
+    home.assert_called_once_with("org", "tooling")
     assert mock_create.call_args.kwargs["repo"] == "org/.github"
     assert mock_create.call_args.kwargs["title"] == "Epic: X"
     assert mock_create.call_args.kwargs["labels"] == ["epic"]
 
 
-def test_main_adds_extra_labels() -> None:
+def test_explicit_private_target_homes_in_self() -> None:
     with (
-        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab") as home,
+        patch(f"{_MOD}.github.repo_visibility", return_value="PRIVATE"),
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
     ):
-        rc = main(["--title", "T", "--label", "standing"])
+        rc = main(["--repo", "org/lab", "--title", "T"])
     assert rc == 0
-    assert mock_create.call_args.kwargs["labels"] == ["epic", "standing"]
+    home.assert_called_once_with("org", "lab")
+    assert mock_create.call_args.kwargs["repo"] == "org/lab"
 
 
-def test_main_dedups_epic_label() -> None:
+def test_prints_resolved_home(capsys: pytest.CaptureFixture[str]) -> None:
     with (
-        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PRIVATE"),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+    ):
+        main(["--repo", "org/lab", "--title", "T"])
+    assert "epic home: org/lab [PRIVATE]" in capsys.readouterr().out
+
+
+def test_adds_extra_labels() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/tooling"),
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/.github"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PUBLIC"),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+    ):
+        rc = main(["--title", "T", "--label", "ad-hoc"])
+    assert rc == 0
+    assert mock_create.call_args.kwargs["labels"] == ["epic", "ad-hoc"]
+
+
+def test_dedups_epic_label() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/tooling"),
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/.github"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PUBLIC"),
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
     ):
         main(["--title", "T", "--label", "epic"])
     assert mock_create.call_args.kwargs["labels"] == ["epic"]
 
 
-def test_main_errors_when_org_undetectable(capsys: pytest.CaptureFixture[str]) -> None:
-    with (
-        patch(f"{_MOD}.github.detect_org", return_value=None),
-        patch(f"{_MOD}.github.create_issue") as mock_create,
-    ):
-        rc = main(["--title", "T"])
+def test_malformed_repo_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.github.create_issue") as mock_create:
+        rc = main(["--repo", "noslash", "--title", "T"])
     assert rc == 1
-    assert "could not determine the GitHub org" in capsys.readouterr().err
+    assert "owner/repo" in capsys.readouterr().err
     mock_create.assert_not_called()
+
+
+def test_current_repo_error_propagates() -> None:
+    # No --repo and current_repo fails (not in a repo) -> fail loud, not silent.
+    with (
+        patch(
+            f"{_MOD}.github.current_repo",
+            side_effect=github.GitHubAPIError(1, "gh repo view", "not a repo"),
+        ),
+        pytest.raises(github.GitHubAPIError),
+    ):
+        main(["--title", "T"])


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-epic-create takes an explicit --repo owner/repo target (default: current repo), derives the epic home from its visibility via resolve_epic_home, and echoes the resolved home before creating.

## Issue Linkage

- Closes #2232

## Notes

- Task of epic #130; depends on the resolver from #2231 (now on develop). Public targets still home in <org>/.github (backward-compatible); a private target homes in itself. Fail-loud: current_repo() errors propagate, and a malformed --repo returns a clear error rather than a traceback. 8 tests pass; validation green.