### PR TITLE
feat(roadmap): source epics from the resolved home (self for private repos)

### DIFF
--- a/src/vergil_tooling/bin/vrg_roadmap.py
+++ b/src/vergil_tooling/bin/vrg_roadmap.py
@@ -1,4 +1,4 @@
-"""Print the generated project roadmap (open epics in the org ``.github`` repo).
+"""Print the generated project roadmap (open epics in a repo's resolved epic home).
 
 A pure read-and-render command — see :mod:`vergil_tooling.lib.roadmap`. The
 nightly job that writes/publishes the rendered markdown is separate (T8c).
@@ -9,7 +9,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from vergil_tooling.lib import github, roadmap
+from vergil_tooling.lib import epics, github, roadmap
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -18,13 +18,33 @@ def main(argv: list[str] | None = None) -> int:
         "--org",
         help="GitHub org whose .github epics to read (default: current repo's owner).",
     )
+    parser.add_argument(
+        "--repo",
+        help=(
+            "Target repo 'owner/repo' whose roadmap to show (its resolved epic "
+            "home; a private repo self-homes its epics). Mutually exclusive with --org."
+        ),
+    )
     args = parser.parse_args(argv)
-    org = args.org or github.current_org()
-    # Scope the App token to the org being read so a cross-org --org selects
+    if args.org and args.repo:
+        print("vrg-roadmap: --org and --repo are mutually exclusive", file=sys.stderr)
+        return 1
+    if args.repo:
+        if "/" not in args.repo:
+            print(
+                f"vrg-roadmap: --repo must be 'owner/repo' (got {args.repo!r})",
+                file=sys.stderr,
+            )
+            return 1
+        owner, bare = args.repo.split("/", 1)
+        org, home = owner, epics.resolve_epic_home(owner, bare)
+    else:
+        org, home = args.org or github.current_org(), None
+    # Scope the App token to the org being read so a cross-org --org/--repo selects
     # that org's installation, not the cwd repo's (#2070).
     try:
         with github.target_org(org):
-            print(roadmap.render(roadmap.gather(org), org))
+            print(roadmap.render(roadmap.gather(org, home=home), org, home=home))
     except github.NoInstallationError as exc:
         print(f"vrg-roadmap: {github.no_installation_message(exc)}", file=sys.stderr)
         return 1

--- a/src/vergil_tooling/lib/roadmap.py
+++ b/src/vergil_tooling/lib/roadmap.py
@@ -1,4 +1,4 @@
-"""Generate the project roadmap from open finite epics in the org ``.github`` repo.
+"""Generate the project roadmap from open finite epics in a repo's resolved epic home.
 
 "Where we're going", derived mechanically from epic metadata — no hand editing.
 ``gather`` reads the open ``epic``-labelled issues (skipping perpetual ``ad-hoc`` buckets)
@@ -28,12 +28,12 @@ class EpicSummary:
     url: str
 
 
