### PR TITLE
fix(pr-workflow): refuse a cross-repo closing issue in submit-pr / report-ready

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -32,6 +32,37 @@ def _emit(payload: dict[str, object]) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def _reject_cross_repo_issue(issue: str) -> None:
+    """Refuse a cross-repo --issue at report time — a PR closes only same-repo issues.
+
+    Mirrors vrg-submit-pr's guard so the error surfaces where the value is entered
+    (report time) rather than later at submit. A PR can only ``Closes`` an issue
+    in its own repo; because issue numbers are not unique across repos, a
+    cross-repo close would shut an unrelated same-numbered issue — a genuine
+    mis-close hazard. Best-effort: if the current repo cannot be resolved (no
+    remote, no gh auth — an offline run), defer silently to vrg-submit-pr's
+    authoritative check. A bare ``#N`` (or a plain number) resolves to the
+    current repo and always passes; the compare is case-insensitive so a
+    differently cased spelling of the current repo is not a false refusal.
+    """
+    try:
+        current = github.current_repo()
+    except (subprocess.CalledProcessError, OSError):
+        return
+    if not current:
+        return
+    try:
+        ref = epics.parse_issue_ref(issue, default_repo=current)
+    except ValueError:
+        return
+    if f"{ref.owner}/{ref.repo}".lower() != current.lower():
+        raise WorkflowError(
+            f"--issue ({ref.slug}) is in a different repo than this PR ({current}); "
+            "a PR can only close an issue in its own repo. File the task in this repo "
+            "and reference the other issue via a comment or a Ref line."
+        )
+
+
 def _reject_epic_issue(issue: str) -> None:
     """Refuse an epic linkage at report time — a PR links a task, not an epic.
 
@@ -73,6 +104,7 @@ def _reject_operational_issue(issue: str) -> None:
 
 
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
+    _reject_cross_repo_issue(str(args.issue))
     _reject_epic_issue(str(args.issue))
     _reject_operational_issue(str(args.issue))
     try:

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -230,6 +230,35 @@ def _print_pr_watch(pr_url: str) -> None:
     print(f"    /vergil:pr-watch {pr_url}")
 
 
+def _reject_if_cross_repo(issue_ref: str) -> None:
+    """Abort if --issue names an issue in a different repo than this PR's own.
+
+    A PR can only ``Closes`` an issue in its own repository: GitHub scopes the
+    close keyword to same-repo linkage, and issue numbers are not unique across
+    repos, so a cross-repo close is a genuine mis-close hazard (an unrelated
+    same-numbered issue would be closed), not a cosmetic slip. Refuse here and
+    tell the caller to file the task in this repo and reference the other issue
+    via a comment or a ``Ref`` line. This runs before the epic/operational
+    guards because it is a cheap, local structural check — no authenticated
+    ``gh`` call — and short-circuiting a cross-repo ref avoids an epic-ness
+    lookup against a repo the token may not even cover. A bare ``#N`` resolves to
+    the current repo and always passes; an unparseable ref defers to the
+    downstream validators. The compare is case-insensitive so a differently
+    cased spelling of the current repo is not a false refusal.
+    """
+    current = github.current_repo()
+    try:
+        ref = epics.parse_issue_ref(issue_ref, default_repo=current)
+    except ValueError:
+        return
+    if current and f"{ref.owner}/{ref.repo}".lower() != current.lower():
+        raise SystemExit(
+            f"vrg-submit-pr: --issue ({ref.slug}) is in a different repo than this "
+            f"PR ({current}); a PR can only close an issue in its own repo. File the "
+            "task in this repo and reference the other issue via a comment or a Ref line."
+        )
+
+
 def _reject_if_epic_link(issue_ref: str) -> None:
     """Abort if the linkage points at an epic — PRs link a task, never an epic.
 
@@ -310,8 +339,8 @@ def _run_cli_mode(args: argparse.Namespace) -> int:
     if args.issue is None or args.summary is None or args.title is None:  # pragma: no cover
         msg = "internal error: CLI mode requires --issue, --summary, and --title"
         raise SystemExit(msg)
-
     issue_ref = resolve_issue_ref(args.issue)
+    _reject_if_cross_repo(issue_ref)
     _reject_if_epic_link(issue_ref)
     _reject_if_operational_task(issue_ref)
     linkage = _resolve_linkage(issue_ref, args.linkage)
