### PR TITLE
fix(worktree-status): stop reporting merged-but-dirty worktrees as active/0-cruft

### DIFF
--- a/src/vergil_tooling/bin/vrg_worktree_status.py
+++ b/src/vergil_tooling/bin/vrg_worktree_status.py
@@ -103,14 +103,23 @@ def _render_table(rows: list[tuple[str, ...]]) -> str:
 def _summary(statuses: list[WorktreeStatus]) -> str:
     total = len(statuses)
     cruft = sum(1 for s in statuses if s.removable)
-    stalled = sum(1 for s in statuses if s.state is WorktreeState.NO_PR)
+    attention = sum(1 for s in statuses if s.needs_attention)
+    # A reused-branch worktree lands as NO_PR *and* needs_attention; count it
+    # only under attention so the buckets stay disjoint and sum to total.
+    stalled = sum(1 for s in statuses if s.state is WorktreeState.NO_PR and not s.needs_attention)
     prepared = sum(1 for s in statuses if s.pr_prepared)
-    active = total - cruft - stalled
+    # Finished-but-stuck worktrees (needs_attention) are pulled out of active:
+    # never let a merged-but-dirty worktree pose as live work behind "0 cruft"
+    # (issue #2347).
+    active = total - cruft - stalled - attention
     line = (
         f"{total} worktrees — {active} active, "
+        f"{attention} needs-attention, "
         f"{stalled} stalled (no-pr), {cruft} cruft (removable). "
         f"{prepared} PR prepared."
     )
+    if attention:
+        line += " Some worktrees need attention (see notes below)."
     if cruft:
         line += " Run vrg-finalize-pr to clean cruft."
     return line

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -50,6 +50,13 @@ class WorktreeStatus:
     ahead: int
     dirty: bool
     detail: str | None = None
+    # True when the PR is merged/closed but the worktree is *not* removable —
+    # a finished-but-stuck worktree (dirty tree, or a reused branch name that
+    # withheld the merged verdict, issue #1719). These are neither live work
+    # nor removable cruft: they need a human's attention. Set by
+    # classify_worktree; defaulted so callers that build a WorktreeStatus by
+    # hand are unaffected. See _summary in vrg_worktree_status.
+    needs_attention: bool = False
     # Local pr-workflow handoff signals (.vergil/pr-workflow.json). Defaulted so
     # classify_worktree and the finalize sweep, which do not gather them, are
     # unaffected; gather_worktree_status attaches them. See _probe_pr_workflow.
