### PR TITLE
fix(ci-evidence): scope harvest artifact download to required gates

### DIFF
--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -10,7 +10,7 @@ The end-to-end flow is split into two orchestrators so a release harvests its
 evidence exactly once (issue #2330):
 
 - :func:`run_harvest` — the network + validation half. Resolve the release PR,
-  select the qualifying CI run, download the ``ci-evidence-*`` artifacts, read
+  select the qualifying CI run, download the required gates' evidence artifacts, read
   the gate conclusions, and enforce completeness; persist the harvested tree
   plus a small JSON state file (:class:`HarvestState`) into a staging directory
   so a later assemble needs no network.
@@ -466,27 +466,44 @@ def select_ci_run(repo: str, head_sha: str, *, workflow: str = "CI") -> dict[str
     return max(qualifying, key=lambda run: run["run_started_at"])
 
 
-def download_evidence_artifacts(repo: str, run_id: int, dest: Path) -> list[Path]:
-    """Download every ``ci-evidence-*`` artifact of *run_id* into ``dest/<gate>/``.
+def download_evidence_artifacts(
+    repo: str, run_id: int, dest: Path, required: Sequence[EvidenceGate]
+) -> list[Path]:
+    """Download *run_id*'s evidence artifacts for the *required* gates only.
 
-    Non-evidence artifacts are ignored. The gate name is the artifact name with
-    the ``ci-evidence-`` prefix stripped; each is downloaded into its own gate
-    directory. Returns the created gate directories, sorted for determinism.
+    Only the **exact** ``ci-evidence-<gate>`` artifact of each required gate is
+    consumed, each into its own ``dest/<gate>/`` directory. The security gate
+    also uploads SARIF *partials* (``ci-evidence-security-part-codeql`` and
+    friends) that carry no ``evidence.json``; scoping to the exact required-gate
+    names ignores those partials — and any other non-matching artifact — rather
+    than mis-parsing them as gates (issue #2340). A required gate whose artifact
+    is genuinely absent from the run is simply not downloaded, surfacing as a
+    substantive :class:`IncompleteEvidenceError` at completeness validation
+    rather than being silently skipped. Returns the created gate directories,
+    sorted for determinism.
     """
+    wanted = {f"{_EVIDENCE_ARTIFACT_PREFIX}{gate.name}": gate.name for gate in required}
     raw = github.read_json(
         "api", f"repos/{repo}/actions/runs/{run_id}/artifacts", "--jq", ".artifacts"
     )
     artifacts = cast("list[dict[str, Any]]", raw)
     gate_dirs: list[Path] = []
     for artifact in artifacts:
-        name = str(artifact.get("name", ""))
-        if not name.startswith(_EVIDENCE_ARTIFACT_PREFIX):
+        gate = wanted.get(str(artifact.get("name", "")))
+        if gate is None:
             continue
-        gate = name[len(_EVIDENCE_ARTIFACT_PREFIX) :]
         gate_dir = dest / gate
         gate_dir.mkdir(parents=True, exist_ok=True)
         github.run(
-            "run", "download", str(run_id), "--repo", repo, "--name", name, "--dir", str(gate_dir)
+            "run",
+            "download",
+            str(run_id),
+            "--repo",
+            repo,
+            "--name",
+            f"{_EVIDENCE_ARTIFACT_PREFIX}{gate}",
+            "--dir",
+            str(gate_dir),
         )
         gate_dirs.append(gate_dir)
     return sorted(gate_dirs)
@@ -620,7 +637,7 @@ def run_harvest(repo: str, merge_sha: str, staging_dir: Path) -> HarvestState:
     required = resolve_required_gates(repo, git.repo_root())
     conclusions = read_gate_conclusions(repo, head_sha)
 
-    gate_dirs = download_evidence_artifacts(repo, int(run["id"]), gates_dest)
+    gate_dirs = download_evidence_artifacts(repo, int(run["id"]), gates_dest, required)
     harvested = load_harvested_gates(gate_dirs, required, conclusions)
     validate_completeness(required, harvested)
 

--- a/tests/vergil_tooling/test_ci_evidence_harvest.py
+++ b/tests/vergil_tooling/test_ci_evidence_harvest.py
@@ -238,6 +238,8 @@ def test_select_ci_run_issues_a_get_not_a_post(monkeypatch: pytest.MonkeyPatch) 
 def test_download_evidence_artifacts_filters_prefix(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    from vergil_tooling.lib.github_config import EvidenceGate
+
     monkeypatch.setattr(
         github,
         "read_json",
@@ -254,8 +256,12 @@ def test_download_evidence_artifacts_filters_prefix(
 
     monkeypatch.setattr(github, "run", _record_run)
 
+    required = (
+        EvidenceGate(name="test", checks=("test / unit",)),
+        EvidenceGate(name="security", checks=("CodeQL",)),
+    )
     dest = tmp_path / "artifacts"
-    result = download_evidence_artifacts("o/r", 99, dest)
+    result = download_evidence_artifacts("o/r", 99, dest, required)
 
     assert result == [dest / "security", dest / "test"]
     assert (dest / "test").is_dir()
@@ -267,12 +273,80 @@ def test_download_evidence_artifacts_filters_prefix(
     assert all("99" in a and "o/r" in a for a in calls)
 
 
+def test_download_evidence_artifacts_ignores_security_sarif_partials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The security gate's SARIF partials (no ``evidence.json``) must be skipped.
+
+    Regression for issue #2340: the harvest previously globbed ``ci-evidence-*``
+    and treated ``ci-evidence-security-part-codeql`` as a gate, crashing on the
+    absent ``gates/security-part-codeql/evidence.json``. Scoping to the exact
+    required-gate names consumes only the consolidated ``ci-evidence-security``.
+    """
+    from vergil_tooling.lib.github_config import EvidenceGate
+
+    monkeypatch.setattr(
+        github,
+        "read_json",
+        lambda *a, **k: [
+            {"name": "ci-evidence-security"},
+            {"name": "ci-evidence-security-part-codeql"},
+            {"name": "ci-evidence-security-part-trivy"},
+            {"name": "ci-evidence-security-part-semgrep"},
+        ],
+    )
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(github, "run", lambda *a: calls.append(a))
+
+    required = (EvidenceGate(name="security", checks=("CodeQL",)),)
+    dest = tmp_path / "artifacts"
+    result = download_evidence_artifacts("o/r", 99, dest, required)
+
+    # Only the consolidated gate directory is created; no partial is materialized.
+    assert result == [dest / "security"]
+    assert not (dest / "security-part-codeql").exists()
+    assert not (dest / "security-part-trivy").exists()
+    assert not (dest / "security-part-semgrep").exists()
+    downloaded_names = {a[a.index("--name") + 1] for a in calls}
+    assert downloaded_names == {"ci-evidence-security"}
+
+
+def test_download_evidence_artifacts_omits_genuinely_absent_gate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A required gate with no artifact is left out — never fabricated or skipped.
+
+    Its absence surfaces downstream as an :class:`IncompleteEvidenceError` at
+    completeness validation (issue #2340), not a silent pass.
+    """
+    from vergil_tooling.lib.github_config import EvidenceGate
+
+    monkeypatch.setattr(github, "read_json", lambda *a, **k: [{"name": "ci-evidence-security"}])
+    monkeypatch.setattr(github, "run", lambda *a: None)
+
+    required = (
+        EvidenceGate(name="security", checks=("CodeQL",)),
+        EvidenceGate(name="test", checks=("test / unit",)),  # no artifact in the run
+    )
+    result = download_evidence_artifacts("o/r", 1, tmp_path, required)
+
+    assert result == [tmp_path / "security"]
+    with pytest.raises(ci_evidence.IncompleteEvidenceError, match="test"):
+        ci_evidence.validate_completeness(
+            required,
+            {"security": ci_evidence.GateEvidence("security", "success", (), {}, ())},
+        )
+
+
 def test_download_evidence_artifacts_none_matching(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    from vergil_tooling.lib.github_config import EvidenceGate
+
     monkeypatch.setattr(github, "read_json", lambda *a, **k: [{"name": "coverage"}])
     monkeypatch.setattr(github, "run", lambda *a: None)
-    assert download_evidence_artifacts("o/r", 1, tmp_path) == []
+    required = (EvidenceGate(name="test", checks=("test / unit",)),)
+    assert download_evidence_artifacts("o/r", 1, tmp_path, required) == []
 
 
 # --- read_gate_conclusions ----------------------------------------------

--- a/tests/vergil_tooling/test_vrg_ci_evidence.py
+++ b/tests/vergil_tooling/test_vrg_ci_evidence.py
@@ -53,7 +53,9 @@ def _wire_github_stages(
 def _full_download(gates: tuple[str, ...]) -> Any:
     """A download fixture that stages ``evidence.json`` + a report for each gate."""
 
-    def _download(_repo: str, _run_id: int, dest: Path) -> list[Path]:
+    def _download(
+        _repo: str, _run_id: int, dest: Path, _required: tuple[EvidenceGate, ...]
+    ) -> list[Path]:
         gate_dirs: list[Path] = []
         for gate in gates:
             gate_dir = dest / gate


### PR DESCRIPTION
# Pull Request

## Summary

- Scope download_evidence_artifacts to the exact ci-evidence-<gate> artifact of each required gate so the security gate's SARIF partials (ci-evidence-security-part-*) no longer crash harvest with a missing evidence.json.

## Issue Linkage

- Closes #2340

## Notes

- Root cause: download_evidence_artifacts globbed ci-evidence-* and parsed every match as a gate; the security gate's SARIF partials (ci-evidence-security-part-codeql/-trivy/-semgrep) have no evidence.json, so harvest crashed with FileNotFoundError, never wrote harvest-state.json, and the attach cascaded (release 2.1.137, CD run 29323611377).

Fix: intersect the run's artifact list with the exact ci-evidence-<gate> names derived from the config's required_evidence_gates set (the same set that drives completeness). Partials and any non-matching artifact are ignored; a required gate whose artifact is genuinely absent is left undownloaded and surfaces as a substantive IncompleteEvidenceError at completeness validation, never a silent skip. Fewer, name-targeted downloads also reduce flakiness.

Tests: added regression coverage that a fixture with ci-evidence-security plus its -part-* partials consumes only the consolidated gate (no partial dirs materialized), and that a genuinely absent required gate is left out and raises IncompleteEvidenceError downstream. Updated the existing download tests and the run_harvest download fixture for the new required-gates argument.

This is the SECOND bake finding for the CI-evidence harvest (epic vergil-project/.github#140); the first, #2335, fixed run-selection. More downstream integration bugs may surface once harvest fully completes and the attach step runs on a real release.

vrg-validate green, 100% coverage (4237 tests).