### PR TITLE
fix(epic-audit): guard task_drift from closing epics; add closed-epic-with-open-child invariant + reopen remediation

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -73,8 +73,9 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--close",
         action="store_true",
         help=(
-            "Close the drifted task issues and rolled-up epics (with an "
-            "explanatory comment on each) instead of only reporting them. A "
+            "Close the drifted task issues and rolled-up epics, and reopen any "
+            "epic wrongly closed while a child was still open (with an "
+            "explanatory comment on each), instead of only reporting them. A "
             "human action (or the scheduled reconciliation sweep) — refused in "
             "interactive agent sessions. Default: read-only."
         ),
@@ -119,9 +120,17 @@ def main(argv: list[str] | None = None) -> int:
     since = (datetime.now(UTC) - timedelta(days=args.window_days)).date().isoformat()
     tasks = epic_audit.task_drift(since, org=org)
     epics_drift = epic_audit.epic_drift(org, home=home)
+    closed_epic_open_children = epic_audit.closed_epic_open_child(org, home=home)
     if args.close:
         closed = epic_audit.close_drift(tasks, epics_drift, org=org, home=home)
-        print(epic_audit.render_closed(closed, org=org, window_days=args.window_days, home=home))
+        # Remediate the closed-epic-with-open-child invariant (issue #2259): reopen
+        # each epic that was wrongly closed while a child was still open.
+        reopened = epic_audit.reopen_epics_with_open_children(closed_epic_open_children)
+        print(
+            epic_audit.render_closed(
+                closed, org=org, window_days=args.window_days, home=home, reopened=reopened
+            )
+        )
         return 0
     epics_outside = epic_audit.epic_outside_dotgithub(org)
     stray = epic_audit.stray_dotgithub_issue(org, home=home)
@@ -138,6 +147,7 @@ def main(argv: list[str] | None = None) -> int:
             stray=stray,
             pending_operational=pending_operational,
             closed_operational_no_success=closed_operational_no_success,
+            closed_epic_open_children=closed_epic_open_children,
         )
     )
     return 0

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -16,6 +16,10 @@ from typing import Any
 
 from vergil_tooling.lib import epics, github, linkage, release, roadmap
 
+# A closed-epic-with-open-child violation (issue #2259): the closed epic paired
+# with the tuple of its still-open children.
+EpicOpenChildViolation = tuple[epics.IssueRef, tuple[epics.IssueRef, ...]]
+
 
 @dataclass(frozen=True)
 class TaskDrift:
@@ -59,8 +63,8 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
         task = int(num)
         task_repo = repo_part or pr_repo
         try:
