### PR TITLE
feat(epics): home ad-hoc epics via the resolver (self for private repos)

### DIFF
--- a/src/vergil_tooling/bin/vrg_adhoc_epic.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_epic.py
@@ -1,8 +1,9 @@
 """Ensure a repo's ad-hoc epic exists (create-if-missing), idempotently.
 
-Ad-hoc epics are centralized: the ``Epic (ad hoc): <repo>`` umbrella (labelled
-``epic`` + ``ad-hoc``) lives in the org's ``.github`` repo, one per repo. This
-provisions it before linking pre-existing issues — e.g. ``migrate-repo`` step 1,
+The ``Epic (ad hoc): <repo>`` umbrella (labelled ``epic`` + ``ad-hoc``) lives in
+the repo's resolved epic home — ``<org>/.github`` for a public repo, the repo
+itself when private — one per repo. This provisions it before linking
+pre-existing issues — e.g. ``migrate-repo`` step 1,
 which must ensure the epic exists before it can link ad-hoc tasks to it. Routing
 work to ``adhoc`` (``vrg-issue-create``/``vrg-epic-move --epic adhoc``) also
 ensures it via the same path.
@@ -22,6 +23,15 @@ from vergil_tooling.lib import epics, github
 
 def cmd_ensure(args: argparse.Namespace) -> int:
     repo = args.repo or github.current_repo()
+    if "/" not in repo:
+        print(
+            f"vrg-adhoc-epic: --repo must be 'owner/repo' (got {repo!r})",
+            file=sys.stderr,
+        )
+        return 1
+    owner, bare = repo.split("/", 1)
+    home = epics.resolve_epic_home(owner, bare)
+    print(f"-> epic home: {home} [{github.repo_visibility(home)}]")
     epic = epics.ensure_adhoc_epic(repo)
     print(f"Ad-hoc epic: {epic.slug}")
     return 0
@@ -33,7 +43,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         prog="vrg-adhoc-epic",
         description=(
             "Manage a repo's ad-hoc epic (Epic (ad hoc): <repo>, labelled "
-            "epic + ad-hoc, located in the org's .github)."
+            "epic + ad-hoc, homed by visibility: <org>/.github for a public "
+            "repo, the repo itself when private)."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -309,9 +309,11 @@ _ADHOC_EPIC_BODY = (
 
 
 def ensure_adhoc_epic(target_repo: str) -> IssueRef:
-    """Return *target_repo*'s ad-hoc epic in ``<org>/.github``, creating it if absent.
+    """Return *target_repo*'s ad-hoc epic in its resolved epic home, creating it if absent.
 
-    All ad-hoc epics live in the org's ``.github`` repo, one per repo, each
+    The home is derived from *target_repo*'s visibility by
+    :func:`resolve_epic_home`: a public repo homes its ad-hoc epic centrally in
+    ``<org>/.github``; a private repo homes it in itself. One per repo, each
     disambiguated by the title ``Epic (ad hoc): <bare repo name>`` and labelled
     ``epic`` + ``ad-hoc``. Idempotent: an existing epic with that title is
     reused; none means create it; two sharing the title is ambiguous and an
@@ -321,13 +323,14 @@ def ensure_adhoc_epic(target_repo: str) -> IssueRef:
     if "/" not in target_repo:
         raise ValueError(f"cannot resolve repo for ad-hoc epic (repo={target_repo!r})")
     owner, bare = target_repo.split("/", 1)
-    dotgithub = f"{owner}/.github"
+    home = resolve_epic_home(owner, bare)
+    home_repo = home.split("/", 1)[1]
     title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}"
     raw: Any = github.read_json(
         "issue",
         "list",
         "--repo",
-        dotgithub,
+        home,
         "--label",
         "epic",
         "--label",
@@ -345,19 +348,18 @@ def ensure_adhoc_epic(target_repo: str) -> IssueRef:
     if len(rows) > 1:
         nums = ", ".join(f"#{r['number']}" for r in rows)
         raise ValueError(
-            f"multiple ad-hoc epics titled {title!r} in {dotgithub} ({nums}) — "
-            "pass an explicit --epic"
+            f"multiple ad-hoc epics titled {title!r} in {home} ({nums}) — pass an explicit --epic"
         )
     if rows:
-        return IssueRef(owner=owner, repo=".github", number=int(rows[0]["number"]))
+        return IssueRef(owner=owner, repo=home_repo, number=int(rows[0]["number"]))
     url = github.create_issue(
-        repo=dotgithub,
+        repo=home,
         title=title,
         body=_ADHOC_EPIC_BODY.format(repo=target_repo),
         labels=list(_ADHOC_EPIC_LABELS),
     )
     number = int(url.rstrip("/").rsplit("/", 1)[-1])
-    return IssueRef(owner=owner, repo=".github", number=number)
+    return IssueRef(owner=owner, repo=home_repo, number=number)
 
 
 # Deprecated alias kept for the ad-hoc rollout window (epic #85); callers still

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -455,7 +455,10 @@ def _adhoc_row(number: int, repo_bare: str = "tooling") -> dict:
 
 
 def test_resolve_epic_ref_adhoc_discovers_single_epic() -> None:
-    with patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]) as mock_list:
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]) as mock_list,
+    ):
         assert epics.resolve_epic_ref("adhoc", repo="org/tooling") == IssueRef(
             "org", ".github", 1972
         )
@@ -466,7 +469,10 @@ def test_resolve_epic_ref_adhoc_discovers_single_epic() -> None:
 
 def test_resolve_epic_ref_standing_is_deprecated_alias_for_adhoc() -> None:
     # 'standing' still resolves during the rollout window, routing to .github.
-    with patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]):
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]),
+    ):
         assert epics.resolve_epic_ref("standing", repo="org/tooling") == IssueRef(
             "org", ".github", 1972
         )
@@ -476,6 +482,7 @@ def test_ensure_adhoc_epic_zero_creates_in_dotgithub() -> None:
     # When no ad-hoc epic exists, ensure creates it in <org>/.github, by title.
     created = "https://github.com/org/.github/issues/77"
     with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
         patch("vergil_tooling.lib.github.read_json", return_value=[]),
         patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
     ):
@@ -484,6 +491,20 @@ def test_ensure_adhoc_epic_zero_creates_in_dotgithub() -> None:
     assert mock_create.call_args.kwargs["repo"] == "org/.github"
     assert mock_create.call_args.kwargs["labels"] == ["epic", "ad-hoc"]
     assert mock_create.call_args.kwargs["title"] == "Epic (ad hoc): tooling"
+
+
+def test_ensure_adhoc_epic_private_repo_homes_in_self() -> None:
+    # A private target homes its ad-hoc epic in the repo itself, not .github.
+    created = "https://github.com/org/lab/issues/3"
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/lab"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
+    ):
+        result = epics.ensure_adhoc_epic("org/lab")
+    assert result == IssueRef("org", "lab", 3)
+    assert mock_create.call_args.kwargs["repo"] == "org/lab"
+    assert mock_create.call_args.kwargs["title"] == "Epic (ad hoc): lab"
 
 
 def test_ensure_adhoc_epic_for_dotgithub_itself() -> None:
@@ -501,6 +522,7 @@ def test_ensure_adhoc_epic_reuses_existing_by_title() -> None:
     # different repo's ad-hoc epic in the same .github list is ignored.
     rows = [_adhoc_row(1972), {"number": 40, "title": "Epic (ad hoc): actions"}]
     with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
         patch("vergil_tooling.lib.github.read_json", return_value=rows),
         patch("vergil_tooling.lib.github.create_issue") as mock_create,
     ):
@@ -509,12 +531,16 @@ def test_ensure_adhoc_epic_reuses_existing_by_title() -> None:
 
 
 def test_ensure_standing_epic_is_backward_compatible_alias() -> None:
-    with patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]):
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]),
+    ):
         assert epics.ensure_standing_epic("org/tooling") == IssueRef("org", ".github", 1972)
 
 
 def test_ensure_adhoc_epic_multiple_same_title_raises() -> None:
     with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
         patch(
             "vergil_tooling.lib.github.read_json",
             return_value=[_adhoc_row(1), _adhoc_row(2)],

--- a/tests/vergil_tooling/test_vrg_adhoc_epic.py
+++ b/tests/vergil_tooling/test_vrg_adhoc_epic.py
@@ -21,6 +21,8 @@ def test_ensure_current_repo(capsys: pytest.CaptureFixture[str]) -> None:
     # The ad-hoc epic for org/repo lives in org/.github (title-disambiguated).
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/.github"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PUBLIC"),
         patch(
             f"{_MOD}.epics.ensure_adhoc_epic",
             return_value=epics.IssueRef("org", ".github", 5),
@@ -30,6 +32,7 @@ def test_ensure_current_repo(capsys: pytest.CaptureFixture[str]) -> None:
     assert rc == 0
     mock_ensure.assert_called_once_with("org/repo")
     out = capsys.readouterr().out
+    assert "epic home: org/.github [PUBLIC]" in out
     assert "Ad-hoc epic:" in out
     assert "org/.github#5" in out
 
@@ -37,6 +40,8 @@ def test_ensure_current_repo(capsys: pytest.CaptureFixture[str]) -> None:
 def test_ensure_repo_override(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.current_repo") as mock_cur,
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/.github"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PUBLIC"),
         patch(
             f"{_MOD}.epics.ensure_adhoc_epic",
             return_value=epics.IssueRef("org", ".github", 9),
@@ -47,3 +52,28 @@ def test_ensure_repo_override(capsys: pytest.CaptureFixture[str]) -> None:
     mock_ensure.assert_called_once_with("org/actions")
     mock_cur.assert_not_called()
     assert "org/.github#9" in capsys.readouterr().out
+
+
+def test_ensure_malformed_repo_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.epics.ensure_adhoc_epic") as mock_ensure:
+        rc = main(["ensure", "--repo", "noslash"])
+    assert rc == 1
+    assert "owner/repo" in capsys.readouterr().err
+    mock_ensure.assert_not_called()
+
+
+def test_ensure_private_repo_echoes_self_home(capsys: pytest.CaptureFixture[str]) -> None:
+    # A private target's ad-hoc epic homes in the repo itself; the echo shows it.
+    with (
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PRIVATE"),
+        patch(
+            f"{_MOD}.epics.ensure_adhoc_epic",
+            return_value=epics.IssueRef("org", "lab", 3),
+        ),
+    ):
+        rc = main(["ensure", "--repo", "org/lab"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "epic home: org/lab [PRIVATE]" in out
+    assert "org/lab#3" in out


### PR DESCRIPTION
# Pull Request

## Summary

- ensure_adhoc_epic derives its home from resolve_epic_home so a private repo's ad-hoc epic lives in the repo itself, and vrg-adhoc-epic echoes the resolved home before provisioning.

## Issue Linkage

- Closes #2233

## Notes

- Task of epic #130; builds on the resolver (#2231). Public repos unchanged (ad-hoc epic still in <org>/.github); the returned IssueRef now carries the resolved home repo. Several existing ad-hoc tests were updated to stub resolve_epic_home (they'd otherwise make real visibility probes). Note: the 'resolve target -> echo home' snippet is now duplicated across vrg-epic-create and vrg-adhoc-epic; a small consolidation follow-up may be worthwhile once #2234/#2235 land. 4085 tests pass; validation green.