### PR TITLE
fix(vrg-vm): abort when a repo declares named instances but none is selected

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -220,6 +220,36 @@ def _workspace_org_repo(workspace: str | None) -> tuple[str | None, str | None]:
     return parts[0], parts[1]
 
 
+def _require_instance_selection(
+    identity: str,
+    org: str,
+    repo: str,
+    stanza: VmStanza | None,
+    inst_name: str | None,
+) -> None:
+    """Abort when a repo's role declares named instances but none was selected.
+
+    Such a role's base tier is a shared template, not a bootable box; composing it
+    with no ``--name`` yields a phantom default whose VM was never created, so the
+    caller would only discover the mistake via a misleading 'VM does not exist'
+    error downstream. Fail early and name the available instances instead. This
+    fires for a borrowed lender too — the check runs on the effective (post-borrow)
+    repo (issue #2251).
+    """
+    if inst_name is not None or stanza is None:
+        return
+    role = stanza.roles.get(identity)
+    if role is None or not role.instances:
+        return
+    choices = sorted(role.instances)
+    avail = ", ".join(choices)
+    msg = (
+        f"{org}/{repo} declares named VM instances ({avail}) but none was selected; "
+        f"pass --name <instance> (e.g. --name {choices[0]})"
+    )
+    raise SpecError(msg)
+
+
 def _resolve_target(args: argparse.Namespace, *, borrow_allowed: bool = False) -> Target:
     """Resolve (identity, optional org/repo) to a base or dedicated VM target.
 
@@ -254,6 +284,8 @@ def _resolve_target(args: argparse.Namespace, *, borrow_allowed: bool = False) -
         eff_org, eff_repo, eff_vm = borrow.org, borrow.repo, borrow.stanza
     else:
         eff_org, eff_repo, eff_vm = org, repo, requested_vm
+
+    _require_instance_selection(name, eff_org, eff_repo, eff_vm, inst_name)
 
     override = identity.overrides.get((eff_org, eff_repo))
     spec = compose_vm_spec(

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -48,7 +48,7 @@ from vergil_tooling.bin.vrg_vm import (
 from vergil_tooling.lib import vm_cloud
 from vergil_tooling.lib.identity import Identity, IdentityConfig
 from vergil_tooling.lib.vm_backend import select_backend
-from vergil_tooling.lib.vm_spec import ComposedSpec
+from vergil_tooling.lib.vm_spec import ComposedSpec, SpecError
 from vergil_tooling.lib.vm_transport import LimaTransport
 
 
@@ -2611,6 +2611,73 @@ class TestBorrowBlocks:
         result = main(["update", "lmf/tooling", "--config", str(cfg)])
         assert result == 1
         assert "borrows the VM of lmf/lab" in capsys.readouterr().err
+
+
+# A role that declares named instances (a local Lima box + an off-platform cloud
+# box) but no usable default. The base [vm.vergil-user] is a shared template the
+# two instances inherit — it is NOT itself a bootable box.
+_INSTANCES_VM = """
+[vm.vergil-user]
+packages = ["qemu-system-x86"]
+
+[vm.vergil-user.instances.local]
+cpus = 12
+
+[vm.vergil-user.instances.cloud]
+backend = "off-platform"
+provider = "gcp"
+region = "us-central1"
+instance = "n2-standard-8"
+volume = "200GiB"
+"""
+
+
+def _named_args(config: Path, workspace: str, name: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        config=config, identity=None, workspace=workspace, command="session", name=name
+    )
+
+
+class TestNamedInstanceRequiresName:
+    """A repo whose role declares named instances must be addressed with --name.
+
+    Resolving one with no name aborts with a message that lists the instances,
+    instead of silently composing a phantom base-only default that then fails a
+    downstream 'VM does not exist' check (issue #2251).
+    """
+
+    def test_direct_no_name_aborts_listing_instances(self, tmp_path: Path) -> None:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "lab", _INSTANCES_VM)
+        cfg = _identities(tmp_path, projects)
+        with pytest.raises(SpecError) as exc:
+            _resolve_target(_args(cfg, "lmf/lab"))
+        msg = str(exc.value)
+        assert "--name" in msg
+        assert "local" in msg
+        assert "cloud" in msg
+
+    def test_borrow_no_name_aborts_listing_instances(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "lab", _INSTANCES_VM)
+        _make_repo(projects, "lmf", "tooling", '\n[vm]\nshared_from = "lmf/lab"\n')
+        cfg = _identities(tmp_path, projects)
+        result = main(["session", "lmf/tooling", "--config", str(cfg)])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "--name" in err
+        assert "local" in err
+        assert "cloud" in err
+
+    def test_borrow_with_name_resolves_to_lender_instance(self, tmp_path: Path) -> None:
+        projects = tmp_path / "projects"
+        _make_repo(projects, "lmf", "lab", _INSTANCES_VM)
+        _make_repo(projects, "lmf", "tooling", '\n[vm]\nshared_from = "lmf/lab"\n')
+        cfg = _identities(tmp_path, projects)
+        target = _resolve_target(_named_args(cfg, "lmf/tooling", "cloud"), borrow_allowed=True)
+        assert target.spec.off_platform is True
 
 
 _OFF_PLATFORM_VM = """


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm now fails fast with a clear 'pass --name <instance>' error (listing the choices) when a repo's role declares named instances and none was selected, instead of silently composing a phantom base-only default that surfaced downstream as a misleading 'VM does not exist' message — the confusion originally hit via a shared_from borrow.

## Issue Linkage

- Closes #2251

## Notes

- Root cause (issue #2251): 'vrg-vm session .../mq-gateway-replay-lab' (no --name) borrowed .../mq-resiliency-lab-for-linux, whose role defines named instances local (Lima) and cloud (off-platform). With no --name the composer applied only the role base (no backend) and synthesized a default Lima VM that was never built, so the user got 'does not exist — create it'. The borrow feature itself is correct; '--name cloud' already resolved to the cloud backend. Fix guards _resolve_target on the effective (post-borrow) repo, so it covers direct use and borrowed lenders across all VM-targeting commands. compose_vm_spec is untouched (default composition still used by list drift-classification and the fingerprint-excludes-instance-name contract). Tests: TestNamedInstanceRequiresName (direct abort, borrow abort, --name still resolves); confirmed against the real logical-minds-foundry configs. Full vrg-validate green (4107 tests).