### PR TITLE
feat(validate): emit machine-readable gate reports from the check registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ src/standard_tooling.egg-info/
 dist/
 build/
 .coverage
+# Machine-readable gate reports emitted at the workspace root by the check
+# registry (see src/vergil_tooling/lib/languages.py). Consumed by the T8
+# evidence-producer composite; never committed.
+coverage.xml
+junit.xml
+pip-audit.json
+licenses.json
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -37,6 +37,29 @@ class Language:
     ecosystem: EcosystemInfo
 
 
+# -- Machine-readable report paths --------------------------------------------
+#
+# Evidence-producing gate commands write these machine-readable reports at the
+# workspace root. The filenames form the path contract shared with the T8
+# evidence-producer composite (epic vergil-project/.github#140): the composite
+# globs these exact names to bundle real report data instead of empty
+# envelopes. Keep this list in sync with the T8 composite glob.
+COVERAGE_REPORT = "coverage.xml"
+JUNIT_REPORT = "junit.xml"
+PIP_AUDIT_REPORT = "pip-audit.json"
+LICENSES_REPORT = "licenses.json"
+
+# The workspace-root report files the Python gate commands emit. Exposed as a
+# single source of truth so consumers (and tests) can assert the contract
+# without re-deriving the individual filenames.
+PYTHON_REPORT_FILES = (
+    COVERAGE_REPORT,
+    JUNIT_REPORT,
+    PIP_AUDIT_REPORT,
+    LICENSES_REPORT,
+)
+
+
 # -- License allowlists (unchanged from validate_commands) --------------------
 
 _PIP_LICENSES_ALLOWLIST = ";".join(
@@ -100,13 +123,26 @@ _REGISTRY: dict[str, Language] = {
             ],
             CheckKind.TYPECHECK: [["mypy", "src/"], ["ty", "check", "src", "tests"]],
             CheckKind.TEST: [
-                ["pytest", "--cov=src", "--cov-branch", "--cov-fail-under=100"],
+                [
+                    "pytest",
+                    "--cov=src",
+                    "--cov-branch",
+                    "--cov-fail-under=100",
+                    "--cov-report=term-missing",
+                    f"--cov-report=xml:{COVERAGE_REPORT}",
+                    f"--junitxml={JUNIT_REPORT}",
+                ],
             ],
             CheckKind.AUDIT: [
                 ["uv", "sync", "--check", "--frozen", "--group", "dev"],
                 ["uv", "lock", "--check"],
-                ["pip-audit"],
-                ["pip-licenses", f"--allow-only={_PIP_LICENSES_ALLOWLIST}"],
+                ["pip-audit", "--format=json", f"--output={PIP_AUDIT_REPORT}"],
+                [
+                    "pip-licenses",
+                    f"--allow-only={_PIP_LICENSES_ALLOWLIST}",
+                    "--format=json",
+                    f"--output-file={LICENSES_REPORT}",
+                ],
             ],
         },
         ecosystem=EcosystemInfo(

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from vergil_tooling.lib.languages import (
+    COVERAGE_REPORT,
+    JUNIT_REPORT,
+    LICENSES_REPORT,
+    PIP_AUDIT_REPORT,
+    PYTHON_REPORT_FILES,
     CheckKind,
     EcosystemInfo,
     ecosystem_metadata,
@@ -43,20 +48,68 @@ def test_python_test_commands() -> None:
     assert any("--cov=src" in c for c in joined)
 
 
+def test_python_test_enforcement_flag_intact() -> None:
+    """The coverage gate (``--cov-fail-under=100``) must survive report wiring."""
+    cmds = language_commands("python", CheckKind.TEST)
+    pytest_cmd = [c for c in cmds if c[0] == "pytest"]
+    assert len(pytest_cmd) == 1
+    assert "--cov-fail-under=100" in pytest_cmd[0]
+
+
+def test_python_test_emits_coverage_xml() -> None:
+    cmds = language_commands("python", CheckKind.TEST)
+    pytest_cmd = [c for c in cmds if c[0] == "pytest"][0]
+    assert f"--cov-report=xml:{COVERAGE_REPORT}" in pytest_cmd
+
+
+def test_python_test_emits_junit_xml() -> None:
+    cmds = language_commands("python", CheckKind.TEST)
+    pytest_cmd = [c for c in cmds if c[0] == "pytest"][0]
+    assert f"--junitxml={JUNIT_REPORT}" in pytest_cmd
+
+
 def test_python_audit_commands() -> None:
     joined = _joined(language_commands("python", CheckKind.AUDIT))
     assert any("uv sync --check" in c for c in joined)
     assert any("uv lock --check" in c for c in joined)
-    assert "pip-audit" in joined
+    assert any(c.startswith("pip-audit") for c in joined)
     assert any("pip-licenses" in c for c in joined)
+
+
+def test_python_audit_pip_audit_emits_json_report() -> None:
+    cmds = language_commands("python", CheckKind.AUDIT)
+    pip_audit_cmd = [c for c in cmds if c[0] == "pip-audit"]
+    assert len(pip_audit_cmd) == 1
+    assert "--format=json" in pip_audit_cmd[0]
+    assert f"--output={PIP_AUDIT_REPORT}" in pip_audit_cmd[0]
 
 
 def test_python_audit_pip_licenses_allowlist_intact() -> None:
     cmds = language_commands("python", CheckKind.AUDIT)
     pip_licenses_cmd = [c for c in cmds if c[0] == "pip-licenses"]
     assert len(pip_licenses_cmd) == 1
-    assert len(pip_licenses_cmd[0]) == 2
-    assert pip_licenses_cmd[0][1].startswith("--allow-only=")
+    assert any(arg.startswith("--allow-only=") for arg in pip_licenses_cmd[0])
+
+
+def test_python_audit_pip_licenses_emits_json_report() -> None:
+    cmds = language_commands("python", CheckKind.AUDIT)
+    pip_licenses_cmd = [c for c in cmds if c[0] == "pip-licenses"][0]
+    assert "--format=json" in pip_licenses_cmd
+    assert f"--output-file={LICENSES_REPORT}" in pip_licenses_cmd
+
+
+def test_python_report_files_contract() -> None:
+    """The shared report-path constants match the T8 path contract."""
+    assert PYTHON_REPORT_FILES == (
+        "coverage.xml",
+        "junit.xml",
+        "pip-audit.json",
+        "licenses.json",
+    )
+    assert COVERAGE_REPORT == "coverage.xml"
+    assert JUNIT_REPORT == "junit.xml"
+    assert PIP_AUDIT_REPORT == "pip-audit.json"
+    assert LICENSES_REPORT == "licenses.json"
 
 
 # -- Go ----------------------------------------------------------------------

--- a/tests/vergil_tooling/test_report_emission.py
+++ b/tests/vergil_tooling/test_report_emission.py
@@ -1,0 +1,100 @@
+"""Integration tests: the check registry's report flags actually write files.
+
+These exercise the real gate tools with the exact report-emitting flags the
+registry produces, proving the machine-readable reports appear at the expected
+paths after a run (not just that the flags are present). Command-shape
+assertions live in ``test_languages.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+from vergil_tooling.lib.languages import (
+    COVERAGE_REPORT,
+    JUNIT_REPORT,
+    LICENSES_REPORT,
+    CheckKind,
+    language_commands,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _registry_cmd(kind: CheckKind, tool: str) -> list[str]:
+    cmds = language_commands("python", kind)
+    matching = [c for c in cmds if c[0] == tool]
+    assert len(matching) == 1, f"expected exactly one {tool} command, got {matching}"
+    return matching[0]
+
+
+def test_test_command_report_flags_write_files(tmp_path: Path) -> None:
+    """pytest, run with the registry's report flags, writes coverage.xml + junit.xml."""
+    (tmp_path / "m.py").write_text("def f() -> int:\n    return 1\n")
+    (tmp_path / "test_m.py").write_text(
+        "from m import f\n\n\ndef test_f() -> None:\n    assert f() == 1\n"
+    )
+
+    pytest_cmd = _registry_cmd(CheckKind.TEST, "pytest")
+    report_flags = [
+        arg
+        for arg in pytest_cmd
+        if arg.startswith("--cov-report=xml:") or arg.startswith("--junitxml=")
+    ]
+    # Both report families must be wired, else this fixture proves nothing.
+    assert len(report_flags) == 2
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "test_m.py",
+            f"--rootdir={tmp_path}",
+            f"--confcutdir={tmp_path}",
+            "-p",
+            "no:cacheprovider",
+            "--cov=m",
+            *report_flags,
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / COVERAGE_REPORT).is_file()
+    assert (tmp_path / JUNIT_REPORT).is_file()
+
+
+def test_audit_pip_licenses_writes_report(tmp_path: Path) -> None:
+    """pip-licenses, run with the registry's output flags, writes licenses.json."""
+    if shutil.which("pip-licenses") is None:
+        import pytest
+
+        pytest.skip("pip-licenses not installed in this environment")
+
+    pip_licenses_cmd = _registry_cmd(CheckKind.AUDIT, "pip-licenses")
+    output_flags = [
+        arg
+        for arg in pip_licenses_cmd
+        if arg.startswith("--format=") or arg.startswith("--output-file=")
+    ]
+    # Both the format and the output-file flags must be wired.
+    assert len(output_flags) == 2
+
+    result = subprocess.run(
+        ["pip-licenses", *output_flags],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / LICENSES_REPORT).is_file()


### PR DESCRIPTION
# Pull Request

## Summary

- Wire the Python test/audit gates in the check registry to emit coverage.xml, junit.xml, pip-audit.json, and licenses.json at the workspace root (as shared constants) so the T8 evidence composite bundles real report data instead of empty envelopes.

## Issue Linkage

- Closes #2291

## Notes

- Path contract shared with the T8 composite glob: coverage.xml, junit.xml, pip-audit.json, licenses.json at the workspace root (defined as constants in languages.py: COVERAGE_REPORT/JUNIT_REPORT/PIP_AUDIT_REPORT/LICENSES_REPORT, plus PYTHON_REPORT_FILES). Enforcement is unchanged: --cov-fail-under=100 kept (plus a term-missing report so terminal diagnostics survive the added xml report), pip-audit still fails on vulnerabilities, and the pip-licenses allowlist gate is intact. Quality (lint/typecheck) gets no new report file: ruff/mypy outputs are not in the 4-file T8 glob contract, so per the issue evidence.json alone is the complete statement for a passing lint. The four reports are gitignored. Tests: command-shape assertions in test_languages.py plus integration tests in test_report_emission.py that run pytest and pip-licenses with the registry flags and confirm the files actually appear. vrg-validate is green (100% coverage; all four files confirmed present at the workspace root after the run).