### PR TITLE
feat(evidence): add GitHub harvest layer (PR resolve, run select, download)

### DIFF
--- a/src/vergil_tooling/bin/vrg_resolve_tracking_issue.py
+++ b/src/vergil_tooling/bin/vrg_resolve_tracking_issue.py
@@ -20,16 +20,16 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import re
 import subprocess
 import sys
 from typing import cast
 
 from vergil_tooling.lib import git, github
-from vergil_tooling.lib.linkage import extract_tracking_issue
+from vergil_tooling.lib.linkage import extract_merge_pr, extract_tracking_issue
 
-_MERGE_PR_RE = re.compile(r"^Merge pull request #(\d+) from ")
-_SQUASH_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+# Backward-compatible alias: the merge/squash subject → PR-number extraction now
+# lives in ``lib.linkage`` (shared with the CI-evidence harvest layer).
+_extract_pr_number = extract_merge_pr
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -48,16 +48,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="PR number (bypasses commit parsing)",
     )
     return parser.parse_args(argv)
-
-
-def _extract_pr_number(subject: str) -> int | None:
-    m = _MERGE_PR_RE.match(subject)
-    if m:
-        return int(m.group(1))
-    m = _SQUASH_PR_RE.search(subject)
-    if m:
-        return int(m.group(1))
-    return None
 
 
 def _pr_from_api(commit: str) -> int | None:

--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -18,7 +18,10 @@ import json
 import shutil
 import tarfile
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+from vergil_tooling.lib import github
+from vergil_tooling.lib.linkage import extract_merge_pr
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -182,3 +185,139 @@ def assemble_bundle(staging_dir: Path, out_tarball: Path) -> Path:
         for member in members:
             tar.add(member, arcname=member.relative_to(staging_dir).as_posix())
     return out_tarball
