### PR TITLE
fix(ci-evidence): force GET on the actions/runs harvest query

### DIFF
--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -448,11 +448,14 @@ def select_ci_run(repo: str, head_sha: str, *, workflow: str = "CI") -> dict[str
     Cancelled and in-progress runs are ignored. Raises
     :class:`NoQualifyingRunError` when no run qualifies (spec §5.2).
     """
+    # The query string MUST be in the endpoint path, not a ``-f head_sha=…``
+    # field: ``gh api`` switches to POST the moment any ``-f``/``-F`` field is
+    # present, and ``GET /actions/runs`` is GET-only, so a POST returns HTTP 404
+    # and silently sinks the whole harvest (issue #2335). Keeping the filter in
+    # the URL preserves the GET verb.
     raw = github.read_json(
         "api",
-        f"repos/{repo}/actions/runs",
-        "-f",
-        f"head_sha={head_sha}",
+        f"repos/{repo}/actions/runs?head_sha={head_sha}",
         "--jq",
         ".workflow_runs",
     )

--- a/tests/vergil_tooling/test_ci_evidence_harvest.py
+++ b/tests/vergil_tooling/test_ci_evidence_harvest.py
@@ -191,6 +191,47 @@ def test_select_ci_run_none_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc.value.head_sha == "deadbeef"
 
 
+def test_select_ci_run_issues_a_get_not_a_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The runs query must reach ``GET /actions/runs`` — never a POST (issue #2335).
+
+    ``gh api`` switches to POST the instant any ``-f``/``-F`` field is present,
+    and ``GET /actions/runs`` is GET-only, so a ``-f head_sha=…`` field produced
+    an HTTP 404 that silently sank the whole harvest. This asserts the *call
+    shape* — no ``-f``/``-F`` fields (unless paired with an explicit ``-X GET``)
+    and the filter carried in the URL — so the regression cannot recur behind a
+    mocked return value.
+    """
+    seen: dict[str, tuple[str, ...]] = {}
+
+    def _record(*args: str, **_kwargs: Any) -> list[Any]:
+        seen["args"] = args
+        return [
+            {
+                "name": "CI",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "t",
+                "id": 5,
+            },
+        ]
+
+    monkeypatch.setattr(github, "read_json", _record)
+    assert select_ci_run("o/r", "abc")["id"] == 5
+
+    args = seen["args"]
+    field_flags = {"-f", "-F", "--field", "--raw-field"}
+    uses_field = any(flag in field_flags for flag in args)
+    forces_get = any(
+        flag in ("-X", "--method") and args[i + 1].upper() == "GET"
+        for i, flag in enumerate(args[:-1])
+    )
+    assert not uses_field or forces_get, (
+        f"select_ci_run must not POST to a GET-only endpoint: {args!r}"
+    )
+    # The head_sha filter must ride the URL, otherwise it was dropped entirely.
+    assert any("head_sha=abc" in str(arg) for arg in args), args
+
+
 # --- download_evidence_artifacts ----------------------------------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- select_ci_run passed head_sha as a -f field, which makes gh api POST to the GET-only /actions/runs endpoint and 404 — silently sinking the whole evidence gate and bundle; the filter now rides the URL so the call stays a GET.

## Issue Linkage

- Closes #2335

## Notes

- Root cause per the release CD logs: gh api defaults to POST when any -f/-F field is present. Audited all five gh api calls in the harvest path (resolve_release_pr's two commit calls, select_ci_run, download_evidence_artifacts, read_gate_conclusions); only select_ci_run carried a -f field — the rest were already field-free GETs — so this is the sole offender. Fix form: moved head_sha into the endpoint query string (repos/{repo}/actions/runs?head_sha=...). Added a call-shape test asserting the constructed gh arg list issues a GET (no -f/-F unless paired with -X GET) with the filter in the URL — the prior tests mocked read_json and never exercised GET-vs-POST. This is the FIRST bake finding for the CI-evidence bundle; further downstream integration bugs may surface now that the harvest proceeds past this point. Validated green in-container at 100% coverage (4235 tests).