### PR TITLE
fix(pr-workflow): freeze a branch after report-ready — refuse post-ready commits/pushes

### DIFF
--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -20,6 +20,7 @@ from vergil_tooling.lib.commit_message import (
     build_commit_message,
     contains_autoclose,
 )
+from vergil_tooling.lib.pr_workflow import freeze
 
 _PROTECTED_BRANCHES = {"develop", "release", "main"}
 
@@ -168,6 +169,20 @@ def main(argv: list[str] | None = None) -> int:
     rc = _validate_commit_context(root, branching_model)
     if rc != 0:
         return rc
+
+    # Freeze gate: once this branch was reported ready, a new commit would move
+    # its tip past the reported/merged commit and strand the worktree
+    # (issue #1719). Reopening requires the deliberate `vrg-pr-workflow unfreeze`.
+    freeze_check = freeze.check_worktree(root, action="add a commit")
+    if freeze_check.read_error is not None:
+        print(
+            f"WARNING: could not read PR-workflow state ({freeze_check.read_error}); "
+            "proceeding without a freeze check.",
+            file=sys.stderr,
+        )
+    if freeze_check.frozen:
+        print(freeze_check.message, file=sys.stderr)
+        return 1
 
     if args.body and contains_autoclose(args.body):
         return _reject(

--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from vergil_tooling.lib import github, identity_mode
 from vergil_tooling.lib.git import _git_auth_env, main_worktree_root
+from vergil_tooling.lib.pr_workflow import freeze
 
 _ALLOWED_SIMPLE: set[str] = {
     # Read-only inspection commands. These only read history, objects, or
@@ -367,6 +368,47 @@ _WORKFLOW_PERMISSION_RE = re.compile(
 )
 
 
+def _current_worktree_root() -> Path | None:
+    """Return the CWD's worktree root, or None when not resolvable.
+
+    Used to locate ``.vergil/pr-workflow.json`` for the freeze check. A
+    non-repo CWD (or any resolution failure) yields None so the push falls
+    through to git's own error rather than this layer masking it.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],  # noqa: S603, S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    root = result.stdout.strip()
+    return Path(root) if root else None
+
+
+def _check_frozen_push() -> str | None:
+    """Return a refusal message when the current worktree's branch is frozen.
+
+    A branch reported ready (``report-ready``) is done; advancing it with a push
+    produces the reused-branch straggler (issue #1719). The human's
+    ``vrg-submit-pr`` pushes via ``lib.git`` directly, not this wrapper, so this
+    guard only stops an *agent* push of a frozen branch. Returns None (push
+    allowed) when not frozen or when the worktree root cannot be resolved.
+    """
+    root = _current_worktree_root()
+    if root is None:
+        return None
+    check = freeze.check_worktree(root, action="advance this branch with a push")
+    if check.read_error is not None:
+        print(
+            f"vrg-git: warning: could not read PR-workflow state ({check.read_error}); "
+            "proceeding without a freeze check.",
+            file=sys.stderr,
+        )
+    return check.message if check.frozen else None
+
+
 def _print_workflow_push_guidance() -> None:
     mode = identity_mode.current_mode()
     print(
@@ -397,6 +439,8 @@ def _print_help() -> None:
         "    (develop, main, release/*).\n"
         "  - Worktree convention: branch switches in the main worktree and\n"
         "    'worktree add' targets outside .worktrees/ are refused.\n"
+        "  - Freeze: a push is refused once the branch was reported ready\n"
+        "    (vrg-pr-workflow report-ready); unfreeze deliberately to reopen it.\n"
         "  - Identity: remote ops run with the GitHub App installation token for\n"
         "    the resolved identity mode (see vrg-whoami).\n"
         "\n"
@@ -475,6 +519,12 @@ def main(argv: list[str] | None = None) -> int:
     if worktree_err:
         print(f"vrg-git: {worktree_err}", file=sys.stderr)
         return 1
+
+    if subcmd == "push":
+        frozen_msg = _check_frozen_push()
+        if frozen_msg is not None:
+            print(frozen_msg, file=sys.stderr)
+            return 1
 
     env = None
     if subcmd in _REMOTE_SUBCOMMANDS:

--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -147,6 +147,24 @@ def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) ->
     return 0
 
 
+def cmd_unfreeze(_args: argparse.Namespace, transport: LocalFileTransport) -> int:
+    """Deliberately reopen a frozen (reported-ready) branch for more commits.
+
+    The sanctioned escape hatch from the post-report-ready freeze: it is a
+    distinct, explicit subcommand precisely so reopening a branch is never a
+    silent side effect of another action.
+    """
+    state = transport.read()
+    if state is None:
+        raise WorkflowError(
+            "no workflow file to unfreeze; run report-ready first (there is nothing frozen here)."
+        )
+    engine.apply_unfreeze(state, now=_now())
+    transport.write(state)
+    _emit({"ok": True, "status": state.status})
+    return 0
+
+
 def cmd_status(_args: argparse.Namespace, transport: LocalFileTransport) -> int:
     state = transport.read()
     if state is None:
@@ -168,6 +186,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p_ready.add_argument("--notes", required=True)
     p_ready.add_argument("--linkage", default="Ref")
     p_ready.set_defaults(func=cmd_report_ready)
+
+    p_unfreeze = sub.add_parser(
+        "unfreeze",
+        help="Deliberately reopen a frozen (reported-ready) branch for more commits",
+    )
+    p_unfreeze.set_defaults(func=cmd_unfreeze)
 
     p_status = sub.add_parser("status", help="Print the current workflow state")
     p_status.set_defaults(func=cmd_status)

--- a/src/vergil_tooling/lib/pr_workflow/engine.py
+++ b/src/vergil_tooling/lib/pr_workflow/engine.py
@@ -83,6 +83,26 @@ def apply_report_ready(
     return state
 
 
+def apply_unfreeze(state: WorkflowState, *, now: str) -> WorkflowState:
+    """Deliberately reopen a reported-ready branch for more commits.
+
+    Drops ``status`` back to ``implementing`` — which lifts the post-report-ready
+    freeze (see ``lib/pr_workflow/freeze``) — while keeping the recorded PR
+    metadata, so a later ``report-ready`` refreshes it rather than initializing
+    afresh. This is the ONLY sanctioned way to lift the freeze and must be an
+    explicit action, never a silent default. An already-submitted worktree
+    cannot be unfrozen: its PR exists, so further work is a new follow-up issue,
+    not a mutation of the merged branch."""
+    if state.submitted is not None:
+        raise WorkflowError(
+            "cannot unfreeze: this branch's PR has already been submitted. "
+            "Further work is a new follow-up issue, not a change to this branch."
+        )
+    state.status = "implementing"
+    state.updated_at = now
+    return state
+
+
 def apply_submitted(
     state: WorkflowState, *, pr_url: str, pr_number: int | None, now: str
 ) -> WorkflowState:

--- a/src/vergil_tooling/lib/pr_workflow/freeze.py
+++ b/src/vergil_tooling/lib/pr_workflow/freeze.py
@@ -1,0 +1,151 @@
+"""Post-report-ready freeze: a branch reported ready is done — never touch it.
+
+Once ``report-ready`` records the PR metadata, the worktree's branch is the
+single deliverable for its issue and must not change before the human submits.
+Committing to (or advancing) it afterwards produces the flagship straggler
+(issue #1719): the PR merges at the reported commit, the branch tip moves past
+it, and worktree cleanup — correctly — refuses to delete unmerged work, stranding
+the tree forever.
+
+This module is the shared predicate + message builder for that freeze. The
+enforcement chokepoints (``vrg-commit`` and the ``vrg-git`` push path) call
+:func:`check_worktree`; the pure helpers are unit-testable in isolation.
+
+"Frozen" mirrors ``worktrees._probe_pr_workflow``'s ``pr_prepared`` — the exact
+``vrg-submit-pr`` ready gate: ``status == "ready"`` and not yet ``submitted``.
+The only sanctioned way to lift it is the deliberate ``vrg-pr-workflow unfreeze``
+action (``engine.apply_unfreeze``), which drops ``status`` back to
+``implementing``; correcting PR prose by re-running ``report-ready`` is metadata,
+not code, and stays allowed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from vergil_tooling.lib import git
+from vergil_tooling.lib.pr_workflow.errors import WorkflowError
+from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from vergil_tooling.lib.pr_workflow.state import WorkflowState
+
+
+@dataclass(frozen=True)
+class FreezeCheck:
+    """The result of checking whether a worktree is frozen against mutation.
+
+    - ``frozen`` — the branch was reported ready and not yet submitted; the
+      caller must refuse the commit/push.
+    - ``message`` — the actionable refusal text (``None`` when not frozen).
+    - ``read_error`` — a captured (never swallowed) reason the state file could
+      not be read; the caller surfaces it as a warning and proceeds rather than
+      hard-blocking legitimate work over a corrupt file.
+    - ``drifted`` — HEAD has already advanced past the reported commit; the
+      straggler state, flagged loudly in ``message``.
+    """
+
+    frozen: bool
+    message: str | None = None
+    read_error: str | None = None
+    drifted: bool = False
+
+
+def is_frozen(state: WorkflowState | None) -> bool:
+    """Return True when *state* marks the worktree frozen after report-ready.
+
+    Frozen == ``status == "ready"`` and not yet ``submitted`` — the same signal
+    ``worktrees._probe_pr_workflow`` reports as ``pr_prepared`` and the gate
+    ``vrg-submit-pr`` uses to pick up a ready worktree. A deliberate
+    ``unfreeze`` drops ``status`` back to ``implementing``, so this returns
+    False again without discarding the recorded PR metadata.
+    """
+    if state is None:
+        return False
+    return state.status == "ready" and state.submitted is None
+
+
+def has_drifted(state: WorkflowState, current_head: str | None) -> bool:
+    """Return True when HEAD has moved past the commit ``report-ready`` recorded.
+
+    A missing recorded ``head_sha`` or an unresolvable current HEAD yields False
+    — drift is asserted only on positive evidence that the two SHAs differ.
+    """
+    recorded = state.git.get("head_sha")
+    if not recorded or not current_head:
+        return False
+    return bool(recorded != current_head)
+
+
+def build_refusal(state: WorkflowState, *, action: str, current_head: str | None) -> str:
+    """Build the actionable refusal message for a frozen-branch mutation.
+
+    *action* is the verb phrase for what is being refused (e.g. ``"add a
+    commit"``). Assumes the caller already confirmed :func:`is_frozen`.
+    """
+    lines = [
+        f"vrg: refusing to {action} — branch reported ready for issue "
+        f"#{state.issue} and is FROZEN.",
+        "",
+        "A task is exactly one PR: once its work is reported ready the branch is",
+        "done and must not change before the human submits it.",
+        "",
+        "More work is a NEW follow-up issue, never a change to this branch:",
+        '  vrg-issue-create --repo <owner>/<repo> --kind task --title "<what>"',
+        "  (or file it under the epic)",
+        "",
+        "Correcting the PR title/summary/notes is still fine — just re-run",
+        "vrg-pr-workflow report-ready (it overwrites the metadata).",
+        "",
+        "If this branch genuinely must reopen for more commits (rare, deliberate),",
+        "explicitly unfreeze it first:",
+        "  vrg-pr-workflow unfreeze",
+    ]
+    if has_drifted(state, current_head):
+        recorded = str(state.git.get("head_sha") or "unknown")
+        lines[0:0] = [
+            f"vrg: DRIFT DETECTED — HEAD ({(current_head or 'unknown')[:8]}) has already "
+            f"moved past the commit reported ready ({recorded[:8]}).",
+            "This is the reused-branch straggler (issue #1719): the merged PR still",
+            f"points at {recorded[:8]}, so worktree cleanup will refuse this tree. Do not",
+            "push it; open a follow-up issue for any further work and unfreeze only if",
+            "you deliberately intend to reopen this branch.",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def _current_head(worktree_root: Path) -> str | None:
+    """Resolve *worktree_root*'s HEAD SHA best-effort (None if unresolvable).
+
+    Drift detection is advisory: an unresolvable HEAD must not turn a real
+    freeze into a silent pass, so failure here only drops the drift note, never
+    the refusal itself.
+    """
+    try:
+        return git.read_output("-C", str(worktree_root), "rev-parse", "HEAD")
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+
+def check_worktree(worktree_root: Path, *, action: str) -> FreezeCheck:
+    """Read *worktree_root*'s workflow state and report its freeze status.
+
+    A read error is captured in ``read_error`` (never swallowed) with
+    ``frozen=False`` so the caller can warn and proceed rather than hard-block
+    every commit on a corrupt state file.
+    """
+    try:
+        state = LocalFileTransport(worktree_root).read()
+    except (WorkflowError, OSError) as exc:
+        return FreezeCheck(frozen=False, read_error=str(exc))
+    if state is None or not is_frozen(state):
+        return FreezeCheck(frozen=False)
+    current_head = _current_head(worktree_root)
+    drifted = has_drifted(state, current_head)
+    message = build_refusal(state, action=action, current_head=current_head)
+    return FreezeCheck(frozen=True, message=message, drifted=drifted)

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -374,6 +374,64 @@ def test_report_ready_rejects_stale_issue(
     assert rc == 1  # stale workflow file guard
 
 
+def _report_ready(issue: str = "42", title: str = "t") -> None:
+    vrg_pr_workflow.main(
+        [
+            "--base",
+            "develop",
+            "report-ready",
+            "--issue",
+            issue,
+            "--title",
+            title,
+            "--summary",
+            "s",
+            "--notes",
+            "n",
+        ]
+    )
+
+
+def test_unfreeze_reopens_after_report_ready(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # After report-ready the worktree is frozen (status ready); unfreeze drops it
+    # back to implementing so commits are allowed again, retaining the metadata.
+    _report_ready()
+    capsys.readouterr()
+    rc = vrg_pr_workflow.main(["--base", "develop", "unfreeze"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "implementing"}
+
+    vrg_pr_workflow.main(["--base", "develop", "status"])
+    state = json.loads(capsys.readouterr().out)
+    assert state["status"] == "implementing"
+    assert state["pr_metadata"]["title"] == "t"
+
+
+def test_unfreeze_with_no_file_errors(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = vrg_pr_workflow.main(["--base", "develop", "unfreeze"])
+    assert rc == 1
+    assert "no workflow file" in capsys.readouterr().err.lower()
+
+
+def test_report_ready_after_unfreeze_refreezes(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The full deliberate-unfreeze round trip: ready -> unfreeze -> report-ready
+    # refreshes the metadata and re-freezes (status ready).
+    _report_ready(title="t1")
+    vrg_pr_workflow.main(["--base", "develop", "unfreeze"])
+    _report_ready(title="t2")
+    capsys.readouterr()
+    vrg_pr_workflow.main(["--base", "develop", "status"])
+    state = json.loads(capsys.readouterr().out)
+    assert state["status"] == "ready"
+    assert state["pr_metadata"]["title"] == "t2"
+
+
 def test_status_with_no_file(in_git_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
     rc = vrg_pr_workflow.main(["--base", "develop", "status"])
     assert rc == 0

--- a/tests/vergil_tooling/pr_workflow/test_engine_reports.py
+++ b/tests/vergil_tooling/pr_workflow/test_engine_reports.py
@@ -94,6 +94,42 @@ def test_apply_submitted_records_marker() -> None:
     }
 
 
+def test_apply_unfreeze_reopens_and_keeps_metadata() -> None:
+    state = _fresh()
+    engine.apply_report_ready(
+        state,
+        title="t",
+        summary="s",
+        notes="n",
+        linkage="Ref",
+        head_sha="ccc",
+        now="2026-06-25T01:00:00Z",
+    )
+    engine.apply_unfreeze(state, now="2026-06-25T02:00:00Z")
+    assert state.status == "implementing"
+    # Metadata is retained so a later report-ready refreshes rather than re-inits.
+    assert state.pr_metadata == {"title": "t", "summary": "s", "notes": "n", "linkage": "Ref"}
+    assert state.updated_at == "2026-06-25T02:00:00Z"
+
+
+def test_apply_unfreeze_refuses_after_submit() -> None:
+    state = _fresh()
+    engine.apply_report_ready(
+        state,
+        title="t",
+        summary="s",
+        notes="n",
+        linkage="Ref",
+        head_sha="ccc",
+        now="2026-06-25T01:00:00Z",
+    )
+    engine.apply_submitted(
+        state, pr_url="https://github.com/o/r/pull/7", pr_number=7, now="2026-06-25T02:00:00Z"
+    )
+    with pytest.raises(WorkflowError, match="already been submitted"):
+        engine.apply_unfreeze(state, now="2026-06-25T03:00:00Z")
+
+
 def test_reject_autoclose_skips_none_values() -> None:
     """_reject_autoclose must not crash when a field value is None."""
     # Access via the module to exercise the None-skip branch (line coverage).

--- a/tests/vergil_tooling/pr_workflow/test_freeze.py
+++ b/tests/vergil_tooling/pr_workflow/test_freeze.py
@@ -1,0 +1,143 @@
+"""Tests for the post-report-ready freeze predicate + message builder (#2346)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vergil_tooling.lib.pr_workflow import engine, freeze
+from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from vergil_tooling.lib.pr_workflow.state import WorkflowState
+
+
+def _ready() -> WorkflowState:
+    state = engine.init_state(
+        issue="42",
+        branch="feature/42-x",
+        base="origin/develop",
+        head_sha="aaaaaaaa1111",
+        base_sha="0000",
+        now="2026-06-25T00:00:00Z",
+    )
+    return engine.apply_report_ready(
+        state,
+        title="t",
+        summary="s",
+        notes="n",
+        linkage="Ref",
+        head_sha="aaaaaaaa1111",
+        now="2026-06-25T01:00:00Z",
+    )
+
+
+# -- is_frozen ---------------------------------------------------------------
+
+
+def test_is_frozen_none() -> None:
+    assert freeze.is_frozen(None) is False
+
+
+def test_is_frozen_implementing() -> None:
+    state = engine.init_state(
+        issue="42",
+        branch="feature/42-x",
+        base="origin/develop",
+        head_sha="aaaa",
+        base_sha="0000",
+        now="2026-06-25T00:00:00Z",
+    )
+    assert freeze.is_frozen(state) is False
+
+
+def test_is_frozen_ready() -> None:
+    assert freeze.is_frozen(_ready()) is True
+
+
+def test_is_frozen_false_after_submit() -> None:
+    state = _ready()
+    engine.apply_submitted(
+        state, pr_url="https://github.com/o/r/pull/7", pr_number=7, now="2026-06-25T02:00:00Z"
+    )
+    assert freeze.is_frozen(state) is False
+
+
+def test_is_frozen_false_after_unfreeze() -> None:
+    state = _ready()
+    engine.apply_unfreeze(state, now="2026-06-25T02:00:00Z")
+    assert freeze.is_frozen(state) is False
+
+
+# -- has_drifted / build_refusal ---------------------------------------------
+
+
+def test_has_drifted_true_when_head_moved() -> None:
+    assert freeze.has_drifted(_ready(), "bbbbbbbb2222") is True
+
+
+def test_has_drifted_false_when_head_matches() -> None:
+    assert freeze.has_drifted(_ready(), "aaaaaaaa1111") is False
+
+
+def test_has_drifted_false_when_head_unknown() -> None:
+    assert freeze.has_drifted(_ready(), None) is False
+
+
+def test_build_refusal_points_at_followup_and_unfreeze() -> None:
+    msg = freeze.build_refusal(_ready(), action="add a commit", current_head="aaaaaaaa1111")
+    assert "FROZEN" in msg
+    assert "#42" in msg
+    assert "vrg-issue-create" in msg
+    assert "vrg-pr-workflow unfreeze" in msg
+    assert "report-ready" in msg
+    # No drift when HEAD still matches the reported commit.
+    assert "DRIFT" not in msg
+
+
+def test_build_refusal_flags_drift_loudly() -> None:
+    msg = freeze.build_refusal(
+        _ready(), action="advance this branch with a push", current_head="bbbbbbbb2222"
+    )
+    assert "DRIFT DETECTED" in msg
+    assert "bbbbbbbb" in msg
+    assert "aaaaaaaa" in msg
+    assert "1719" in msg
+
+
+# -- check_worktree (I/O) ----------------------------------------------------
+
+
+def _write_state(tmp_path: Path, state: WorkflowState) -> None:
+    LocalFileTransport(tmp_path).write(state)
+
+
+def test_check_worktree_no_file(tmp_path: Path) -> None:
+    check = freeze.check_worktree(tmp_path, action="add a commit")
+    assert check.frozen is False
+    assert check.read_error is None
+
+
+def test_check_worktree_frozen(tmp_path: Path) -> None:
+    _write_state(tmp_path, _ready())
+    check = freeze.check_worktree(tmp_path, action="add a commit")
+    assert check.frozen is True
+    assert check.message is not None
+    assert "FROZEN" in check.message
+
+
+def test_check_worktree_not_frozen_when_implementing(tmp_path: Path) -> None:
+    state = _ready()
+    engine.apply_unfreeze(state, now="2026-06-25T02:00:00Z")
+    _write_state(tmp_path, state)
+    check = freeze.check_worktree(tmp_path, action="add a commit")
+    assert check.frozen is False
+
+
+def test_check_worktree_captures_read_error(tmp_path: Path) -> None:
+    (tmp_path / ".vergil").mkdir()
+    (tmp_path / ".vergil" / "pr-workflow.json").write_text("{ not json")
+    check = freeze.check_worktree(tmp_path, action="add a commit")
+    assert check.frozen is False
+    assert check.read_error is not None

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -485,3 +485,42 @@ def test_validate_admits_safe_body_content(tmp_path: Path, body: str) -> None:
             ]
         )
     assert result == 0
+
+
+# --------------------------------------------------------------------------
+# Post-report-ready freeze (#2346)
+# --------------------------------------------------------------------------
+
+
+def test_main_refuses_commit_when_frozen(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vergil_tooling.lib.pr_workflow.freeze import FreezeCheck
+
+    with (
+        _commit_environment(tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_commit.freeze.check_worktree",
+            return_value=FreezeCheck(frozen=True, message="branch is FROZEN; use unfreeze"),
+        ),
+    ):
+        result = main(_DEFAULT_ARGS)
+    assert result == 1
+    assert "FROZEN" in capsys.readouterr().err
+
+
+def test_main_warns_but_proceeds_on_freeze_read_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vergil_tooling.lib.pr_workflow.freeze import FreezeCheck
+
+    with (
+        _commit_environment(tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_commit.freeze.check_worktree",
+            return_value=FreezeCheck(frozen=False, read_error="bad json"),
+        ),
+    ):
+        result = main(["--type", "feat", "--scope", "core", "--message", "add feature"])
+    assert result == 0
+    assert "could not read PR-workflow state" in capsys.readouterr().err

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -564,6 +564,66 @@ def test_push_normal_allowed() -> None:
     assert rc == 0
 
 
+def test_push_refused_when_frozen(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    # A branch reported ready is frozen; an agent push is refused before any
+    # git push runs (#2346).
+    from vergil_tooling.lib.pr_workflow.freeze import FreezeCheck
+
+    with (
+        patch("vergil_tooling.bin.vrg_git._current_worktree_root", return_value=tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_git.freeze.check_worktree",
+            return_value=FreezeCheck(frozen=True, message="branch FROZEN; unfreeze first"),
+        ),
+        patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+    ):
+        rc = main(["push", "origin", "feature/42-x"])
+    assert rc == 1
+    assert "FROZEN" in capsys.readouterr().err
+    mock_run.assert_not_called()
+
+
+def test_push_warns_but_proceeds_on_freeze_read_error(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    # A corrupt PR-workflow state must not hard-block a push; it warns and
+    # proceeds rather than silently swallowing the read error (#2346).
+    from vergil_tooling.lib.pr_workflow.freeze import FreezeCheck
+
+    with (
+        patch("vergil_tooling.bin.vrg_git._current_worktree_root", return_value=tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_git.freeze.check_worktree",
+            return_value=FreezeCheck(frozen=False, read_error="bad json"),
+        ),
+        patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        rc = main(["push", "origin", "feature/42-x"])
+    assert rc == 0
+    assert "could not read PR-workflow state" in capsys.readouterr().err
+
+
+def test_push_allowed_when_not_frozen(tmp_path: Path) -> None:
+    from vergil_tooling.lib.pr_workflow.freeze import FreezeCheck
+
+    with (
+        patch("vergil_tooling.bin.vrg_git._current_worktree_root", return_value=tmp_path),
+        patch(
+            "vergil_tooling.bin.vrg_git.freeze.check_worktree",
+            return_value=FreezeCheck(frozen=False),
+        ),
+        patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        rc = main(["push", "origin", "feature/42-x"])
+    assert rc == 0
+
+
 def test_checkout_dot_denied(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["checkout", "--", "."]) != 0
 


### PR DESCRIPTION
# Pull Request

## Summary

- Once report-ready records a branch's PR metadata, vrg-commit and the vrg-git push path refuse further commits or branch-advancing pushes to that now-frozen branch, preventing the reused-branch straggler (issue #1719), with a deliberate 'vrg-pr-workflow unfreeze' as the only sanctioned reopen path.

## Issue Linkage

- Closes #2346

## Notes

- Freeze == status ready and not-yet-submitted (mirrors worktrees._probe_pr_workflow's pr_prepared, unmodified per the parallel rework). Enforcement lives in two chokepoints: vrg-commit (before building the commit) and the vrg-git push path (before token minting); raw git is already blocked so these are the only mutation routes. New lib/pr_workflow/freeze holds the pure predicate + message builder and does drift detection against the recorded head_sha (surfaced loudly when HEAD already moved). Re-running report-ready to correct title/summary/notes still works; unfreeze (new engine.apply_unfreeze + 'vrg-pr-workflow unfreeze' subcommand) drops status back to implementing while keeping metadata and refuses once submitted. An unreadable state file warns and proceeds rather than silently hard-blocking commits. The human's vrg-submit-pr pushes via lib.git directly, so it is unaffected. Tests cover frozen refusal, allowed metadata re-report, deliberate unfreeze round-trip, and already-drifted detection.