### PR TITLE
refactor(epics): retire the deprecated standing alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,6 @@ vrg-roadmap = "vergil_tooling.bin.vrg_roadmap:main"
 vrg-sarif-evaluate = "vergil_tooling.bin.vrg_sarif_evaluate:main"
 vrg-scorecard = "vergil_tooling.bin.vrg_scorecard:main"
 vrg-semgrep-scan = "vergil_tooling.bin.vrg_semgrep_scan:main"
-# Deprecated alias for vrg-adhoc-epic during the ad-hoc rollout (epic #85); removed in Task 11.
-vrg-standing-epic = "vergil_tooling.bin.vrg_adhoc_epic:main"
 vrg-submit-pr = "vergil_tooling.bin.vrg_submit_pr:main"
 vrg-triage-create = "vergil_tooling.bin.vrg_triage_create:main"
 vrg-update-deps = "vergil_tooling.bin.vrg_update_deps:main"

--- a/src/vergil_tooling/bin/vrg_adhoc_epic.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_epic.py
@@ -7,10 +7,6 @@ pre-existing issues — e.g. ``migrate-repo`` step 1,
 which must ensure the epic exists before it can link ad-hoc tasks to it. Routing
 work to ``adhoc`` (``vrg-issue-create``/``vrg-epic-move --epic adhoc``) also
 ensures it via the same path.