+
+
+# --- GitHub harvest layer ------------------------------------------------
+#
+# All GitHub I/O for the evidence bundle, isolated behind mockable functions so
+# the CLI and the bundle core stay network-free. Every call routes through
+# ``vergil_tooling.lib.github``, whose ``_run_with_retry`` already retries
+# transient API failures — no bespoke retry loop is needed here.
+
+# Prefix a gate workflow uploads its evidence artifact under
+# (``ci-evidence-<gate>``); the producer convention that decouples gate
+# workflows from this harvester (spec §7).
+_EVIDENCE_ARTIFACT_PREFIX = "ci-evidence-"
+
+
+class NoQualifyingRunError(Exception):
+    """No COMPLETED + SUCCESS CI run exists for the release head SHA.
+
+    The one substantive-failure boundary of the harvest layer (spec §5.2):
+    unlike a transient API error, it means the release commit was never
+    validated by a green CI run, so no evidence can be harvested.
+    """
+
+    def __init__(self, head_sha: str) -> None:
+        super().__init__(f"no completed+success CI run for head SHA {head_sha}")
+        self.head_sha = head_sha
+
+
+def _pr_from_commit_api(repo: str, merge_sha: str) -> int | None:
+    """Return the PR number ``merge_sha`` closed, via ``/commits/{sha}/pulls``.
+
+    Prefers a merged PR; falls back to the first associated PR. Returns None
+    when the API associates no PR with the commit.
+    """
+    raw = github.read_json("api", f"repos/{repo}/commits/{merge_sha}/pulls")
+    prs = cast("list[dict[str, Any]]", raw) if isinstance(raw, list) else []
+    merged = [pr for pr in prs if pr.get("merged_at")]
+    chosen = merged or prs
+    if not chosen:
+        return None
+    return int(chosen[0]["number"])
+
+
+def resolve_release_pr(repo: str, merge_sha: str) -> int:
+    """Resolve the release PR a merge commit closed.
+
+    Primary: the ``/commits/{sha}/pulls`` API. Fallback: the merge/squash
+    commit subject (:func:`~vergil_tooling.lib.linkage.extract_merge_pr`) when
+    the API associates no PR. Raises ``ValueError`` when neither resolves a PR.
+    """
+    pr = _pr_from_commit_api(repo, merge_sha)
+    if pr is not None:
+        return pr
+    message = github.read_output(
+        "api", f"repos/{repo}/commits/{merge_sha}", "--jq", ".commit.message"
+    )
+    subject = message.splitlines()[0] if message else ""
+    pr = extract_merge_pr(subject)
+    if pr is not None:
+        return pr
+    msg = f"cannot resolve release PR for {merge_sha} in {repo}"
+    raise ValueError(msg)
+
+
+def _is_qualifying_run(run: Mapping[str, Any], workflow: str) -> bool:
+    """True when *run* is the named workflow, COMPLETED, and SUCCESS (spec §5.2).
+
+    Cancelled and in-progress runs are excluded: only a run that completed
+    successfully attests the release commit.
+    """
+    return (
+        run.get("name") == workflow
+        and run.get("status") == "completed"
+        and run.get("conclusion") == "success"
+    )
+
+
+def select_ci_run(repo: str, head_sha: str, *, workflow: str = "CI") -> dict[str, Any]:
+    """Return the latest COMPLETED + SUCCESS *workflow* run for ``head_sha``.
+
+    Cancelled and in-progress runs are ignored. Raises
+    :class:`NoQualifyingRunError` when no run qualifies (spec §5.2).
+    """
+    raw = github.read_json(
+        "api",
+        f"repos/{repo}/actions/runs",
+        "-f",
+        f"head_sha={head_sha}",
+        "--jq",
+        ".workflow_runs",
+    )
+    runs = cast("list[dict[str, Any]]", raw)
+    qualifying = [run for run in runs if _is_qualifying_run(run, workflow)]
+    if not qualifying:
+        raise NoQualifyingRunError(head_sha)
+    return max(qualifying, key=lambda run: run["run_started_at"])
+
+
+def download_evidence_artifacts(repo: str, run_id: int, dest: Path) -> list[Path]:
+    """Download every ``ci-evidence-*`` artifact of *run_id* into ``dest/<gate>/``.
+
+    Non-evidence artifacts are ignored. The gate name is the artifact name with
+    the ``ci-evidence-`` prefix stripped; each is downloaded into its own gate
+    directory. Returns the created gate directories, sorted for determinism.
+    """
+    raw = github.read_json(
+        "api", f"repos/{repo}/actions/runs/{run_id}/artifacts", "--jq", ".artifacts"
+    )
+    artifacts = cast("list[dict[str, Any]]", raw)
+    gate_dirs: list[Path] = []
+    for artifact in artifacts:
+        name = str(artifact.get("name", ""))
+        if not name.startswith(_EVIDENCE_ARTIFACT_PREFIX):
+            continue
+        gate = name[len(_EVIDENCE_ARTIFACT_PREFIX) :]
+        gate_dir = dest / gate
+        gate_dir.mkdir(parents=True, exist_ok=True)
+        github.run(
+            "run", "download", str(run_id), "--repo", repo, "--name", name, "--dir", str(gate_dir)
+        )
+        gate_dirs.append(gate_dir)
+    return sorted(gate_dirs)
+
+
+def read_gate_conclusions(repo: str, head_sha: str) -> dict[str, str]:
+    """Return a check-run name → conclusion map for ``head_sha``.
+
+    Feeds both the manifest's ``checks.json`` snapshot and completeness
+    validation. A null conclusion (e.g. a still-neutral check) maps to the
+    empty string.
+    """
+    raw = github.read_json(
+        "api", f"repos/{repo}/commits/{head_sha}/check-runs", "--jq", ".check_runs"
+    )
+    check_runs = cast("list[dict[str, Any]]", raw)
+    return {str(run["name"]): str(run.get("conclusion") or "") for run in check_runs}

--- a/src/vergil_tooling/lib/linkage.py
+++ b/src/vergil_tooling/lib/linkage.py
@@ -127,6 +127,31 @@ def freetext_linkage_error(found: str, primary_issue: str) -> str:
     )
 
 
