### PR TITLE
feat(vrg-gh): allow the agent to run 'issue transfer' for finite-epic relocation

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -13,7 +13,7 @@ import sys
 from vergil_tooling.lib import github, identity_mode, retry
 
 _ALLOWED: dict[str, set[str]] = {
-    "issue": {"view", "close", "reopen", "edit", "list", "comment"},
+    "issue": {"view", "close", "reopen", "edit", "list", "comment", "transfer"},
     "pr": {"view", "checks", "list", "diff", "comment", "edit", "review", "merge"},
     "run": {"list", "view", "watch"},
     "repo": {"view", "list"},

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -52,6 +52,7 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
     ("issue", "edit"),
     ("issue", "list"),
     ("issue", "comment"),
+    ("issue", "transfer"),
     ("pr", "view"),
     ("pr", "checks"),
     ("pr", "list"),
@@ -523,6 +524,24 @@ class TestAgentDenials:
         assert rc == 0
         args = mock_run.call_args[0][0]
         assert args[:3] == ["gh", "issue", "reopen"]
+
+    def test_issue_transfer_allowed_for_user_agent(self) -> None:
+        # Allowed for USER: transferring a finite epic's issues into a
+        # relocation target is a mechanical repository move, and the
+        # audit identity stays barred because `issue` is absent from its
+        # allowlist (issue #2270).
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+                return_value=None,
+            ),
+            patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed()
+            rc = main(["issue", "transfer", "42", "vergil-project/other-repo"])
+        assert rc == 0
+        args = mock_run.call_args[0][0]
+        assert args[:3] == ["gh", "issue", "transfer"]
 
     def test_pr_merge_denied_unconditionally_for_agent(
         self, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
# Pull Request

## Summary

- Add "transfer" to the issue allowlist in vrg_gh.py so human and user identities can run gh issue transfer for relocating a finite epic's issues to another repository.

## Issue Linkage

- Closes #2270

## Notes

- Only the _ALLOWED issue set changed; no denied-pair entry added. The audit identity stays read-only because issue is absent from _ALLOWED_AUDIT. _print_help() is derived from _ALLOWED so it reflects transfer automatically. Tests add the (issue, transfer) allowed pair and a USER-agent forwarding assertion. vrg-validate green: 4127 passed, 100% coverage.