### PR TITLE
feat(epic-audit): flag epics outside .github only for public repos

### DIFF
--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -206,11 +206,15 @@ _INTAKE_LABELS = frozenset({"triage", "idea", "research"})
 
 
 def epic_outside_dotgithub(org: str) -> list[str]:
-    """Open ``epic``-labelled issues living outside ``<org>/.github`` (invariant 1).
+    """Open ``epic``-labelled issues wrongly outside ``<org>/.github`` (invariant 1).
 
-    Invariant 1 (epic #85): all epics live in the org's ``.github``. Any open
-    epic-labelled issue in another repo is a violation; returns their
-    ``owner/repo#n`` slugs.
+    Invariant 1 (epic #85, generalized for visibility-based homes in epic #130):
+    a **public** repo's epics live centrally in the org's ``.github``; a
+    **private** repo legitimately homes its own epics in itself. So an open
+    epic-labelled issue outside ``.github`` is a violation only when its repo is
+    public. Visibility is probed per repo (memoized); a probe error is fail-loud
+    — a genuine leaked-out public epic must never be masked by a silent skip.
+    Returns the ``owner/repo#n`` slugs of violations.
     """
     raw: Any = github.read_json(
         "search",
@@ -230,6 +234,8 @@ def epic_outside_dotgithub(org: str) -> list[str]:
         name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
         if not name_with_owner or name_with_owner == dotgithub:
             continue
+        if not github.is_public(name_with_owner):
+            continue  # private repo legitimately self-homes its epics (fail-loud on probe error)
         violations.append(f"{name_with_owner}#{item['number']}")
     return violations
 
@@ -344,7 +350,9 @@ def render(
     if epics_outside or stray or closed_operational_no_success:
         lines += ["", "## Invariant violations (issues in the wrong place)", ""]
         if epics_outside:
-            lines.append("**Epics outside `.github`** — move each to the org's `.github`:")
+            lines.append(
+                "**Epics outside `.github`** (public repos) — move each to the org's `.github`:"
+            )
             lines += [f"- {slug}" for slug in sorted(epics_outside)]
         if stray:
             lines.append("**Stray `.github` issues** — not an epic, intake, or linked task:")

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from vergil_tooling.lib import epic_audit, epics, github, roadmap
 from vergil_tooling.lib.epic_audit import TaskDrift
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def test_task_drift_flags_open_task_behind_merged_pr() -> None:
@@ -162,17 +160,45 @@ def test_epic_drift_flags_all_done_open_epics() -> None:
     assert [e.number for e in result] == [40]
 
 
-def test_epic_outside_dotgithub_flags_non_dotgithub_epics() -> None:
+def test_epic_outside_dotgithub_flags_public_non_dotgithub_epics() -> None:
     issues = [
         {"number": 99, "repository": {"nameWithOwner": "vergil-project/vergil-tooling"}},
         {"number": 40, "repository": {"nameWithOwner": "vergil-project/.github"}},  # ok
         {"number": 5, "repository": {}},  # no repo -> skipped
     ]
-    with patch("vergil_tooling.lib.github.read_json", return_value=issues) as mock_search:
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=issues) as mock_search,
+        patch("vergil_tooling.lib.github.is_public", return_value=True),
+    ):
         result = epic_audit.epic_outside_dotgithub("vergil-project")
     assert result == ["vergil-project/vergil-tooling#99"]
     args = mock_search.call_args.args
     assert "search" in args and "issues" in args and "epic" in args
+
+
+def test_epic_outside_dotgithub_ignores_private_repo_epic() -> None:
+    # A private repo legitimately self-homes its epics -> not a violation.
+    issues = [{"number": 4, "repository": {"nameWithOwner": "vergil-project/lab"}}]
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=issues),
+        patch("vergil_tooling.lib.github.is_public", return_value=False),
+    ):
+        assert epic_audit.epic_outside_dotgithub("vergil-project") == []
+
+
+def test_epic_outside_dotgithub_fails_loud_on_probe_error() -> None:
+    # A visibility probe that errors must raise, never silently skip (a genuine
+    # leaked-out public epic would otherwise be masked).
+    issues = [{"number": 4, "repository": {"nameWithOwner": "vergil-project/lab"}}]
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=issues),
+        patch(
+            "vergil_tooling.lib.github.is_public",
+            side_effect=github.GitHubAPIError(1, "cmd", "boom"),
+        ),
+        pytest.raises(github.GitHubAPIError),
+    ):
+        epic_audit.epic_outside_dotgithub("vergil-project")
 
 
 def test_stray_dotgithub_issue_flags_unlinked_non_epic_non_intake() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Invariant 1 now flags an epic outside <org>/.github only when its repo is public, so the org audit stops false-flagging a private repo's legitimately self-homed epics; the visibility probe is fail-loud.

## Issue Linkage

- Closes #2234

## Notes

- Task of epic #130; builds on the resolver (#2231). Scoped to the invariant generalization + render text (the correctness fix that keeps the org audit from mis-flagging private epics). The larger self-contained 'vrg-epic-audit --repo <private>' sourcing (threading resolve_epic_home through operational_pending/stray/close_drift) is deferred to a follow-up issue linked under the epic. 30 audit tests + full validation green.