### PR TITLE
fix(vm): keep interactive cloud sessions off the shared SSH control master

### DIFF
--- a/src/vergil_tooling/lib/vm_transport.py
+++ b/src/vergil_tooling/lib/vm_transport.py
@@ -444,12 +444,23 @@ class IapTransport:
         self.project = project
         self.ssh_user = ssh_user
 
-    def _base(self) -> list[str]:
+    def _base(self, *, mux: bool = True) -> list[str]:
         # Multiplexing options ride the underlying ssh via ``--ssh-flag``. The
         # glued ``-oKey=Val`` form (no space) is used deliberately: gcloud splits a
         # ``--ssh-flag`` value on spaces, so ``-o ControlPath=…`` would arrive as
         # two mangled tokens — the glued form passes through intact.
-        mux = [f"--ssh-flag=-o{key}={value}" for key, value in ssh_mux_options(self.host, _cwd())]
+        #
+        # ``mux=False`` (interactive :meth:`exec_session` only) opts out of the shared
+        # control socket: a long-lived human PTY gains nothing from multiplexing and is
+        # the sole victim of the reap-on-start teardown (#2345) — a concurrent session's
+        # ``close()`` does ``ssh -O exit`` on the (host, cwd)-keyed socket and kills the
+        # master out from under it ("Shared connection … closed"). Off the socket, the
+        # session opens its own connection and is immune. Keepalive bounding is retained.
+        mux_flags = (
+            [f"--ssh-flag=-o{key}={value}" for key, value in ssh_mux_options(self.host, _cwd())]
+            if mux
+            else []
+        )
         # Connection-liveness bounding (#2202) rides the same glued --ssh-flag form.
         keepalive = [f"--ssh-flag=-o{key}={value}" for key, value in _ssh_keepalive_options()]
         return [
@@ -461,7 +472,7 @@ class IapTransport:
             f"--zone={self.zone}",
             f"--project={self.project}",
             *keepalive,
-            *mux,
+            *mux_flags,
         ]
 
     def run(
@@ -498,7 +509,9 @@ class IapTransport:
 
     def exec_session(self, workdir: str, inner: str) -> NoReturn:
         remote = f"cd {workdir} && {inner}"
-        cmd = [*self._base(), "--", "-t", remote]
+        # mux=False: the interactive session stays off the shared control socket so a
+        # concurrent session's reap-on-start can't tear it down mid-use (#2345).
+        cmd = [*self._base(mux=False), "--", "-t", remote]
         os.execvp(cmd[0], cmd)  # noqa: S606, S607
 
     def close(self) -> None:
@@ -522,10 +535,14 @@ class SshTransport:
         self.ssh_user = ssh_user
         self.key_path = key_path
 
-    def _base(self, *, pty: bool = False) -> list[str]:
+    def _base(self, *, pty: bool = False, mux: bool = True) -> list[str]:
         # Connection-liveness bounding (#2202) + multiplexing, both as split -o pairs.
+        # ``mux=False`` (interactive :meth:`exec_session` only) drops the shared control
+        # socket so a concurrent session's reap-on-start can't kill the PTY mid-use
+        # (#2345); keepalive bounding is retained. See IapTransport._base for the rationale.
+        mux_opts = ssh_mux_options(self.host, _cwd()) if mux else []
         opts: list[str] = []
-        for key, value in [*_ssh_keepalive_options(), *ssh_mux_options(self.host, _cwd())]:
+        for key, value in [*_ssh_keepalive_options(), *mux_opts]:
             opts += ["-o", f"{key}={value}"]
         return [
             "ssh",
@@ -570,7 +587,8 @@ class SshTransport:
 
     def exec_session(self, workdir: str, inner: str) -> NoReturn:
         remote = f"cd {shlex.quote(workdir)} && {inner}"
-        cmd = [*self._base(pty=True), remote]
+        # mux=False: keep the interactive session off the shared control socket (#2345).
+        cmd = [*self._base(pty=True, mux=False), remote]
         os.execvp(cmd[0], cmd)  # noqa: S606, S607
 
     def close(self) -> None:

--- a/tests/vergil_tooling/test_vm_transport.py
+++ b/tests/vergil_tooling/test_vm_transport.py
@@ -320,6 +320,17 @@ class TestIapTransport:
         assert "--tunnel-through-iap" in cmd
         assert cmd[-3:] == ["--", "-t", "cd /work && exec bash"]
 
+    @patch("vergil_tooling.lib.vm_transport.os.execvp")
+    def test_exec_session_stays_off_shared_mux_socket(self, mock_execvp: MagicMock) -> None:
+        # #2345: the interactive PTY must NOT ride the shared control socket, or a
+        # concurrent session's reap-on-start tears it down ("Shared connection closed").
+        # It keeps its own connection but retains keepalive bounding.
+        IapTransport("inst", "z", "p", "vergil").exec_session("/work", "exec bash")
+        cmd = mock_execvp.call_args[0][1]
+        assert not any("Control" in a for a in cmd)
+        assert "--ssh-flag=-oServerAliveInterval=15" in cmd
+        assert "--ssh-flag=-oConnectTimeout=30" in cmd
+
     @patch("vergil_tooling.lib.vm_transport.subprocess.Popen")
     def test_popen_streams_over_iap_tunnel(self, mock_popen: MagicMock) -> None:
         IapTransport("inst", "z", "p", "vergil").popen(
@@ -491,6 +502,17 @@ class TestSshTransport:
         # the remote command (the bug: -t after user@host → no PTY allocated).
         assert cmd.index("-t") < cmd.index("ubuntu@1.2.3.4")
         assert any("cd /work && exec bash" in a for a in cmd)
+
+    @patch("vergil_tooling.lib.vm_transport.os.execvp")
+    def test_exec_session_stays_off_shared_mux_socket(self, mock_execvp: MagicMock) -> None:
+        # #2345: interactive PTY off the shared control socket, keepalive retained.
+        SshTransport(host="1.2.3.4", ssh_user="ubuntu", key_path="/k/key").exec_session(
+            "/work", "exec bash"
+        )
+        cmd = mock_execvp.call_args[0][1]
+        assert not any("Control" in a for a in cmd)
+        assert "ServerAliveInterval=15" in cmd
+        assert "ConnectTimeout=30" in cmd
 
 
 _HEX16 = 16


### PR DESCRIPTION
# Pull Request

## Summary

- Interactive off-platform (IAP/ssh) sessions dropped frequently with "Shared connection to X closed" (exit 255) because they rode the shared SSH ControlMaster, and #2202 reap-on-start (`ssh -O exit` on the (host, cwd)-keyed socket) tore the master out from under a live PTY whenever a concurrent session/command hit the same box. exec_session now opens its own dedicated connection (mux=False, no ControlPath); run/pipe/popen keep multiplexing so the provisioning-burst win (#2098) is preserved. Keepalive bounding retained on the interactive connection.

## Issue Linkage

- Closes #2345

## Notes

- Root cause found by static analysis + git timeline (regression window 2026-07-08, #2202); the kill-switch experiment (VERGIL_VM_DISABLE_SSH_MUX=1) was deliberately skipped per human request to fix proactively. `ssh -O check` before `-O exit` was considered and rejected (cannot distinguish a wedged master from a live-in-use one). Secondary contributor not addressed here: ServerAliveCountMax=4 can still drop a genuinely idle interactive session after ~60s — trivial follow-up if drops persist. Validation: 4239 passed, 100% coverage, vrg-validate green.