### PR TITLE
feat(docs): link CI evidence bundle from release pages

### DIFF
--- a/src/vergil_tooling/bin/vrg_ci_evidence.py
+++ b/src/vergil_tooling/bin/vrg_ci_evidence.py
@@ -82,9 +82,9 @@ def cmd_bundle(args: argparse.Namespace) -> int:
         )
         manifest_path = ci_evidence.write_manifest(manifest, staging)
 
-        tarball = out_dir / f"{tag}-ci-evidence.tar.gz"
+        tarball = out_dir / ci_evidence.evidence_asset_name(tag)
         ci_evidence.assemble_bundle(staging, tarball)
-        shutil.copyfile(manifest_path, out_dir / f"{tag}-ci-evidence-manifest.json")
+        shutil.copyfile(manifest_path, out_dir / ci_evidence.evidence_manifest_name(tag))
 
     return 0
 

--- a/src/vergil_tooling/bin/vrg_docs_stage.py
+++ b/src/vergil_tooling/bin/vrg_docs_stage.py
@@ -5,9 +5,34 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import Any, cast
 
+from vergil_tooling.lib import github
+from vergil_tooling.lib.ci_evidence import evidence_asset_name
 from vergil_tooling.lib.docs import stage_docs
+from vergil_tooling.lib.github import GitHubAPIError
 from vergil_tooling.lib.output import emit_error, write_output
+
+
+def _has_evidence_asset(repo: str, tag: str) -> bool:
+    """Return whether release *tag* carries the CI-evidence bundle asset.
+
+    One cheap ``gh release view`` per release at docs-build time. A release that
+    does not exist yet (404) legitimately has no asset, so that is reported as
+    ``False``; any other ``gh`` failure propagates rather than being silently
+    swallowed as "no evidence".
+    """
+    try:
+        data = github.read_json("release", "view", tag, "--repo", repo, "--json", "assets")
+    except GitHubAPIError as exc:
+        stderr = (exc.stderr or "").lower()
+        if "not found" in stderr or "404" in stderr:
+            return False
+        raise
+    raw_assets = data.get("assets") if isinstance(data, dict) else None
+    assets = cast("list[dict[str, Any]]", raw_assets) if isinstance(raw_assets, list) else []
+    asset_name = evidence_asset_name(tag)
+    return any(asset.get("name") == asset_name for asset in assets)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -33,6 +58,12 @@ def main(argv: list[str] | None = None) -> int:
         default=Path("CHANGELOG.md"),
         help="Source changelog file",
     )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="owner/name of the repo (default: resolved from the git remote); "
+        "used to link each release page to its CI-evidence bundle",
+    )
     args = parser.parse_args(argv)
 
     if not args.docs_dir.is_dir():
@@ -40,10 +71,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     changelog = args.changelog if args.changelog.is_file() else None
+    repo = args.repo or github.current_repo()
     count = stage_docs(
         docs_dir=args.docs_dir,
         releases_dir=args.releases_dir,
         changelog=changelog,
+        repo=repo,
+        has_evidence_asset=lambda tag: _has_evidence_asset(repo, tag),
     )
     write_output("releases_staged", str(count))
     return 0

--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -34,6 +34,22 @@ if TYPE_CHECKING:
 # Schema version of the manifest object (spec §8).
 SCHEMA_VERSION = "1.0"
 
