### PR TITLE
fix(finalize-pr): surface stuck merged worktrees + guarded clear of untracked-only dirt

### DIFF
--- a/docs/site/docs/reference/dev/finalize-pr.md
+++ b/docs/site/docs/reference/dev/finalize-pr.md
@@ -61,7 +61,7 @@ followed by the usual sweep, pull, and prune.
 ```bash
 vrg-finalize-pr [PR | --cleanup-only] [--target-branch BRANCH]
                 [--strategy {merge,squash,rebase}]
-                [--allow-provenance-violation] [--dry-run]
+                [--allow-provenance-violation] [--clean-dirty] [--dry-run]
 ```
 
 ## Arguments
@@ -73,6 +73,7 @@ vrg-finalize-pr [PR | --cleanup-only] [--target-branch BRANCH]
 | `--target-branch` | Branch to switch to (default: `develop`) |
 | `--strategy` | Merge strategy when a PR is given (default: `squash`) |
 | `--allow-provenance-violation` | Proceed despite provenance violations (conscious human override) |
+| `--clean-dirty` | Opt-in: clear a merged/closed worktree whose only dirt is untracked build/validation output, after showing what will be deleted and confirming. Never touches modified tracked files or a reused-branch straggler with unmerged commits (issue #2348). |
 | `--dry-run` | Show what would be done without making changes |
 
 ## Behavior
@@ -128,6 +129,40 @@ target's tip as merged:
 Both guards gate the worktree removal as strictly as the branch
 deletion. The explicit-target cleanup (step 1a) is unaffected — the
 just-merged PR branch has merge evidence by construction.
+
+#### Stuck merged worktrees are surfaced, not buried
+
+A merged/closed worktree the sweep cannot remove — its tree is dirty,
+or its branch name was reused after a same-named PR merged
+(issue #1719) — is neither live work nor removable cruft. Rather than leaving
+the skip reason inside the collapsed progress-stage log (where a clean
+`✓ cleanup` summary hides it), finalize reports every such worktree
+**prominently after the pipeline**, with the reason, so finishing with
+stuck worktrees is impossible to miss (issue #2348).
+
+#### `--clean-dirty`: guarded clear of untracked-only dirt
+
+The common Mac case is a merged worktree whose only "dirt" is
+un-gitignored build or validation output. `--clean-dirty` offers an
+opt-in path to clear exactly that, after the pipeline, on real stdio:
+
+- Only a **merged/closed** worktree whose **every** uncommitted path is
+  **untracked** is a candidate. A reused-branch straggler classifies as
+  `no-pr`/`draft` (its merged verdict withheld, issue #1719), so it is
+  never in a clearable state and its unmerged commits are never at risk.
+- A worktree with **modified tracked files** is refused — those are
+  never discarded — and left surfaced as needing attention.
+- Each removal **shows exactly what will be deleted** (the untracked
+  paths) and **requires confirmation** before `git worktree remove
+  --force` discards the output and deletes the branch.
+
+The default guards are unchanged: without `--clean-dirty`, anything with
+tracked modifications or unmerged commits is protected, as before.
+
+> **Tip:** the cleaner fix is to gitignore your validation output so the
+> worktree is never dirtied in the first place — then it sweeps
+> automatically with no `--clean-dirty` needed. That is repo-specific
+> configuration, out of scope for finalize itself.
 
 Eternal branches are protected based on the `branching_model`:
 

--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -168,6 +168,12 @@ class FinalizeContext:
     root: Path
     merged_branch: str | None = None
     deleted: list[str] = field(default_factory=list)
+    # Merged/closed worktrees the sweep could not remove — dirty, or a
+    # reused branch name with unmerged commits (issue #1719). Collected in
+    # _stage_cleanup and surfaced (and optionally cleared) after the pipeline
+    # tears down its live display, so the skip reason is impossible to miss
+    # instead of buried in the collapsed stage log (issue #2348).
+    stuck: list[worktrees.WorktreeStatus] = field(default_factory=list)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -214,6 +220,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--dry-run", action="store_true", help="Show what would be done without making changes"
     )
     parser.add_argument(
+        "--clean-dirty",
+        action="store_true",
+        help="Opt-in: clear a merged/closed worktree whose only dirt is "
+        "untracked build/validation output, after showing exactly what will "
+        "be deleted and confirming. Never touches modified tracked files or a "
+        "reused-branch straggler with unmerged commits (issue #2348).",
+    )
+    parser.add_argument(
         "--release",
         action="store_true",
         help="After a successful finalize, chain straight into vrg-release "
@@ -258,7 +272,9 @@ def _worktree_is_dirty(wt_path: Path) -> bool:
     return bool(result.stdout.strip())
 
 
-def _delete_branch_and_worktree(branch: str, root: Path, *, dry_run: bool) -> bool:
+def _delete_branch_and_worktree(
+    branch: str, root: Path, *, dry_run: bool, force: bool = False
+) -> bool:
     """Remove *branch* and its canonical worktree; True if the branch was deleted.
 
     Shared by the explicit-target step (the PR branch just merged, which
@@ -278,14 +294,22 @@ def _delete_branch_and_worktree(branch: str, root: Path, *, dry_run: bool) -> bo
     force-push during a CI fixup loop (the upstream-tracking ref is gone
     after `fetch --prune`). Trusting our own filter avoids the
     disagreement. Issue #307.
+
+    ``force`` is the opt-in ``--clean-dirty`` path (issue #2348): it skips
+    the dirty guard and passes ``git worktree remove --force`` so a
+    worktree dirtied only by untracked build output is discarded. Callers
+    must have already vetted that the dirt is untracked-only and the PR
+    merged/closed — the default (``force=False``) still refuses any dirty
+    worktree, so the standing guards are unweakened.
     """
     wt = worktrees.worktree_for_branch(branch, root)
     if wt is not None:
-        if _worktree_is_dirty(wt):
+        if not force and _worktree_is_dirty(wt):
             print(f"  Skipping {branch}: worktree {wt} has uncommitted changes")
             return False
+        remove_cmd = ["worktree", "remove", *(["--force"] if force else []), str(wt)]
         print(f"  Removing worktree: {wt}")
-        _run(["worktree", "remove", str(wt)], dry_run=dry_run)
+        _run(remove_cmd, dry_run=dry_run)
     print(f"  Deleting merged branch: {branch}")
     _run(["branch", "-D", branch], dry_run=dry_run)
     if not dry_run:
@@ -293,6 +317,131 @@ def _delete_branch_and_worktree(branch: str, root: Path, *, dry_run: bool) -> bo
         if removed:
             print(f"  Cleaned {removed} cached container image(s) for {branch}")
     return True
+
+
+def _worktree_porcelain(wt_path: Path) -> str:
+    """Return ``git status --porcelain`` for *wt_path*, or '' if git fails.
+
+    Used by the guarded clear to inspect *what* the dirt is. An empty string
+    — whether a clean tree or a git error — makes ``_dirt_is_untracked_only``
+    refuse, the safe direction: never delete on unproven-clean evidence.
+    """
+    result = subprocess.run(  # noqa: S603
+        ("git", "-C", str(wt_path), "status", "--porcelain"),  # noqa: S607
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _dirt_is_untracked_only(porcelain: str) -> bool:
+    """True when every uncommitted path in *porcelain* is an untracked file.
+
+    ``git status --porcelain`` marks untracked files with a ``??`` status
+    code; every other code (`` M``, ``M ``, ``A ``, ``D ``, ``R ``, …) is a
+    tracked-file change the guarded clear must never discard. An empty
+    porcelain returns ``False`` — there is nothing to clear, and callers
+    reach this only for a tree already known dirty.
+    """
+    lines = [ln for ln in porcelain.splitlines() if ln.strip()]
+    return bool(lines) and all(ln.startswith("??") for ln in lines)
+
+
+_CLEARABLE_STATES = (worktrees.WorktreeState.MERGED, worktrees.WorktreeState.CLOSED)
+
+
+def _clean_dirty_worktrees(
+    stuck: list[worktrees.WorktreeStatus], root: Path, *, dry_run: bool, assume_yes: bool
+) -> list[worktrees.WorktreeStatus]:
+    """Guarded opt-in clear of untracked-only dirt (issue #2348).
+
+    Runs after the pipeline, on real stdio, so its confirmation prompt reaches
+    the human (a stage's stdout is redirected into the collapsed log). The
+    guards are strict and never weakened:
+
+    - A reused-branch straggler classifies as NO_PR/DRAFT (its merged verdict
+      is withheld, issue #1719), so it is never in a clearable state here and
+      its unmerged commits are never at risk.
+    - Only a MERGED/CLOSED worktree whose *every* uncommitted path is untracked
+      is a candidate; a modified tracked file is refused.
+    - Each removal shows exactly what will be deleted and is confirmed.
+
+    Returns the worktrees left in place (refused, or declined), so the caller
+    surfaces only what still needs attention.
+    """
+    remaining: list[worktrees.WorktreeStatus] = []
+    for status in stuck:
+        branch = status.worktree.branch
+        if status.state not in _CLEARABLE_STATES:
+            print(
+                f"  --clean-dirty: refusing {branch}: not a merged/closed worktree "
+                "(branch name reused — has unmerged commits, issue #1719)."
+            )
+            remaining.append(status)
+            continue
+        porcelain = _worktree_porcelain(status.worktree.path)
+        if not _dirt_is_untracked_only(porcelain):
+            print(
+                f"  --clean-dirty: refusing {branch}: working tree has modified "
+                "tracked files — not untracked-only build output."
+            )
+            remaining.append(status)
+            continue
+        paths = [ln[3:].strip() for ln in porcelain.splitlines() if ln.strip()]
+        print(f"  --clean-dirty: {branch} ({status.state.value}) — would remove the worktree and:")
+        for path in paths:
+            print(f"      untracked: {path}")
+        # In dry-run the confirm is skipped and _delete_branch_and_worktree
+        # (dry_run=True) prints the git commands it would run; otherwise
+        # confirm gates the real, irreversible removal.
+        if not dry_run and not confirm(
+            f"Clear worktree {status.worktree.path.name} and delete {branch}?",
+            assume_yes=assume_yes,
+            default=False,
+        ):
+            print(f"  --clean-dirty: left {branch} in place.")
+            remaining.append(status)
+            continue
+        _delete_branch_and_worktree(branch, root, dry_run=dry_run, force=True)
+    return remaining
+
+
+def _report_stuck_worktrees(stuck: list[worktrees.WorktreeStatus], *, clean_dirty: bool) -> None:
+    """Prominently report merged/closed worktrees the sweep left behind.
+
+    Printed after the pipeline so it lands below the collapsed stage log where
+    the human running finalize cannot miss it (issue #2348)."""
+    if not stuck:
+        return
+    print()
+    print(f"⚠  {len(stuck)} merged/closed worktree(s) left in place — needs attention:")
+    for status in stuck:
+        detail = status.detail or f"{status.state.value}, not removable"
+        print(f"   • {status.worktree.branch}: {detail}")
+    if not clean_dirty:
+        print(
+            "   Re-run with --clean-dirty to clear any dirtied only by untracked "
+            "build output (each is shown and confirmed first)."
+        )
+
+
+def _handle_stuck_worktrees(ctx: FinalizeContext) -> None:
+    """Surface — and, with --clean-dirty, guardedly clear — stuck worktrees.
+
+    The post-pipeline half of issue #2348: ``_stage_cleanup`` collected any
+    merged/closed worktree it could not remove into ``ctx.stuck``; here, on
+    real stdio, they are optionally cleared (untracked-only dirt) and the
+    remainder is surfaced prominently.
+    """
+    stuck = ctx.stuck
+    if not stuck:
+        return
+    if ctx.args.clean_dirty:
+        stuck = _clean_dirty_worktrees(
+            stuck, ctx.root, dry_run=ctx.args.dry_run, assume_yes=ctx.args.yes
+        )
+    _report_stuck_worktrees(stuck, clean_dirty=ctx.args.clean_dirty)
 
 
 def _infer_pr(root: Path, target_branch: str, *, assume_yes: bool = False) -> str | None:
@@ -546,6 +695,12 @@ def _stage_cleanup(ctx: FinalizeContext) -> None:
             continue
         status = worktrees.gather_worktree_status(wt, target=args.target_branch)
         if not status.removable:
+            if status.needs_attention:
+                # Finished-but-stuck: merged/closed but dirty, or a reused
+                # branch name (issue #1719). Collect it so it is surfaced
+                # after the pipeline instead of buried in the collapsed stage
+                # log (issue #2348).
+                ctx.stuck.append(status)
             print(f"  Skipping {branch}: {status.state.value} (not removable)")
             continue
         if _delete_branch_and_worktree(branch, root, dry_run=args.dry_run):
@@ -780,6 +935,13 @@ def main(argv: list[str] | None = None) -> int:
         args=args,
         repo_root=root,
     )
+
+    # Surface — and, with --clean-dirty, guardedly clear — any merged/closed
+    # worktrees the sweep could not remove (issue #2348). Runs after the
+    # pipeline has torn down its live display so the report (and the
+    # confirmation prompt) reaches the human on real stdio, and regardless of
+    # rc so a stuck worktree is never hidden behind a failed later stage.
+    _handle_stuck_worktrees(ctx)
 
     # Task closure and epic rollup are event-driven now (epic
     # vergil-project/.github#75): the PR's `Closes #N` linkage closes the task on

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -16,6 +16,7 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     FinalizeContext,
     FinalizeError,
     _check_cd_workflow_status,
+    _dirt_is_untracked_only,
     _parse_pr_list,
     _resolve_open_prs,
     _resolve_strategy,
@@ -1646,6 +1647,236 @@ def test_sweep_skips_eternal_branch_worktree(tmp_path: Path) -> None:
     assert result == 0
     gather.assert_not_called()
     deleter.assert_not_called()
+
+
+# -- surface + guarded clear of stuck merged worktrees (issue #2348) ----------
+
+
+def _stuck_status(
+    tmp_path: Path,
+    *,
+    branch: str = "feature/9-x",
+    state: WorktreeState = WorktreeState.MERGED,
+    detail: str | None = "merged PR #9 but worktree is dirty — 1 uncommitted path(s): out.log.",
+) -> WorktreeStatus:
+    """A merged/closed-but-stuck worktree status: dirty, not removable, and
+    flagged needs_attention (what gather_worktree_status returns for the
+    build-turd case, issue #2347)."""
+    wt = Worktree(path=tmp_path / ".worktrees" / "issue-9-x", branch=branch)
+    return WorktreeStatus(
+        worktree=wt,
+        state=state,
+        pr_number=9,
+        ahead=1,
+        dirty=True,
+        detail=detail,
+        needs_attention=True,
+    )
+
+
+@contextmanager
+def _sweep_with_stuck(tmp_path: Path, status: WorktreeStatus) -> Iterator[list[tuple[str, ...]]]:
+    """Drive a cleanup-only run whose single worktree classifies as *status*.
+
+    Yields the captured git.run call list so a test can assert on (or against)
+    the deletion commands. gather_worktree_status is stubbed to *status*, so
+    the worktree arm records it as stuck (issue #2348).
+    """
+    calls: list[tuple[str, ...]] = []
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run", side_effect=lambda *a: calls.append(a)),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[status.worktree]),
+        patch(_MOD + ".worktrees.gather_worktree_status", return_value=status),
+        patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+    ):
+        yield calls
+
+
+def test_parse_args_clean_dirty_defaults_false() -> None:
+    assert parse_args([]).clean_dirty is False
+
+
+def test_parse_args_clean_dirty_flag() -> None:
+    assert parse_args(["--clean-dirty"]).clean_dirty is True
+
+
+def test_dirt_is_untracked_only_true_for_all_untracked() -> None:
+    assert _dirt_is_untracked_only("?? out.log\n?? .coverage\n") is True
+
+
+def test_dirt_is_untracked_only_false_for_modified_tracked() -> None:
+    assert _dirt_is_untracked_only(" M src/app.py\n") is False
+    assert _dirt_is_untracked_only("M  src/app.py\n") is False
+    assert _dirt_is_untracked_only("A  new.py\n") is False
+
+
+def test_dirt_is_untracked_only_false_when_mixed() -> None:
+    assert _dirt_is_untracked_only("?? out.log\n M src/app.py\n") is False
+
+
+def test_dirt_is_untracked_only_false_when_empty() -> None:
+    assert _dirt_is_untracked_only("") is False
+    assert _dirt_is_untracked_only("\n  \n") is False
+
+
+def test_stuck_merged_worktree_is_surfaced_not_buried(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A merged-but-dirty worktree the sweep leaves behind is reported
+    prominently after the pipeline, with its reason — not just in the
+    collapsed stage log (issue #2348)."""
+    _make_profile(tmp_path, "library-release")
+    status = _stuck_status(tmp_path)
+    with _sweep_with_stuck(tmp_path, status) as calls:
+        rc = main(["--cleanup-only"])
+    assert rc == 0
+    # Default (no --clean-dirty): never deletes.
+    assert not any(c[:1] == ("worktree",) for c in calls)
+    assert not any(c[:2] == ("branch", "-D") for c in calls)
+    out = capsys.readouterr().out
+    assert "needs attention" in out
+    assert "feature/9-x" in out
+    assert "worktree is dirty" in out
+    assert "--clean-dirty" in out  # points at the opt-in remedy
+
+
+def test_clean_dirty_clears_untracked_only_worktree(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--clean-dirty force-removes a merged worktree dirtied only by untracked
+    build output, after confirmation."""
+    _make_profile(tmp_path, "library-release")
+    status = _stuck_status(tmp_path)
+    with (
+        _sweep_with_stuck(tmp_path, status) as calls,
+        patch(_MOD + "._worktree_porcelain", return_value="?? out.log\n?? .coverage\n"),
+        patch(_MOD + ".confirm", return_value=True) as confirm,
+    ):
+        rc = main(["--cleanup-only", "--clean-dirty"])
+    assert rc == 0
+    confirm.assert_called_once()
+    assert ("worktree", "remove", "--force", str(status.worktree.path)) in calls
+    assert ("branch", "-D", "feature/9-x") in calls
+    out = capsys.readouterr().out
+    assert "untracked: out.log" in out
+    # Cleared → not re-surfaced as needing attention.
+    assert "needs attention" not in out
+
+
+def test_clean_dirty_refuses_modified_tracked_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--clean-dirty never discards modified tracked files: the worktree is
+    refused (no deletion) and surfaced as still needing attention."""
+    _make_profile(tmp_path, "library-release")
+    status = _stuck_status(tmp_path)
+    with (
+        _sweep_with_stuck(tmp_path, status) as calls,
+        patch(_MOD + "._worktree_porcelain", return_value=" M src/app.py\n?? out.log\n"),
+        patch(_MOD + ".confirm") as confirm,
+    ):
+        rc = main(["--cleanup-only", "--clean-dirty"])
+    assert rc == 0
+    confirm.assert_not_called()
+    assert not any(c[:1] == ("worktree",) for c in calls)
+    assert not any(c[:2] == ("branch", "-D") for c in calls)
+    out = capsys.readouterr().out
+    assert "refusing feature/9-x" in out
+    assert "modified tracked files" in out
+    assert "needs attention" in out
+
+
+def test_clean_dirty_refuses_reused_branch_straggler(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #1719: a reused branch name classifies as NO_PR (its merged
+    verdict withheld). --clean-dirty must never clear it — its current commits
+    are unmerged — so the porcelain is not even inspected."""
+    _make_profile(tmp_path, "library-release")
+    status = _stuck_status(
+        tmp_path,
+        branch="feature/286-reused",
+        state=WorktreeState.NO_PR,
+        detail="closed PR #293 head 0ldd0cs does not match branch tip — reused (issue #1719)",
+    )
+    with (
+        _sweep_with_stuck(tmp_path, status) as calls,
+        patch(_MOD + "._worktree_porcelain") as porcelain,
+        patch(_MOD + ".confirm") as confirm,
+    ):
+        rc = main(["--cleanup-only", "--clean-dirty"])
+    assert rc == 0
+    porcelain.assert_not_called()  # state guard decides before reading dirt
+    confirm.assert_not_called()
+    assert not any(c[:1] == ("worktree",) for c in calls)
+    assert not any(c[:2] == ("branch", "-D") for c in calls)
+    out = capsys.readouterr().out
+    assert "refusing feature/286-reused" in out
+    assert "reused" in out
+
+
+def test_clean_dirty_decline_leaves_worktree_and_surfaces(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Declining the confirmation leaves the worktree untouched and still
+    surfaced as needing attention. This status carries no detail, exercising
+    the fallback description in the surfaced report."""
+    _make_profile(tmp_path, "library-release")
+    status = _stuck_status(tmp_path, detail=None)
+    with (
+        _sweep_with_stuck(tmp_path, status) as calls,
+        patch(_MOD + "._worktree_porcelain", return_value="?? out.log\n"),
+        patch(_MOD + ".confirm", return_value=False),
+    ):
+        rc = main(["--cleanup-only", "--clean-dirty"])
+    assert rc == 0
+    assert not any(c[:1] == ("worktree",) for c in calls)
+    out = capsys.readouterr().out
+    assert "left feature/9-x in place" in out
+    assert "needs attention" in out
+    assert "merged, not removable" in out  # detail=None → fallback
+
+
+def test_clean_dirty_dry_run_shows_plan_without_removing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--clean-dirty --dry-run shows what would be deleted and neither prompts
+    nor removes anything."""
+    _make_profile(tmp_path, "library-release")
+    status = _stuck_status(tmp_path)
+    with (
+        _sweep_with_stuck(tmp_path, status) as calls,
+        patch(_MOD + "._worktree_porcelain", return_value="?? out.log\n"),
+        patch(_MOD + ".confirm") as confirm,
+    ):
+        rc = main(["--cleanup-only", "--clean-dirty", "--dry-run"])
+    assert rc == 0
+    confirm.assert_not_called()
+    assert not any(c[:1] == ("worktree",) for c in calls)
+    out = capsys.readouterr().out
+    assert "would remove the worktree and:" in out
+    assert "[dry-run] git worktree remove --force" in out
+
+
+def test_clean_dirty_reads_porcelain_from_worktree_path() -> None:
+    """_worktree_porcelain shells git into the worktree and returns its
+    porcelain; a git failure yields '' so the caller refuses (safe default)."""
+    from vergil_tooling.bin.vrg_finalize_pr import _worktree_porcelain
+
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=0, stdout="?? out.log\n"),
+    ):
+        assert _worktree_porcelain(Path("/wt")) == "?? out.log\n"
+    with patch(
+        _MOD + ".subprocess.run",
+        return_value=CompletedProcess(args=(), returncode=128, stdout=""),
+    ):
+        assert _worktree_porcelain(Path("/wt")) == ""
 
 
 # -- --release: chain into vrg-release after a clean finalize (issue #1634) ----


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-finalize-pr now reports merged/closed worktrees it could not remove prominently after the pipeline (instead of burying the reason in the collapsed stage log), and adds an opt-in --clean-dirty path that clears a merged worktree dirtied solely by untracked build output after confirmation, while refusing modified tracked files and reused-branch stragglers.

## Issue Linkage

- Closes #2348

## Notes

- Builds on #2347: reuses WorktreeStatus.needs_attention/detail from gather_worktree_status rather than reclassifying. Change 1 collects stuck worktrees in _stage_cleanup into FinalizeContext.stuck and surfaces them from main() after run_pipeline (real stdio, escaping the collapsed log). Change 2 (--clean-dirty) runs post-pipeline so its confirmation prompt reaches the human; guards: only MERGED/CLOSED state (a reused branch classifies as NO_PR/DRAFT and is excluded, protecting unmerged commits), only when every porcelain line is '??' (untracked), each removal shown and confirmed. Reuses _delete_branch_and_worktree with a new force=True flag (git worktree remove --force) rather than duplicating removal logic; default force=False keeps the existing dirty-worktree guard. Docs updated in reference/dev/finalize-pr.md incl. the gitignore-your-validation-output tip. Validation 100% green (4287 passed, 100% coverage).