### PR TITLE
feat(epic-link): refuse public task under a private epic (visibility boundary)

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_link.py
+++ b/src/vergil_tooling/bin/vrg_epic_link.py
@@ -7,7 +7,11 @@ fallback. This CLI creates the reliable native link via ``epics.add_child``
 when creating a task under an epic, and to backfill reflink-only children.
 
 Refs are ``owner/repo#N`` or bare ``#N`` (bare resolves to the current repo).
-The epic typically lives in the org ``.github`` repo, so pass it fully-qualified.
+The epic lives in its resolved home (``.github`` for a public repo, the repo
+itself when private), so pass it fully-qualified. A public task may not
+hard-link under a private epic — that would leak the private repo's name and
+break cross-boundary roll-up; such dependencies use a soft ``Blocked-by:``
+reference from the private side instead (epic #130).
 """
 
 from __future__ import annotations
@@ -37,6 +41,23 @@ def main(argv: list[str] | None = None) -> int:
         owner = epics.single_target_org(epic, task)
     except ValueError as exc:
         print(f"vrg-epic-link: {exc}", file=sys.stderr)
+        return 1
+    # Visibility-boundary guard (epic #130): a task may hard-link to an epic only
+    # if it is no more publicly visible than the epic's home. A public task under
+    # a private epic would leak the private repo's name into a public issue and
+    # break cross-boundary roll-up. Binary is_public suffices; fail-loud on a
+    # probe error (never silently allow a leaking link).
+    task_repo = f"{task.owner}/{task.repo}"
+    epic_home = f"{epic.owner}/{epic.repo}"
+    if github.is_public(task_repo) and not github.is_public(epic_home):
+        print(
+            f"vrg-epic-link: refusing to link public task {task.slug} under "
+            f"less-visible epic {epic.slug} — a public issue must not name a "
+            f"private epic (leak) and cross-boundary roll-up cannot fire. File "
+            f"the public work as its own task and reference it from the private "
+            f"epic's body with 'Blocked-by: {task_repo}#{task.number}'.",
+            file=sys.stderr,
+        )
         return 1
     try:
         with github.target_org(owner):

--- a/tests/vergil_tooling/test_vrg_epic_link.py
+++ b/tests/vergil_tooling/test_vrg_epic_link.py
@@ -20,6 +20,7 @@ def test_parse_args_requires_epic_and_task() -> None:
 def test_main_links_task_under_epic() -> None:
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.is_public", return_value=True),
         patch(f"{_MOD}.epics.add_child") as mock_add,
     ):
         rc = main(["--epic", "org/.github#40", "--task", "#42"])
@@ -45,6 +46,7 @@ def test_main_scopes_token_to_target_owner() -> None:
     cwd org's (#2070)."""
     with (
         patch(f"{_MOD}.github.current_repo", return_value="cwd-org/repo"),
+        patch(f"{_MOD}.github.is_public", return_value=True),
         patch(f"{_MOD}.github.target_org") as mock_scope,
         patch(f"{_MOD}.epics.add_child"),
     ):
@@ -66,6 +68,7 @@ def test_main_rejects_cross_org_refs() -> None:
 def test_main_reports_missing_installation() -> None:
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.is_public", return_value=True),
         patch(
             f"{_MOD}.epics.add_child",
             side_effect=github.NoInstallationError("org", []),
@@ -73,3 +76,39 @@ def test_main_reports_missing_installation() -> None:
     ):
         rc = main(["--epic", "org/.github#40", "--task", "#42"])
     assert rc == 1
+
+
+def test_refuses_public_task_under_private_epic(capsys: pytest.CaptureFixture[str]) -> None:
+    # A public task must not be a native sub-issue of a private epic: it would
+    # leak the private repo's name and break cross-boundary roll-up.
+    def pub(nwo: str) -> bool:
+        return {"org/tooling": True, "org/lab": False}[nwo]
+
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/tooling"),
+        patch(f"{_MOD}.github.is_public", side_effect=pub),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--epic", "org/lab#5", "--task", "org/tooling#9"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "refusing to link public task" in err
+    assert "Blocked-by" in err
+    mock_add.assert_not_called()
+
+
+def test_allows_private_task_under_public_epic() -> None:
+    # The reverse is fine: a private child under a public parent doesn't leak and
+    # roll-up reads the public parent.
+    def pub(nwo: str) -> bool:
+        return {"org/.github": True, "org/lab": False}[nwo]
+
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/lab"),
+        patch(f"{_MOD}.github.is_public", side_effect=pub),
+        patch(f"{_MOD}.github.target_org"),
+        patch(f"{_MOD}.epics.add_child") as mock_add,
+    ):
+        rc = main(["--epic", "org/.github#5", "--task", "org/lab#9"])
+    assert rc == 0
+    mock_add.assert_called_once()


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-epic-link now refuses to hard-link a public task under a less-visible (private) epic, preventing a public issue from naming the private repo and breaking cross-boundary roll-up; the reverse (private child, public parent) stays allowed.

## Issue Linkage

- Closes #2236

## Notes

- Task of epic #130; the cross-visibility protection identified during design. Guard runs after single_target_org (so cross-org is still rejected first) and is fail-loud on a probe error. The refusal message points at the sanctioned soft-reference pattern (Blocked-by: from the private epic's body). Existing valid-link tests stub is_public=True. 8 link tests + full validation green.