### PR TITLE
feat(pr-workflow): add GitHubTransport relay over refs/vergil/pr-workflow

### DIFF
--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -71,6 +71,29 @@ def read_output(*args: str) -> str:
     return result.stdout.strip()
 
 
+def read_output_stdin(stdin: str, *args: str) -> str:
+    """Run a git command feeding *stdin*, and return stripped stdout.
+
+    The stdin sibling of ``read_output``, for plumbing that reads its payload
+    from standard input (``hash-object --stdin``, ``mktree``) rather than argv.
+    """
+    env = _git_env(args)
+    try:
+        result = subprocess.run(  # noqa: S603
+            ("git", *args),  # noqa: S607
+            check=True,
+            text=True,
+            capture_output=True,
+            input=stdin,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.stderr:
+            print(exc.stderr, end="", file=sys.stderr)
+        raise
+    return result.stdout.strip()
+
+
 def repo_root() -> Path:
     """Return the repository root directory."""
     return Path(read_output("rev-parse", "--show-toplevel"))

--- a/src/vergil_tooling/lib/pr_workflow/github_transport.py
+++ b/src/vergil_tooling/lib/pr_workflow/github_transport.py
@@ -1,0 +1,85 @@
+"""The GitHub-ref transport: relay pr-workflow.json over a reserved git ref.
+
+Carries the workflow state across filesystems (a cloud VM and the Mac never
+share a disk) via the reserved ref ``refs/vergil/pr-workflow/<branch>``. Nested
+slashes are valid, so ``feature/123-x`` maps to
+``refs/vergil/pr-workflow/feature/123-x``; the namespace is invisible to the
+branch/PR UI and to default fetch refspecs, so it never pollutes history.
+
+The ref points at a **single-file commit** holding ``pr-workflow.json`` — GitHub
+rejects a ref that does not resolve to a commit. ``write`` builds that commit
+entirely **out-of-band** with git plumbing (``hash-object`` -> ``mktree`` ->
+``commit-tree``) and force-pushes the resulting SHA straight to the ref. It
+never runs ``git commit`` and never touches HEAD, the index, or the working
+tree, so the push is a pure ref write. That freeze-neutrality is load-bearing:
+``report-ready`` arms the post-report freeze (epic #146), and a normal commit
+would advance the feature branch out from under it (design
+2026-06-24-cloud-pr-handoff, Deliverable B).
+"""
+
+from __future__ import annotations
+
+from vergil_tooling.lib import git
+from vergil_tooling.lib.pr_workflow.state import WorkflowState
+from vergil_tooling.lib.pr_workflow.transport import Transport
+
+_FILE = "pr-workflow.json"
+_REF_PREFIX = "refs/vergil/pr-workflow"
+_COMMIT_MESSAGE = "vergil: pr-workflow relay"
+# The regular-file mode git uses for a blob entry in a tree.
+_BLOB_MODE = "100644"
+
+
+class GitHubTransport(Transport):
+    """Relay the workflow state over ``refs/vergil/pr-workflow/<branch>``."""
+
+    def __init__(
+        self, branch: str, *, base: str = "origin/develop", remote: str = "origin"
+    ) -> None:
+        self.branch = branch
+        self.base = base
+        self.remote = remote
+
+    @property
+    def ref(self) -> str:
+        """The reserved ref carrying this branch's workflow payload."""
+        return f"{_REF_PREFIX}/{self.branch}"
+
+    def _remote_ref_exists(self) -> bool:
+        """Return True when the relay ref is present on the remote."""
+        return bool(git.read_output("ls-remote", self.remote, self.ref))
+
+    def read(self) -> WorkflowState | None:
+        """Fetch the relay ref and parse its payload; None if the ref is absent."""
+        if not self._remote_ref_exists():
+            return None
+        # Fetch into FETCH_HEAD only — a read that never writes a local ref and
+        # never touches HEAD/index/worktree.
+        git.read_output("fetch", self.remote, self.ref)
+        return WorkflowState.from_json(git.read_output("show", f"FETCH_HEAD:{_FILE}"))
+
+    def write(self, state: WorkflowState) -> None:
+        """Build the single-file commit out-of-band and force-push it to the ref.
+
+        INVARIANT: never runs ``git commit``; never mutates HEAD, the index, or
+        the working tree. The blob/tree/commit are built with plumbing and the
+        push targets only the reserved ref, keeping the write freeze-neutral.
+        """
+        blob = git.read_output_stdin(state.to_json(), "hash-object", "-w", "--stdin")
+        tree = git.read_output_stdin(f"{_BLOB_MODE} blob {blob}\t{_FILE}\n", "mktree")
+        commit = git.read_output("commit-tree", tree, "-m", _COMMIT_MESSAGE)
+        git.run("push", "--force", self.remote, f"{commit}:{self.ref}")
+
+    def delete(self) -> None:
+        """Remove the relay ref from the remote; a no-op when it is absent."""
+        if not self._remote_ref_exists():
+            return
+        git.run("push", self.remote, f":{self.ref}")
+
+    def head_sha(self) -> str:
+        """Return the current HEAD commit SHA."""
+        return git.commit_sha("HEAD")
+
+    def merge_base(self) -> str:
+        """Return the merge-base SHA of the base ref and HEAD."""
+        return git.read_output("merge-base", self.base, "HEAD")

--- a/tests/vergil_tooling/pr_workflow/test_github_transport.py
+++ b/tests/vergil_tooling/pr_workflow/test_github_transport.py
@@ -1,0 +1,125 @@
+"""GitHubTransport relay over ``refs/vergil/pr-workflow/<branch>`` (#2366).
+
+Exercised against a throwaway local bare remote + clone, so no network or real
+GitHub App is involved. ``GitHubTransport`` shells out through ``lib/git``,
+which runs git in the process CWD; the fixture ``chdir``s into the clone.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vergil_tooling.lib.pr_workflow.github_transport import GitHubTransport
+from vergil_tooling.lib.pr_workflow.state import WorkflowState
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_BRANCH = "feature/2366-x"
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.run(  # noqa: S603
+        ("git", *args),  # noqa: S607
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def clone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A clone wired to a bare origin, with ``develop`` pushed and CWD set to it."""
+    remote = tmp_path / "remote.git"
+    clone = tmp_path / "clone"
+    _git("init", "--bare", str(remote), cwd=tmp_path)
+    _git("init", str(clone), cwd=tmp_path)
+    _git("config", "user.name", "Test", cwd=clone)
+    _git("config", "user.email", "test@example.com", cwd=clone)
+    _git("remote", "add", "origin", str(remote), cwd=clone)
+    (clone / "README.md").write_text("hi\n")
+    _git("add", ".", cwd=clone)
+    _git("commit", "-m", "init", cwd=clone)
+    _git("branch", "-M", "develop", cwd=clone)
+    _git("push", "origin", "develop", cwd=clone)
+    _git("fetch", "origin", cwd=clone)
+    monkeypatch.chdir(clone)
+    return clone
+
+
+def _state(head: str = "bbb") -> WorkflowState:
+    return WorkflowState(
+        issue="2366",
+        branch=_BRANCH,
+        base="origin/develop",
+        status="ready",
+        created_at="2026-07-14T00:00:00Z",
+        updated_at="2026-07-14T00:00:00Z",
+        git={"base_sha": "aaa", "head_sha": head},
+    )
+
+
+def test_ref_derives_from_branch() -> None:
+    transport = GitHubTransport("feature/9-y")
+    assert transport.ref == "refs/vergil/pr-workflow/feature/9-y"
+
+
+def test_read_returns_none_when_ref_absent(clone: Path) -> None:
+    assert GitHubTransport(_BRANCH).read() is None
+
+
+def test_write_then_read_round_trips(clone: Path) -> None:
+    transport = GitHubTransport(_BRANCH)
+    transport.write(_state())
+    assert transport.read() == _state()
+
+
+def test_write_is_a_pure_ref_write_leaving_head_index_worktree_untouched(
+    clone: Path,
+) -> None:
+    """The freeze-neutral invariant: write() must not run ``git commit`` or
+    otherwise mutate HEAD, the index, or the working tree."""
+    head_before = _git("rev-parse", "HEAD", cwd=clone)
+    status_before = _git("status", "--porcelain", cwd=clone)
+
+    GitHubTransport(_BRANCH).write(_state())
+
+    assert _git("rev-parse", "HEAD", cwd=clone) == head_before
+    assert _git("status", "--porcelain", cwd=clone) == status_before
+    # And the ref landed on the remote — the write really happened, out-of-band.
+    assert _git("ls-remote", "origin", GitHubTransport(_BRANCH).ref, cwd=clone)
+
+
+def test_write_force_overwrites_existing_ref(clone: Path) -> None:
+    transport = GitHubTransport(_BRANCH)
+    transport.write(_state(head="first"))
+    transport.write(_state(head="second"))
+    read = transport.read()
+    assert read is not None
+    assert read.git["head_sha"] == "second"
+
+
+def test_delete_removes_the_ref(clone: Path) -> None:
+    transport = GitHubTransport(_BRANCH)
+    transport.write(_state())
+    transport.delete()
+    assert transport.read() is None
+
+
+def test_delete_is_a_noop_when_ref_absent(clone: Path) -> None:
+    # No ref was ever written; delete must not raise.
+    GitHubTransport(_BRANCH).delete()
+    assert GitHubTransport(_BRANCH).read() is None
+
+
+def test_head_sha_returns_current_head(clone: Path) -> None:
+    assert GitHubTransport(_BRANCH).head_sha() == _git("rev-parse", "HEAD", cwd=clone)
+
+
+def test_merge_base_resolves_against_base(clone: Path) -> None:
+    expected = _git("merge-base", "origin/develop", "HEAD", cwd=clone)
+    assert GitHubTransport(_BRANCH).merge_base() == expected

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -86,6 +86,42 @@ def test_read_output_returns_stripped_stdout() -> None:
     assert "GIT_CONFIG_KEY_0" not in kwargs["env"]
 
 
+def test_read_output_stdin_feeds_stdin_and_returns_stripped_stdout() -> None:
+    with patch("vergil_tooling.lib.git.subprocess.run") as mock_run:
+        mock_run.return_value = _completed(stdout="  blobsha  \n")
+        result = git.read_output_stdin("payload", "hash-object", "-w", "--stdin")
+    assert result == "blobsha"
+    _args, kwargs = mock_run.call_args
+    assert _args[0] == ("git", "hash-object", "-w", "--stdin")
+    assert kwargs["input"] == "payload"
+    assert kwargs["check"] is True
+    assert kwargs["capture_output"] is True
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_read_output_stdin_prints_stderr_on_error(capsys: pytest.CaptureFixture[str]) -> None:
+    err = subprocess.CalledProcessError(1, "git mktree", stderr="fatal: bad tree\n")
+    err.stdout = ""
+    with (
+        patch("vergil_tooling.lib.git.subprocess.run", side_effect=err),
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        git.read_output_stdin("spec", "mktree")
+    assert "bad tree" in capsys.readouterr().err
+
+
+def test_read_output_stdin_error_no_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    err = subprocess.CalledProcessError(1, "git mktree")
+    err.stderr = ""
+    err.stdout = ""
+    with (
+        patch("vergil_tooling.lib.git.subprocess.run", side_effect=err),
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        git.read_output_stdin("spec", "mktree")
+    assert capsys.readouterr().err == ""
+
+
 def test_repo_root_returns_path() -> None:
     with patch("vergil_tooling.lib.git.read_output", return_value="/var/repo"):  # noqa: S108
         result = git.repo_root()


### PR DESCRIPTION
# Pull Request

## Summary

- Add GitHubTransport carrying pr-workflow.json across filesystems via the reserved ref refs/vergil/pr-workflow/<branch>, building the payload commit out-of-band so the write stays freeze-neutral.

## Issue Linkage

- Closes #2366

## Notes

- Task 2 of epic vergil-project/.github#148. Scope is only the transport (read/write/delete + head_sha/merge_base); config selection, oracle handoff, drift guard, and vrg-submit-pr integration are separate tasks. write() builds the single-file commit via git plumbing (hash-object -> mktree -> commit-tree) and force-pushes the SHA directly to the ref, never running git commit and never touching HEAD/index/worktree; the freeze-neutral invariant test asserts rev-parse HEAD and status --porcelain are unchanged after write(). delete() is a no-op when the ref is absent. Tested against a throwaway local bare-remote+clone fixture; 100% coverage, full validation green.