### PR TITLE
docs(epics): document the epic model, compliance invariants, and finite-epic relocation

### DIFF
--- a/docs/site/docs/guides/epic-home-visibility-flip.md
+++ b/docs/site/docs/guides/epic-home-visibility-flip.md
@@ -19,46 +19,51 @@ the runbook for when it happens.
 
 - **Epics move.** A public→private flip moves the repo's epics from
   `<org>/.github` into the repo itself; a private→public flip moves them
-  the other way.
+  the other way. The epic issue is **transferred** (not re-created), so
+  its history and comments follow it. It gets a new number in the
+  destination repo.
 - **Tasks do not move.** A task always lives in its member repo (1:1 with
-  its PR), independent of visibility. Only the epic issue relocates, and
-  each task's parent link is re-pointed at the epic's new location.
+  its PR), independent of visibility. Only the epic issue relocates.
 
-There is **no dedicated relocation tool** — the procedure composes the
-existing commands. (A convenience `--to-home` wrapper is deliberately
-deferred unless the manual procedure proves painful in practice.)
+There is **no dedicated relocation wrapper** — the procedure composes
+`vrg-gh issue transfer` (an intra-org issue move) with `vrg-epic-link`.
 
 ## Procedure
 
-Do the following once per epic that the flipped repo owns. `vrg-epic-move`
-re-parents a *task* under a different epic; it does not transfer an epic
-between repos, so the relocation is re-create + re-parent + close.
+Do the following once per epic that the flipped repo owns.
 
-1. **Confirm the new home.** Run `vrg-epic-create --repo <owner>/<repo>`
+1. **Confirm the new home.** Run `vrg-epic-create --repo <org>/<repo>`
    (or check the table above) — it echoes the resolved home and its
-   visibility, e.g. `-> epic home: <owner>/<repo> [PRIVATE]`.
+   visibility, e.g. `-> epic home: <org>/<repo> [PRIVATE]`.
 
-2. **Re-create the epic in the new home.** Copy the old epic's title,
-   body, and labels:
-
-   ```bash
-   vrg-epic-create --repo <owner>/<repo> \
-     --title "Epic: <same title>" --body-file <copied-body.md>
-   ```
-
-   Note the new epic's number `<NEW>`.
-
-3. **Re-parent each child task** from the old epic to the new one:
+2. **Transfer the epic into its new home.** An intra-org `issue transfer`
+   moves the epic between repos under the same org, carrying its history
+   with it:
 
    ```bash
-   vrg-epic-move --task <owner>/<repo>#<TASK> --epic <new-home>#<NEW>
+   vrg-gh issue transfer <n> <org>/.github -R <org>/<src-repo>
    ```
 
-   List the old epic's children first with the audit/roadmap tooling if
-   you need the full set.
+   **Always pin the source with `-R`.** The `-R`/`--repo` owner selects
+   the GitHub App installation and names the source repo unambiguously;
+   `<n>` is the epic's number *in that source repo* and the trailing
+   `<org>/.github` is the destination. (For a public→private flip the
+   destination is the member repo instead.) The transfer is intra-org —
+   one installation token cannot reach two owners. GitHub assigns the
+   epic a new number in the destination.
 
-4. **Close the old epic** with a comment pointing at the replacement, so
-   the drift audit does not re-surface it.
+3. **Relink reflink-only children.** Children linked as **native
+   sub-issues** ride the transfer — their parent link is preserved
+   automatically. Children linked only by a portable `Parent:` body
+   reflink still point at the epic's old location, so re-point each with:
+
+   ```bash
+   vrg-epic-link --epic <org>/.github#<NEW> --task <org>/<repo>#<TASK>
+   ```
+
+4. **Verify.** Run `vrg-epic-audit` and confirm no invariant violation
+   remains — no epic outside `.github` for a public repo, no stray
+   `.github` issue, no closed epic with an open child.
 
 ## Cross-visibility caveat
 

--- a/docs/site/docs/guides/permission-model.md
+++ b/docs/site/docs/guides/permission-model.md
@@ -133,6 +133,7 @@ second-level subcommands as a pair.
 | `issue edit` | Updating metadata |
 | `issue list` | Read-only |
 | `issue comment` | Adding comments |
+| `issue transfer` | Intra-org issue move (finite-epic relocation) |
 | `pr view` | Read-only |
 | `pr checks` | CI status |
 | `pr list` | Read-only |

