### PR TITLE
feat(vm): resume a VM session by exact name (--resume NAME)

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2379,6 +2379,8 @@ def _session_inner(
         "--path",
         rel_path,
     ]
+    if args.resume is not None:
+        resolve_cmd += ["--resume-name", args.resume]
     if args.slot is not None:
         resolve_cmd += ["--slot", str(args.slot)]
     if args.fork:
@@ -2437,6 +2439,13 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
 
 
 def _cmd_session(args: argparse.Namespace) -> int:
+    if args.resume is not None and (args.slot is not None or args.fork or args.fresh):
+        print(
+            "ERROR: --resume selects a session by name and cannot be combined with "
+            "--slot/--fork/--fresh (which select by slot).",
+            file=sys.stderr,
+        )
+        return 1
     target = _resolve_target(args, borrow_allowed=True)
     name, identity, config = target.identity_name, target.identity, target.config
 
@@ -2774,6 +2783,16 @@ def main(argv: list[str] | None = None) -> int:
         "--slot",
         type=int,
         help="Session slot number (1-99); default picks the lowest idle/free slot",
+    )
+    p_session.add_argument(
+        "--resume",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Resume the session with this exact display name (e.g. an epic "
+            "session's renamed title, 'epic-85-centralize-epics-adhoc'), instead "
+            "of selecting by slot. Mutually exclusive with --slot/--fork/--fresh."
+        ),
     )
     p_session.add_argument(
         "--fork",

--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -34,6 +34,7 @@ from vergil_tooling.lib.session import (
     parse_archived,
     parse_name,
     plan_session,
+    select_by_name,
 )
 
 
@@ -407,9 +408,18 @@ def resolve(
     extra: list[str],
     stale_days: int,
     archive_days: int,
+    resume_name: str | None = None,
 ) -> int:
-    """Plan, auto-archive stale cold slots, then exec Claude for one identity + path."""
+    """Plan, auto-archive stale cold slots, then exec Claude for one identity + path.
+
+    ``resume_name`` short-circuits the slot machinery: it resumes the session with
+    that exact display name (an epic-renamed title that does not fit the slot
+    scheme), with no staleness sweep or prompt — the caller named the session
+    explicitly, so it is resumed as-is.
+    """
     names, active, last_active = _read_state(_project_slug(str(Path.cwd())))
+    if resume_name is not None:
+        return _execute(path, select_by_name(resume_name, names, active, last_active), extra, names)
     slots = build_slots(identity, path, names, active, last_active)
     plan = plan_session(
         identity, path, slots, _now(), stale_days, archive_days, requested_slot, fork, fresh
@@ -470,6 +480,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--slot", type=int)
     parser.add_argument("--fork", action="store_true")
     parser.add_argument("--fresh", action="store_true")
+    parser.add_argument("--resume-name", dest="resume_name", default=None)
     parser.add_argument("--stale-days", type=int, default=7, dest="stale_days")
     parser.add_argument("--archive-days", type=int, default=14, dest="archive_days")
     parser.add_argument("--list-json", action="store_true", dest="list_json")
@@ -495,6 +506,7 @@ def main(argv: list[str] | None = None) -> int:
         extra,
         args.stale_days,
         args.archive_days,
+        args.resume_name,
     )
 
 

--- a/src/vergil_tooling/lib/session.py
+++ b/src/vergil_tooling/lib/session.py
@@ -303,6 +303,39 @@ def _select_fork(identity: str, path: str, slots: dict[int, Slot], slot: int | N
     return Fork(info.session_id, make_name(identity, free, path))
 
 
+def select_by_name(
+    requested_name: str,
+    name_by_session: dict[str, str],
+    active_sessions: set[str],
+    last_active: dict[str, float] | None = None,
+) -> Decision:
+    """Resume the session whose current name equals ``requested_name`` exactly.
+
+    Sessions renamed to a human-facing title — e.g. an epic session renamed to
+    ``epic-85-centralize-epics-adhoc`` — do not fit the ``<identity>:<NN>:<path>``
+    slot scheme and so fall out of the slot map entirely; the only way to address
+    them is by their exact display name. ``name_by_session`` maps session id to
+    its current name (see the resolver's state read); the match is exact, so an
+    ``archived@…`` label never collides with a live title.
+
+    A name may be held by more than one session id — a ``/clear`` rotation leaves
+    the abandoned id still carrying the title in its transcript — so ties resolve
+    by the module's standard collision rule (:func:`_displaces`): a live session
+    beats a dead one, then the more recently active wins. No match refuses.
+    """
+    la = last_active or {}
+    best: tuple[str, bool, float | None] | None = None
+    for session_id, name in name_by_session.items():
+        if name != requested_name:
+            continue
+        active = session_id in active_sessions
+        if best is None or _displaces(best[1], best[2], active, la.get(session_id)):
+            best = (session_id, active, la.get(session_id))
+    if best is None:
+        return Refuse(f"no session named {requested_name!r} for this workspace")
+    return Resume(best[0])
+
+
 @dataclass(frozen=True)
 class PromptStale:
     """Warn-band: the resolver must prompt resume/fresh/cancel, then act."""

--- a/tests/vergil_tooling/test_session.py
+++ b/tests/vergil_tooling/test_session.py
@@ -20,6 +20,7 @@ from vergil_tooling.lib.session import (
     parse_name,
     plan_session,
     select,
+    select_by_name,
 )
 
 
@@ -475,3 +476,42 @@ def test_plan_all_slots_active_refused() -> None:
     slots = {n: _slot(n, f"s{n}", active=True) for n in range(1, SLOT_MAX + 1)}
     plan = _plan(slots)
     assert isinstance(plan.action, Refuse)
+
+
+# --- select_by_name (resume a session by its exact display name) ---
+
+
+def test_select_by_name_resumes_exact_match() -> None:
+    names = {"s1": "epic-85-centralize-epics-adhoc", "s2": "vergil:01:p"}
+    assert select_by_name("epic-85-centralize-epics-adhoc", names, set()) == Resume("s1")
+
+
+def test_select_by_name_refuses_when_no_match() -> None:
+    result = select_by_name("no-such-session", {"s1": "vergil:01:p"}, set())
+    assert isinstance(result, Refuse)
+    assert "no-such-session" in result.message
+
+
+def test_select_by_name_live_beats_dead_on_collision() -> None:
+    # A /clear rotation leaves the abandoned id still carrying the title; the
+    # live claimant of the same name wins.
+    names = {"dead": "epic-85", "live": "epic-85"}
+    assert select_by_name("epic-85", names, {"live"}) == Resume("live")
+
+
+def test_select_by_name_recency_breaks_tie_between_idle() -> None:
+    names = {"old": "epic-85", "new": "epic-85"}
+    last_active = {"old": 100.0, "new": 200.0}
+    assert select_by_name("epic-85", names, set(), last_active) == Resume("new")
+
+
+def test_select_by_name_keeps_incumbent_when_later_does_not_displace() -> None:
+    # The live incumbent is seen first; a later dead session sharing the name
+    # must not displace it (the _displaces-returns-False path).
+    names = {"live": "epic-85", "dead": "epic-85"}
+    assert select_by_name("epic-85", names, {"live"}) == Resume("live")
+
+
+def test_select_by_name_match_is_exact_not_substring() -> None:
+    result = select_by_name("epic-85", {"s1": "epic-850-other"}, set())
+    assert isinstance(result, Refuse)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2241,6 +2241,19 @@ class TestSession:
         assert "--fork" in inner
         assert "--slot 2" in inner
 
+    def test_session_resume_passed_to_resolver(
+        self,
+        _age: MagicMock,
+        _copy: MagicMock,
+        _link: MagicMock,
+        mock_exec: MagicMock,
+        config_file: Path,
+    ) -> None:
+        main(
+            ["session", "--config", str(config_file), "--resume", "epic-85-adhoc", "vergil-tooling"]
+        )
+        assert "--resume-name epic-85-adhoc" in self._inner(mock_exec)
+
     def test_session_no_model_no_flag(
         self,
         _age: MagicMock,
@@ -2305,7 +2318,7 @@ def test_session_inner_strips_leading_double_dash() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False)
+    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "", 7, 14)
     assert "exec bash" in inner
     assert "vrg-vm-resolve-session" not in inner
@@ -2316,7 +2329,7 @@ def test_session_inner_raw_override_ignores_model() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False)
+    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "opus", 7, 14)
     assert "exec bash" in inner
     assert "--model" not in inner