-            issue = github.read_json(
-                "issue", "view", str(task), "--repo", task_repo, "--json", "state,title,body"
+            issue: Any = github.read_json(
+                "issue", "view", str(task), "--repo", task_repo, "--json", "state,title,body,labels"
             )
         except github.GitHubAPIError:
             # The task is in a repo this run can't see (cross-org, private, or
@@ -76,6 +80,20 @@ def task_drift(since: str, *, org: str) -> list[TaskDrift]:
         if not isinstance(issue, dict):
             continue
         if str(issue.get("state") or "").upper() != "OPEN":
+            continue
+        labels = {str((label or {}).get("name", "")) for label in (issue.get("labels") or [])}
+        if "epic" in labels:
+            # A PR may legitimately ``Ref`` an epic (associating the PR with the
+            # epic). That is not a slipped task: epic closure is owned by
+            # epic_drift/rollup, which enforces all_children_closed. Closing an
+            # epic here would bypass that guard and orphan its open children
+            # (issue #2259, Fix A).
+            continue
+        if labels & epics.operational_labels() or labels & _INTAKE_LABELS:
+            # An operational task (validation/deployment) closes on a recorded
+            # ``Outcome:`` comment, and intake issues (triage/idea/research) are
+            # never PR-tracked tasks — a merged PR ``Ref``ing either is not the
+            # slipped-task drift this sweep closes.
             continue
         # A merged release PR Refs its release: X.Y.Z tracking issue, which stays
         # open as vrg-release bookkeeping — not drift. Skip it so the audit does
@@ -291,6 +309,48 @@ def stray_dotgithub_issue(org: str, *, home: str | None = None) -> list[str]:
     return strays
 
 
+def closed_epic_open_child(org: str, *, home: str | None = None) -> list[EpicOpenChildViolation]:
+    """Closed epics that still have an open child (invariant, issue #2259 Fix B).
+
+    Core invariant: *an epic must never be closed while it has open children*. A
+    PR that legitimately ``Ref``'d an epic once tripped ``task_drift`` into
+    closing the epic directly, orphaning its open tasks — and no audit check
+    caught the result. This is that check. Uses **native children** as the
+    authoritative signal (``child_states``); perpetual (``ad-hoc``/``standing``)
+    epics are skipped — they never roll up, so being closed-with-open-children is
+    not a violation for them. Report-only: like the other invariants it is never
+    auto-acted (remediation is :func:`reopen_epics_with_open_children`, gated to a
+    human). Scoped to the resolved epic *home* (default ``<org>/.github``).
+    """
+    if home is None:
+        home = f"{org}/.github"
+    home_owner, home_repo = home.split("/", 1)
+    raw: Any = github.read_json(
+        "issue",
+        "list",
+        "--repo",
+        home,
+        "--label",
+        "epic",
+        "--state",
+        "closed",
+        "--limit",
+        "300",
+        "--json",
+        "number,title,labels",
+    )
+    violations: list[EpicOpenChildViolation] = []
+    for item in raw if isinstance(raw, list) else []:
+        labels = {str((label or {}).get("name", "")) for label in (item.get("labels") or [])}
+        if labels & {"ad-hoc", "standing"}:
+            continue  # perpetual epics never roll up; closed-with-open-child doesn't apply
+        epic = epics.IssueRef(home_owner, home_repo, int(item["number"]))
+        open_kids = tuple(cs.ref for cs in epics.child_states(epic) if cs.state == "OPEN")
+        if open_kids:
+            violations.append((epic, open_kids))
+    return violations
+
+
 def render(
     tasks: list[TaskDrift],
     epic_summaries: list[roadmap.EpicSummary],
@@ -302,6 +362,7 @@ def render(
     stray: list[str] | None = None,
     pending_operational: list[OperationalStatus] | None = None,
     closed_operational_no_success: list[str] | None = None,
+    closed_epic_open_children: list[EpicOpenChildViolation] | None = None,
 ) -> str:
     """Format the drift + invariant report; a clean state says so explicitly.
 
@@ -311,13 +372,15 @@ def render(
     violations (epic #85). ``pending_operational`` lists epics still gated on
     operational tasks (validations/deployments, runnable vs blocked);
     ``closed_operational_no_success`` is the operational invariant (a closed
-    operational task with no recorded success comment). Each section appears only
-    when it has something to report.
+    operational task with no recorded success comment). ``closed_epic_open_children``
+    is the closed-epic-with-open-child invariant (issue #2259). Each section
+    appears only when it has something to report.
     """
     epics_outside = epics_outside or []
     stray = stray or []
     pending_operational = pending_operational or []
     closed_operational_no_success = closed_operational_no_success or []
+    closed_epic_open_children = closed_epic_open_children or []
     scope = f"the **{home}** repo" if home and home != f"{org}/.github" else f"the **{org}** org"
     banner = (
         f"_Read-only audit of {scope} (merged PRs from the last "
@@ -333,6 +396,7 @@ def render(
             stray,
             pending_operational,
             closed_operational_no_success,
+            closed_epic_open_children,
         ]
     ):
         return "\n".join([*header, "_No drift — everything that should be closed is closed._", ""])
@@ -364,7 +428,7 @@ def render(
                 or "none"
             )
             lines.append(f"- {status.epic.slug} — runnable: {runnable}; blocked: {blocked}")
-    if epics_outside or stray or closed_operational_no_success:
+    if epics_outside or stray or closed_operational_no_success or closed_epic_open_children:
         lines += ["", "## Invariant violations (issues in the wrong place)", ""]
         if epics_outside:
             lines.append(
@@ -377,6 +441,18 @@ def render(
         if closed_operational_no_success:
             lines.append("**Validation tasks closed without a PASS comment** — re-open and run:")
             lines += [f"- {slug}" for slug in sorted(closed_operational_no_success)]
+        if closed_epic_open_children:
+            lines.append(
+                "**Closed epics with open children** — an epic must not be closed "
+                "while a child is open; reopen each (`--close` remediates):"
+            )
+            for closed_epic, kids in sorted(
+                closed_epic_open_children, key=lambda v: (v[0].owner, v[0].repo, v[0].number)
+            ):
+                open_kids = ", ".join(
+                    kid.slug for kid in sorted(kids, key=lambda k: (k.owner, k.repo, k.number))
+                )
+                lines.append(f"- {closed_epic.slug} — open children: {open_kids}")
     lines.append("")
     return "\n".join(lines)
 
@@ -387,6 +463,36 @@ _TASK_CLOSE_COMMENT = (
 _EPIC_CLOSE_COMMENT = (
     "Closed by `vrg-epic-audit`: all {total} child tasks are closed; the epic rolled up."
 )
+_EPIC_REOPEN_COMMENT = (
+    "Reopened by `vrg-epic-audit`: the epic was closed while child {child} is still "
+    "open — an epic cannot be closed while it has open children."
+)
+
+
+def reopen_epics_with_open_children(violations: list[EpicOpenChildViolation]) -> list[str]:
+    """Reopen each closed epic that still has an open child (issue #2259 Fix C).
+
+    The inverse of ``epic_drift``'s close: it restores the *an epic must never be
+    closed while it has open children* invariant that ``task_drift`` violated,
+    leaving an explanatory comment naming an open child. *violations* is the
+    output of :func:`closed_epic_open_child` (already closed epics), so every
+    reopen is meaningful; ``gh issue reopen`` on an already-open epic is a no-op,
+    so a repeat run is idempotent. Returns the reopened epic slugs. This performs
+    outward-effecting GitHub writes; the caller gates it to a human.
+    """
+    reopened: list[str] = []
+    for epic, open_kids in sorted(violations, key=lambda v: (v[0].owner, v[0].repo, v[0].number)):
+        github.run(
+            "issue",
+            "reopen",
+            str(epic.number),
+            "--repo",
+            f"{epic.owner}/{epic.repo}",
+            "--comment",
+            _EPIC_REOPEN_COMMENT.format(child=open_kids[0].slug),
+        )
+        reopened.append(epic.slug)
+    return reopened
 
 
 def close_drift(
@@ -432,14 +538,33 @@ def close_drift(
     return closed
 
 
-def render_closed(closed: list[str], *, org: str, window_days: int, home: str | None = None) -> str:
-    """Summarize a ``--close`` run: what was actually closed."""
+def render_closed(
+    closed: list[str],
+    *,
+    org: str,
+    window_days: int,
+    home: str | None = None,
+    reopened: list[str] | None = None,
+) -> str:
+    """Summarize a ``--close`` run: what was closed and what was reopened.
+
+    ``reopened`` is the closed-epic-with-open-child remediation (issue #2259):
+    epics that were wrongly closed while a child was still open, now reopened.
+    """
+    reopened = reopened or []
     scope = f"the **{home}** repo" if home and home != f"{org}/.github" else f"the **{org}** org"
     banner = f"_Closed drift on {scope} (merged PRs from the last {window_days} days)._"
     header = ["# Epic/task drift audit — closed", "", banner, ""]
-    if not closed:
+    if not closed and not reopened:
         return "\n".join([*header, "_No drift — nothing to close._", ""])
-    lines = [*header, "## Closed", ""]
-    lines += [f"- {slug}" for slug in closed]
-    lines.append("")
+    lines = [*header]
+    if closed:
+        lines += ["## Closed", "", *[f"- {slug}" for slug in closed], ""]
+    if reopened:
+        lines += [
+            "## Reopened (epic was closed with an open child)",
+            "",
+            *[f"- {slug}" for slug in reopened],
+            "",
+        ]
     return "\n".join(lines)

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -157,15 +157,42 @@ def _native_child_states(epic: IssueRef) -> list[ChildState]:
     return [ChildState(ref=_ref_from_node(n), state=str(n["state"]).upper()) for n in nodes]
 
 
+def _body_declares_parent(body: str, epic: IssueRef) -> bool:
+    """True iff *body* carries a ``Parent:`` line naming exactly *epic*."""
+    return any(
+        match.group(1) == epic.owner
+        and match.group(2) == epic.repo
+        and int(match.group(3)) == epic.number
+        for match in _PARENT_RE.finditer(body)
+    )
+
+
 def _reflink_child_states(epic: IssueRef) -> list[ChildState]:
-    """Portable fallback: issues whose body references this epic as ``Parent:``."""
+    """Portable fallback: issues whose body references this epic as ``Parent:``.
+
+    ``gh search issues`` is punctuation-blind full-text search across *all* of
+    GitHub, so a bare ``Parent: <slug>`` query returns cross-repo false positives
+    — unrelated issues that merely contain those words (issue #2259, Fix D). Two
+    guards keep the fallback sound: scope the search to the epic's org with
+    ``--owner``, and verify each candidate's body actually carries a
+    ``Parent: <epic slug>`` line (via :func:`_body_declares_parent`) before
+    accepting it.
+    """
     results: Any = github.read_json(
-        "search", "issues", f"Parent: {epic.slug}", "--json", "number,state,repository"
+        "search",
+        "issues",
+        f"Parent: {epic.slug}",
+        "--owner",
+        epic.owner,
+        "--json",
+        "number,state,repository,body",
     )
     states: list[ChildState] = []
     for item in results if isinstance(results, list) else []:
         name_with_owner = str((item.get("repository") or {}).get("nameWithOwner", ""))
         if "/" not in name_with_owner:
+            continue
+        if not _body_declares_parent(str(item.get("body") or ""), epic):
             continue
         owner, name = name_with_owner.split("/", 1)
         states.append(

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -125,6 +125,83 @@ def test_task_drift_skips_unresolvable_task(capsys: pytest.CaptureFixture[str]) 
     assert "skipping vergil-project/vergil-tooling#2105" in capsys.readouterr().err
 
 
+def test_task_drift_skips_epic_ref() -> None:
+    # A merged PR may legitimately ``Ref`` an epic; that is not a slipped task.
+    # Closing the epic here would orphan its open children (issue #2259, Fix A).
+    prs = [
+        {
+            "number": 22,
+            "repository": {"nameWithOwner": "logical-minds-foundry/.github"},
+            "url": "u22",
+            "body": "Ref #19",
+        },
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        return {
+            "state": "open",
+            "title": "Epic: MQ Configuration Guides",
+            "body": "epic body",
+            "labels": [{"name": "epic"}],
+        }
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        assert epic_audit.task_drift("2026-06-01", org="logical-minds-foundry") == []
+
+
+def test_task_drift_skips_operational_and_intake_refs() -> None:
+    # An operational task (closes on an Outcome comment) and an intake issue
+    # (triage/idea/research) are never PR-tracked tasks — a merged PR Ref'ing
+    # either is not slipped-task drift.
+    prs = [
+        {
+            "number": 30,
+            "repository": {"nameWithOwner": "org/repo"},
+            "url": "u30",
+            "body": "Ref #7",
+        },
+        {
+            "number": 31,
+            "repository": {"nameWithOwner": "org/repo"},
+            "url": "u31",
+            "body": "Ref #8",
+        },
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        label = "validation" if args[2] == "7" else "idea"
+        return {"state": "open", "title": "t", "body": "b", "labels": [{"name": label}]}
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        assert epic_audit.task_drift("2026-06-01", org="org") == []
+
+
+def test_task_drift_still_flags_labelled_plain_task() -> None:
+    # The label guard must not over-skip: an ordinary task carrying a non-special
+    # label (e.g. ``bug``) is still drift when its PR merged and it stays open.
+    prs = [
+        {
+            "number": 40,
+            "repository": {"nameWithOwner": "org/repo"},
+            "url": "u40",
+            "body": "Ref #41",
+        },
+    ]
+
+    def fake_read_json(*args: str) -> object:
+        if args[0] == "search":
+            return prs
+        return {"state": "open", "title": "fix: t", "body": "b", "labels": [{"name": "bug"}]}
+
+    with patch("vergil_tooling.lib.github.read_json", side_effect=fake_read_json):
+        result = epic_audit.task_drift("2026-06-01", org="org")
+    assert result == [TaskDrift("org/repo", 41, 40, "u40")]
+
+
 def test_task_drift_returns_empty_on_non_list() -> None:
     with patch("vergil_tooling.lib.github.read_json", return_value={"x": 1}):
         assert epic_audit.task_drift("2026-06-01", org="vergil-project") == []
@@ -222,6 +299,95 @@ def test_stray_dotgithub_issue_flags_unlinked_non_epic_non_intake() -> None:
     ):
         result = epic_audit.stray_dotgithub_issue("vergil-project")
     assert result == ["vergil-project/.github#7"]
+
+
+# -- closed-epic-with-open-child invariant + reopen remediation (issue #2259) --
+
+
+def test_closed_epic_open_child_flags_closed_epic_with_open_child() -> None:
+    listing = [
+        {"number": 19, "title": "MQ Guides", "labels": []},  # has an open child -> violation
+        {"number": 15, "title": "Cockpit", "labels": []},  # all children closed -> ok
+        {"number": 99, "title": "Ad hoc", "labels": [{"name": "ad-hoc"}]},  # perpetual -> skipped
+    ]
+
+    def fake_child_states(epic: epics.IssueRef) -> list[epics.ChildState]:
+        if epic.number == 19:
+            return [
+                epics.ChildState(epics.IssueRef("org", "lab", 462), "OPEN"),
+                epics.ChildState(epics.IssueRef("org", "lab", 463), "CLOSED"),
+            ]
+        return [epics.ChildState(epics.IssueRef("org", "lab", 1), "CLOSED")]
+
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=listing),
+        patch("vergil_tooling.lib.epics.child_states", side_effect=fake_child_states),
+    ):
+        result = epic_audit.closed_epic_open_child("org")
+    assert result == [(epics.IssueRef("org", ".github", 19), (epics.IssueRef("org", "lab", 462),))]
+
+
+def test_closed_epic_open_child_skips_perpetual_before_fetching_children() -> None:
+    # A perpetual (ad-hoc/standing) epic is skipped without a children lookup.
+    listing = [{"number": 99, "title": "Ad hoc", "labels": [{"name": "standing"}]}]
+    child_states = MagicMock()
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=listing),
+        patch("vergil_tooling.lib.epics.child_states", child_states),
+    ):
+        assert epic_audit.closed_epic_open_child("org") == []
+    child_states.assert_not_called()
+
+
+def test_closed_epic_open_child_scopes_to_home() -> None:
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=[]) as mock_list,
+        patch("vergil_tooling.lib.epics.child_states", return_value=[]),
+    ):
+        epic_audit.closed_epic_open_child("org", home="org/lab")
+    assert "org/lab" in mock_list.call_args.args  # lists the home, not <org>/.github
+    assert "closed" in mock_list.call_args.args  # only closed epics
+
+
+def test_reopen_epics_with_open_children_reopens_and_comments() -> None:
+    violations: list[epic_audit.EpicOpenChildViolation] = [
+        (epics.IssueRef("org", ".github", 19), (epics.IssueRef("org", "lab", 462),))
+    ]
+    run = MagicMock()
+    with patch("vergil_tooling.lib.github.run", run):
+        reopened = epic_audit.reopen_epics_with_open_children(violations)
+    assert reopened == ["org/.github#19"]
+    assert run.call_args.args[:5] == ("issue", "reopen", "19", "--repo", "org/.github")
+    assert "org/lab#462" in run.call_args.args[-1]
+
+
+def test_reopen_epics_with_open_children_empty_is_noop() -> None:
+    run = MagicMock()
+    with patch("vergil_tooling.lib.github.run", run):
+        assert epic_audit.reopen_epics_with_open_children([]) == []
+    run.assert_not_called()
+
+
+def test_render_flags_closed_epic_with_open_child() -> None:
+    out = epic_audit.render(
+        [],
+        [],
+        org="org",
+        window_days=30,
+        closed_epic_open_children=[
+            (epics.IssueRef("org", ".github", 19), (epics.IssueRef("org", "lab", 462),))
+        ],
+    )
+    assert "Invariant violations" in out
+    assert "Closed epics with open children" in out
+    assert "org/.github#19" in out
+    assert "org/lab#462" in out
+
+
+def test_render_closed_lists_reopened_epics() -> None:
+    out = epic_audit.render_closed([], org="org", window_days=30, reopened=["org/.github#19"])
+    assert "Reopened" in out
+    assert "org/.github#19" in out
 
 
 def test_render_shows_invariant_violations() -> None:

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -67,7 +67,14 @@ def test_child_states_native() -> None:
 
 def test_child_states_reflink_fallback_when_native_empty() -> None:
     empty = {"node": {"subIssues": {"nodes": []}}}
-    search = [{"number": 41, "state": "OPEN", "repository": {"nameWithOwner": "org/.github"}}]
+    search = [
+        {
+            "number": 41,
+            "state": "OPEN",
+            "repository": {"nameWithOwner": "org/.github"},
+            "body": "Parent: org/.github#40",
+        }
+    ]
     with (
         patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
         patch("vergil_tooling.lib.github.graphql", return_value=empty),
@@ -75,8 +82,10 @@ def test_child_states_reflink_fallback_when_native_empty() -> None:
     ):
         result = epics.child_states(EPIC)
     assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN")]
-    # the fallback searches for the epic's Parent: marker
+    # the fallback searches for the epic's Parent: marker, scoped to the org
     assert "Parent: org/.github#40" in mock_search.call_args.args
+    assert "--owner" in mock_search.call_args.args
+    assert "org" in mock_search.call_args.args
 
 
 # -- parent_of ---------------------------------------------------------------
@@ -183,8 +192,49 @@ def test_issue_state_uppercases() -> None:
 
 def test_reflink_skips_results_without_repo() -> None:
     search = [
-        {"number": 41, "state": "OPEN", "repository": {"nameWithOwner": "org/.github"}},
-        {"number": 99, "state": "OPEN", "repository": {}},  # malformed -> skipped
+        {
+            "number": 41,
+            "state": "OPEN",
+            "repository": {"nameWithOwner": "org/.github"},
+            "body": "Parent: org/.github#40",
+        },
+        {"number": 99, "state": "OPEN", "repository": {}, "body": "Parent: org/.github#40"},
+    ]
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch(
+            "vergil_tooling.lib.github.graphql",
+            return_value={"node": {"subIssues": {"nodes": []}}},
+        ),
+        patch("vergil_tooling.lib.github.read_json", return_value=search),
+    ):
+        result = epics.child_states(EPIC)
+    assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN")]
+
+
+def test_reflink_rejects_full_text_false_positive() -> None:
+    # gh search issues is punctuation-blind full-text search: a foreign issue can
+    # match on words alone. Without a real ``Parent: <epic slug>`` line in its
+    # body it must not be treated as a child (issue #2259, Fix D).
+    search = [
+        {
+            "number": 41,
+            "state": "OPEN",
+            "repository": {"nameWithOwner": "org/.github"},
+            "body": "Parent: org/.github#40",  # genuine child
+        },
+        {
+            "number": 3465,
+            "state": "OPEN",
+            "repository": {"nameWithOwner": "org/unrelated"},
+            "body": "mentions Parent and org/.github#40 in prose but no real reflink line",
+        },
+        {
+            "number": 77,
+            "state": "CLOSED",
+            "repository": {"nameWithOwner": "org/other"},
+            "body": "Parent: org/.github#41",  # references a DIFFERENT epic
+        },
     ]
     with (
         patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -21,6 +21,7 @@ def test_main_repo_scopes_to_resolved_home() -> None:
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]) as ed,
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
         patch(f"{_MOD}.epic_audit.stray_dotgithub_issue", return_value=[]) as stray,
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=[]) as ceoc,
     ):
         rc = main(["--repo", "org/lab"])
     assert rc == 0
