### PR TITLE
fix(vrg-gh): allow the user/agent identity to run 'issue reopen'

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -52,16 +52,13 @@ _DENIED_AGENT: dict[str, dict[str, str]] = {
         "edit": "PR edit requires a human maintainer.",
         "merge": "PR merge requires a human maintainer.",
     },
-    "issue": {
-        # `issue close` is intentionally NOT denied here: closing is now
-        # automated (vrg-finalize-pr closes tasks, rollup closes epics) and
-        # documented as mechanical, so a manual USER close is safe and is the
-        # one genuinely useful case (repo migration). AUDIT stays barred from
-        # closing because `issue` is not in its allowlist at all (least
-        # privilege). `reopen` stays denied for agents — the lib path covers
-        # reopen-on-late-child. See issue #1966.
-        "reopen": "Issue reopen requires a human maintainer.",
-    },
+    # `issue` has no agent-denied pairs: `close` and `reopen` are both
+    # non-destructive and reversible, so both are allowed for the USER agent
+    # (closing is automated/mechanical; reopening is trivially re-closed and
+    # lets an agent run reopen remediation directly). AUDIT stays barred from
+    # both because `issue` is not in its allowlist at all (least privilege).
+    # See issues #1966 (original close/reopen split) and #2260 (un-denying
+    # reopen).
 }
 
 _DENIED_HUMAN: dict[str, dict[str, str]] = {
@@ -226,7 +223,7 @@ def _print_help() -> None:
         "What it enforces:\n"
         f"  - Allowed (human/user): {allowed}.\n"
         "    The audit identity is narrower (read-only pr actions); agents are\n"
-        "    barred from pr create/edit/merge and issue reopen.\n"
+        "    barred from pr create/edit/merge.\n"
         "  - Denied outright: gh auth, pr close, repo edit/create/delete.\n"
         "  - gh api is gated by identity: human full, audit read-only GET, user\n"
         "    denied.\n"

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -466,7 +466,6 @@ class TestAgentDenials:
     @pytest.mark.parametrize(
         ("top", "sub"),
         [
-            ("issue", "reopen"),
             ("pr", "edit"),
             ("pr", "merge"),
         ],
@@ -508,12 +507,22 @@ class TestAgentDenials:
         args = mock_run.call_args[0][0]
         assert args[:3] == ["gh", "issue", "close"]
 
-    def test_issue_reopen_still_says_human_maintainer(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        main(["issue", "reopen", "42"])
-        err = capsys.readouterr().err
-        assert "human maintainer" in err.lower()
+    def test_issue_reopen_allowed_for_user_agent(self) -> None:
+        # Re-allowed for USER: reopen is non-destructive and reversible
+        # (an errant reopen is trivially re-closed), mirroring `close`. This
+        # lets an agent run reopen remediation directly (issue #2260).
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "reopen", "42"])
+        assert rc == 0
+        args = mock_run.call_args[0][0]
+        assert args[:3] == ["gh", "issue", "reopen"]
 
     def test_pr_merge_denied_unconditionally_for_agent(
         self, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
# Pull Request

## Summary

- Remove reopen from the issue agent denied-pairs so the USER/agent identity may run 'vrg-gh issue reopen', matching the symmetric, non-destructive 'issue close' allowance.

## Issue Linkage

- Closes #2260

## Notes

- Removes the reopen entry from _DENIED_AGENT[issue] in bin/vrg_gh.py, updates the adjacent comment and the usage/help text (drops the 'issue reopen' clause), and flips the tests that asserted reopen was denied for the user identity to assert it is allowed (mirrors the existing issue close test). AUDIT stays read-only — 'issue' is absent from its allowlist. Unblocks agent-run reopen remediation (#2259, Fix C). vrg-validate green.