### PR TITLE
docs(pr-lifecycle): document the report-ready freeze contract and honest worktree hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,39 @@ finalization are human actions. The PR handoff is:
    state file, previews the PR, and submits after confirmation.
 3. The human merges and runs post-merge cleanup (`vrg-finalize-pr`).
 
+**Once you run `report-ready`, the branch is frozen.** `report-ready`
+records the branch as the single, finished deliverable for its issue, so
+until the human submits it must not change. Enforcement is at two
+chokepoints — `vrg-commit` refuses a further commit and the `vrg-git`
+push path refuses a further push — both printing an actionable refusal
+(and a loud DRIFT warning if HEAD has already advanced past the reported
+commit, the reused-branch straggler of epic #146 / issue #1719). The rule
+follows directly from "a task is exactly one PR": more work is a **new
+follow-up issue**, never a change to this branch. Two things stay allowed:
+
+- **Correcting the PR prose** — re-running `report-ready` overwrites the
+  recorded title/summary/notes. That is metadata, not code, so it is not
+  frozen.
+- **Deliberately reopening the branch** — `vrg-pr-workflow unfreeze` drops
+  the workflow back to `implementing` (keeping the recorded metadata) so
+  commits/pushes are allowed again. This is the *only* sanctioned way to
+  lift the freeze; it is a distinct, explicit action precisely so
+  reopening a branch is never a silent side effect. An **already-submitted**
+  branch cannot be unfrozen — its PR exists, so further work is a new
+  follow-up issue, full stop.
+
+When the human finalizes, `vrg-finalize-pr` will not silently strand a
+merged worktree it cannot remove (dirty tree, or a reused branch name with
+unmerged commits): it surfaces every such worktree **prominently after the
+pipeline** with the reason. For the common Mac case — a merged worktree
+dirtied only by un-gitignored build/validation output — `--clean-dirty` is
+an opt-in that clears exactly that after showing the untracked paths and
+confirming; it never touches modified tracked files or a reused-branch
+straggler's unmerged commits. The cleaner fix is to gitignore that output
+in the first place, so the worktree is never dirtied and sweeps
+automatically — consuming repos should keep validation/build artifacts out
+of the tree.
+
 ### Cloud session prompt contract (off-platform VMs)
 
 The PR handoff above assumes the agent and the human share one

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -251,6 +251,15 @@ Add `.worktrees/` to your `.gitignore`:
 echo '.worktrees/' >> .gitignore
 ```
 
+!!! tip "Gitignore your validation/build output too"
+    Also keep validation and build artifacts (coverage reports, compiled
+    output, cache dirs, temporary venvs) out of the tree via `.gitignore`.
+    Un-gitignored output dirties a worktree, and a *merged* worktree left
+    dirty is one `vrg-finalize-pr` cannot auto-remove — it surfaces as
+    **needs-attention** in `vrg-worktree-status` and requires the opt-in
+    `--clean-dirty` (or a manual clean) to clear. Gitignoring the output
+    up front means merged worktrees sweep automatically.
+
 Add a `## Parallel AI agent development` section to your
 `CLAUDE.md`. Every managed repo has one you can copy — they differ
 only in the repo name and example issue number. The canonical text

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -132,7 +132,6 @@ full flag list.
 vrg-submit-pr \
   --issue 42 \
   --summary "Add LRU cache to pipeline" \
-  --linkage Fixes \
   --notes "$(cat /tmp/pr-notes.txt)"
 ```
 
@@ -154,6 +153,18 @@ vrg-submit-pr \
     [vergil-tooling#268](https://github.com/vergil-project/vergil-tooling/issues/268).
 
 See the [vrg-submit-pr reference](../reference/dev/submit-pr.md).
+
+!!! note "Agent handoff and the post-report-ready freeze"
+    In an agent session, submission is a **human** action. The agent
+    instead runs `vrg-pr-workflow report-ready` to record the PR
+    metadata in `.vergil/pr-workflow.json`, then stops; the human runs
+    `vrg-submit-pr`. Recording ready **freezes the branch**: `vrg-commit`
+    and the `vrg-git` push path refuse further commits/pushes on it,
+    because a task is exactly one PR and more work is a new follow-up
+    issue. Correcting the PR prose (re-running `report-ready`) is still
+    allowed; deliberately reopening the branch needs
+    `vrg-pr-workflow unfreeze`. See the tool's entry in the
+    [CLI Tools Overview](../reference/cli-tools-overview.md#vrg-pr-workflow).
 
 ### 4. Wait for review, merge manually
 
@@ -179,6 +190,15 @@ This:
 Run this immediately after the PR merges. A Stop hook in the plugin
 will remind you if you try to end the session with an unsubmitted
 or unfinalized PR still dangling.
+
+A merged worktree the sweep cannot remove (a dirty tree, or a reused
+branch name with unmerged commits) is not deleted silently —
+`vrg-finalize-pr` surfaces it **prominently after the pipeline** so it
+is impossible to miss, and `vrg-worktree-status` counts it under
+**needs-attention** rather than hiding it as active. When the only dirt
+is un-gitignored build/validation output, `--clean-dirty` clears it
+after confirmation; better still, gitignore that output so the worktree
+sweeps automatically.
 
 See the [vrg-finalize-pr reference](../reference/dev/finalize-pr.md).
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -34,7 +34,7 @@ and opens a PR with a populated template body.
 | Attribute | Value |
 |---|---|
 | Source | `vergil_tooling.bin.vrg_submit_pr` |
-| Args | `--issue` (required), `--summary` (required), `--linkage` (default: Fixes), `--notes`, `--title`, `--dry-run` |
+| Args | `--issue` (required), `--summary` (required), `--linkage` (default: Ref; `vrg-submit-pr` auto-selects `Closes` for a managed task — `Fixes`/`Resolves` are banned), `--notes`, `--title`, `--dry-run` |
 | Preconditions | Git repo, `gh` CLI on PATH |
 | Failure mode | Subprocess error from `git push` or `gh pr create` |
 | Exit codes | 0 success |
@@ -55,6 +55,29 @@ standards failures during the pr-watch reconcile loop (denied to the
 | Preconditions | Git repo, `gh` CLI on PATH, PR open, agent identities on the PR's head branch |
 | Failure mode | `SystemExit`/diagnostic on identity, scope, or state rejection |
 | Exit codes | 0 success, 1 rejection or error |
+| Status | Active |
+
+### vrg-pr-workflow
+
+Record and manage the PR handoff state in `.vergil/pr-workflow.json` —
+the oracle `vrg-submit-pr` reads. `report-ready` writes the PR metadata
+(`--issue/--title/--summary/--notes`, optional `--linkage`) and marks the
+branch **ready**; it is idempotent — re-running overwrites the recorded
+prose (correcting the title/summary/notes is always allowed). Reaching
+**ready** *freezes* the branch: `vrg-commit` and the `vrg-git` push path
+then refuse further commits/pushes, because a task is exactly one PR and
+more work is a new follow-up issue (epic #146). `unfreeze` is the only
+sanctioned way to reopen a still-unsubmitted branch — it drops the state
+back to `implementing` while keeping the metadata; an already-submitted
+branch cannot be unfrozen. `status` prints the current state.
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_pr_workflow` |
+| Args | `report-ready` (`--issue`, `--title`, `--summary`, `--notes` required; `--linkage` default Ref), `unfreeze`, `status`; global `--base` (default: origin/develop) |
+| Preconditions | Git repo; run from the worktree whose branch is being staged |
+| Failure mode | `WorkflowError` on stderr (e.g. unfreeze after submit, or nothing to unfreeze) |
+| Exit codes | 0 success, 1 error |
 | Status | Active |
 
 ### vrg-merge-when-green
@@ -93,12 +116,18 @@ Finalize a pull request. Given a PR, runs the provenance check, merges
 it, then cleans up; with no PR, runs cleanup only. Cleanup switches to
 the target branch, fast-forward pulls, deletes merged local branches
 (auto-removing worktrees inside `.worktrees/` when necessary), prunes
-remotes, runs validation, and checks the CD workflow status.
+remotes, runs validation, and checks the CD workflow status. A
+merged/closed worktree the sweep cannot remove — a dirty tree, or a
+reused branch name with unmerged commits (issue #1719) — is surfaced
+**prominently after the pipeline** rather than buried in the stage log;
+`--clean-dirty` opt-in clears one whose only dirt is untracked
+build/validation output, after showing the paths and confirming
+(issue #2348).
 
 | Attribute | Value |
 |---|---|
 | Source | `vergil_tooling.bin.vrg_finalize_pr` |
-| Args | `PR` (optional), `--target-branch` (default: develop), `--strategy` (default: squash), `--allow-provenance-violation`, `--dry-run` |
+| Args | `PR` (optional), `--target-branch` (default: develop), `--strategy` (default: squash), `--allow-provenance-violation`, `--clean-dirty`, `--dry-run` |
 | Preconditions | Must run from the main worktree, `vrg-container-run` on PATH |
 | Failure mode | Provenance violations, a dirty working tree, validation failures, or a failed CD run all return exit 1 |
 | Exit codes | 0 success, 1 provenance/worktree/validation/CD failure or unrecognized branching model |
@@ -111,7 +140,13 @@ state, so removable cruft (merged/closed PRs whose worktree was never
 cleaned up) is distinguishable from in-flight work at a glance.
 Read-only — cleanup stays `vrg-finalize-pr`'s job. PR state is queried
 from GitHub per worktree; a failed lookup shows as `unknown` with the
-reason rather than being silently downgraded.
+reason rather than being silently downgraded. The summary counts fall
+into disjoint buckets — **active**, **needs-attention**, **stalled
+(no-pr)**, and **cruft (removable)**. A finished-but-stuck worktree
+(merged/closed but not removable: dirty, or a reused branch name whose
+merged verdict was withheld, issue #1719) is counted under
+**needs-attention** with an actionable note, never miscounted as active
+behind a "0 cruft" message (issue #2347).
 
 | Attribute | Value |
 |---|---|

--- a/docs/specs/worktree-convention.md
+++ b/docs/specs/worktree-convention.md
@@ -184,8 +184,12 @@ vrg-finalize-pr                                # handles branch delete,
 
 `vrg-finalize-pr` removes the worktree for each merged branch when that
 worktree lives under the canonical `.worktrees/` directory (skipping any
-with uncommitted changes). If you need to remove one by hand, the raw
-git procedure is:
+with uncommitted changes). A merged worktree it cannot remove — dirty, or
+a reused branch name with unmerged commits — is not dropped silently: it
+is surfaced prominently after the pipeline and counted under
+`needs-attention` by `vrg-worktree-status`, and `--clean-dirty` can clear
+one dirtied only by untracked build output (issues #2347, #2348). If you
+need to remove one by hand, the raw git procedure is:
 
 ```bash
 cd ~/dev/github/<project>


### PR DESCRIPTION
# Pull Request

## Summary

- Sweep vergil-tooling docs to reflect epic #146's PR-lifecycle and worktree-hygiene changes: the post-report-ready branch freeze, the vrg-worktree-status needs-attention bucket, and the vrg-finalize-pr stuck-worktree surfacing / --clean-dirty behavior.

## Issue Linkage

- Closes #2349

## Notes

- Grounded in the merged code on develop (freeze.py, worktrees.py, vrg_finalize_pr.py, vrg_pr_workflow.py). finalize-pr.md was already updated by #2348 and left as-is (verified consistent). Also fixed a genuine stale pointer unrelated additions surfaced: the vrg-submit-pr --linkage default was documented as the banned 'Fixes' in cli-tools-overview and in a git-workflow example — corrected to Ref. docs/plans and docs/specs point-in-time design docs were left untouched except the canonical/living worktree-convention spec, which got a one-line note so it does not read as a silent skip.