+# Merge-commit subject patterns for recovering the PR a commit closed, when the
+# GitHub ``/commits/{sha}/pulls`` API is unavailable. ``Merge pull request #N
+# from ...`` is the merge-commit subject; ``... (#N)`` is the squash-merge
+# subject. Shared by ``vrg-resolve-tracking-issue`` and the CI-evidence harvest
+# layer so merge→PR recovery is recognized identically in both.
+_MERGE_PR_RE = re.compile(r"^Merge pull request #(\d+) from ")
+_SQUASH_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def extract_merge_pr(subject: str) -> int | None:
+    """Return the PR number a merge/squash commit *subject* closed, or None.
+
+    Recognizes the merge-commit subject (``Merge pull request #N from ...``)
+    and the squash-merge subject (``... (#N)``). The fallback used when the
+    ``/commits/{sha}/pulls`` API returns no PR.
+    """
+    m = _MERGE_PR_RE.match(subject)
+    if m:
+        return int(m.group(1))
+    m = _SQUASH_PR_RE.search(subject)
+    if m:
+        return int(m.group(1))
+    return None
+
+
 def extract_tracking_issue(text: str) -> int | None:
     """Return the tracking issue number from a ``Ref #N`` / ``Closes #N`` match.
 

--- a/tests/vergil_tooling/test_ci_evidence_harvest.py
+++ b/tests/vergil_tooling/test_ci_evidence_harvest.py
@@ -1,0 +1,257 @@
+"""Tests for the GitHub harvest layer in vergil_tooling.lib.ci_evidence.
+
+All GitHub I/O is mocked at the ``vergil_tooling.lib.github`` boundary
+(``read_json`` / ``read_output`` / ``run``), mirroring the ``test_github.py``
+monkeypatch style: the harvest functions are pure orchestration over those
+wrappers, so the tests assert the selection/filter logic, never the network.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from vergil_tooling.lib import ci_evidence, github
+from vergil_tooling.lib.ci_evidence import (
+    NoQualifyingRunError,
+    download_evidence_artifacts,
+    read_gate_conclusions,
+    resolve_release_pr,
+    select_ci_run,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --- resolve_release_pr -------------------------------------------------
+
+
+def test_resolve_release_pr_prefers_merged_from_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {"number": 10, "merged_at": None},
+            {"number": 42, "merged_at": "2026-07-12T00:00:00Z"},
+        ],
+    )
+    assert resolve_release_pr("o/r", "abc") == 42
+
+
+def test_resolve_release_pr_falls_back_to_first_unmerged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [{"number": 7, "merged_at": None}, {"number": 8}],
+    )
+    assert resolve_release_pr("o/r", "abc") == 7
+
+
+def test_resolve_release_pr_uses_subject_when_api_has_no_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(github, "read_json", lambda *a, **k: {})
+    monkeypatch.setattr(
+        github,
+        "read_output",
+        lambda *a, **k: "Merge pull request #55 from o/release/x\n\nbody",
+    )
+    assert resolve_release_pr("o/r", "abc") == 55
+
+
+def test_resolve_release_pr_uses_squash_subject(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github, "read_json", lambda *a, **k: [])
+    monkeypatch.setattr(github, "read_output", lambda *a, **k: "chore(release): prepare (#99)")
+    assert resolve_release_pr("o/r", "abc") == 99
+
+
+def test_resolve_release_pr_raises_when_unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github, "read_json", lambda *a, **k: [])
+    monkeypatch.setattr(github, "read_output", lambda *a, **k: "")
+    with pytest.raises(ValueError, match="cannot resolve release PR"):
+        resolve_release_pr("o/r", "abc")
+
+
+# --- select_ci_run ------------------------------------------------------
+
+
+def test_select_ci_run_ignores_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "run_started_at": "2026-07-12T00:00:00Z",
+                "id": 1,
+            },
+            {
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "2026-07-12T00:05:00Z",
+                "id": 42,
+            },
+        ],
+    )
+    assert select_ci_run("o/r", "abc")["id"] == 42
+
+
+def test_select_ci_run_picks_latest_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "2026-07-12T00:00:00Z",
+                "id": 1,
+            },
+            {
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "2026-07-12T00:09:00Z",
+                "id": 2,
+            },
+        ],
+    )
+    assert select_ci_run("o/r", "abc")["id"] == 2
+
+
+def test_select_ci_run_ignores_other_workflow_and_in_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {
+                "name": "Nightly",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "t",
+                "id": 1,
+            },
+            {
+                "name": "CI",
+                "status": "in_progress",
+                "conclusion": None,
+                "run_started_at": "t",
+                "id": 2,
+            },
+            {
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "t",
+                "id": 3,
+            },
+        ],
+    )
+    assert select_ci_run("o/r", "abc")["id"] == 3
+
+
+def test_select_ci_run_honors_workflow_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {
+                "name": "Release",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "t",
+                "id": 7,
+            },
+        ],
+    )
+    assert select_ci_run("o/r", "abc", workflow="Release")["id"] == 7
+
+
+def test_select_ci_run_none_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {"name": "CI", "status": "completed", "conclusion": "cancelled", "run_started_at": "t"},
+        ],
+    )
+    with pytest.raises(NoQualifyingRunError) as exc:
+        select_ci_run("o/r", "deadbeef")
+    assert exc.value.head_sha == "deadbeef"
+
+
+# --- download_evidence_artifacts ----------------------------------------
+
+
+def test_download_evidence_artifacts_filters_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {"name": "ci-evidence-test"},
+            {"name": "ci-evidence-security"},
+            {"name": "build-logs"},
+        ],
+    )
+    calls: list[tuple[str, ...]] = []
+
+    def _record_run(*args: str) -> None:
+        calls.append(args)
+
+    monkeypatch.setattr(github, "run", _record_run)
+
+    dest = tmp_path / "artifacts"
+    result = download_evidence_artifacts("o/r", 99, dest)
+
+    assert result == [dest / "security", dest / "test"]
+    assert (dest / "test").is_dir()
+    assert (dest / "security").is_dir()
+    assert not (dest / "build-logs").exists()
+    downloaded_names = {a[a.index("--name") + 1] for a in calls}
+    assert downloaded_names == {"ci-evidence-test", "ci-evidence-security"}
+    # run-id and repo are threaded to every download call.
+    assert all("99" in a and "o/r" in a for a in calls)
+
+
+def test_download_evidence_artifacts_none_matching(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(github, "read_json", lambda *a, **k: [{"name": "coverage"}])
+    monkeypatch.setattr(github, "run", lambda *a: None)
+    assert download_evidence_artifacts("o/r", 1, tmp_path) == []
+
+
+# --- read_gate_conclusions ----------------------------------------------
+
+
+def test_read_gate_conclusions_maps_name_to_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {"name": "test / unit / 3.14", "conclusion": "success"},
+            {"name": "security / codeql", "conclusion": None},
+        ],
+    )
+    result = read_gate_conclusions("o/r", "abc")
+    assert result == {"test / unit / 3.14": "success", "security / codeql": ""}
+
+
+def test_qualifying_run_predicate_is_reusable() -> None:
+    run: dict[str, Any] = {"name": "CI", "status": "completed", "conclusion": "success"}
+    assert ci_evidence._is_qualifying_run(run, "CI")
+    assert not ci_evidence._is_qualifying_run({**run, "conclusion": "cancelled"}, "CI")


### PR DESCRIPTION
# Pull Request

## Summary

- Extend lib/ci_evidence.py with the evidence bundle's GitHub I/O — resolve_release_pr, select_ci_run, download_evidence_artifacts, and read_gate_conclusions — isolated behind mockable functions that route through lib.github and reuse its transient-retry wrapper.

## Issue Linkage

- Closes #2301

## Notes

- T3 of epic vergil-project/.github#140 (extends the merged T2). select_ci_run selects only COMPLETED+SUCCESS runs, ignoring cancelled/in-progress (spec 5.2); NoQualifyingRunError is the one substantive-failure boundary. download_evidence_artifacts filters ci-evidence-* and stages each under dest/<gate>/. The merge/squash subject to PR-number regex moved from vrg-resolve-tracking-issue into lib.linkage (extract_merge_pr) as a single source of truth, with a backward-compatible alias keeping the existing tests green. New tests mock github.read_json/read_output/run; vrg-validate green at 100% coverage.