### PR TITLE
refactor(ci-evidence): split vrg-ci-evidence into harvest + assemble subcommands

### DIFF
--- a/src/vergil_tooling/bin/vrg_ci_evidence.py
+++ b/src/vergil_tooling/bin/vrg_ci_evidence.py
@@ -1,91 +1,84 @@
 """``vrg-ci-evidence`` — the CI-evidence harvester CLI.
 
-A thin orchestrator over :mod:`vergil_tooling.lib.ci_evidence`: every stage is a
-call into the library, the CLI only wires them together and maps the two
-substantive failures (:class:`~vergil_tooling.lib.ci_evidence.IncompleteEvidenceError`,
+A thin orchestrator over :mod:`vergil_tooling.lib.ci_evidence`: every subcommand
+maps to one library orchestrator, and the CLI only wires argparse to it and maps
+the two substantive failures
+(:class:`~vergil_tooling.lib.ci_evidence.IncompleteEvidenceError`,
 :class:`~vergil_tooling.lib.ci_evidence.NoQualifyingRunError`) to a non-zero exit
 via :func:`~vergil_tooling.lib.output.emit_error`.
 
+The atomic flow is split into two subcommands so a release harvests its evidence
+exactly once (issue #2330):
+
+- ``harvest`` — resolve → select run → download → validate; persist the
+  harvested tree + a JSON state file into a staging dir (the pre-publish gate).
+- ``assemble`` — consume the persisted harvest → build the manifest, tar the
+  tree, drop a standalone manifest (the post-release attach; no network).
+- ``bundle`` — ``harvest`` then ``assemble`` composed through a temp staging dir
+  (back-compat + local dogfooding).
+
 ``--generated-at`` is caller-injected (CD supplies the release timestamp), so the
-harvest stays a pure function of its inputs and the bundle is byte-reproducible.
+assemble stays a pure function of its inputs and the bundle is byte-reproducible.
 """
 
 from __future__ import annotations
 
 import argparse
-import shutil
 import sys
-import tempfile
 from pathlib import Path
 
-from vergil_tooling.lib import ci_evidence, git, github
+from vergil_tooling.lib import ci_evidence
 from vergil_tooling.lib.ci_evidence import (
-    HarvestContext,
     IncompleteEvidenceError,
     NoQualifyingRunError,
 )
 from vergil_tooling.lib.output import emit_error
 
 
-def cmd_bundle(args: argparse.Namespace) -> int:
-    """Harvest the release's CI evidence and assemble the bundle + manifest.
+def cmd_harvest(args: argparse.Namespace) -> int:
+    """Harvest the release's CI evidence into a staging dir (pre-publish gate).
 
-    Each line is one library stage: resolve the release PR, its validated head
-    SHA and the qualifying CI run; derive the required gates and the check-run
-    conclusions; download and parse the evidence artifacts; enforce completeness
-    (raises before anything is written on a missing gate); stage the metadata,
-    build and write the manifest, tar the tree, and drop a standalone manifest
-    next to the tarball.
+    Delegates to :func:`~vergil_tooling.lib.ci_evidence.run_harvest`, which
+    resolves the release PR, selects the qualifying CI run, downloads the
+    evidence artifacts, enforces completeness, and persists the harvested tree
+    plus a state file into ``--out-dir`` for a later network-free assemble.
     """
-    repo: str = args.repo
-    version: str = args.version
-    tag = f"v{version}"
-    out_dir = Path(args.out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    ci_evidence.run_harvest(args.repo, args.merge_sha, Path(args.out_dir))
+    return 0
 
-    release_pr = ci_evidence.resolve_release_pr(repo, args.merge_sha)
-    head_sha = github.head_sha(str(release_pr))
-    run = ci_evidence.select_ci_run(repo, head_sha)
 
-    required = ci_evidence.resolve_required_gates(repo, git.repo_root())
-    conclusions = ci_evidence.read_gate_conclusions(repo, head_sha)
+def cmd_assemble(args: argparse.Namespace) -> int:
+    """Assemble the bundle from a persisted harvest (post-release attach).
 
