### PR TITLE
feat(evidence): derive required evidence-gate set from branch-protection config

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -329,6 +329,93 @@ def desired_ci_gates_ruleset(
     )
 
 
+# ---------------------------------------------------------------------------
+# Evidence-gate derivation (issue #2289)
+# ---------------------------------------------------------------------------
+#
+# The set of gates a repo MUST emit CI evidence for is derived from the *same*
+# required-status-check computation that drives branch protection
+# (``desired_ci_gates_ruleset``). This makes the enforced gates and the
+# evidence-required gates provably identical — no hand-maintained list, no drift.
+
+
+@dataclass(frozen=True)
+class EvidenceGate:
+    """An evidence-producing gate and the required checks classified under it."""
+
+    name: str  # "security" | "test" | "audit" | "quality"
+    checks: tuple[str, ...]  # required check names classified under this gate
+
+
+# GHAS check-run names that carry no ``<gate> /`` prefix but still belong to the
+# security gate (created by the GitHub Advanced Security app, not the workflow).
+_EVIDENCE_GATE_LITERALS: dict[str, str] = {
+    "Trivy": "security",
+    "Semgrep OSS": "security",
+    "CodeQL": "security",
+}
+
+# Ordered prefix table: a required check whose name starts with the prefix maps
+# to the gate. ``version /`` is non-evidence-producing (``None``): the version
+# bump check is a policy assertion, not a durable-output gate.
+_EVIDENCE_GATE_PREFIXES: tuple[tuple[str, str | None], ...] = (
+    ("security /", "security"),
+    ("test /", "test"),
+    ("audit /", "audit"),
+    ("quality /", "quality"),
+    ("version /", None),
+)
+
+# Canonical output order for grouped evidence gates (deterministic tuple order).
+_EVIDENCE_GATE_ORDER: tuple[str, ...] = ("security", "test", "audit", "quality")
+
+
+def classify_evidence_gate(check_name: str) -> str | None:
+    """Map a required status-check name to its evidence gate.
+
+    Returns the gate name (``security``/``test``/``audit``/``quality``) or
+    ``None`` when the check is non-evidence-producing (e.g. ``version /
+    version-bump``, or any name matching no known prefix/literal).
+    """
+    literal = _EVIDENCE_GATE_LITERALS.get(check_name)
+    if literal is not None:
+        return literal
+    for prefix, gate in _EVIDENCE_GATE_PREFIXES:
+        if check_name.startswith(prefix):
+            return gate
+    return None
+
+
+def required_evidence_gates(
+    project: ProjectConfig,
+    ci: CiConfig,
+    *,
+    ghas: bool,
+) -> tuple[EvidenceGate, ...]:
+    """The evidence-producing gates this repo MUST emit.
+
+    Derived from the same required-status-check computation that drives branch
+    protection (:func:`desired_ci_gates_ruleset`), so the enforced gates and the
+    evidence-required gates cannot drift apart.
+    """
+    ruleset = desired_ci_gates_ruleset(project, ci, ghas=ghas)
+    checks = _extract_status_checks(ruleset.rules) or []
+
+    grouped: dict[str, list[str]] = {}
+    for check in checks:
+        name = str(check.get("context", ""))
+        gate = classify_evidence_gate(name)
+        if gate is None:
+            continue
+        grouped.setdefault(gate, []).append(name)
+
+    return tuple(
+        EvidenceGate(name=gate, checks=tuple(grouped[gate]))
+        for gate in _EVIDENCE_GATE_ORDER
+        if gate in grouped
+    )
+
+
 def compute_desired_state(
     config: VergilConfig, *, visibility: str, is_org: bool, app_mode: bool = False
 ) -> DesiredState:

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -21,6 +21,7 @@ from vergil_tooling.lib.config import (
 from vergil_tooling.lib.github import GitHubAPIError
 from vergil_tooling.lib.github_config import (
     DesiredRuleset,
+    EvidenceGate,
     FetchResult,
     _apply_actions_permissions,
     _apply_repo_settings,
@@ -33,6 +34,7 @@ from vergil_tooling.lib.github_config import (
     _normalize_rules,
     _ruleset_body,
     apply_desired_state,
+    classify_evidence_gate,
     compute_desired_state,
     compute_diff,
     desired_actions_permissions,
@@ -44,6 +46,7 @@ from vergil_tooling.lib.github_config import (
     fetch_actual_state,
     format_rules_delta,
     ghas_available,
+    required_evidence_gates,
 )
 
 
@@ -1838,3 +1841,76 @@ def test_ruleset_body_none_bypass_actors_becomes_empty_list() -> None:
     )
     body = _ruleset_body(ruleset)
     assert body["bypass_actors"] == []
+
+
+# ---------------------------------------------------------------------------
+# Evidence-gate derivation (issue #2289)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyEvidenceGate:
+    def test_quality_prefix(self) -> None:
+        assert classify_evidence_gate("quality / lint / 3.14") == "quality"
+
+    def test_quality_common_prefix(self) -> None:
+        assert classify_evidence_gate("quality / common") == "quality"
+
+    def test_test_prefix(self) -> None:
+        assert classify_evidence_gate("test / unit / 3.14") == "test"
+
+    def test_audit_prefix(self) -> None:
+        assert classify_evidence_gate("audit / dependencies / 3.14") == "audit"
+
+    def test_security_prefixed(self) -> None:
+        assert classify_evidence_gate("security / codeql") == "security"
+
+    def test_security_ghas_literal(self) -> None:
+        assert classify_evidence_gate("CodeQL") == "security"
+        assert classify_evidence_gate("Trivy") == "security"
+        assert classify_evidence_gate("Semgrep OSS") == "security"
+
+    def test_version_is_non_evidence(self) -> None:
+        assert classify_evidence_gate("version / version-bump") is None
+
+    def test_unknown_is_non_evidence(self) -> None:
+        assert classify_evidence_gate("something / else") is None
+
+
+class TestRequiredEvidenceGates:
+    def test_groups_checks_by_gate(self) -> None:
+        gates = required_evidence_gates(_project(), _ci(), ghas=True)
+        names = {g.name for g in gates}
+        assert names == {"security", "test", "audit", "quality"}
+
+    def test_gate_carries_its_classified_checks(self) -> None:
+        gates = {g.name: g for g in required_evidence_gates(_project(), _ci(), ghas=True)}
+        assert "test / unit / 3.14" in gates["test"].checks
+        assert "audit / dependencies / 3.14" in gates["audit"].checks
+        assert "quality / common" in gates["quality"].checks
+        assert "security / trivy" in gates["security"].checks
+
+    def test_no_ghas_drops_codeql_from_security(self) -> None:
+        gates = {g.name: g for g in required_evidence_gates(_project(), _ci(), ghas=False)}
+        assert not any("CodeQL" in c for c in gates["security"].checks)
+
+    def test_version_check_is_never_an_evidence_gate(self) -> None:
+        gates = {g.name for g in required_evidence_gates(_project(), _ci(), ghas=True)}
+        assert "version" not in gates
+
+    def test_gate_absent_when_no_required_check(self) -> None:
+        # A project with no primary language emits neither ``test / unit`` nor
+        # ``audit / dependencies`` checks, so those evidence gates are absent —
+        # the evidence-required set tracks the enforced set exactly.
+        gates = {
+            g.name
+            for g in required_evidence_gates(
+                _project(language=None), _ci(versions=["latest"]), ghas=False
+            )
+        }
+        assert "test" not in gates
+        assert "audit" not in gates
+
+    def test_evidence_gate_carries_name_and_checks(self) -> None:
+        gate = EvidenceGate(name="test", checks=("test / unit / 3.14",))
+        assert gate.name == "test"
+        assert gate.checks == ("test / unit / 3.14",)


### PR DESCRIPTION
# Pull Request

## Summary

- Add EvidenceGate, classify_evidence_gate, and required_evidence_gates to github_config so the evidence-producing gate set is derived from the same required-status-check computation that drives branch protection, eliminating any hand-maintained list or drift.

## Issue Linkage

- Closes #2289

## Notes

- Task T1 of epic vergil-project/.github#140. classify_evidence_gate uses a module-level prefix/literal table (security/test/audit/quality; version -> None); required_evidence_gates reuses _extract_status_checks over desired_ci_gates_ruleset (single source of truth). Note: the plan's illustrative test_gate_absent_when_no_required_check asserted quality absent, but 'quality / common' is always emitted so quality is never absent; the test honors the same intent by asserting the test/audit gates are absent for a no-language project. 100% coverage on the module; vrg-validate green.