@@ -95,6 +102,12 @@ def classify_worktree(
     equals the branch tip, the MERGED/CLOSED verdict is dropped and the
     branch is classified by its local commits (NO_PR / DRAFT) — never
     removable — so the straggler sweep cannot delete unmerged work.
+
+    A merged/closed PR whose worktree is *not* removable — the tree is
+    dirty, or the branch name was reused — is flagged ``needs_attention``.
+    Such a worktree is finished-but-stuck: not live work, but not safe to
+    delete either. The flag keeps ``_summary`` from miscounting it as
+    ``active`` and hiding it behind a "0 cruft" message (issue #2347).
     """
     if pr_lookup_failed:
         state = WorktreeState.UNKNOWN
@@ -113,6 +126,11 @@ def classify_worktree(
         state = WorktreeState.NO_PR
     else:
         state = WorktreeState.DRAFT
+    # Finished (PR merged/closed) but not removable → needs attention: either
+    # the tree is dirty, or the merged verdict was withheld for a reused
+    # branch name. Removable cruft (merged/closed + clean + matching tip) and
+    # live work never qualify.
+    needs_attention = pr_state in ("MERGED", "CLOSED") and (dirty or not merged_head_matches_tip)
     return WorktreeStatus(
         worktree=worktree,
         state=state,
@@ -120,6 +138,7 @@ def classify_worktree(
         ahead=ahead,
         dirty=dirty,
         detail=detail,
+        needs_attention=needs_attention,
     )
 
 
@@ -196,6 +215,23 @@ def _probe_pr_workflow(worktree: Worktree) -> tuple[str | None, str | None, bool
     return state.status, None, prepared
 
 
+def _describe_dirt(porcelain: str, *, limit: int = 5) -> str:
+    """Render ``git status --porcelain`` output as a human-readable summary.
+
+    Shows the count of uncommitted paths and up to *limit* of them (stripped
+    of the two-char porcelain status prefix) so the human can see at a glance
+    that the dirt is, e.g., just build output. Overflow is reported as a
+    ``(+N more)`` tail rather than a wall of paths.
+    """
+    paths = [line[3:].strip() for line in porcelain.splitlines() if line.strip()]
+    count = len(paths)
+    shown = paths[:limit]
+    preview = ", ".join(shown)
+    if count > limit:
+        preview += f" (+{count - limit} more)"
+    return f"{count} uncommitted path(s): {preview}"
+
+
 def gather_worktree_status(
     worktree: Worktree, *, target: str, with_freshness: bool = False
 ) -> WorktreeStatus:
@@ -217,7 +253,8 @@ def gather_worktree_status(
     ``vrg-worktree-status``; the finalize sweep leaves them unset.
     """
     ahead = git.commits_ahead(target, worktree.branch)
-    dirty = bool(git.read_output("-C", str(worktree.path), "status", "--porcelain"))
+    porcelain = git.read_output("-C", str(worktree.path), "status", "--porcelain")
+    dirty = bool(porcelain)
     workflow_status, workflow_error, pr_prepared = _probe_pr_workflow(worktree)
     # Freshness is opt-in: only vrg-worktree-status needs it. The finalize
     # straggler sweep also drives this function and must not pay for (or be
@@ -265,6 +302,17 @@ def gather_worktree_status(
                 f"closed PR #{pr_number} head {shown} does not match branch "
                 f"tip {tip[:8]} — branch name reused after that PR merged "
                 f"(issue #1719); current commits are unmerged"
+            )
+        elif dirty:
+            # Merged/closed and the tip matches, but the tree is dirty, so the
+            # worktree is stuck: not removable cruft, not live work. Surface an
+            # actionable note showing *what* the dirt is (often just build
+            # output) so the human can clear it and run vrg-finalize-pr (#2347).
+            verb = "merged" if pr_state == "MERGED" else "closed"
+            detail = (
+                f"{verb} PR #{pr_number} but worktree is dirty — "
+                f"{_describe_dirt(porcelain)}. "
+                f"Commit, stash, or discard the changes, then run vrg-finalize-pr."
             )
 
     return _with_workflow(

--- a/tests/vergil_tooling/test_vrg_worktree_status.py
+++ b/tests/vergil_tooling/test_vrg_worktree_status.py
@@ -23,6 +23,7 @@ def _status(
     ahead: int = 0,
     dirty: bool = False,
     detail: str | None = None,
+    needs_attention: bool = False,
     workflow_status: str | None = None,
     workflow_error: str | None = None,
     pr_prepared: bool = False,
@@ -37,6 +38,7 @@ def _status(
         ahead=ahead,
         dirty=dirty,
         detail=detail,
+        needs_attention=needs_attention,
         workflow_status=workflow_status,
         workflow_error=workflow_error,
         pr_prepared=pr_prepared,
@@ -183,6 +185,98 @@ def test_main_surfaces_reused_branch_detail(capsys: pytest.CaptureFixture[str]) 
     assert "note: feature/286-build-buckets:" in out
     assert "#293" in out
     assert "0 cruft" in out
+
+
+def test_main_merged_dirty_is_needs_attention_not_active(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Issue #2347: the real Mac bug — merged-but-dirty worktrees were counted
+    as active behind '0 cruft'. They must now land in needs-attention, never
+    active, and never be hidden by a 'nothing to clean' message."""
+    statuses = [
+        _status(
+            "feature/1-merged-dirty",
+            WorktreeState.MERGED,
+            pr=101,
+            ahead=2,
+            dirty=True,
+            needs_attention=True,
+            detail="merged PR #101 but worktree is dirty — 1 uncommitted path(s): dist/out.js. "
+            "Commit, stash, or discard the changes, then run vrg-finalize-pr.",
+        ),
+        _status("feature/2-open", WorktreeState.OPEN_PR, pr=102, ahead=1),
+    ]
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 active" in out
+    assert "1 needs-attention" in out
+    assert "0 cruft (removable)" in out
+    # The dirty worktree must not be sold as "nothing to clean".
+    assert "Some worktrees need attention" in out
+    assert "note: feature/1-merged-dirty:" in out
+    assert "dist/out.js" in out
+
+
+def test_main_four_merged_dirty_never_reported_all_active(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The exact Mac regression: four merged, stuck worktrees were reported as
+    '4 active … 0 cruft'. They must now be 0 active / 4 needs-attention."""
+    statuses = [
+        _status(
+            f"feature/{i}-stuck",
+            WorktreeState.MERGED,
+            pr=200 + i,
+            ahead=1,
+            dirty=True,
+            needs_attention=True,
+            detail=f"merged PR #{200 + i} but worktree is dirty — 1 uncommitted path(s): x.log.",
+        )
+        for i in range(4)
+    ]
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0 active" in out
+    assert "4 needs-attention" in out
+    assert "0 cruft (removable)" in out
+
+
+def test_main_reused_branch_is_needs_attention_not_stalled(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    statuses = [
+        _status(
+            "feature/286-build-buckets",
+            WorktreeState.NO_PR,
+            pr=293,
+            ahead=9,
+            needs_attention=True,
+            detail="closed PR #293 head 0ldd0cs does not match branch tip 7ead128 — reused",
+        )
+    ]
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 needs-attention" in out
+    assert "0 stalled (no-pr)" in out
+    assert "note: feature/286-build-buckets:" in out
 
 
 def test_row_renders_relative_ages() -> None:

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -265,6 +265,48 @@ def test_classify_merged_head_match_remains_removable() -> None:
     assert status.removable is True
 
 
+# -- needs_attention (issue #2347) -------------------------------------------
+
+
+def test_classify_merged_dirty_needs_attention() -> None:
+    """Issue #2347: a merged PR whose tree is dirty is finished-but-stuck —
+    not removable, not live work — and must be flagged needs_attention."""
+    status = _classify(pr_number=11, pr_state="MERGED", ahead=2, dirty=True)
+    assert status.state is WorktreeState.MERGED
+    assert status.removable is False
+    assert status.needs_attention is True
+
+
+def test_classify_closed_dirty_needs_attention() -> None:
+    status = _classify(pr_number=12, pr_state="CLOSED", ahead=1, dirty=True)
+    assert status.state is WorktreeState.CLOSED
+    assert status.removable is False
+    assert status.needs_attention is True
+
+
+def test_classify_merged_clean_is_not_needs_attention() -> None:
+    """Removable cruft (merged + clean + matching tip) is not needs_attention;
+    it stays plain cleanup, never the attention bucket."""
+    status = _classify(pr_number=11, pr_state="MERGED", ahead=2)
+    assert status.removable is True
+    assert status.needs_attention is False
+
+
+def test_classify_reused_branch_needs_attention() -> None:
+    """A reused branch name withholds the merged verdict (issue #1719); the
+    worktree is still finished-but-stuck, so it is flagged needs_attention."""
+    status = _classify(pr_number=293, pr_state="MERGED", ahead=9, merged_head_matches_tip=False)
+    assert status.state is WorktreeState.NO_PR
+    assert status.removable is False
+    assert status.needs_attention is True
+
+
+def test_classify_live_work_is_not_needs_attention() -> None:
+    assert _classify(pr_number=10, pr_state="OPEN", ahead=2).needs_attention is False
+    assert _classify(ahead=1).needs_attention is False  # NO_PR stalled
+    assert _classify(pr_lookup_failed=True).needs_attention is False
+
+
 # -- gather_worktree_status (I/O wrapper) ------------------------------------
 
 
@@ -320,6 +362,72 @@ def test_gather_dirty_overlay_blocks_removal() -> None:
     assert status.removable is False
 
 
+def test_gather_merged_dirty_flags_attention_with_dirt_detail() -> None:
+    """Issue #2347: reproduce the real Mac scenario — a merged worktree left
+    dirty by build output. It must be flagged needs_attention (not removable,
+    not live work) with an actionable note naming the offending paths."""
+    porcelain = " M dist/app.js\n?? build/out.log\n?? coverage/\n"
+    with (
+        patch(_MOD + ".git.commits_ahead", return_value=2),
+        patch(_MOD + ".git.read_output", return_value=porcelain),
+        patch(_MOD + ".git.commit_sha", return_value="cafef00d"),
+        patch(_MOD + ".github.pr_for_branch", return_value=None),
+        patch(
+            _MOD + ".github.closed_pr_for_branch",
+            return_value={"number": "11", "url": "", "title": "t", "headRefOid": "cafef00d"},
+        ),
+        patch(_MOD + ".github.pr_state", return_value="MERGED"),
+    ):
+        status = gather_worktree_status(_SAMPLE_WT, target="develop")
+    assert status.state is WorktreeState.MERGED
+    assert status.dirty is True
+    assert status.removable is False
+    assert status.needs_attention is True
+    assert status.detail is not None
+    assert "merged PR #11" in status.detail
+    assert "dirty" in status.detail
+    assert "3 uncommitted path(s)" in status.detail
+    assert "dist/app.js" in status.detail
+    assert "vrg-finalize-pr" in status.detail
+
+
+def test_gather_merged_dirt_detail_truncates_long_lists() -> None:
+    porcelain = "".join(f"?? file{i}.tmp\n" for i in range(8))
+    with (
+        patch(_MOD + ".git.commits_ahead", return_value=0),
+        patch(_MOD + ".git.read_output", return_value=porcelain),
+        patch(_MOD + ".git.commit_sha", return_value="cafef00d"),
+        patch(_MOD + ".github.pr_for_branch", return_value=None),
+        patch(
+            _MOD + ".github.closed_pr_for_branch",
+            return_value={"number": "11", "url": "", "title": "t", "headRefOid": "cafef00d"},
+        ),
+        patch(_MOD + ".github.pr_state", return_value="MERGED"),
+    ):
+        status = gather_worktree_status(_SAMPLE_WT, target="develop")
+    assert status.detail is not None
+    assert "8 uncommitted path(s)" in status.detail
+    assert "(+3 more)" in status.detail
+
+
+def test_gather_merged_clean_has_no_attention_or_dirt_detail() -> None:
+    with (
+        patch(_MOD + ".git.commits_ahead", return_value=1),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".git.commit_sha", return_value="cafef00d"),
+        patch(_MOD + ".github.pr_for_branch", return_value=None),
+        patch(
+            _MOD + ".github.closed_pr_for_branch",
+            return_value={"number": "11", "url": "", "title": "t", "headRefOid": "cafef00d"},
+        ),
+        patch(_MOD + ".github.pr_state", return_value="MERGED"),
+    ):
+        status = gather_worktree_status(_SAMPLE_WT, target="develop")
+    assert status.removable is True
+    assert status.needs_attention is False
+    assert status.detail is None
+
+
 def test_gather_reused_branch_name_is_not_removable() -> None:
     """Issue #1719: a branch name reused after a same-named PR merged must
     not be classified MERGED — its current tip carries unmerged work."""
@@ -338,6 +446,7 @@ def test_gather_reused_branch_name_is_not_removable() -> None:
         status = gather_worktree_status(_SAMPLE_WT, target="develop")
     assert status.state is WorktreeState.NO_PR
     assert status.removable is False
+    assert status.needs_attention is True
     assert status.detail is not None
     assert "#293" in status.detail
     assert "reused" in status.detail


### PR DESCRIPTION
# Pull Request

## Summary

- Flag merged/closed-but-not-removable worktrees (dirty tree or reused branch name) as a distinct needs-attention category so vrg-worktree-status never counts them as active or hides them behind a '0 cruft' message, and emit an actionable note naming the offending paths.

## Issue Linkage

- Closes #2347

## Notes

- Core fix in lib/worktrees.py (new needs_attention flag on WorktreeStatus, set in classify_worktree when a merged/closed PR is not removable) and bin/vrg_worktree_status.py _summary (new disjoint needs-attention bucket; active = total - cruft - stalled - attention). gather_worktree_status now captures the porcelain dirt and sets an actionable detail note for the merged-but-dirty case (count + up to 5 paths + remedy). Tests reproduce the real Mac scenario: a merged+dirty worktree, and the four-stuck-worktrees regression (0 active / 4 needs-attention / 0 cruft). Reused-branch (#1719) case keeps its existing note and is now surfaced as needs-attention rather than folded into stalled. Full validation green at 100% coverage.