### PR TITLE
feat(pr-workflow): report-ready always pushes the relay ref

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -13,6 +13,7 @@ import json
 import subprocess
 import sys
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import epics, git, github
 from vergil_tooling.lib.linkage import (
@@ -24,7 +25,9 @@ from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
 from vergil_tooling.lib.pr_workflow.github_transport import GitHubTransport
 from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
-from vergil_tooling.lib.pr_workflow.state import WorkflowState
+
+if TYPE_CHECKING:
+    from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
 
 def _now() -> str:

--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -8,6 +8,7 @@ and ``vrg-submit-pr`` (human-run) reads it. ``status`` prints the current state.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import subprocess
 import sys
@@ -21,7 +22,9 @@ from vergil_tooling.lib.linkage import (
 )
 from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
+from vergil_tooling.lib.pr_workflow.github_transport import GitHubTransport
 from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
+from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
 
 def _now() -> str:
@@ -103,6 +106,32 @@ def _reject_operational_issue(issue: str) -> None:
         )
 
 
+def _push_relay_ref(state: WorkflowState, base: str) -> None:
+    """Mirror the ready state onto the reserved relay ref, after the local write.
+
+    Unconditional by design (Task 3, epic vergil-project/.github#148): every
+    ``report-ready`` also force-pushes the state to
+    ``refs/vergil/pr-workflow/<branch>`` via ``GitHubTransport`` — no
+    off-platform detection — so a cloud VM's report-ready is visible to the Mac
+    that later runs ``vrg-submit-pr`` (the two never share a disk). The durable
+    local file has already been written and stays put; a push failure is
+    therefore surfaced loudly on stderr but never rolls the local state back.
+
+    ``report-ready`` speaks a JSON-on-stdout contract, so the relay push's git
+    chatter is redirected to stderr — where "loud" belongs — keeping stdout a
+    pure JSON document whether the push succeeds or fails.
+    """
+    relay = GitHubTransport(git.current_branch(), base=base)
+    try:
+        with contextlib.redirect_stdout(sys.stderr):
+            relay.write(state)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(
+            f"warning: could not push pr-workflow relay ref {relay.ref}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
     _reject_cross_repo_issue(str(args.issue))
     _reject_epic_issue(str(args.issue))
@@ -140,6 +169,7 @@ def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) ->
         now=_now(),
     )
     transport.write(state)
+    _push_relay_ref(state, args.base)
     response: dict[str, object] = {"ok": True, "status": state.status}
     if linkage_warning:
         response["warning"] = linkage_warning

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -75,6 +75,83 @@ def test_report_ready_initializes_and_records(
     assert state["pr_metadata"]["title"] == "t"
 
 
+def test_report_ready_pushes_relay_ref(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Task 3 (#2367): report-ready always mirrors the ready state onto the relay
+    # ref via GitHubTransport, in addition to the local file write. The trigger
+    # is unconditional (no off-platform detection).
+    with patch("vergil_tooling.bin.vrg_pr_workflow.GitHubTransport") as mock_transport:
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "status": "ready"}
+    # The relay was written with the ready state, after the local write.
+    mock_transport.assert_called_once()
+    write = mock_transport.return_value.write
+    write.assert_called_once()
+    (pushed_state,) = write.call_args.args
+    assert pushed_state.status == "ready"
+    assert pushed_state.pr_metadata is not None
+    assert pushed_state.pr_metadata["title"] == "t"
+    # And the durable local file was written too.
+    assert (in_git_repo / ".vergil" / "pr-workflow.json").is_file()
+
+
+def test_report_ready_relay_push_failure_surfaces_but_local_persists(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A relay push failure surfaces loudly on stderr but never undoes the durable
+    # local write (which happens first and stays): report-ready still succeeds
+    # and .vergil/pr-workflow.json still holds the ready state.
+    with patch("vergil_tooling.bin.vrg_pr_workflow.GitHubTransport") as mock_transport:
+        mock_transport.return_value.ref = "refs/vergil/pr-workflow/feature/42-x"
+        mock_transport.return_value.write.side_effect = subprocess.CalledProcessError(
+            1, ("git", "push")
+        )
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "42",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    captured = capsys.readouterr()
+    # Local write is durable: the command still succeeds and stdout is unchanged.
+    assert rc == 0
+    assert json.loads(captured.out) == {"ok": True, "status": "ready"}
+    # The push failure surfaced loudly on stderr.
+    assert "warning" in captured.err.lower()
+    assert "relay ref" in captured.err.lower()
+    # And the local state file persists with the ready metadata.
+    state_path = in_git_repo / ".vergil" / "pr-workflow.json"
+    assert state_path.is_file()
+    persisted = json.loads(state_path.read_text())
+    assert persisted["status"] == "ready"
+    assert persisted["pr_metadata"]["title"] == "t"
+
+
 def test_report_ready_rejects_epic(in_git_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
     # Guard parity with vrg-submit-pr: report-ready refuses an epic linkage at
     # the point the value is entered, instead of only failing later at submit.


### PR DESCRIPTION
# Pull Request

## Summary

- report-ready now unconditionally mirrors the ready state onto the reserved relay ref via GitHubTransport after the durable local write, so a cloud VM's report-ready reaches the Mac that runs vrg-submit-pr.

## Issue Linkage

- Closes #2367

## Notes

- After the LocalFileTransport write, cmd_report_ready calls GitHubTransport(current_branch, base=base).write(state) unconditionally (no off-platform detection). The local write happens first and stays; a push failure is caught (CalledProcessError/OSError) and surfaced loudly on stderr as a warning without rolling back the local state (report-ready still exits 0). The relay push's git chatter is redirected to stderr so report-ready's JSON-on-stdout contract stays intact. Two new e2e tests cover ref-written-on-report-ready and push-failure-surfaces-while-local-persists; module coverage 100%; full vrg-validate green. Task 3 of epic vergil-project/.github#148.