-def _open_epics(org: str) -> list[Any]:
+def _open_epics(home: str) -> list[Any]:
     raw: Any = github.read_json(
         "issue",
         "list",
         "--repo",
-        f"{org}/.github",
+        home,
         "--label",
         "epic",
         "--state",
@@ -53,16 +53,21 @@ def _is_perpetual(epic: Any) -> bool:
     return bool(names & {"ad-hoc", "standing"})
 
 
-def gather(org: str | None = None) -> list[EpicSummary]:
-    """Summarize every open finite (non-perpetual) epic in *org*'s ``.github``.
+def gather(org: str | None = None, *, home: str | None = None) -> list[EpicSummary]:
+    """Summarize every open finite (non-perpetual) epic in the resolved epic *home*.
 
-    *org* defaults to the owner of the current repo's git remote, so the same
-    command reports each org's own roadmap.
+    *org* defaults to the current repo's owner. *home* defaults to that org's
+    ``.github`` (via :func:`epics.resolve_epic_home`), so the default is the
+    org-level roadmap; pass an explicit *home* (a private repo that self-homes
+    its epics) to scope the roadmap to that repo.
     """
     if org is None:
         org = github.current_org()
+    if home is None:
+        home = epics.resolve_epic_home(org, ".github")
+    home_owner, home_repo = home.split("/", 1)
     summaries: list[EpicSummary] = []
-    for epic in _open_epics(org):
+    for epic in _open_epics(home):
         if _is_perpetual(epic):
             continue
         # Defense in depth: a release tracking issue is never epic-labelled, so
@@ -74,7 +79,7 @@ def gather(org: str | None = None) -> list[EpicSummary]:
         ):
             continue
         number = int(epic["number"])
-        children = epics.child_states(epics.IssueRef(org, ".github", number))
+        children = epics.child_states(epics.IssueRef(home_owner, home_repo, number))
         repos = tuple(sorted({f"{c.ref.owner}/{c.ref.repo}" for c in children}))
         closed = sum(1 for c in children if c.state == "CLOSED")
         milestone = epic.get("milestone")
@@ -103,11 +108,11 @@ def _row(epic: EpicSummary) -> str:
     )
 
 
-def render(summaries: list[EpicSummary], org: str | None = None) -> str:
+def render(summaries: list[EpicSummary], org: str | None = None, *, home: str | None = None) -> str:
     """Render the roadmap markdown as a table per milestone."""
     if not summaries:
         return "# Roadmap\n\n_No active epics._\n"
-    source = f"{org}/.github" if org else "the org .github repo"
+    source = home or (f"{org}/.github" if org else "the org .github repo")
     by_milestone: dict[str, list[EpicSummary]] = {}
     for epic in summaries:
         by_milestone.setdefault(epic.milestone or "No milestone", []).append(epic)

--- a/tests/vergil_tooling/test_roadmap.py
+++ b/tests/vergil_tooling/test_roadmap.py
@@ -177,6 +177,38 @@ def test_render_without_org_uses_generic_source() -> None:
     assert "open epics in the org .github repo" in out
 
 
+def test_gather_reads_from_explicit_private_home() -> None:
+    # A private repo self-homes its epics; gather scopes to that home, not .github.
+    epic_list = [
+        {
+            "number": 2,
+            "title": "Lab epic",
+            "createdAt": "2026-07-09T00:00:00Z",
+            "milestone": None,
+            "labels": [{"name": "epic"}],
+            "url": "u2",
+        }
+    ]
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=epic_list) as mock_read,
+        patch("vergil_tooling.lib.epics.child_states", return_value=[]) as mock_children,
+    ):
+        result = roadmap.gather("org", home="org/lab")
+    assert result[0].number == 2
+    # The private home drives both the epic query and the child rollup.
+    assert "org/lab" in mock_read.call_args.args
+    assert (mock_children.call_args.args[0].owner, mock_children.call_args.args[0].repo) == (
+        "org",
+        "lab",
+    )
+
+
+def test_render_uses_explicit_home_source() -> None:
+    summaries = [EpicSummary(2, "Lab", "2026-07-09", None, (), 0, 0, "u2")]
+    out = roadmap.render(summaries, "org", home="org/lab")
+    assert "open epics in org/lab" in out
+
+
 def test_gather_defaults_org_to_current_repo_owner() -> None:
     epic_list = [
         {

--- a/tests/vergil_tooling/test_vrg_roadmap.py
+++ b/tests/vergil_tooling/test_vrg_roadmap.py
@@ -50,3 +50,32 @@ def test_main_reports_missing_installation() -> None:
     ):
         rc = main(["--org", "other-org"])
     assert rc == 1
+
+
+def test_main_repo_uses_resolved_home() -> None:
+    with (
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab") as mock_home,
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.roadmap.gather", return_value=[]) as mock_gather,
+    ):
+        rc = main(["--repo", "org/lab"])
+    assert rc == 0
+    mock_home.assert_called_once_with("org", "lab")
+    mock_scope.assert_called_once_with("org")
+    assert mock_gather.call_args.kwargs["home"] == "org/lab"
+
+
+def test_main_org_and_repo_mutually_exclusive(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.roadmap.gather") as mock_gather:
+        rc = main(["--org", "x", "--repo", "x/y"])
+    assert rc == 1
+    assert "mutually exclusive" in capsys.readouterr().err
+    mock_gather.assert_not_called()
+
+
+def test_main_malformed_repo_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.roadmap.gather") as mock_gather:
+        rc = main(["--repo", "noslash"])
+    assert rc == 1
+    assert "owner/repo" in capsys.readouterr().err
+    mock_gather.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- roadmap.gather/render source from a resolved epic home (default: the org's .github, unchanged), and vrg-roadmap gains --repo owner/repo to scope the roadmap to a private repo's self-homed epics.

## Issue Linkage

- Closes #2235

## Notes

- Task of epic #130; builds on the resolver (#2231). The default path calls resolve_epic_home(org, '.github'), which short-circuits without a visibility probe, so the org-level roadmap is byte-for-byte unchanged and existing tests pass untouched. --org and --repo are mutually exclusive; org roadmap omits private epics by design. 18 roadmap tests + full validation green.