+
+def evidence_asset_name(tag: str) -> str:
+    """Return the CI-evidence tarball asset name for a release *tag*.
+
+    The single source of truth for the bundle's published filename: both the
+    harvester (which writes and uploads the asset) and the doc-site link (which
+    points at it) derive the name here, so they cannot drift apart.
+    """
+    return f"{tag}-ci-evidence.tar.gz"
+
+
+def evidence_manifest_name(tag: str) -> str:
+    """Return the CI-evidence standalone-manifest asset name for a release *tag*."""
+    return f"{tag}-ci-evidence-manifest.json"
+
+
 # Fixed human-orientation text written into ``evidence/README.md``. A module
 # constant (not inline) so the archive's README is defined in exactly one place.
 _README_TEXT = """\

--- a/src/vergil_tooling/lib/docs.py
+++ b/src/vergil_tooling/lib/docs.py
@@ -7,7 +7,10 @@ import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from vergil_tooling.lib.ci_evidence import evidence_asset_name
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 _SEMVER_RE = re.compile(r"v?(\d+)\.(\d+)\.(\d+)")
@@ -64,15 +67,37 @@ def generate_release_index(entries: list[ReleaseEntry]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def evidence_link_line(repo: str, tag: str, *, has_asset: bool) -> str | None:
+    """Return the CI-evidence download line for a release page, or ``None``.
+
+    Pure: the asset lookup is done by the caller (which passes ``has_asset`` —
+    typically one ``gh release view`` per release at docs-build time), so this
+    function stays trivially testable. The asset filename is shared with the
+    harvester via :func:`~vergil_tooling.lib.ci_evidence.evidence_asset_name`,
+    so the linked name cannot drift from the published one.
+    """
+    if not has_asset:
+        return None
+    asset = evidence_asset_name(tag)
+    url = f"https://github.com/{repo}/releases/download/{tag}/{asset}"
+    return f"**CI Evidence:** All gates passed — full audit bundle available. [Download →]({url})"
+
+
 def stage_docs(
     *,
     docs_dir: Path,
     releases_dir: Path,
     changelog: Path | None,
+    repo: str | None = None,
+    has_evidence_asset: Callable[[str], bool] | None = None,
 ) -> int:
     """Stage changelog and release notes into the docs build directory.
 
-    Returns the number of release notes staged.
+    When both *repo* and *has_evidence_asset* are given, each staged release
+    page gets a CI-evidence download line appended (via
+    :func:`evidence_link_line`) if the release carries the evidence asset —
+    ``has_evidence_asset(tag)`` resolves that (the impure ``gh`` lookup lives in
+    the caller). Returns the number of release notes staged.
     """
     docs_releases = docs_dir / "releases"
     docs_releases.mkdir(parents=True, exist_ok=True)
@@ -83,7 +108,14 @@ def stage_docs(
     entries = collect_releases(releases_dir)
     for entry in entries:
         src = releases_dir / entry.filename
-        shutil.copy2(src, docs_releases / entry.filename)
+        dst = docs_releases / entry.filename
+        shutil.copy2(src, dst)
+        if repo is not None and has_evidence_asset is not None:
+            tag = dst.stem
+            line = evidence_link_line(repo, tag, has_asset=has_evidence_asset(tag))
+            if line is not None:
+                with dst.open("a", encoding="utf-8") as fh:
+                    fh.write(f"\n{line}\n")
 
     index_content = generate_release_index(entries)
     (docs_releases / "index.md").write_text(index_content, encoding="utf-8")

--- a/tests/vergil_tooling/test_ci_evidence.py
+++ b/tests/vergil_tooling/test_ci_evidence.py
@@ -15,6 +15,8 @@ from vergil_tooling.lib.ci_evidence import (
     assemble_bundle,
     build_manifest,
     copy_sbom,
+    evidence_asset_name,
+    evidence_manifest_name,
     sha256_file,
     validate_completeness,
     write_checks_json,
@@ -25,6 +27,14 @@ from vergil_tooling.lib.github_config import EvidenceGate
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class TestEvidenceAssetNames:
+    def test_asset_name(self) -> None:
+        assert evidence_asset_name("v2.1.129") == "v2.1.129-ci-evidence.tar.gz"
+
+    def test_manifest_name(self) -> None:
+        assert evidence_manifest_name("v2.1.129") == "v2.1.129-ci-evidence-manifest.json"
 
 
 def _stage_one_gate(tmp_path: Path) -> Path:

--- a/tests/vergil_tooling/test_docs.py
+++ b/tests/vergil_tooling/test_docs.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from vergil_tooling.lib.docs import (
     ReleaseEntry,
     collect_releases,
+    evidence_link_line,
     generate_release_index,
     patch_nav,
     semver_key,
@@ -88,6 +89,18 @@ class TestGenerateReleaseIndex:
         assert "No releases yet." in content
 
 
+class TestEvidenceLinkLine:
+    def test_present(self) -> None:
+        line = evidence_link_line("o/r", "v2.1.129", has_asset=True)
+        assert line is not None
+        assert "All gates passed" in line
+        assert "v2.1.129-ci-evidence.tar.gz" in line
+        assert "https://github.com/o/r/releases/download/v2.1.129/" in line
+
+    def test_absent(self) -> None:
+        assert evidence_link_line("o/r", "v1.0.0", has_asset=False) is None
+
+
 class TestStageDocs:
     def test_stages_changelog_and_releases(self, tmp_path: Path) -> None:
         docs_dir = tmp_path / "docs"
@@ -122,6 +135,49 @@ class TestStageDocs:
         assert count == 0
         index = (docs_dir / "releases" / "index.md").read_text()
         assert "No releases yet." in index
+
+    def test_appends_evidence_line_when_asset_present(self, tmp_path: Path) -> None:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        releases = tmp_path / "releases"
+        releases.mkdir()
+        (releases / "v2.1.129.md").write_text("# Release 2.1.129 (2026-07-01)\n")
+        stage_docs(
+            docs_dir=docs_dir,
+            releases_dir=releases,
+            changelog=None,
+            repo="o/r",
+            has_evidence_asset=lambda tag: True,
+        )
+        staged = (docs_dir / "releases" / "v2.1.129.md").read_text()
+        assert "**CI Evidence:**" in staged
+        assert "v2.1.129-ci-evidence.tar.gz" in staged
+
+    def test_no_evidence_line_when_asset_absent(self, tmp_path: Path) -> None:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        releases = tmp_path / "releases"
+        releases.mkdir()
+        (releases / "v2.1.129.md").write_text("# Release 2.1.129 (2026-07-01)\n")
+        stage_docs(
+            docs_dir=docs_dir,
+            releases_dir=releases,
+            changelog=None,
+            repo="o/r",
+            has_evidence_asset=lambda tag: False,
+        )
+        staged = (docs_dir / "releases" / "v2.1.129.md").read_text()
+        assert "CI Evidence" not in staged
+
+    def test_no_evidence_linking_without_resolver(self, tmp_path: Path) -> None:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        releases = tmp_path / "releases"
+        releases.mkdir()
+        (releases / "v2.1.129.md").write_text("# Release 2.1.129 (2026-07-01)\n")
+        stage_docs(docs_dir=docs_dir, releases_dir=releases, changelog=None)
+        staged = (docs_dir / "releases" / "v2.1.129.md").read_text()
+        assert "CI Evidence" not in staged
 
 
 _NAV_TEMPLATE = """\

