### PR TITLE
fix(docs): batch CI-evidence asset lookups into a single releases API call

### DIFF
--- a/src/vergil_tooling/bin/vrg_docs_stage.py
+++ b/src/vergil_tooling/bin/vrg_docs_stage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vergil_tooling.lib import github
 from vergil_tooling.lib.ci_evidence import evidence_asset_name
@@ -13,26 +13,61 @@ from vergil_tooling.lib.docs import stage_docs
 from vergil_tooling.lib.github import GitHubAPIError
 from vergil_tooling.lib.output import emit_error, write_output
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-def _has_evidence_asset(repo: str, tag: str) -> bool:
-    """Return whether release *tag* carries the CI-evidence bundle asset.
 
-    One cheap ``gh release view`` per release at docs-build time. A release that
-    does not exist yet (404) legitimately has no asset, so that is reported as
-    ``False``; any other ``gh`` failure propagates rather than being silently
-    swallowed as "no evidence".
+def _evidence_asset_tags(repo: str) -> frozenset[str]:
+    """Return the set of release tags that carry the CI-evidence bundle asset.
+
+    A **single** paginated ``gh api`` call lists every release and its assets, so
+    membership is resolved with one network round-trip regardless of release
+    count — replacing the old one-``gh release view``-per-release lookup, whose
+    N calls multiplied GitHub's flakiness into the docs build. A tag whose
+    release does not exist simply never appears in the listing (reported as
+    no-evidence), so no per-tag 404 handling is needed. Any genuine ``gh``
+    failure propagates rather than being swallowed as "no evidence".
     """
-    try:
-        data = github.read_json("release", "view", tag, "--repo", repo, "--json", "assets")
-    except GitHubAPIError as exc:
-        stderr = (exc.stderr or "").lower()
-        if "not found" in stderr or "404" in stderr:
-            return False
-        raise
-    raw_assets = data.get("assets") if isinstance(data, dict) else None
-    assets = cast("list[dict[str, Any]]", raw_assets) if isinstance(raw_assets, list) else []
-    asset_name = evidence_asset_name(tag)
-    return any(asset.get("name") == asset_name for asset in assets)
+    data = github.read_json("api", f"repos/{repo}/releases", "--paginate")
+    releases = data if isinstance(data, list) else []
+    tags: set[str] = set()
+    for item in releases:
+        if not isinstance(item, dict):
+            continue
+        release = cast("dict[str, Any]", item)
+        tag = release.get("tag_name")
+        if not isinstance(tag, str):
+            continue
+        raw_assets = release.get("assets")
+        assets = raw_assets if isinstance(raw_assets, list) else []
+        wanted = evidence_asset_name(tag)
+        if any(isinstance(asset, dict) and asset.get("name") == wanted for asset in assets):
+            tags.add(tag)
+    return frozenset(tags)
+
+
+def _evidence_resolver(repo: str) -> Callable[[str], bool]:
+    """Build a ``tag -> has-evidence-asset`` resolver backed by one API call.
+
+    The batched releases listing is fetched lazily on first use and cached, so a
+    docs build with no release pages makes zero calls and any build with one or
+    more makes exactly one, no matter how many releases exist.
+    """
+    tags: frozenset[str] | None = None
+
+    def resolve(tag: str) -> bool:
+        nonlocal tags
+        if tags is None:
+            tags = _evidence_asset_tags(repo)
+        return tag in tags
+
+    return resolve
+
+
+def _is_auth_error(exc: GitHubAPIError) -> bool:
+    """Return whether *exc* looks like an unauthenticated ``gh`` invocation."""
+    text = (exc.stderr or "").lower()
+    return "gh_token" in text or "gh auth login" in text
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -72,13 +107,19 @@ def main(argv: list[str] | None = None) -> int:
 
     changelog = args.changelog if args.changelog.is_file() else None
     repo = args.repo or github.current_repo()
-    count = stage_docs(
-        docs_dir=args.docs_dir,
-        releases_dir=args.releases_dir,
-        changelog=changelog,
-        repo=repo,
-        has_evidence_asset=lambda tag: _has_evidence_asset(repo, tag),
-    )
+    try:
+        count = stage_docs(
+            docs_dir=args.docs_dir,
+            releases_dir=args.releases_dir,
+            changelog=changelog,
+            repo=repo,
+            has_evidence_asset=_evidence_resolver(repo),
+        )
+    except GitHubAPIError as exc:
+        if _is_auth_error(exc):
+            emit_error("GH_TOKEN required for evidence linking; gh is not authenticated")
+            return 1
+        raise
     write_output("releases_staged", str(count))
     return 0
 

--- a/src/vergil_tooling/lib/docs.py
+++ b/src/vergil_tooling/lib/docs.py
@@ -71,8 +71,8 @@ def evidence_link_line(repo: str, tag: str, *, has_asset: bool) -> str | None:
     """Return the CI-evidence download line for a release page, or ``None``.
 
     Pure: the asset lookup is done by the caller (which passes ``has_asset`` —
-    typically one ``gh release view`` per release at docs-build time), so this
-    function stays trivially testable. The asset filename is shared with the
+    resolved once from a single batched releases listing, not per release), so
+    this function stays trivially testable. The asset filename is shared with the
     harvester via :func:`~vergil_tooling.lib.ci_evidence.evidence_asset_name`,
     so the linked name cannot drift from the published one.
     """

--- a/tests/vergil_tooling/test_vrg_docs_stage.py
+++ b/tests/vergil_tooling/test_vrg_docs_stage.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import pytest
 
-from vergil_tooling.bin.vrg_docs_stage import _has_evidence_asset, main
+from vergil_tooling.bin.vrg_docs_stage import (
+    _evidence_asset_tags,
+    _evidence_resolver,
+    _is_auth_error,
+    main,
+)
 from vergil_tooling.lib.github import GitHubAPIError
 
 if TYPE_CHECKING:
@@ -27,7 +32,7 @@ def test_stages_successfully(tmp_path: Path) -> None:
     with (
         patch(f"{_MOD}.write_output") as mock_out,
         patch(f"{_MOD}.github.current_repo", return_value="o/r"),
-        patch(f"{_MOD}._has_evidence_asset", return_value=False),
+        patch(f"{_MOD}._evidence_asset_tags", return_value=frozenset()),
     ):
         rc = main(
             [
@@ -53,7 +58,7 @@ def test_links_evidence_with_explicit_repo(tmp_path: Path) -> None:
     (releases / "v2.1.129.md").write_text("# Release 2.1.129 (2026-07-01)\n")
     with (
         patch(f"{_MOD}.write_output"),
-        patch(f"{_MOD}._has_evidence_asset", return_value=True) as mock_has,
+        patch(f"{_MOD}._evidence_asset_tags", return_value=frozenset({"v2.1.129"})) as mock_tags,
         patch(f"{_MOD}.github.current_repo") as mock_current,
     ):
         rc = main(
@@ -70,10 +75,42 @@ def test_links_evidence_with_explicit_repo(tmp_path: Path) -> None:
         )
     assert rc == 0
     mock_current.assert_not_called()  # explicit --repo skips remote resolution
-    mock_has.assert_called_once_with("o/r", "v2.1.129")
+    mock_tags.assert_called_once_with("o/r")  # one batched call, not per release
     staged = (docs / "releases" / "v2.1.129.md").read_text()
     assert "**CI Evidence:**" in staged
     assert "v2.1.129-ci-evidence.tar.gz" in staged
+
+
+def test_single_api_call_for_many_releases(tmp_path: Path) -> None:
+    """The batched lookup makes exactly one API call regardless of release count."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    releases = tmp_path / "releases"
+    releases.mkdir()
+    tags = ["v1.0.0", "v1.1.0", "v2.0.0", "v2.1.0"]
+    for tag in tags:
+        (releases / f"{tag}.md").write_text(f"# Release {tag.lstrip('v')} (2026-01-01)\n")
+    payload = [{"tag_name": tag, "assets": [{"name": f"{tag}-ci-evidence.tar.gz"}]} for tag in tags]
+    with (
+        patch(f"{_MOD}.write_output"),
+        patch(f"{_MOD}.github.read_json", return_value=payload) as mock_read,
+    ):
+        rc = main(
+            [
+                "--docs-dir",
+                str(docs),
+                "--releases-dir",
+                str(releases),
+                "--changelog",
+                str(tmp_path / "nope.md"),
+                "--repo",
+                "o/r",
+            ]
+        )
+    assert rc == 0
+    mock_read.assert_called_once_with("api", "repos/o/r/releases", "--paginate")
+    for tag in tags:
+        assert "**CI Evidence:**" in (docs / "releases" / f"{tag}.md").read_text()
 
 
 def test_missing_docs_dir(tmp_path: Path) -> None:
@@ -91,6 +128,7 @@ def test_missing_changelog(tmp_path: Path) -> None:
     with (
         patch(f"{_MOD}.write_output"),
         patch(f"{_MOD}.github.current_repo", return_value="o/r"),
+        patch(f"{_MOD}._evidence_asset_tags", return_value=frozenset()),
     ):
         rc = main(
             [
@@ -106,7 +144,7 @@ def test_missing_changelog(tmp_path: Path) -> None:
     assert not (docs / "changelog.md").exists()
 
 
-def test_empty_releases(tmp_path: Path) -> None:
+def test_empty_releases_makes_no_api_call(tmp_path: Path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
     releases = tmp_path / "releases"
@@ -114,37 +152,158 @@ def test_empty_releases(tmp_path: Path) -> None:
     with (
         patch(f"{_MOD}.write_output") as mock_out,
         patch(f"{_MOD}.github.current_repo", return_value="o/r"),
+        patch(f"{_MOD}.github.read_json") as mock_read,
     ):
         rc = main(["--docs-dir", str(docs), "--releases-dir", str(releases)])
     assert rc == 0
     mock_out.assert_called_once_with("releases_staged", "0")
+    mock_read.assert_not_called()  # lazy resolver: zero release pages, zero calls
 
 
-class TestHasEvidenceAsset:
+def test_auth_error_emits_clean_message(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    releases = tmp_path / "releases"
+    releases.mkdir()
+    (releases / "v1.0.0.md").write_text("# Release 1.0.0 (2026-01-01)\n")
+    err = GitHubAPIError(
+        1, "gh api", stderr="gh: To use GitHub CLI, populate the GH_TOKEN environment variable"
+    )
+    with (
+        patch(f"{_MOD}.github.read_json", side_effect=err),
+        patch(f"{_MOD}.emit_error") as mock_err,
+    ):
+        rc = main(
+            [
+                "--docs-dir",
+                str(docs),
+                "--releases-dir",
+                str(releases),
+                "--repo",
+                "o/r",
+            ]
+        )
+    assert rc == 1
+    mock_err.assert_called_once()
+    assert "GH_TOKEN" in mock_err.call_args.args[0]
+
+
+def test_non_auth_error_propagates(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    releases = tmp_path / "releases"
+    releases.mkdir()
+    (releases / "v1.0.0.md").write_text("# Release 1.0.0 (2026-01-01)\n")
+    err = GitHubAPIError(1, "gh api", stderr="HTTP 500 boom")
+    with (
+        patch(f"{_MOD}.github.read_json", side_effect=err),
+        pytest.raises(GitHubAPIError),
+    ):
+        main(
+            [
+                "--docs-dir",
+                str(docs),
+                "--releases-dir",
+                str(releases),
+                "--repo",
+                "o/r",
+            ]
+        )
+
+
+class TestEvidenceAssetTags:
     def test_asset_present(self) -> None:
-        with patch(
-            f"{_MOD}.github.read_json",
-            return_value={"assets": [{"name": "v2.1.129-ci-evidence.tar.gz"}]},
-        ):
-            assert _has_evidence_asset("o/r", "v2.1.129") is True
+        payload = [{"tag_name": "v2.1.129", "assets": [{"name": "v2.1.129-ci-evidence.tar.gz"}]}]
+        with patch(f"{_MOD}.github.read_json", return_value=payload):
+            assert _evidence_asset_tags("o/r") == frozenset({"v2.1.129"})
 
     def test_asset_absent(self) -> None:
-        with patch(
-            f"{_MOD}.github.read_json",
-            return_value={"assets": [{"name": "other.txt"}]},
+        payload = [{"tag_name": "v2.1.129", "assets": [{"name": "other.txt"}]}]
+        with patch(f"{_MOD}.github.read_json", return_value=payload):
+            assert _evidence_asset_tags("o/r") == frozenset()
+
+    def test_mixed_releases_single_call(self) -> None:
+        payload = [
+            {"tag_name": "v1.0.0", "assets": [{"name": "v1.0.0-ci-evidence.tar.gz"}]},
+            {"tag_name": "v1.1.0", "assets": [{"name": "sbom.json"}]},
+            {"tag_name": "v1.2.0", "assets": [{"name": "v1.2.0-ci-evidence.tar.gz"}]},
+        ]
+        with patch(f"{_MOD}.github.read_json", return_value=payload) as mock_read:
+            assert _evidence_asset_tags("o/r") == frozenset({"v1.0.0", "v1.2.0"})
+        mock_read.assert_called_once_with("api", "repos/o/r/releases", "--paginate")
+
+    def test_non_list_payload_is_empty(self) -> None:
+        with patch(f"{_MOD}.github.read_json", return_value={"message": "Not Found"}):
+            assert _evidence_asset_tags("o/r") == frozenset()
+
+    def test_non_dict_release_skipped(self) -> None:
+        payload = [
+            "junk",
+            {"tag_name": "v1.0.0", "assets": [{"name": "v1.0.0-ci-evidence.tar.gz"}]},
+        ]
+        with patch(f"{_MOD}.github.read_json", return_value=payload):
+            assert _evidence_asset_tags("o/r") == frozenset({"v1.0.0"})
+
+    def test_non_str_tag_skipped(self) -> None:
+        payload = [{"tag_name": None, "assets": [{"name": "x"}]}]
+        with patch(f"{_MOD}.github.read_json", return_value=payload):
+            assert _evidence_asset_tags("o/r") == frozenset()
+
+    def test_non_list_assets_is_no_asset(self) -> None:
+        payload = [{"tag_name": "v1.0.0", "assets": None}]
+        with patch(f"{_MOD}.github.read_json", return_value=payload):
+            assert _evidence_asset_tags("o/r") == frozenset()
+
+    def test_non_dict_asset_skipped(self) -> None:
+        payload = [
+            {"tag_name": "v1.0.0", "assets": ["junk", {"name": "v1.0.0-ci-evidence.tar.gz"}]},
+        ]
+        with patch(f"{_MOD}.github.read_json", return_value=payload):
+            assert _evidence_asset_tags("o/r") == frozenset({"v1.0.0"})
+
+    def test_error_propagates(self) -> None:
+        err = GitHubAPIError(1, "gh api", stderr="HTTP 500 boom")
+        with (
+            patch(f"{_MOD}.github.read_json", side_effect=err),
+            pytest.raises(GitHubAPIError),
         ):
-            assert _has_evidence_asset("o/r", "v2.1.129") is False
+            _evidence_asset_tags("o/r")
 
-    def test_release_not_found_is_no_asset(self) -> None:
-        err = GitHubAPIError(1, "gh release view", stderr="release not found")
-        with patch(f"{_MOD}.github.read_json", side_effect=err):
-            assert _has_evidence_asset("o/r", "v9.9.9") is False
 
-    def test_other_error_propagates(self) -> None:
-        err = GitHubAPIError(1, "gh release view", stderr="HTTP 500 boom")
-        with patch(f"{_MOD}.github.read_json", side_effect=err), pytest.raises(GitHubAPIError):
-            _has_evidence_asset("o/r", "v2.1.129")
+class TestEvidenceResolver:
+    def test_resolves_membership(self) -> None:
+        with patch(f"{_MOD}._evidence_asset_tags", return_value=frozenset({"v1.0.0"})):
+            resolve = _evidence_resolver("o/r")
+            assert resolve("v1.0.0") is True
+            assert resolve("v2.0.0") is False
 
-    def test_non_dict_payload_is_no_asset(self) -> None:
-        with patch(f"{_MOD}.github.read_json", return_value=[]):
-            assert _has_evidence_asset("o/r", "v2.1.129") is False
+    def test_caches_single_call(self) -> None:
+        with patch(f"{_MOD}._evidence_asset_tags", return_value=frozenset({"v1.0.0"})) as mock_tags:
+            resolve = _evidence_resolver("o/r")
+            resolve("v1.0.0")
+            resolve("v2.0.0")
+            resolve("v1.0.0")
+        mock_tags.assert_called_once_with("o/r")
+
+    def test_lazy_no_call_when_unused(self) -> None:
+        with patch(f"{_MOD}._evidence_asset_tags") as mock_tags:
+            _evidence_resolver("o/r")
+        mock_tags.assert_not_called()
+
+
+class TestIsAuthError:
+    def test_gh_token_message(self) -> None:
+        exc = GitHubAPIError(1, "gh api", stderr="populate the GH_TOKEN environment variable")
+        assert _is_auth_error(exc) is True
+
+    def test_gh_auth_login_message(self) -> None:
+        exc = GitHubAPIError(1, "gh api", stderr="please run: gh auth login")
+        assert _is_auth_error(exc) is True
+
+    def test_other_message(self) -> None:
+        exc = GitHubAPIError(1, "gh api", stderr="HTTP 500 boom")
+        assert _is_auth_error(exc) is False
+
+    def test_no_stderr(self) -> None:
+        exc = GitHubAPIError(1, "gh api", stderr=None)
+        assert _is_auth_error(exc) is False


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the per-release gh release view evidence lookup in vrg-docs-stage with a single paginated gh api releases call that builds a tag->has-evidence-asset set once, cutting docs-build API calls from N to at most one and shrinking GitHub's flakiness surface.

## Issue Linkage

- Closes #2319

## Notes

- Behavior-preserving for the docs output: stage_docs' pure Callable[[str], bool] interface is unchanged; only the resolver behind it is batched. The resolver is lazy+cached (zero release pages -> zero calls, one or more -> exactly one). No-silent-failure preserved: a genuine gh error still propagates; an unauthenticated gh now emits a clean 'GH_TOKEN required' message instead of a raw traceback, still failing loudly. evidence_asset_name remains the single source of the asset name. Tests rewritten for the batched path (incl. a single-API-call-for-many-releases assertion); vrg-validate green at 100% coverage. Part of epic vergil-project/.github#140.