@@ -552,6 +581,7 @@ def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: b
     """
     fields = submission.read_pr_fields(worktree_root)
     issue_ref = resolve_issue_ref(fields["issue"])
+    _reject_if_cross_repo(issue_ref)
     _reject_if_epic_link(issue_ref)
     _reject_if_operational_task(issue_ref)
     branch = git.current_branch()

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -130,6 +130,118 @@ def test_report_ready_rejects_operational_task(
     assert "operational task" in capsys.readouterr().err.lower()
 
 
+def test_report_ready_rejects_cross_repo_issue(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Guard parity with vrg-submit-pr: report-ready refuses a cross-repo --issue.
+    # A PR can only close an issue in its own repo, and because issue numbers are
+    # not unique across repos, a cross-repo close is a genuine mis-close hazard.
+    # The check runs first, so no epic/operational gh call hits the foreign repo.
+    with patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "org/.github#127",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 1
+    assert "different repo" in capsys.readouterr().err.lower()
+
+
+def test_report_ready_defers_cross_repo_when_repo_unresolvable(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # If the current repo cannot be resolved (offline), the cross-repo guard
+    # defers rather than blocking; vrg-submit-pr's check still catches it later.
+    with patch(
+        "vergil_tooling.bin.vrg_pr_workflow.github.current_repo",
+        side_effect=subprocess.CalledProcessError(1, "gh"),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "org/.github#127",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "ready"}
+
+
+def test_report_ready_defers_cross_repo_when_repo_empty(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An empty current repo (nothing to compare against) defers rather than
+    # blocking; a bare same-repo issue then proceeds normally.
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value=""),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "ready"}
+
+
+def test_report_ready_allows_explicit_same_repo_ref(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # An explicit owner/repo#N matching the current repo passes the cross-repo
+    # guard (same repo) and proceeds.
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_epic_linkage", return_value=False),
+        patch("vergil_tooling.bin.vrg_pr_workflow.epics.is_operational_task", return_value=False),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "org/repo#42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "ready"}
+
+
 def test_report_ready_allows_non_epic_task(
     in_git_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -11,6 +11,7 @@ import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
     _push_branch,
+    _reject_if_cross_repo,
     _reject_if_epic_link,
     _reject_if_operational_task,
     _resolve_linkage,
@@ -41,6 +42,7 @@ def _no_epic_link_check() -> Iterator[None]:
     don't shadow them.
     """
     with (
+        patch(_MOD + "._reject_if_cross_repo"),
         patch(_MOD + "._reject_if_epic_link"),
         patch(_MOD + "._reject_if_operational_task"),
         patch(_MOD + "._task_linkage", side_effect=lambda _ref, requested: (requested, None)),
@@ -1652,6 +1654,47 @@ def test_main_batch_routes_to_run_submit_batch() -> None:
         rc = main(["--all", "--finalize", "--base", "develop"])
     assert rc == 0
     run_batch.assert_called_once()
+
+
+# -- _reject_if_cross_repo (a PR closes only same-repo issues) ----------------
+
+
+def test_reject_if_cross_repo_raises_for_other_repo() -> None:
+    # A cross-repo ref is refused: a PR here cannot Closes an issue elsewhere.
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        pytest.raises(SystemExit, match="different repo"),
+    ):
+        _reject_if_cross_repo("org/.github#127")
+
+
+def test_reject_if_cross_repo_passes_for_same_repo_bare_ref() -> None:
+    # A bare #N resolves to the current repo, so it is same-repo and passes.
+    with patch(f"{_MOD}.github.current_repo", return_value="org/repo"):
+        _reject_if_cross_repo("#42")
+
+
+def test_reject_if_cross_repo_passes_for_explicit_same_repo_ref() -> None:
+    with patch(f"{_MOD}.github.current_repo", return_value="org/repo"):
+        _reject_if_cross_repo("org/repo#42")
+
+
+def test_reject_if_cross_repo_passes_for_case_insensitive_match() -> None:
+    # Differently cased spellings of the current repo are not a false refusal.
+    with patch(f"{_MOD}.github.current_repo", return_value="Org/Repo"):
+        _reject_if_cross_repo("org/repo#42")
+
+
+def test_reject_if_cross_repo_noop_when_repo_unresolvable() -> None:
+    # No current repo to compare against: defer to downstream validation.
+    with patch(f"{_MOD}.github.current_repo", return_value=""):
+        _reject_if_cross_repo("org/repo#42")
+
+
+def test_reject_if_cross_repo_noop_for_unparseable_ref() -> None:
+    # A ref with no resolvable repo defers rather than erroring.
+    with patch(f"{_MOD}.github.current_repo", return_value="org/repo"):
+        _reject_if_cross_repo("not-a-ref")
 
 
 # -- _reject_if_epic_link (PRs link tasks, not epics) ------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Add a fourth guard to vrg-submit-pr and vrg-pr-workflow report-ready that refuses an --issue naming a different repo than the PR's own, closing the cross-repo mis-close hazard where a PR could Closes an unrelated same-numbered issue in another repo.

## Issue Linkage

- Closes #2243

## Notes

- Mirrors the existing _reject_if_epic_link / _reject_if_operational_task guards. The cross-repo check runs first because it is a cheap local structural check (no gh call) and short-circuits before an epic-ness lookup against a repo the token may not cover. A bare issue number resolves to the current repo and always passes; the compare is case-insensitive. report-ready is best-effort — an unresolvable current repo defers to submit-pr's authoritative check. 100% coverage held; validation green via vrg-container-run -- vrg-validate.