--- a/tests/vergil_tooling/test_vrg_docs_stage.py
+++ b/tests/vergil_tooling/test_vrg_docs_stage.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from vergil_tooling.bin.vrg_docs_stage import main
+import pytest
+
+from vergil_tooling.bin.vrg_docs_stage import _has_evidence_asset, main
+from vergil_tooling.lib.github import GitHubAPIError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -21,7 +24,11 @@ def test_stages_successfully(tmp_path: Path) -> None:
     (releases / "v1.0.0.md").write_text("# Release 1.0.0 (2026-01-01)\n")
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text("# Changelog\n")
-    with patch(f"{_MOD}.write_output") as mock_out:
+    with (
+        patch(f"{_MOD}.write_output") as mock_out,
+        patch(f"{_MOD}.github.current_repo", return_value="o/r"),
+        patch(f"{_MOD}._has_evidence_asset", return_value=False),
+    ):
         rc = main(
             [
                 "--docs-dir",
@@ -38,6 +45,37 @@ def test_stages_successfully(tmp_path: Path) -> None:
     assert (docs / "releases" / "index.md").is_file()
 
 
+def test_links_evidence_with_explicit_repo(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    releases = tmp_path / "releases"
+    releases.mkdir()
+    (releases / "v2.1.129.md").write_text("# Release 2.1.129 (2026-07-01)\n")
+    with (
+        patch(f"{_MOD}.write_output"),
+        patch(f"{_MOD}._has_evidence_asset", return_value=True) as mock_has,
+        patch(f"{_MOD}.github.current_repo") as mock_current,
+    ):
+        rc = main(
+            [
+                "--docs-dir",
+                str(docs),
+                "--releases-dir",
+                str(releases),
+                "--changelog",
+                str(tmp_path / "nope.md"),
+                "--repo",
+                "o/r",
+            ]
+        )
+    assert rc == 0
+    mock_current.assert_not_called()  # explicit --repo skips remote resolution
+    mock_has.assert_called_once_with("o/r", "v2.1.129")
+    staged = (docs / "releases" / "v2.1.129.md").read_text()
+    assert "**CI Evidence:**" in staged
+    assert "v2.1.129-ci-evidence.tar.gz" in staged
+
+
 def test_missing_docs_dir(tmp_path: Path) -> None:
     with patch(f"{_MOD}.emit_error") as mock_err:
         rc = main(["--docs-dir", str(tmp_path / "missing"), "--releases-dir", str(tmp_path)])
@@ -50,7 +88,10 @@ def test_missing_changelog(tmp_path: Path) -> None:
     docs.mkdir()
     releases = tmp_path / "releases"
     releases.mkdir()
-    with patch(f"{_MOD}.write_output"):
+    with (
+        patch(f"{_MOD}.write_output"),
+        patch(f"{_MOD}.github.current_repo", return_value="o/r"),
+    ):
         rc = main(
             [
                 "--docs-dir",
@@ -70,7 +111,40 @@ def test_empty_releases(tmp_path: Path) -> None:
     docs.mkdir()
     releases = tmp_path / "releases"
     releases.mkdir()
-    with patch(f"{_MOD}.write_output") as mock_out:
+    with (
+        patch(f"{_MOD}.write_output") as mock_out,
+        patch(f"{_MOD}.github.current_repo", return_value="o/r"),
+    ):
         rc = main(["--docs-dir", str(docs), "--releases-dir", str(releases)])
     assert rc == 0
     mock_out.assert_called_once_with("releases_staged", "0")
+
+
+class TestHasEvidenceAsset:
+    def test_asset_present(self) -> None:
+        with patch(
+            f"{_MOD}.github.read_json",
+            return_value={"assets": [{"name": "v2.1.129-ci-evidence.tar.gz"}]},
+        ):
+            assert _has_evidence_asset("o/r", "v2.1.129") is True
+
+    def test_asset_absent(self) -> None:
+        with patch(
+            f"{_MOD}.github.read_json",
+            return_value={"assets": [{"name": "other.txt"}]},
+        ):
+            assert _has_evidence_asset("o/r", "v2.1.129") is False
+
+    def test_release_not_found_is_no_asset(self) -> None:
+        err = GitHubAPIError(1, "gh release view", stderr="release not found")
+        with patch(f"{_MOD}.github.read_json", side_effect=err):
+            assert _has_evidence_asset("o/r", "v9.9.9") is False
+
+    def test_other_error_propagates(self) -> None:
+        err = GitHubAPIError(1, "gh release view", stderr="HTTP 500 boom")
+        with patch(f"{_MOD}.github.read_json", side_effect=err), pytest.raises(GitHubAPIError):
+            _has_evidence_asset("o/r", "v2.1.129")
+
+    def test_non_dict_payload_is_no_asset(self) -> None:
+        with patch(f"{_MOD}.github.read_json", return_value=[]):
+            assert _has_evidence_asset("o/r", "v2.1.129") is False


### PR DESCRIPTION
# Pull Request

## Summary

- Add a pure evidence_link_line builder to lib/docs.py and wire vrg-docs-stage to resolve the asset per release via gh and append a CI-evidence download line to each release page, with a shared evidence_asset_name/evidence_manifest_name helper in lib/ci_evidence.py used by both the harvester and the doc-site link to prevent filename drift.

## Issue Linkage

- Closes #2316

## Notes

- Task T6 of epic vergil-project/.github#140 (depends on T5, merged). evidence_link_line is pure (no gh call inside); the impure 'gh release view <tag> --json assets' lookup lives in vrg-docs-stage — a 404 means no asset, any other gh error propagates (no silent failure). Evidence linking is default-on: vrg-docs-stage auto-resolves the repo from the git remote (overridable with --repo), so no vergil-actions composite change is required for the doc-site surface to appear. vrg-validate green with 100% coverage on new lines.