@@ -28,6 +29,7 @@ def test_main_repo_scopes_to_resolved_home() -> None:
     assert ed.call_args.kwargs["home"] == "org/lab"
     assert op.call_args.kwargs["home"] == "org/lab"
     assert stray.call_args.kwargs["home"] == "org/lab"
+    assert ceoc.call_args.kwargs["home"] == "org/lab"
 
 
 def test_main_repo_malformed_errors(capsys: pytest.CaptureFixture[str]) -> None:
@@ -45,6 +47,7 @@ def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
         patch(f"{_MOD}.epic_audit.stray_dotgithub_issue", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=[]),
     ):
         rc = main([])
     out = capsys.readouterr().out
@@ -70,6 +73,7 @@ def test_main_reports_invariant_violations(capsys: pytest.CaptureFixture[str]) -
             f"{_MOD}.epic_audit.stray_dotgithub_issue",
             return_value=["vergil-project/.github#7"],
         ),
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=[]),
     ):
         rc = main([])
     out = capsys.readouterr().out
@@ -96,6 +100,7 @@ def test_window_days_controls_since() -> None:
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
         patch(f"{_MOD}.epic_audit.epic_outside_dotgithub", return_value=[]),
         patch(f"{_MOD}.epic_audit.stray_dotgithub_issue", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=[]),
     ):
         rc = main(["--window-days", "7"])
     assert rc == 0