--- a/docs/site/docs/standards/github-issues.md
+++ b/docs/site/docs/standards/github-issues.md
@@ -82,30 +82,74 @@ Create a sub-issue when:
 
 Sub-issue rules:
 
-- Link each sub-issue to its parent using the sub-issues API (see below).
+- Link each sub-issue to its parent with the sanctioned tooling (see below).
 - The PR should close the sub-issue, not the parent, unless the PR completes
   the parent's full scope.
 
-### Linking a sub-issue via the API
+### Linking a sub-issue
 
-Creating a sub-issue relationship is a two-step process:
+Raw `gh api` is blocked for agents, so sub-issue links are created through the
+sanctioned tools. Both establish the same native GitHub sub-issue relationship
+(with a portable `Parent:` body reflink as the cross-forge fallback) that the
+rollup reads — never hand-roll the link.
 
-1. **Get the child issue's database ID** (this is the numeric ID, not the
-   issue number):
+- **A new task under its parent** — create it already linked:
 
-   ```bash
-   gh api repos/{owner}/{repo}/issues/{child_number} --jq '.id'
-   ```
+  ```bash
+  vrg-issue-create --epic <owner>/<repo>#<parent> --repo <owner>/<repo> \
+    --title "<what>"
+  ```
 
-2. **Link the child to the parent**:
+- **An existing task** — link it (or backfill a reflink-only child):
 
-   ```bash
-   gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues \
-     --method POST -F sub_issue_id={database_id}
-   ```
+  ```bash
+  vrg-epic-link --epic <owner>/<repo>#<parent> --task <owner>/<repo>#<child>
+  ```
 
-Use `-F` (not `-f`) for `sub_issue_id` — the API requires an integer, and
-`-f` sends a string.
+## Epics
+
+An **epic** is an umbrella issue — carrying the `epic` label — over the *task*
+issues that deliver it. Tasks may live in other repos in the same org; the link
+is a native GitHub sub-issue, with a portable `Parent:` body reflink as the
+cross-forge fallback.
+
+### Finite vs perpetual epics
+
+- **Finite epic** — a bounded initiative with a definite end. It **rolls up**:
+  once every child task is closed, `vrg-finalize-pr` closes the epic. A *managed
+  task* (an issue with an `epic`-labelled parent) links its PR with `Closes`, so
+  the task auto-closes on merge and the final close rolls its epic up.
+- **Perpetual (ad-hoc) epic** — a standing umbrella for unplanned work in one
+  repo. Titled `Epic (ad hoc): <repo>`, labelled `epic` + `ad-hoc`, one per repo,
+  and it **never auto-closes**. Target it with `vrg-issue-create --epic adhoc`.
+  (The older `standing` alias is **retired** — only `ad-hoc` remains.)
+
+### Epic home (the `<org>/.github` rule)
+
+An epic's home repo is derived from repository visibility:
+
+- A **public** repo homes its epics centrally in the org's `.github`.
+- A **private** repo (with a public `.github`) homes its epics **in itself**.
+- A **private** `.github` means the whole org is private, so everything homes in
+  `.github`.
+
+Ad-hoc epics follow the same rule — `Epic (ad hoc): <repo>` lives in the repo's
+resolved home. See
+[Epic home visibility flips](../guides/epic-home-visibility-flip.md) for
+relocating epics when a repo's visibility changes.
+
+### Compliance invariants
+
+`vrg-epic-audit` reports (read-only) any drift from the model:
+
+- **Epics live in `.github`.** An open `epic`-labelled issue outside `.github` in
+  a *public* repo is a violation (a private repo self-homes legitimately).
+- **No stray `.github` issues.** The epic home holds only epics, intake
+  (`triage`/`idea`/`research`), and tasks linked under an epic; any other open
+  issue there is a stray.
+- **An epic is never closed while a child is open.** A closed finite epic with an
+  open child is a violation (perpetual `ad-hoc` epics are exempt — they never
+  roll up).
 
 ## Closing behavior
 


### PR DESCRIPTION
# Pull Request

## Summary

- Document the epic/task model in vergil-tooling's docs/site: the Epics section and compliance invariants in the github-issues standard, the issue transfer allowlist entry in the permission model, and the transfer-based finite-epic relocation runbook.

## Issue Linkage

- Closes #2279

## Notes

- Grounded every statement in the code (epics.py, epic_audit.py, vrg_gh.py). Rewrote the stale gh api sub-issue linking section to use vrg-issue-create and vrg-epic-link. vrg-validate green in-container. Same-repo task; the close keyword is auto-selected at submit time.