-    with tempfile.TemporaryDirectory() as tmp:
-        staging = Path(tmp)
-        gates_dest = staging / "evidence" / "gates"
-        gates_dest.mkdir(parents=True, exist_ok=True)
+    Delegates to :func:`~vergil_tooling.lib.ci_evidence.run_assemble`, which
+    reads the persisted state + tree from ``--staging`` and writes the tarball +
+    standalone manifest into ``--out-dir``. No network.
+    """
+    ci_evidence.run_assemble(
+        Path(args.staging),
+        version=args.version,
+        generated_at=args.generated_at,
+        out_dir=Path(args.out_dir),
+        sbom_file=Path(args.sbom_file) if args.sbom_file else None,
+    )
+    return 0
 
-        gate_dirs = ci_evidence.download_evidence_artifacts(repo, int(run["id"]), gates_dest)
-        harvested = ci_evidence.load_harvested_gates(gate_dirs, required, conclusions)
-        ci_evidence.validate_completeness(required, harvested)
 
-        ci_evidence.write_checks_json(conclusions, staging)
-        ci_evidence.write_readme(staging)
-        if args.sbom_file:
-            ci_evidence.copy_sbom(Path(args.sbom_file), staging)
+def cmd_bundle(args: argparse.Namespace) -> int:
+    """Harvest then assemble in one shot (back-compat + local dogfooding).
 
-        ctx = HarvestContext(
-            repo=repo,
-            version=version,
-            tag=tag,
-            released_commit=args.merge_sha,
-            release_pr=release_pr,
-            validated_head_sha=head_sha,
-            ci_run_urls=(str(run["html_url"]),),
-        )
-        manifest = ci_evidence.build_manifest(
-            ctx,
-            list(harvested.values()),
-            generated_at=args.generated_at,
-            missing_gates=[],
-            staging_dir=staging,
-        )
-        manifest_path = ci_evidence.write_manifest(manifest, staging)
-
-        tarball = out_dir / ci_evidence.evidence_asset_name(tag)
-        ci_evidence.assemble_bundle(staging, tarball)
-        shutil.copyfile(manifest_path, out_dir / ci_evidence.evidence_manifest_name(tag))
-
+    Delegates to :func:`~vergil_tooling.lib.ci_evidence.run_bundle`, which
+    composes ``harvest`` and ``assemble`` over a throwaway staging directory —
+    the original atomic behaviour.
+    """
+    ci_evidence.run_bundle(
+        args.repo,
+        version=args.version,
+        merge_sha=args.merge_sha,
+        generated_at=args.generated_at,
+        out_dir=Path(args.out_dir),
+        sbom_file=Path(args.sbom_file) if args.sbom_file else None,
+    )
     return 0
 
 
@@ -96,7 +89,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_bundle = sub.add_parser("bundle", help="Assemble the CI-evidence bundle for a release.")
+    p_harvest = sub.add_parser(
+        "harvest", help="Harvest a release's CI evidence into a staging dir (gate)."
+    )
+    p_harvest.add_argument("--repo", required=True, help="owner/name of the release repo")
+    p_harvest.add_argument("--merge-sha", required=True, help="release merge commit SHA")
+    p_harvest.add_argument(
+        "--out-dir", required=True, help="staging directory for the harvested tree + state"
+    )
+    p_harvest.set_defaults(func=cmd_harvest)
+
+    p_assemble = sub.add_parser(
+        "assemble", help="Assemble the bundle from a persisted harvest (no network)."
+    )
+    p_assemble.add_argument(
+        "--staging", required=True, help="staging directory a prior harvest wrote"
+    )
+    p_assemble.add_argument("--version", required=True, help="release version, e.g. 2.1.129")
+    p_assemble.add_argument(
+        "--generated-at", required=True, help="ISO-8601 timestamp (caller-injected)"
+    )
+    p_assemble.add_argument("--out-dir", required=True, help="directory for the bundle + manifest")
+    p_assemble.add_argument("--sbom-file", default=None, help="optional pre-built SBOM to include")
+    p_assemble.set_defaults(func=cmd_assemble)
+
+    p_bundle = sub.add_parser("bundle", help="Harvest + assemble in one shot (back-compat).")
     p_bundle.add_argument("--repo", required=True, help="owner/name of the release repo")
     p_bundle.add_argument("--version", required=True, help="release version, e.g. 2.1.129")
     p_bundle.add_argument("--merge-sha", required=True, help="release merge commit SHA")

--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -6,7 +6,22 @@ build the ``manifest.json`` index (schema 1.0, spec §8), write the raw
 already-built SBOM into the tree, and tar the ``evidence/`` tree into the
 release asset.
 
-Determinism: every function is a pure function of its inputs. Timestamps
+The end-to-end flow is split into two orchestrators so a release harvests its
+evidence exactly once (issue #2330):
+
+- :func:`run_harvest` — the network + validation half. Resolve the release PR,
+  select the qualifying CI run, download the ``ci-evidence-*`` artifacts, read
+  the gate conclusions, and enforce completeness; persist the harvested tree
+  plus a small JSON state file (:class:`HarvestState`) into a staging directory
+  so a later assemble needs no network.
+- :func:`run_assemble` — the network-free half. Read the persisted harvest and
+  state, write ``checks.json`` / ``README.md`` / the SBOM, build and write the
+  manifest, and tar the tree into the release asset + a standalone manifest.
+
+:func:`run_bundle` composes the two (a temp staging dir) so the original atomic
+``bundle`` behaviour is preserved for local dogfooding and back-compat.
+
+Determinism: every pure function is a pure function of its inputs. Timestamps
 (``generated_at``) are injected by the caller, never read from the clock here,
 so the logic stays unit-testable and byte-reproducible.
 """