@@ -140,6 +145,8 @@ def test_close_allowed_for_scheduled_sweep(capsys: pytest.CaptureFixture[str]) -
         patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=[]),
+        patch(f"{_MOD}.epic_audit.reopen_epics_with_open_children", return_value=[]),
         patch(f"{_MOD}.epic_audit.close_drift", close_drift),
     ):
         rc = main(["--close"])
@@ -159,6 +166,8 @@ def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]
         patch(f"{_MOD}.epic_audit.closed_operational_without_success", return_value=[]),
         patch(f"{_MOD}.epic_audit.task_drift", return_value=["T"]),
         patch(f"{_MOD}.epic_audit.epic_drift", return_value=["E"]),
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=[]),
+        patch(f"{_MOD}.epic_audit.reopen_epics_with_open_children", return_value=[]),
         patch(f"{_MOD}.epic_audit.close_drift", close_drift),
     ):
         rc = main(["--close"])
@@ -169,3 +178,25 @@ def test_close_as_human_closes_and_summarizes(capsys: pytest.CaptureFixture[str]
     out = capsys.readouterr().out
     assert "closed" in out.lower()
     assert "o/r#1" in out
+
+
+def test_close_reopens_closed_epic_with_open_child(capsys: pytest.CaptureFixture[str]) -> None:
+    # The --close path remediates the closed-epic-with-open-child invariant by
+    # reopening each violating epic (issue #2259, Fix C).
+    violations = [("EPIC_VIOLATION",)]
+    reopen = MagicMock(return_value=["vergil-project/.github#19"])
+    with (
+        patch(f"{_MOD}.identity_mode.is_human", return_value=True),
+        patch(f"{_MOD}.github.detect_org", return_value="vergil-project"),
+        patch(f"{_MOD}.epic_audit.task_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.epic_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.closed_epic_open_child", return_value=violations),
+        patch(f"{_MOD}.epic_audit.close_drift", return_value=[]),
+        patch(f"{_MOD}.epic_audit.reopen_epics_with_open_children", reopen),
+    ):
+        rc = main(["--close"])
+    assert rc == 0
+    reopen.assert_called_once_with(violations)
+    out = capsys.readouterr().out
+    assert "Reopened" in out
+    assert "vergil-project/.github#19" in out


### PR DESCRIPTION
# Pull Request

## Summary

- task_drift closed any open issue a merged PR Ref'd with no is_epic guard, so a PR legitimately Ref'ing an epic closed the epic and orphaned its open children; this guards task_drift, adds the detecting invariant, adds human-gated reopen remediation, and hardens the reflink child search against full-text false positives.

## Issue Linkage

- Closes #2259

## Notes

- Four fixes for #2259, in two commits. Fix A: task_drift now fetches labels and skips epics (plus operational/intake hardening) so epic closure stays owned by epic_drift/rollup. Fix B: new epic_audit.closed_epic_open_child lists closed epics in the home with an open native child (perpetual epics skipped), rendered read-only under Invariant violations. Fix C: the --close path reopens each such epic via epic_audit.reopen_epics_with_open_children (idempotent; gated to human/sweep) — depends on #2260 having landed so agents/the sweep may reopen. Fix D (separate epics.py commit): _reflink_child_states now scopes the gh search to --owner and verifies each candidate body carries a real 'Parent: <epic slug>' line, killing cross-repo false positives. vrg-validate green (4125 tests). Remediation ordering per the issue: land before the next --close so #19 is not re-closed.