### PR TITLE
feat(evidence): add completeness validator with substantive-failure error

### DIFF
--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
 
+    from vergil_tooling.lib.github_config import EvidenceGate
+
 # Schema version of the manifest object (spec §8).
 SCHEMA_VERSION = "1.0"
 
@@ -185,6 +187,41 @@ def assemble_bundle(staging_dir: Path, out_tarball: Path) -> Path:
         for member in members:
             tar.add(member, arcname=member.relative_to(staging_dir).as_posix())
     return out_tarball
+
+
+# --- Completeness validation ---------------------------------------------
+#
+# The publish invariant, as a pure function: cross-check the required
+# evidence-gate set (derived from branch protection, T1) against what was
+# actually harvested (T3). A required gate with no harvested evidence is a
+# substantive failure — terminal in enforcing mode (spec §9.2).
+
+
+class IncompleteEvidenceError(Exception):
+    """A required evidence gate produced no harvested evidence.
+
+    Thin, data-carrying: ``.missing`` lists every required gate name with no
+    evidence. The message format is defined here once so the CLI (T5) can reuse
+    it via ``emit_error``. Substantive failure — terminal in enforcing mode.
+    """
+
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = missing
+        super().__init__(f"missing evidence for required gates: {missing}")
+
+
+def validate_completeness(
+    required: Sequence[EvidenceGate],
+    harvested: Mapping[str, GateEvidence],
+) -> None:
+    """Raise :class:`IncompleteEvidenceError` for required gates lacking evidence.
+
+    A pure set-difference of required gate names against harvested keys. The
+    ``missing`` list preserves ``required`` order for a stable, readable report.
+    """
+    missing = [gate.name for gate in required if gate.name not in harvested]
+    if missing:
+        raise IncompleteEvidenceError(missing)
 
 
 # --- GitHub harvest layer ------------------------------------------------

--- a/tests/vergil_tooling/test_ci_evidence.py
+++ b/tests/vergil_tooling/test_ci_evidence.py
@@ -6,16 +6,21 @@ import json
 import tarfile
 from typing import TYPE_CHECKING
 
+import pytest
+
 from vergil_tooling.lib.ci_evidence import (
     GateEvidence,
     HarvestContext,
+    IncompleteEvidenceError,
     assemble_bundle,
     build_manifest,
     copy_sbom,
     sha256_file,
+    validate_completeness,
     write_checks_json,
     write_readme,
 )
+from vergil_tooling.lib.github_config import EvidenceGate
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -146,3 +151,33 @@ def test_copy_sbom(tmp_path: Path) -> None:
     out = copy_sbom(sbom, staging)
     assert out == staging / "evidence" / "gates" / "sbom" / "sbom.cdx.json"
     assert out.read_text() == "{}"
+
+
+def _gate_evidence(name: str) -> GateEvidence:
+    """A minimal GateEvidence for completeness tests (files unused here)."""
+    return GateEvidence(
+        name=name,
+        conclusion="success",
+        tools=(),
+        metrics={},
+        files=(),
+    )
+
+
+def test_validate_completeness_all_present_ok() -> None:
+    validate_completeness(
+        [EvidenceGate("test", ("test / unit / 3.14",))],
+        {"test": _gate_evidence("test")},
+    )  # no raise
+
+
+def test_validate_completeness_missing_required_raises() -> None:
+    with pytest.raises(IncompleteEvidenceError) as excinfo:
+        validate_completeness(
+            [
+                EvidenceGate("security", ("Trivy",)),
+                EvidenceGate("test", ("test / unit / 3.14",)),
+            ],
+            {"test": _gate_evidence("test")},
+        )
+    assert excinfo.value.missing == ["security"]


### PR DESCRIPTION
# Pull Request

## Summary

- Add IncompleteEvidenceError and validate_completeness to lib/ci_evidence.py — a pure set-difference of the required evidence-gate set against harvested gates that raises listing every required gate with no evidence.

## Issue Linkage

- Closes #2306

## Notes

- Task T4 of epic vergil-project/.github#140. Extends the existing ci_evidence.py (T1 EvidenceGate, T2/T3 GateEvidence already merged). IncompleteEvidenceError is thin and data-carrying (.missing), message defined once for CLI (T5) reuse. Two new tests: all-present -> no raise; missing required gate -> raises with the right .missing list. vrg-validate green at 100% coverage.