-
-``vrg-standing-epic`` remains as a deprecated alias for this command during the
-ad-hoc rollout (epic vergil-project/.github#85); it is removed once the
-migration is complete.
 """
 
 from __future__ import annotations

--- a/src/vergil_tooling/bin/vrg_epic_move.py
+++ b/src/vergil_tooling/bin/vrg_epic_move.py
@@ -2,8 +2,8 @@
 
 GitHub sub-issues allow only one parent, so re-parenting is unlink-then-link.
 The target epic is resolved via :func:`epics.resolve_epic_ref` (accepting the
-``adhoc`` sentinel and its deprecated ``standing`` alias, and validating
-epic-ness); moving a task already under the target epic is a no-op.
+``adhoc`` sentinel and validating epic-ness); moving a task already under the
+target epic is a no-op.
 """
 
 from __future__ import annotations
@@ -28,11 +28,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         task = epics.parse_issue_ref(args.task, default_repo=default_repo)
         # Scope the App token to the task's owner (#2070). The epic must live in
-        # the same org — the 'adhoc' sentinel (and its deprecated 'standing'
-        # alias) resolves within the task's org (.github), so only an explicit
-        # ref can diverge; guard that before any network call so a cross-org
-        # mistake is a clear message, not a cwd-scoped 403.
-        if args.epic not in ("standing", "adhoc"):
+        # the same org — the 'adhoc' sentinel resolves within the task's org
+        # (.github), so only an explicit ref can diverge; guard that before any
+        # network call so a cross-org mistake is a clear message, not a
+        # cwd-scoped 403.
+        if args.epic != "adhoc":
             epic_owner = epics.parse_issue_ref(args.epic, default_repo=default_repo).owner
             if epic_owner != task.owner:
                 raise ValueError(

--- a/src/vergil_tooling/bin/vrg_epic_rollup.py
+++ b/src/vergil_tooling/bin/vrg_epic_rollup.py
@@ -6,10 +6,9 @@ Thin CLI over ``epics.rollup`` for the ``on: issues.closed`` Action (issue
 tasks are now closed.
 
 ``epics.rollup`` is a no-op unless the closed issue is a managed task with an
-``epic``-labeled, non-perpetual parent (an ``ad-hoc`` epic, or its deprecated
-``standing`` alias, never auto-closes), so this is safe to fire on *every*
-issue close. Moving rollup here makes it event-driven — it no longer depends on
-``vrg-finalize-pr`` running.
+``epic``-labeled, non-perpetual parent (an ``ad-hoc`` epic never auto-closes),
+so this is safe to fire on *every* issue close. Moving rollup here makes it
+event-driven — it no longer depends on ``vrg-finalize-pr`` running.
 
 Refs are ``owner/repo#N`` or bare ``#N`` (bare resolves to the current repo).
 """

--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -2,9 +2,9 @@
 
 Every issue must be born linked to an epic (a native sub-issue), so this is the
 only sanctioned issue-creation path: ``vrg-gh`` denies raw ``gh issue create``
-and redirects here. ``--epic`` is required — pass ``--epic adhoc`` (or the
-deprecated alias ``standing``) to target the repo's ad-hoc epic in ``.github``,
-or an explicit ``owner/repo#N`` / ``#N`` epic ref.
+and redirects here. ``--epic`` is required — pass ``--epic adhoc`` to target the
+repo's ad-hoc epic in ``.github``, or an explicit ``owner/repo#N`` / ``#N`` epic
+ref.
 
 If the issue is created but the link fails, the created issue's URL is reported
 so it is never a silent orphan; recover with ``vrg-epic-move``.
@@ -84,10 +84,10 @@ def main(argv: list[str] | None = None) -> int:
     repo = args.repo or github.current_repo()
     owner, name = repo.split("/", 1)
     # Pre-network cross-org guard: the issue and its epic must share an owner so
-    # one App-installation token reaches both (#2070). The 'adhoc' sentinel (and
-    # its deprecated 'standing' alias) resolves within *repo*'s org (.github), so
-    # only an explicit epic ref can diverge.
-    if args.epic not in ("standing", "adhoc"):
+    # one App-installation token reaches both (#2070). The 'adhoc' sentinel
+    # resolves within *repo*'s org (.github), so only an explicit epic ref can
+    # diverge.
+    if args.epic != "adhoc":
         try:
             epic_owner = epics.parse_issue_ref(args.epic, default_repo=repo).owner
         except ValueError as exc:

--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -11,7 +11,6 @@
     {"name": "rtfm", "color": "f9d0c4", "description": "Resolved by reading existing docs"},
     {"name": "observability", "color": "1d76db", "description": "Monitoring, reporting, health checks"},
     {"name": "epic", "color": "6f42c1", "description": "Umbrella issue; finite epics close when all sub-issues close"},
-    {"name": "standing", "color": "5319e7", "description": "Deprecated alias for ad-hoc; retired after the ad-hoc migration (epic #85)"},
     {"name": "ad-hoc", "color": "5319e7", "description": "Perpetual umbrella for ad-hoc work; never auto-closes"},
     {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
@@ -19,5 +18,5 @@
     {"name": "validation", "color": "006b75", "description": "Post-merge validation: run the checklist, record PASS/FAIL as a comment; never auto-closed"},
     {"name": "deployment", "color": "0052cc", "description": "Deployment task: install/sync merged changes so they are usable; never auto-closed"}
   ],
-  "delete": ["enhancement"]
+  "delete": ["enhancement", "standing"]
 }

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -316,8 +316,8 @@ def closed_epic_open_child(org: str, *, home: str | None = None) -> list[EpicOpe
     PR that legitimately ``Ref``'d an epic once tripped ``task_drift`` into
     closing the epic directly, orphaning its open tasks — and no audit check
     caught the result. This is that check. Uses **native children** as the
-    authoritative signal (``child_states``); perpetual (``ad-hoc``/``standing``)
-    epics are skipped — they never roll up, so being closed-with-open-children is
+    authoritative signal (``child_states``); perpetual (``ad-hoc``) epics are
+    skipped — they never roll up, so being closed-with-open-children is
     not a violation for them. Report-only: like the other invariants it is never
     auto-acted (remediation is :func:`reopen_epics_with_open_children`, gated to a
     human). Scoped to the resolved epic *home* (default ``<org>/.github``).
@@ -342,7 +342,7 @@ def closed_epic_open_child(org: str, *, home: str | None = None) -> list[EpicOpe
     violations: list[EpicOpenChildViolation] = []
     for item in raw if isinstance(raw, list) else []:
         labels = {str((label or {}).get("name", "")) for label in (item.get("labels") or [])}
-        if labels & {"ad-hoc", "standing"}:
+        if "ad-hoc" in labels:
             continue  # perpetual epics never roll up; closed-with-open-child doesn't apply
         epic = epics.IssueRef(home_owner, home_repo, int(item["number"]))
         open_kids = tuple(cs.ref for cs in epics.child_states(epic) if cs.state == "OPEN")

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -296,12 +296,12 @@ def is_epic(ref: IssueRef) -> bool:
 def resolve_epic_ref(ref: str, *, repo: str) -> IssueRef:
     """Resolve an epic ref, accepting the ``"adhoc"`` sentinel.
 
-    ``"adhoc"`` (and the deprecated alias ``"standing"``) ensures *repo*'s ad-hoc
-    epic exists in ``<org>/.github`` — creating it if absent and reusing it
-    otherwise — via :func:`ensure_adhoc_epic`. Any other ref is parsed with
+    ``"adhoc"`` ensures *repo*'s ad-hoc epic exists in ``<org>/.github`` —
+    creating it if absent and reusing it otherwise — via
+    :func:`ensure_adhoc_epic`. Any other ref is parsed with
     :func:`parse_issue_ref` and validated to carry the ``epic`` label.
     """
-    if ref in ("adhoc", "standing"):
+    if ref == "adhoc":
         return ensure_adhoc_epic(repo)
     epic = parse_issue_ref(ref, default_repo=repo)
     if not is_epic(epic):
@@ -389,12 +389,6 @@ def ensure_adhoc_epic(target_repo: str) -> IssueRef:
     return IssueRef(owner=owner, repo=home_repo, number=number)
 
 
-# Deprecated alias kept for the ad-hoc rollout window (epic #85); callers still
-# importing ``ensure_standing_epic`` keep working. Removed in the retire-standing
-# task once the migration is complete.
-ensure_standing_epic = ensure_adhoc_epic
-
-
 def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
     """True if *ref* points at an epic, so it must not be linked as a PR's task.
 
@@ -454,13 +448,12 @@ def rollup(task: IssueRef) -> None:
 
     A no-op unless the task has an ``epic``-labeled parent (the transition gate):
     legacy issues have no epic parent, so finalize never rolls them up. An
-    ``ad-hoc`` epic (or its deprecated ``standing`` alias) is perpetual and never
-    auto-closes.
+    ``ad-hoc`` epic is perpetual and never auto-closes.
     """
     parent = parent_of(task)
     if parent is None or not is_epic(parent):
         return
-    if _labels(parent) & {"ad-hoc", "standing"}:
+    if "ad-hoc" in _labels(parent):
         return
     if all_children_closed(parent):
         print(f"Rolling up epic {parent.slug} — all child tasks closed.")

--- a/src/vergil_tooling/lib/roadmap.py
+++ b/src/vergil_tooling/lib/roadmap.py
@@ -47,10 +47,10 @@ def _open_epics(home: str) -> list[Any]:
 
 
 def _is_perpetual(epic: Any) -> bool:
-    """True if the epic is a perpetual ad-hoc bucket (``ad-hoc``, or its
-    deprecated ``standing`` alias) — excluded from the strategic roadmap."""
+    """True if the epic is a perpetual ``ad-hoc`` bucket — excluded from the
+    strategic roadmap."""
     names = {(label or {}).get("name") for label in (epic.get("labels") or [])}
-    return bool(names & {"ad-hoc", "standing"})
+    return "ad-hoc" in names
 
 
 def gather(org: str | None = None, *, home: str | None = None) -> list[EpicSummary]:

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -328,8 +328,8 @@ def test_closed_epic_open_child_flags_closed_epic_with_open_child() -> None:
 
 
 def test_closed_epic_open_child_skips_perpetual_before_fetching_children() -> None:
-    # A perpetual (ad-hoc/standing) epic is skipped without a children lookup.
-    listing = [{"number": 99, "title": "Ad hoc", "labels": [{"name": "standing"}]}]
+    # A perpetual (ad-hoc) epic is skipped without a children lookup.
+    listing = [{"number": 99, "title": "Ad hoc", "labels": [{"name": "ad-hoc"}]}]
     child_states = MagicMock()
     with (
         patch("vergil_tooling.lib.github.read_json", return_value=listing),

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -416,19 +416,6 @@ def test_rollup_skips_adhoc_epic() -> None:
     mock_run.assert_not_called()
 
 
-def test_rollup_skips_standing_epic_alias() -> None:
-    # 'standing' remains perpetual during the rollout window (deprecated alias).
-    with (
-        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
-        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
-        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "standing"}),
-        patch("vergil_tooling.lib.epics.all_children_closed", return_value=True),
-        patch("vergil_tooling.lib.github.run") as mock_run,
-    ):
-        epics.rollup(TASK)
-    mock_run.assert_not_called()
-
-
 def test_rollup_skips_when_children_remain_open() -> None:
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
@@ -517,17 +504,6 @@ def test_resolve_epic_ref_adhoc_discovers_single_epic() -> None:
     assert "org/.github" in args and "epic" in args and "ad-hoc" in args
 
 
-def test_resolve_epic_ref_standing_is_deprecated_alias_for_adhoc() -> None:
-    # 'standing' still resolves during the rollout window, routing to .github.
-    with (
-        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
-        patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]),
-    ):
-        assert epics.resolve_epic_ref("standing", repo="org/tooling") == IssueRef(
-            "org", ".github", 1972
-        )
-
-
 def test_ensure_adhoc_epic_zero_creates_in_dotgithub() -> None:
     # When no ad-hoc epic exists, ensure creates it in <org>/.github, by title.
     created = "https://github.com/org/.github/issues/77"
@@ -578,14 +554,6 @@ def test_ensure_adhoc_epic_reuses_existing_by_title() -> None:
     ):
         assert epics.ensure_adhoc_epic("org/tooling") == IssueRef("org", ".github", 1972)
     mock_create.assert_not_called()
-
-
-def test_ensure_standing_epic_is_backward_compatible_alias() -> None:
-    with (
-        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
-        patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]),
-    ):
-        assert epics.ensure_standing_epic("org/tooling") == IssueRef("org", ".github", 1972)
 
 
 def test_ensure_adhoc_epic_multiple_same_title_raises() -> None:

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -63,11 +63,10 @@ def test_delete_list_is_strings() -> None:
 
 def test_registry_includes_convention_labels() -> None:
     # epic/task convention (epic #40, #85): Role (epic, ad-hoc), Stage (triage),
-    # Kind (idea, research), Exception (hotfix). "standing" is retained during the
-    # ad-hoc rollout window as a deprecated alias (removed in epic #85, Task 11).
-    # The remaining Kind axis reuses the existing conventional-commit labels.
+    # Kind (idea, research), Exception (hotfix). The remaining Kind axis reuses
+    # the existing conventional-commit labels.
     names = {label["name"] for label in load_labels()["labels"]}
-    for required in {"epic", "ad-hoc", "standing", "triage", "idea", "research", "hotfix"}:
+    for required in {"epic", "ad-hoc", "triage", "idea", "research", "hotfix"}:
         assert required in names, f"convention label missing: {required}"
 
 
@@ -104,8 +103,9 @@ def test_label_descriptions_within_github_limit() -> None:
         assert length <= 100, f"{label['name']} description is {length} chars (max 100)"
 
 
-def test_label_change_is_additive_only() -> None:
-    # Convention labels are added additively; retiring default cruft is deferred
-    # to the per-repo migration pass (epic #40, Task 9). This task must not
-    # enqueue any new deletions beyond the pre-existing one.
-    assert load_labels()["delete"] == ["enhancement"]
+def test_delete_list_retires_deprecated_labels() -> None:
+    # The delete list retires default cruft (``enhancement``) and the deprecated
+    # ``standing`` alias, removed once the ad-hoc migration completed (epic #85,
+    # retire-standing task): no live ``standing`` epics remain, so a sync must
+    # de-provision the label.
+    assert load_labels()["delete"] == ["enhancement", "standing"]

--- a/tests/vergil_tooling/test_roadmap.py
+++ b/tests/vergil_tooling/test_roadmap.py
@@ -12,7 +12,7 @@ def _child(owner: str, repo: str, number: int, state: str) -> epics.ChildState:
     return epics.ChildState(epics.IssueRef(owner, repo, number), state)
 
 
-def test_gather_summarizes_open_epics_and_skips_standing() -> None:
+def test_gather_summarizes_open_epics_and_skips_adhoc() -> None:
     epic_list = [
         {
             "number": 40,
@@ -27,7 +27,7 @@ def test_gather_summarizes_open_epics_and_skips_standing() -> None:
             "title": "Ad-hoc",
             "createdAt": "2026-01-01T00:00:00Z",
             "milestone": None,
-            "labels": [{"name": "epic"}, {"name": "standing"}],  # standing -> skipped
+            "labels": [{"name": "epic"}, {"name": "ad-hoc"}],  # ad-hoc -> skipped
             "url": "u5",
         },
     ]
@@ -53,8 +53,7 @@ def test_gather_summarizes_open_epics_and_skips_standing() -> None:
 
 
 def test_gather_skips_adhoc_epic() -> None:
-    # The ad-hoc bucket is perpetual and excluded from the strategic roadmap,
-    # just like the deprecated 'standing' alias (epic #85).
+    # The ad-hoc bucket is perpetual and excluded from the strategic roadmap.
     epic_list = [
         {
             "number": 40,

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -127,7 +127,8 @@ def test_main_sync_provisions_all_labels() -> None:
     assert result == 0
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
-    assert len(label_calls) == 18  # 17 + deployment (epic vergil-project/.github#124)
+    # 18 before retiring the deprecated 'standing' alias (retire-standing task).
+    assert len(label_calls) == 17
 
 
 def test_main_sync_uses_force_with_color_description() -> None:
@@ -144,8 +145,9 @@ def test_main_sync_deletes_deprecated_labels() -> None:
     with patch("vergil_tooling.bin.vrg_ensure_label.github.run") as mock_run:
         main(["--repo", "o/r", "--sync"])
     delete_calls = [c for c in mock_run.call_args_list if c.args[1] == "delete"]
-    assert len(delete_calls) == 1
-    assert "enhancement" in delete_calls[0].args
+    assert len(delete_calls) == 2
+    deleted = {c.args[2] for c in delete_calls}
+    assert deleted == {"enhancement", "standing"}
 
 
 def test_main_sync_delete_ignores_missing_label() -> None:

--- a/tests/vergil_tooling/test_vrg_epic_move.py
+++ b/tests/vergil_tooling/test_vrg_epic_move.py
@@ -18,7 +18,7 @@ TASK = epics.IssueRef("org", "repo", 42)
 
 def test_parse_args_requires_task_and_epic() -> None:
     with pytest.raises(SystemExit):
-        parse_args(["--epic", "standing"])  # missing --task
+        parse_args(["--epic", "adhoc"])  # missing --task
 
 
 def test_main_reparents_unlink_then_link() -> None:
@@ -72,19 +72,6 @@ def test_main_rejects_non_epic_target() -> None:
         rc = main(["--task", "#42", "--epic", "#999"])
     assert rc == 1
     mock_add.assert_not_called()
-
-
-def test_main_accepts_standing_epic() -> None:
-    """The 'standing' sentinel skips the cross-org guard (it resolves in-repo)."""
-    with (
-        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
-        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=NEW),
-        patch(f"{_MOD}.epics.parent_of", return_value=None),
-        patch(f"{_MOD}.epics.add_child") as mock_add,
-    ):
-        rc = main(["--task", "#42", "--epic", "standing"])
-    assert rc == 0
-    mock_add.assert_called_once_with(NEW, TASK)
 
 
 def test_main_accepts_adhoc_epic() -> None:

--- a/tests/vergil_tooling/test_vrg_issue_create.py
+++ b/tests/vergil_tooling/test_vrg_issue_create.py
@@ -26,7 +26,7 @@ def test_parse_args_requires_epic() -> None:
 
 def test_parse_args_requires_title() -> None:
     with pytest.raises(SystemExit):
-        parse_args(["--epic", "standing"])  # missing --title
+        parse_args(["--epic", "adhoc"])  # missing --title
 
 
 def test_main_creates_issue_and_links_under_epic() -> None:
@@ -36,9 +36,9 @@ def test_main_creates_issue_and_links_under_epic() -> None:
         patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
         patch(f"{_MOD}.epics.add_child") as mock_add,
     ):
-        rc = main(["--epic", "standing", "--title", "T", "--body", "B", "--label", "bug"])
+        rc = main(["--epic", "adhoc", "--title", "T", "--body", "B", "--label", "bug"])
     assert rc == 0
-    mock_resolve.assert_called_once_with("standing", repo="org/repo")
+    mock_resolve.assert_called_once_with("adhoc", repo="org/repo")
     assert mock_create.call_args.kwargs["title"] == "T"
     assert mock_create.call_args.kwargs["labels"] == ["bug"]
     mock_add.assert_called_once_with(EPIC, epics.IssueRef("org", "repo", 123))
@@ -165,8 +165,8 @@ def test_kind_defaults_to_task_without_validation_label() -> None:
 
 
 def test_main_adhoc_sentinel_skips_cross_org_guard() -> None:
-    # 'adhoc' (like the deprecated 'standing') resolves within the repo's org
-    # (.github), so it must skip the explicit-ref cross-org guard and link.
+    # 'adhoc' resolves within the repo's org (.github), so it must skip the
+    # explicit-ref cross-org guard and link.
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
         patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC) as mock_resolve,
@@ -184,11 +184,11 @@ def test_main_epic_resolution_failure_creates_nothing() -> None:
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
         patch(
             f"{_MOD}.epics.resolve_epic_ref",
-            side_effect=ValueError("multiple standing epics in org/repo — pass an explicit --epic"),
+            side_effect=ValueError("multiple ad-hoc epics in org/repo — pass an explicit --epic"),
         ),
         patch(f"{_MOD}.github.create_issue") as mock_create,
     ):
-        rc = main(["--epic", "standing", "--title", "T"])
+        rc = main(["--epic", "adhoc", "--title", "T"])
     assert rc == 1
     mock_create.assert_not_called()
 
@@ -200,7 +200,7 @@ def test_main_link_failure_reports_created_issue(capsys: pytest.CaptureFixture[s
         patch(f"{_MOD}.github.create_issue", return_value=_URL),
         patch(f"{_MOD}.epics.add_child", side_effect=RuntimeError("link failed")),
     ):
-        rc = main(["--epic", "standing", "--title", "T"])
+        rc = main(["--epic", "adhoc", "--title", "T"])
     assert rc == 1
     err = capsys.readouterr().err
     assert "123" in err  # orphan-safe: the created issue is surfaced
@@ -214,7 +214,7 @@ def test_main_scopes_token_to_repo_owner() -> None:
         patch(f"{_MOD}.github.create_issue", return_value=_URL),
         patch(f"{_MOD}.epics.add_child"),
     ):
-        rc = main(["--repo", "other-org/repo", "--epic", "standing", "--title", "T"])
+        rc = main(["--repo", "other-org/repo", "--epic", "adhoc", "--title", "T"])
     assert rc == 0
     mock_scope.assert_called_once_with("other-org")
 
@@ -261,6 +261,6 @@ def test_main_reports_missing_installation() -> None:
         ),
         patch(f"{_MOD}.github.create_issue") as mock_create,
     ):
-        rc = main(["--epic", "standing", "--title", "T"])
+        rc = main(["--epic", "adhoc", "--title", "T"])
     assert rc == 1
     mock_create.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the deprecated 'standing' epic alias/sentinel/label across epics.py, its callers, roadmap, epic_audit, pyproject, and the label registry, leaving 'ad-hoc' as the sole perpetual-bucket model.

## Issue Linkage

- Closes #2129

## Notes

- Removes: the ensure_standing_epic alias and 'standing' sentinel acceptance in resolve_epic_ref; 'standing' from the perpetual-label checks in rollup/roadmap/epic_audit (keeps 'ad-hoc'); the 'standing' entries in the cross-org sentinel guards of vrg-issue-create and vrg-epic-move; the vrg-standing-epic console-script alias; and the 'standing' label registry entry (now in the delete list so a --sync de-provisions it). Safe now: the ad-hoc model superseded standing, all active orgs are migrated, and no live 'standing' epics remain. The one-shot adhoc_migrate module is intentionally untouched (it operates on historical standing epics; it is not the deprecated alias). ad-hoc behavior is unchanged and fully covered; validation green at 4122 passed.