@@ -17,17 +32,18 @@ import hashlib
 import json
 import shutil
 import tarfile
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from vergil_tooling.lib import github
+from vergil_tooling.lib import git, github
 from vergil_tooling.lib.config import read_config
 from vergil_tooling.lib.github_config import ghas_available, required_evidence_gates
 from vergil_tooling.lib.linkage import extract_merge_pr
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-    from pathlib import Path
 
     from vergil_tooling.lib.github_config import EvidenceGate
 
@@ -97,6 +113,51 @@ class HarvestContext:
     release_pr: int
     validated_head_sha: str
     ci_run_urls: tuple[str, ...]
+
+
+# --- Persisted harvest state (harvest → assemble hand-off, issue #2330) --
+#
+# ``run_harvest`` writes a small JSON state file next to the harvested
+# ``evidence/`` tree so a later ``run_assemble`` can rebuild the manifest with
+# no network. The schema is a stable interface: cd-release (vergil-actions)
+# persists it across two workflow steps, and other callers may read it, so it
+# is versioned and only extended in a backward-compatible way.
+
+# Filename of the persisted state, written at the staging-dir root (a sibling
+# of ``evidence/``, so it is never tarred into the bundle).
+HARVEST_STATE_FILENAME = "harvest-state.json"
+
+# Schema version of the persisted state object. Bump only on a
+# backward-incompatible change; ``read_harvest_state`` refuses an unknown major.
+HARVEST_STATE_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class HarvestState:
+    """The network-derived facts a harvest persists for a later assemble.
+
+    Everything :func:`run_assemble` needs that it cannot re-derive from the
+    on-disk ``evidence/`` tree, and nothing that assemble supplies itself
+    (``version``, ``generated_at``, the SBOM). Serialised to
+    ``<staging>/harvest-state.json`` (schema
+    :data:`HARVEST_STATE_SCHEMA_VERSION`).
+
+    - ``repo`` / ``released_commit`` — release identity for the manifest.
+    - ``release_pr`` / ``validated_head_sha`` / ``ci_run_urls`` — provenance.
+    - ``checks`` — the raw check-run name → conclusion snapshot, reproducing
+      ``checks.json`` at assemble time without a second API call.
+    - ``gate_conclusions`` — per-gate name → aggregated conclusion, injected
+      into each rebuilt :class:`GateEvidence` (the gate's tools/metrics/files
+      come from the persisted tree).
+    """
+
+    repo: str
+    released_commit: str
+    release_pr: int
+    validated_head_sha: str
+    ci_run_urls: tuple[str, ...]
+    checks: dict[str, str]
+    gate_conclusions: dict[str, str]
 
 
 def _evidence_root(staging_dir: Path) -> Path:
@@ -198,6 +259,55 @@ def write_manifest(manifest: Mapping[str, Any], staging_dir: Path) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def write_harvest_state(state: HarvestState, staging_dir: Path) -> Path:
+    """Serialise *state* to ``<staging_dir>/harvest-state.json`` (schema §2330).
+
+    Written at the staging-dir root — a sibling of ``evidence/`` — so it rides
+    the job filesystem between the harvest and assemble steps without being
+    tarred into the bundle. ``sort_keys`` keeps the bytes deterministic.
+    """
+    path = staging_dir / HARVEST_STATE_FILENAME
+    payload = {
+        "schema_version": HARVEST_STATE_SCHEMA_VERSION,
+        "repo": state.repo,
+        "released_commit": state.released_commit,
+        "release_pr": state.release_pr,
+        "validated_head_sha": state.validated_head_sha,
+        "ci_run_urls": list(state.ci_run_urls),
+        "checks": dict(state.checks),
+        "gate_conclusions": dict(state.gate_conclusions),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def read_harvest_state(staging_dir: Path) -> HarvestState:
+    """Load the :class:`HarvestState` persisted at ``<staging_dir>``.
+
+    Raises :class:`ValueError` on an unknown ``schema_version`` — an assemble
+    against an incompatible harvest is a hard failure, never a silent
+    best-effort read.
+    """
+    path = staging_dir / HARVEST_STATE_FILENAME
+    data = json.loads(path.read_text(encoding="utf-8"))
+    schema = data.get("schema_version")
+    if schema != HARVEST_STATE_SCHEMA_VERSION:
+        msg = (
+            f"unsupported harvest-state schema {schema!r} at {path} "
+            f"(expected {HARVEST_STATE_SCHEMA_VERSION!r})"
+        )
+        raise ValueError(msg)
+    return HarvestState(
+        repo=str(data["repo"]),
+        released_commit=str(data["released_commit"]),
+        release_pr=int(data["release_pr"]),
+        validated_head_sha=str(data["validated_head_sha"]),
+        ci_run_urls=tuple(str(url) for url in data["ci_run_urls"]),
+        checks={str(k): str(v) for k, v in data["checks"].items()},
+        gate_conclusions={str(k): str(v) for k, v in data["gate_conclusions"].items()},
+    )
 
 
 def copy_sbom(sbom_file: Path, staging_dir: Path) -> Path:
@@ -461,3 +571,139 @@ def load_harvested_gates(
         evidence = load_gate_evidence(gate_dir, conclusion=conclusion)
         harvested[evidence.name] = evidence
     return harvested
+
+
+def load_harvested_gates_from_state(state: HarvestState, staging_dir: Path) -> list[GateEvidence]:
+    """Rebuild the harvested gates from a persisted state + on-disk tree.
+
+    The network-free counterpart of :func:`load_harvested_gates`: the per-gate
+    conclusion comes from ``state.gate_conclusions`` (already aggregated at
+    harvest time) and the tools/metrics/files come from the persisted
+    ``evidence/gates/<gate>/`` tree. Gates are returned in sorted-name order to
+    match :func:`load_harvested_gates`, so the manifest stays byte-reproducible.
+    """
+    gates_root = _evidence_root(staging_dir) / "gates"
+    return [
+        load_gate_evidence(gates_root / name, conclusion=conclusion)
+        for name, conclusion in sorted(state.gate_conclusions.items())
+    ]
+
+
+# --- End-to-end orchestrators (issue #2330) ------------------------------
+#
+# The two halves of a release's CI-evidence flow, split so the harvest runs
+# exactly once. ``run_harvest`` is the network + validation gate; ``run_assemble``
+# is the network-free attach; ``run_bundle`` composes them for back-compat.
+
+
+def run_harvest(repo: str, merge_sha: str, staging_dir: Path) -> HarvestState:
+    """Harvest a release's CI evidence into ``staging_dir`` (the pre-publish gate).
+
+    Each line is one library stage: resolve the release PR, its validated head
+    SHA and the qualifying CI run; derive the required gates and the check-run
+    conclusions; download and parse the evidence artifacts; enforce completeness
+    (raises :class:`IncompleteEvidenceError` before any state is persisted on a
+    missing gate). The harvested ``evidence/gates/`` tree and a
+    :class:`HarvestState` file are written into ``staging_dir`` so a later
+    :func:`run_assemble` needs no network. Returns the persisted state.
+    """
+    gates_dest = _evidence_root(staging_dir) / "gates"
+    gates_dest.mkdir(parents=True, exist_ok=True)
+
+    release_pr = resolve_release_pr(repo, merge_sha)
+    head_sha = github.head_sha(str(release_pr))
+    run = select_ci_run(repo, head_sha)
+
+    required = resolve_required_gates(repo, git.repo_root())
+    conclusions = read_gate_conclusions(repo, head_sha)
+
+    gate_dirs = download_evidence_artifacts(repo, int(run["id"]), gates_dest)
+    harvested = load_harvested_gates(gate_dirs, required, conclusions)
+    validate_completeness(required, harvested)
+
+    state = HarvestState(
+        repo=repo,
+        released_commit=merge_sha,
+        release_pr=release_pr,
+        validated_head_sha=head_sha,
+        ci_run_urls=(str(run["html_url"]),),
+        checks=dict(conclusions),
+        gate_conclusions={name: gate.conclusion for name, gate in harvested.items()},
+    )
+    write_harvest_state(state, staging_dir)
+    return state
+
+
+def run_assemble(
+    staging_dir: Path,
+    *,
+    version: str,
+    generated_at: str,
+    out_dir: Path,
+    sbom_file: Path | None = None,
+) -> tuple[Path, Path]:
+    """Assemble the bundle from a persisted harvest (the post-release attach).
+
+    Network-free: read the :class:`HarvestState` and the on-disk ``evidence/``
+    tree, write ``checks.json`` / ``README.md`` / the optional SBOM, build and
+    write the manifest, tar the tree, and drop a standalone manifest next to the
+    tarball. Returns ``(tarball, standalone_manifest)`` in ``out_dir``.
+    """
+    state = read_harvest_state(staging_dir)
+    tag = f"v{version}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    write_checks_json(state.checks, staging_dir)
+    write_readme(staging_dir)
+    if sbom_file is not None:
+        copy_sbom(sbom_file, staging_dir)
+
+    gates = load_harvested_gates_from_state(state, staging_dir)
+    ctx = HarvestContext(
+        repo=state.repo,
+        version=version,
+        tag=tag,
+        released_commit=state.released_commit,
+        release_pr=state.release_pr,
+        validated_head_sha=state.validated_head_sha,
+        ci_run_urls=state.ci_run_urls,
+    )
+    manifest = build_manifest(
+        ctx, gates, generated_at=generated_at, missing_gates=[], staging_dir=staging_dir
+    )
+    manifest_path = write_manifest(manifest, staging_dir)
+
+    tarball = out_dir / evidence_asset_name(tag)
+    assemble_bundle(staging_dir, tarball)
+    standalone = out_dir / evidence_manifest_name(tag)
+    shutil.copyfile(manifest_path, standalone)
+    return tarball, standalone
+
+
+def run_bundle(
+    repo: str,
+    *,
+    version: str,
+    merge_sha: str,
+    generated_at: str,
+    out_dir: Path,
+    sbom_file: Path | None = None,
+) -> tuple[Path, Path]:
+    """Harvest then assemble in one shot, through a throwaway staging dir.
+
+    The original atomic ``bundle`` behaviour: :func:`run_harvest` followed by
+    :func:`run_assemble` over the same staging directory, so local dogfooding
+    and back-compat callers keep a single command. A release that runs the two
+    steps separately (cd-release) persists one shared staging dir instead and so
+    harvests only once.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp)
+        run_harvest(repo, merge_sha, staging)
+        return run_assemble(
+            staging,
+            version=version,
+            generated_at=generated_at,
+            out_dir=out_dir,
+            sbom_file=sbom_file,
+        )

--- a/tests/vergil_tooling/test_ci_evidence.py
+++ b/tests/vergil_tooling/test_ci_evidence.py
@@ -11,15 +11,19 @@ import pytest
 from vergil_tooling.lib.ci_evidence import (
     GateEvidence,
     HarvestContext,
+    HarvestState,
     IncompleteEvidenceError,
     assemble_bundle,
     build_manifest,
     copy_sbom,
     evidence_asset_name,
     evidence_manifest_name,
+    load_harvested_gates_from_state,
+    read_harvest_state,
     sha256_file,
     validate_completeness,
     write_checks_json,
+    write_harvest_state,
     write_manifest,
     write_readme,
 )
@@ -204,3 +208,80 @@ def test_validate_completeness_missing_required_raises() -> None:
             {"test": _gate_evidence("test")},
         )
     assert excinfo.value.missing == ["security"]
+
+
+# --- Persisted harvest state (issue #2330) ------------------------------
+
+
+def _state() -> HarvestState:
+    return HarvestState(
+        repo="o/r",
+        released_commit="deadbeef",
+        release_pr=2281,
+        validated_head_sha="cafef00d",
+        ci_run_urls=(
+            "https://github.com/o/r/actions/runs/1",
+            "https://github.com/o/r/actions/runs/2",
+        ),
+        checks={"CodeQL": "success", "test / unit": "success"},
+        gate_conclusions={"security": "success", "test": "success"},
+    )
+
+
+def test_write_read_harvest_state_roundtrip(tmp_path: Path) -> None:
+    staging = tmp_path / "s"
+    staging.mkdir()
+    state = _state()
+    path = write_harvest_state(state, staging)
+    assert path == staging / "harvest-state.json"
+    # Written at the staging root, a sibling of evidence/, so it is never tarred.
+    assert path.parent == staging
+    assert read_harvest_state(staging) == state
+
+
+def test_harvest_state_bytes_are_deterministic(tmp_path: Path) -> None:
+    staging = tmp_path / "s"
+    staging.mkdir()
+    first = write_harvest_state(_state(), staging).read_text()
+    second = write_harvest_state(_state(), staging).read_text()
+    assert first == second
+    # sort_keys -> stable key order in the on-disk bytes.
+    assert first.index('"ci_run_urls"') < first.index('"repo"')
+
+
+def test_read_harvest_state_rejects_unknown_schema(tmp_path: Path) -> None:
+    staging = tmp_path / "s"
+    staging.mkdir()
+    (staging / "harvest-state.json").write_text(
+        json.dumps({"schema_version": "9.9"}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="unsupported harvest-state schema"):
+        read_harvest_state(staging)
+
+
+def test_load_harvested_gates_from_state_rebuilds_sorted_gates(tmp_path: Path) -> None:
+    staging = tmp_path / "s"
+    for gate in ("test", "security"):
+        gate_dir = staging / "evidence" / "gates" / gate
+        gate_dir.mkdir(parents=True)
+        (gate_dir / "evidence.json").write_text(
+            json.dumps({"tools": [{"name": gate}], "metrics": {"n": 1}}), encoding="utf-8"
+        )
+        (gate_dir / f"{gate}.report").write_text("report", encoding="utf-8")
+    state = HarvestState(
+        repo="o/r",
+        released_commit="deadbeef",
+        release_pr=1,
+        validated_head_sha="c",
+        ci_run_urls=("u",),
+        checks={},
+        gate_conclusions={"test": "success", "security": "failure"},
+    )
+
+    gates = load_harvested_gates_from_state(state, staging)
+
+    # Sorted by name to match load_harvested_gates -> byte-reproducible manifest.
+    assert [gate.name for gate in gates] == ["security", "test"]
+    assert gates[0].conclusion == "failure"  # conclusion comes from the state
+    assert gates[1].conclusion == "success"
+    assert gates[1].tools == ({"name": "test"},)  # tools/files come from the tree

--- a/tests/vergil_tooling/test_vrg_ci_evidence.py
+++ b/tests/vergil_tooling/test_vrg_ci_evidence.py
@@ -1,11 +1,13 @@
-"""Tests for the ``vrg-ci-evidence`` CLI (``bundle`` subcommand).
+"""Tests for the ``vrg-ci-evidence`` CLI (``harvest`` / ``assemble`` / ``bundle``).
 
 The CLI is a thin orchestrator over :mod:`vergil_tooling.lib.ci_evidence`, so the
 tests mock only the GitHub-touching stages (PR resolution, head SHA, run
 selection, required-gate derivation, check conclusions, artifact download) to
-fixtures and let the pure bundle-core stages run for real. The happy path asserts
+fixtures and let the pure bundle-core stages run for real. The happy paths assert
 the tarball + standalone manifest land; the failure paths assert a missing gate
-and an unqualified run both exit non-zero with no tarball.
+and an unqualified run both exit non-zero with no tarball. The split path
+additionally proves ``assemble`` needs no network and is byte-identical to the
+atomic ``bundle`` (issue #2330).
 """
 
 from __future__ import annotations
@@ -202,3 +204,216 @@ def test_bundle_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
         vrg_ci_evidence.main(["bundle", "--help"])
     assert excinfo.value.code == 0
     assert "--repo" in capsys.readouterr().out
+
+
+# --- harvest / assemble split (issue #2330) -----------------------------
+
+
+def _harvest_argv(staging: Path) -> list[str]:
+    return ["harvest", "--repo", "o/r", "--merge-sha", "deadbeef", "--out-dir", str(staging)]
+
+
+def _assemble_argv(staging: Path, out_dir: Path, *, sbom: Path | None = None) -> list[str]:
+    argv = [
+        "assemble",
+        "--staging",
+        str(staging),
+        "--version",
+        "2.1.129",
+        "--generated-at",
+        "2026-07-13T00:00:00Z",
+        "--out-dir",
+        str(out_dir),
+    ]
+    if sbom is not None:
+        argv += ["--sbom-file", str(sbom)]
+    return argv
+
+
+def _break_github_stages(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repoint every GitHub-touching stage at a raiser to prove no network use."""
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        msg = "assemble must not touch the network"
+        raise AssertionError(msg)
+
+    for name in (
+        "resolve_release_pr",
+        "select_ci_run",
+        "resolve_required_gates",
+        "read_gate_conclusions",
+        "download_evidence_artifacts",
+    ):
+        monkeypatch.setattr(ci_evidence, name, _boom)
+    monkeypatch.setattr(github, "head_sha", _boom)
+
+
+def test_harvest_persists_tree_and_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    required = (
+        EvidenceGate(name="security", checks=("CodeQL",)),
+        EvidenceGate(name="test", checks=("test / unit",)),
+    )
+    _wire_github_stages(
+        monkeypatch,
+        tmp_path,
+        required=required,
+        conclusions={"CodeQL": "success", "test / unit": "success"},
+        download=_full_download(("security", "test")),
+    )
+    staging = tmp_path / "staging"
+
+    rc = main(_harvest_argv(staging))
+
+    assert rc == 0
+    # The harvested tree is persisted, but no assemble outputs exist yet.
+    assert (staging / "evidence" / "gates" / "test" / "test.report").exists()
+    assert not (staging / "evidence" / "manifest.json").exists()
+    assert not (staging / "evidence" / "checks.json").exists()
+
+    state = json.loads((staging / "harvest-state.json").read_text())
+    assert state["schema_version"] == "1.0"
+    assert state["repo"] == "o/r"
+    assert state["released_commit"] == "deadbeef"
+    assert state["release_pr"] == 2281
+    assert state["validated_head_sha"] == "cafef00d"
+    assert state["ci_run_urls"] == ["https://github.com/o/r/actions/runs/123"]
+    assert state["checks"] == {"CodeQL": "success", "test / unit": "success"}
+    assert state["gate_conclusions"] == {"security": "success", "test": "success"}
+
+
+def test_harvest_missing_required_gate_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    required = (
+        EvidenceGate(name="security", checks=("CodeQL",)),
+        EvidenceGate(name="test", checks=("test / unit",)),
+    )
+    _wire_github_stages(
+        monkeypatch,
+        tmp_path,
+        required=required,
+        conclusions={"CodeQL": "success", "test / unit": "success"},
+        download=_full_download(("test",)),  # security missing
+    )
+    staging = tmp_path / "staging"
+
+    rc = main(_harvest_argv(staging))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "missing evidence" in err
+    assert "security" in err
+    # A failed gate persists no state file (the raise precedes the write).
+    assert not (staging / "harvest-state.json").exists()
+
+
+def test_assemble_consumes_harvest_without_network(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    required = (
+        EvidenceGate(name="security", checks=("CodeQL",)),
+        EvidenceGate(name="test", checks=("test / unit",)),
+    )
+    _wire_github_stages(
+        monkeypatch,
+        tmp_path,
+        required=required,
+        conclusions={"CodeQL": "success", "test / unit": "success"},
+        download=_full_download(("security", "test")),
+    )
+    staging = tmp_path / "staging"
+    assert main(_harvest_argv(staging)) == 0
+
+    # Break every GitHub stage: a passing assemble proves it is network-free.
+    _break_github_stages(monkeypatch)
+    out_dir = tmp_path / "out"
+
+    rc = main(_assemble_argv(staging, out_dir))
+
+    assert rc == 0
+    tarball = out_dir / "v2.1.129-ci-evidence.tar.gz"
+    manifest_path = out_dir / "v2.1.129-ci-evidence-manifest.json"
+    assert tarball.exists()
+    assert manifest_path.exists()
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["provenance"]["release_pr"] == 2281
+    assert manifest["provenance"]["validated_head_sha"] == "cafef00d"
+    assert manifest["generated_at"] == "2026-07-13T00:00:00Z"
+    assert {gate["name"] for gate in manifest["gates"]} == {"security", "test"}
+
+    with tarfile.open(tarball) as tar:
+        names = tar.getnames()
+    assert "evidence/checks.json" in names
+    assert "evidence/manifest.json" in names
+    assert "evidence/gates/test/test.report" in names
+    # The state file is a sibling of evidence/, so it is never tarred in.
+    assert "harvest-state.json" not in names
+
+
+def test_assemble_includes_sbom_when_given(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _wire_github_stages(
+        monkeypatch,
+        tmp_path,
+        required=(EvidenceGate(name="test", checks=("test / unit",)),),
+        conclusions={"test / unit": "success"},
+        download=_full_download(("test",)),
+    )
+    staging = tmp_path / "staging"
+    assert main(_harvest_argv(staging)) == 0
+
+    out_dir = tmp_path / "out"
+    sbom = tmp_path / "sbom.cdx.json"
+    sbom.write_text("{}", encoding="utf-8")
+
+    rc = main(_assemble_argv(staging, out_dir, sbom=sbom))
+
+    assert rc == 0
+    with tarfile.open(out_dir / "v2.1.129-ci-evidence.tar.gz") as tar:
+        names = tar.getnames()
+    assert "evidence/gates/sbom/sbom.cdx.json" in names
+
+
+def test_harvest_then_assemble_matches_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    required = (
+        EvidenceGate(name="security", checks=("CodeQL",)),
+        EvidenceGate(name="test", checks=("test / unit",)),
+    )
+    _wire_github_stages(
+        monkeypatch,
+        tmp_path,
+        required=required,
+        conclusions={"CodeQL": "success", "test / unit": "success"},
+        download=_full_download(("security", "test")),
+    )
+
+    # Atomic bundle.
+    bundle_out = tmp_path / "bundle-out"
+    assert main(_argv(bundle_out)) == 0
+    bundle_manifest = (bundle_out / "v2.1.129-ci-evidence-manifest.json").read_text()
+
+    # Split harvest + assemble with the same injected generated-at.
+    staging = tmp_path / "staging"
+    split_out = tmp_path / "split-out"
+    assert main(_harvest_argv(staging)) == 0
+    assert main(_assemble_argv(staging, split_out)) == 0
+    split_manifest = (split_out / "v2.1.129-ci-evidence-manifest.json").read_text()
+
+    # The split path is byte-for-byte identical to the atomic path.
+    assert split_manifest == bundle_manifest
+
+
+def test_harvest_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        vrg_ci_evidence.main(["harvest", "--help"])
+    assert excinfo.value.code == 0
+    assert "--merge-sha" in capsys.readouterr().out
+
+
+def test_assemble_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        vrg_ci_evidence.main(["assemble", "--help"])
+    assert excinfo.value.code == 0
+    assert "--staging" in capsys.readouterr().out


### PR DESCRIPTION
# Pull Request

## Summary

- Split the atomic vrg-ci-evidence bundle into a network+validation harvest subcommand that persists a versioned harvest-state.json, and a network-free assemble subcommand that consumes it, so a release can harvest once instead of twice; bundle is recomposed from the two and stays byte-identical.

## Issue Linkage

- Closes #2330

## Notes

- Scope is the vergil-tooling CLI split only; the cd-release rewiring is the dependent vergil-actions follow-up. bundle behaviour is preserved (composed over a temp staging dir) and the split path is proven byte-for-byte identical to bundle by test. harvest-state.json (HARVEST_STATE_SCHEMA_VERSION 1.0) is the stable hand-off interface Part 2 wires against. vrg-container-run -- vrg-validate green; 100% line coverage on both changed modules.