### PR TITLE
fix(cd): grant actions:read so CD starts with cd-release@v2.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read # cd-release@v2.1 evidence harvest downloads the release PR's ci-evidence artifacts
   attestations: write
   contents: write
   id-token: write


### PR DESCRIPTION
# Pull Request

## Summary

- Add actions:read to cd.yml's top-level permissions so the release job grants cd-release.yml@v2.1 the scope it now needs to download the release PR's ci-evidence artifacts, fixing the startup_failure that broke every CD run.

## Issue Linkage

- Closes #2320

## Notes

- One-line change: adds 'actions: read' (with an explanatory comment) to the top-level permissions block of .github/workflows/cd.yml. The docs job's own contents:write override is untouched and no other permission changed. Validated green via vrg-container-run -- vrg-validate (actionlint/yamllint clean). Fleet-wide rollout of the same grant to other cd-release@v2.1 consumers is a separate follow-up noted in the issue.