### PR TITLE
feat(epic-audit): self-contained --repo audit sourced from the resolved home

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -11,7 +11,7 @@ import os
 import sys
 from datetime import UTC, datetime, timedelta
 
-from vergil_tooling.lib import epic_audit, github, identity_mode
+from vergil_tooling.lib import epic_audit, epics, github, identity_mode
 
 _DEFAULT_WINDOW_DAYS = 30
 
@@ -61,6 +61,15 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help=(f"How many days back to scan for merged PRs (default: {_DEFAULT_WINDOW_DAYS})."),
     )
     parser.add_argument(
+        "--repo",
+        help=(
+            "Audit a single repo's resolved epic home ('owner/repo') instead of "
+            "the org's .github — a private repo self-homes its epics. The "
+            "home-scoped checks (epic drift, stray issues, operational-pending, "
+            "and --close) then target that repo."
+        ),
+    )
+    parser.add_argument(
         "--close",
         action="store_true",
         help=(
@@ -87,32 +96,44 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    org = github.detect_org()
-    if org is None:
-        print(
-            "vrg-epic-audit: could not determine the GitHub org from this "
-            "repo's 'origin' remote; run it from inside a repo in the org you "
-            "want to audit.",
-            file=sys.stderr,
-        )
-        return 1
+    if args.repo:
+        if "/" not in args.repo:
+            print(
+                f"vrg-epic-audit: --repo must be 'owner/repo' (got {args.repo!r})",
+                file=sys.stderr,
+            )
+            return 1
+        owner, bare = args.repo.split("/", 1)
+        org, home = owner, epics.resolve_epic_home(owner, bare)
+    else:
+        org = github.detect_org()
+        if org is None:
+            print(
+                "vrg-epic-audit: could not determine the GitHub org from this "
+                "repo's 'origin' remote; run it from inside a repo in the org you "
+                "want to audit.",
+                file=sys.stderr,
+            )
+            return 1
+        home = f"{org}/.github"
     since = (datetime.now(UTC) - timedelta(days=args.window_days)).date().isoformat()
     tasks = epic_audit.task_drift(since, org=org)
-    epics = epic_audit.epic_drift()
+    epics_drift = epic_audit.epic_drift(org, home=home)
     if args.close:
-        closed = epic_audit.close_drift(tasks, epics, org=org)
-        print(epic_audit.render_closed(closed, org=org, window_days=args.window_days))
+        closed = epic_audit.close_drift(tasks, epics_drift, org=org, home=home)
+        print(epic_audit.render_closed(closed, org=org, window_days=args.window_days, home=home))
         return 0
     epics_outside = epic_audit.epic_outside_dotgithub(org)
-    stray = epic_audit.stray_dotgithub_issue(org)
-    pending_operational = epic_audit.operational_pending(org)
+    stray = epic_audit.stray_dotgithub_issue(org, home=home)
+    pending_operational = epic_audit.operational_pending(org, home=home)
     closed_operational_no_success = epic_audit.closed_operational_without_success(org)
     print(
         epic_audit.render(
             tasks,
-            epics,
+            epics_drift,
             org=org,
             window_days=args.window_days,
+            home=home,
             epics_outside=epics_outside,
             stray=stray,
             pending_operational=pending_operational,

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -92,9 +92,17 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
     return drift
 
 
-def epic_drift() -> list[roadmap.EpicSummary]:
-    """Open, non-perpetual epics whose children are all closed (should roll up)."""
-    return [epic for epic in roadmap.gather() if epic.total > 0 and epic.closed == epic.total]
+def epic_drift(org: str | None = None, *, home: str | None = None) -> list[roadmap.EpicSummary]:
+    """Open, non-perpetual epics whose children are all closed (should roll up).
+
+    Scoped to the resolved epic *home* (default: the org's ``.github``), so a
+    ``--repo``-targeted audit sees only that repo's epics.
+    """
+    return [
+        epic
+        for epic in roadmap.gather(org, home=home)
+        if epic.total > 0 and epic.closed == epic.total
+    ]
 
 
 @dataclass(frozen=True)
@@ -138,17 +146,21 @@ def operational_status(epic: epics.IssueRef) -> OperationalStatus:
     )
 
 
-def operational_pending(org: str) -> list[OperationalStatus]:
+def operational_pending(org: str, *, home: str | None = None) -> list[OperationalStatus]:
     """Open finite epics with outstanding operational children.
 
     Reports the "code-complete, operation-pending" state that keeps an epic
     honestly not-done: its code tasks may all be merged, but until its
     operational tasks (validations, deployments, …) run the epic is not finished.
-    Only epics with at least one open operational child appear.
+    Only epics with at least one open operational child appear. Scoped to the
+    resolved epic *home* (default ``<org>/.github``).
     """
+    if home is None:
+        home = f"{org}/.github"
+    home_owner, home_repo = home.split("/", 1)
     pending: list[OperationalStatus] = []
-    for summary in roadmap.gather(org):
-        status = operational_status(epics.IssueRef(org, ".github", summary.number))
+    for summary in roadmap.gather(org, home=home):
+        status = operational_status(epics.IssueRef(home_owner, home_repo, summary.number))
         if status.pending:
             pending.append(status)
     return pending
@@ -240,22 +252,25 @@ def epic_outside_dotgithub(org: str) -> list[str]:
     return violations
 
 
-def stray_dotgithub_issue(org: str) -> list[str]:
-    """Open ``<org>/.github`` issues that violate invariant 2 (epic #85).
+def stray_dotgithub_issue(org: str, *, home: str | None = None) -> list[str]:
+    """Open issues in the epic *home* that violate invariant 2 (epic #85).
 
-    ``.github`` holds only epics, intake (``triage``/``idea``/``research``), and
-    managed tasks whose closing PR lands in ``.github`` (a task linked under an
-    epic). An open ``.github`` issue that is none of these — an unlinked,
-    non-epic, non-intake issue — is a stray; returns their slugs. When a
-    candidate's parent cannot be confirmed as an epic it is reported (fail-loud,
-    the human decides).
+    The home holds only epics, intake (``triage``/``idea``/``research``), and
+    managed tasks whose closing PR lands there (a task linked under an epic). An
+    open issue that is none of these — an unlinked, non-epic, non-intake issue —
+    is a stray; returns their slugs. *home* defaults to ``<org>/.github``; a
+    ``--repo``-targeted audit passes the repo's resolved home. When a candidate's
+    parent cannot be confirmed as an epic it is reported (fail-loud, the human
+    decides).
     """
-    dotgithub = f"{org}/.github"
+    if home is None:
+        home = f"{org}/.github"
+    home_owner, home_repo = home.split("/", 1)
     raw: Any = github.read_json(
         "issue",
         "list",
         "--repo",
-        dotgithub,
+        home,
         "--state",
         "open",
         "--limit",
@@ -269,10 +284,10 @@ def stray_dotgithub_issue(org: str) -> list[str]:
         if "epic" in labels or (labels & _INTAKE_LABELS):
             continue
         number = int(item["number"])
-        parent = epics.parent_of(epics.IssueRef(org, ".github", number))
+        parent = epics.parent_of(epics.IssueRef(home_owner, home_repo, number))
         if parent is not None and epics.is_epic(parent):
             continue
-        strays.append(f"{dotgithub}#{number}")
+        strays.append(f"{home}#{number}")
     return strays
 
 
@@ -282,6 +297,7 @@ def render(
     *,
     org: str,
     window_days: int,
+    home: str | None = None,
     epics_outside: list[str] | None = None,
     stray: list[str] | None = None,
     pending_operational: list[OperationalStatus] | None = None,
@@ -302,8 +318,9 @@ def render(
     stray = stray or []
     pending_operational = pending_operational or []
     closed_operational_no_success = closed_operational_no_success or []
+    scope = f"the **{home}** repo" if home and home != f"{org}/.github" else f"the **{org}** org"
     banner = (
-        f"_Read-only audit of the **{org}** org (merged PRs from the last "
+        f"_Read-only audit of {scope} (merged PRs from the last "
         f"{window_days} days) — this report changes nothing; run `--close` (as "
         "a human) to close what it lists._"
     )
@@ -377,13 +394,17 @@ def close_drift(
     epics: list[roadmap.EpicSummary],
     *,
     org: str,
+    home: str | None = None,
 ) -> list[str]:
     """Close each drifted task and rolled-up epic, leaving a comment on each.
 
-    Epics live in ``{org}/.github``. Returns the ``owner/repo#n`` slugs closed,
-    in the order acted on. This performs outward-effecting GitHub writes; the
-    caller is responsible for gating it to a human.
+    Epics live in the resolved *home* (default ``{org}/.github``). Returns the
+    ``owner/repo#n`` slugs closed, in the order acted on. This performs
+    outward-effecting GitHub writes; the caller is responsible for gating it to a
+    human.
     """
+    if home is None:
+        home = f"{org}/.github"
     closed: list[str] = []
     for task in sorted(tasks, key=lambda t: (t.repo, t.task)):
         github.run(
@@ -396,7 +417,7 @@ def close_drift(
             _TASK_CLOSE_COMMENT.format(pr=task.pr_number),
         )
         closed.append(f"{task.repo}#{task.task}")
-    epic_repo = f"{org}/.github"
+    epic_repo = home
     for epic in sorted(epics, key=lambda e: e.number):
         github.run(
             "issue",
@@ -411,9 +432,10 @@ def close_drift(
     return closed
 
 
-def render_closed(closed: list[str], *, org: str, window_days: int) -> str:
+def render_closed(closed: list[str], *, org: str, window_days: int, home: str | None = None) -> str:
     """Summarize a ``--close`` run: what was actually closed."""
-    banner = f"_Closed drift on the **{org}** org (merged PRs from the last {window_days} days)._"
+    scope = f"the **{home}** repo" if home and home != f"{org}/.github" else f"the **{org}** org"
+    banner = f"_Closed drift on {scope} (merged PRs from the last {window_days} days)._"
     header = ["# Epic/task drift audit — closed", "", banner, ""]
     if not closed:
         return "\n".join([*header, "_No drift — nothing to close._", ""])

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -482,3 +482,50 @@ def test_render_flags_closed_operational_without_success() -> None:
     )
     assert "PASS comment" in out
     assert "org/repo#55" in out
+
+
+# -- self-contained --repo audit (epic #130, home-scoped checks) --------------
+def test_stray_dotgithub_issue_scopes_to_home() -> None:
+    issues = [{"number": 7, "labels": []}]  # unlinked, non-epic, non-intake -> stray
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=issues) as mock_list,
+        patch("vergil_tooling.lib.epics.parent_of", return_value=None),
+    ):
+        result = epic_audit.stray_dotgithub_issue("org", home="org/lab")
+    assert result == ["org/lab#7"]
+    assert "org/lab" in mock_list.call_args.args  # read the home, not <org>/.github
+
+
+def test_operational_pending_scopes_to_home() -> None:
+    captured: list[epics.IssueRef] = []
+
+    def fake_status(epic: epics.IssueRef) -> epic_audit.OperationalStatus:
+        captured.append(epic)
+        return epic_audit.OperationalStatus(epic, (), (), {})
+
+    with (
+        patch("vergil_tooling.lib.epic_audit.roadmap.gather", return_value=[MagicMock(number=5)]),
+        patch("vergil_tooling.lib.epic_audit.operational_status", side_effect=fake_status),
+    ):
+        epic_audit.operational_pending("org", home="org/lab")
+    assert (captured[0].owner, captured[0].repo) == ("org", "lab")
+
+
+def test_close_drift_closes_epics_in_home() -> None:
+    epic_summaries = [roadmap.EpicSummary(5, "Lab", "2026-07-09", None, (), 1, 1, "u5")]
+    run = MagicMock()
+    with patch("vergil_tooling.lib.github.run", run):
+        closed = epic_audit.close_drift([], epic_summaries, org="org", home="org/lab")
+    assert closed == ["org/lab#5"]
+    assert run.call_args.args[:5] == ("issue", "close", "5", "--repo", "org/lab")
+
+
+def test_epic_drift_scopes_to_home() -> None:
+    with patch("vergil_tooling.lib.epic_audit.roadmap.gather", return_value=[]) as gather:
+        epic_audit.epic_drift("org", home="org/lab")
+    assert gather.call_args.kwargs["home"] == "org/lab"
+
+
+def test_render_banner_names_home_when_repo_scoped() -> None:
+    out = epic_audit.render([], [], org="org", window_days=30, home="org/lab")
+    assert "**org/lab**" in out  # banner names the scoped home, not the org

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -12,6 +12,30 @@ from vergil_tooling.bin.vrg_epic_audit import main
 _MOD = "vergil_tooling.bin.vrg_epic_audit"
 
 
+def test_main_repo_scopes_to_resolved_home() -> None:
+    with (
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab") as home,
+        patch(f"{_MOD}.epic_audit.operational_pending", return_value=[]) as op,
+        patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
+        patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]) as ed,
+        patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
+        patch(f"{_MOD}.epic_audit.stray_dotgithub_issue", return_value=[]) as stray,
+    ):
+        rc = main(["--repo", "org/lab"])
+    assert rc == 0
+    home.assert_called_once_with("org", "lab")
+    assert ed.call_args.kwargs["home"] == "org/lab"
+    assert op.call_args.kwargs["home"] == "org/lab"
+    assert stray.call_args.kwargs["home"] == "org/lab"
+
+
+def test_main_repo_malformed_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["--repo", "noslash"])
+    assert rc == 1
+    assert "owner/repo" in capsys.readouterr().err
+
+
 def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
@@ -120,7 +144,9 @@ def test_close_allowed_for_scheduled_sweep(capsys: pytest.CaptureFixture[str]) -
     ):
         rc = main(["--close"])
     assert rc == 0
-    close_drift.assert_called_once_with(["T"], ["E"], org="vergil-project")
+    close_drift.assert_called_once_with(
+        ["T"], ["E"], org="vergil-project", home="vergil-project/.github"
+    )
     assert "o/r#1" in capsys.readouterr().out
 
 
@@ -137,7 +163,9 @@ def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]
     ):
         rc = main(["--close"])
     assert rc == 0
-    close_drift.assert_called_once_with(["T"], ["E"], org="vergil-project")
+    close_drift.assert_called_once_with(
+        ["T"], ["E"], org="vergil-project", home="vergil-project/.github"
+    )
     out = capsys.readouterr().out
     assert "closed" in out.lower()
     assert "o/r#1" in out


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-epic-audit --repo <owner>/<repo> audits that repo's resolved epic home (a private repo self-homes its epics), threading the home through epic_drift, operational_pending, stray_dotgithub_issue, and close_drift, and naming it in the report banner.

## Issue Linkage

- Closes #2244

## Notes

- Task of epic #130 — the deferred second half of #2234 (its follow-up). home defaults to <org>/.github via a keyword-only param, so the default org audit is byte-for-byte unchanged and every existing test passes untouched. The org-wide checks (task_drift, epic_outside_dotgithub, closed_operational_without_success) intentionally stay org-scoped — they surface org-level signals regardless of --repo. Note: develop advanced past this branch in an unrelated file (vrg_vm); no conflict, but a rebase before merge is harmless. 46 audit tests + full validation green.