@@ -2327,7 +2340,7 @@ def test_session_inner_includes_thresholds() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False)
+    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "", 5, 30)
     assert "--stale-days 5" in inner
     assert "--archive-days 30" in inner
@@ -2338,9 +2351,37 @@ def test_session_inner_fresh_flag() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=True)
+    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=True, resume=None)
     inner = _session_inner(ns, "vergil", "p", "", 7, 14)
     assert "--fresh" in inner
+
+
+def test_session_inner_resume_name() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _session_inner
+
+    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume="epic-85-adhoc")
+    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    assert "--resume-name epic-85-adhoc" in inner
+
+
+def test_cmd_session_rejects_resume_with_slot() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _cmd_session
+
+    ns = argparse.Namespace(resume="epic-85", slot=3, fork=False, fresh=False)
+    assert _cmd_session(ns) == 1
+
+
+def test_cmd_session_rejects_resume_with_fork() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _cmd_session
+
+    ns = argparse.Namespace(resume="epic-85", slot=None, fork=True, fresh=False)
+    assert _cmd_session(ns) == 1
 
 
 def test_format_age() -> None:

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -396,7 +396,7 @@ def capture_exec(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 DAY = 86400.0
 
 
-def _resolve(identity: str, path: str, **kw: object) -> int:
+def _resolve(identity: str, path: str, resume_name: str | None = None, **kw: object) -> int:
     defaults: dict[str, object] = {
         "requested_slot": None,
         "fork": False,
@@ -406,7 +406,7 @@ def _resolve(identity: str, path: str, **kw: object) -> int:
         "archive_days": 14,
     }
     defaults.update(kw)
-    return r.resolve(identity, path, **defaults)  # type: ignore[arg-type]
+    return r.resolve(identity, path, resume_name=resume_name, **defaults)  # type: ignore[arg-type]
 
 
 def test_resolve_create(
@@ -430,6 +430,28 @@ def test_resolve_resume(
     # -n is re-asserted on resume so Claude restores the prompt-box title.
     assert capture_exec == [["claude", "--resume", "s1", "-n", "id:01:p"]]
     assert "Resuming session id:01:p" in capsys.readouterr().err
+
+
+def test_resolve_by_name_resumes_named_session(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        r, "_read_state", lambda *_a: ({"s1": "epic-85-adhoc", "s2": "id:01:p"}, set(), {})
+    )
+    assert _resolve("id", "p", resume_name="epic-85-adhoc") == 0
+    # Resume-by-name bypasses the slot machinery; -n restores the title.
+    assert capture_exec == [["claude", "--resume", "s1", "-n", "epic-85-adhoc"]]
+    assert "Resuming session epic-85-adhoc" in capsys.readouterr().err
+
+
+def test_resolve_by_name_refuses_unknown_name(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, set(), {}))
+    assert _resolve("id", "p", resume_name="ghost") == 1
+    assert "no session named 'ghost'" in capsys.readouterr().err
 
 
 def test_resolve_fork(
@@ -686,8 +708,19 @@ def test_main_dispatches_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
         ]
     )
     assert code == 0
-    # args order: identity, path, slot, fork, fresh, extra, stale_days, archive_days
-    assert seen["args"] == ("id", "p", 2, False, True, ["x"], 7, 14)
+    # args order: identity, path, slot, fork, fresh, extra, stale_days,
+    # archive_days, resume_name
+    assert seen["args"] == ("id", "p", 2, False, True, ["x"], 7, 14, None)
+
+
+def test_main_passes_resume_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(r, "resolve", lambda *args: seen.update(args=args) or 0)
+    r.main(["--identity", "id", "--path", "p", "--resume-name", "epic-85-adhoc"])
+    # resume_name is the final positional arg.
+    passed = seen["args"]
+    assert isinstance(passed, tuple)
+    assert passed[-1] == "epic-85-adhoc"
 
 
 def test_main_strips_leading_double_dash(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add '--resume NAME' to 'vrg-vm session' so a session can be reconnected by its exact display name, reaching epic-renamed sessions that fall outside the slot-number scheme.

## Issue Linkage

- Closes #2282

## Notes

- Host flag --resume is mutually exclusive with --slot/--fork/--fresh (guarded in _cmd_session, covering both Lima and cloud paths) and threads to the in-VM resolver as --resume-name. New pure-logic session.select_by_name() does an exact-name lookup, reusing the existing _displaces liveness-then-recency rule for the /clear-rotation collision case; no match refuses, and an explicitly named resume runs no staleness sweep/prompt. Archived (archived@...) titles never collide with a live name since the match is exact. Tests added across test_session/test_vrg_vm_resolve/test_vrg_vm; full vrg-validate green at 100% coverage. Not driven against a live Lima VM here — the in-VM reconnect is worth a post-merge smoke test.