### PR TITLE
refactor(submit-pr): shared PR-open core + worktree-free relay branch-list path

### DIFF
--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -1,16 +1,26 @@
 """PR submission wrapper that constructs standards-compliant PR bodies.
 
-Supports two modes:
-- **Template mode** (no CLI args): reads the PR workflow state file
+Supports three modes:
+- **Template mode** (no args): reads the PR workflow state file
   (``.vergil/pr-workflow.json``); shows a summary, prompts for
   confirmation, pushes the branch, and creates the PR.
-- **CLI argument mode** (args provided): existing direct invocation
-  for human emergency use.
+- **CLI argument mode** (``--issue``/``--summary``/``--title``): existing
+  direct invocation for human emergency use.
+- **Relay branch mode** (positional ``branches``): opens PRs for
+  branches that are already on origin, worktree-free (issue #2368). Each
+  branch's ready-state is resolved from a local worktree's
+  ``pr-workflow.json`` when one exists, else the relay ref
+  (``GitHubTransport``); origin's tip is verified against the recorded
+  ``head_sha`` and the PR is opened **without** pushing (``--head`` names
+  the source branch). This is the Mac-side of the cloud→Mac relay handoff:
+  the branch and its metadata already rode GitHub, so no worktree, no
+  ``git.current_branch()``, and no push are involved.
 
-Both modes ensure the branch is pushed using the human's host
+The template and CLI modes push the branch using the human's host
 credentials before creating the PR. Because the human is the superset
 of any agent's rights, this carries workflow-touching pushes that the
-agent's own credentials would be rejected for.
+agent's own credentials would be rejected for. The relay mode never
+pushes — the branch is already on origin.
 
 Agent identities are blocked — PR submission is a Chief Steward
 (human) operation.
@@ -42,6 +52,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import epics, git, github, identity_mode, worktrees
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
@@ -49,11 +60,24 @@ from vergil_tooling.lib.linkage import ALLOWED_LINKAGES, normalize_linkage
 from vergil_tooling.lib.pr_body import build_pr_body, resolve_issue_ref
 from vergil_tooling.lib.pr_workflow import batch, submission
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
+from vergil_tooling.lib.pr_workflow.github_transport import GitHubTransport
+from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
+
+if TYPE_CHECKING:
+    from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Create a standards-compliant pull request.")
+    parser.add_argument(
+        "branches",
+        nargs="*",
+        help="Relay path: one or more branches (already on origin) to open PRs "
+        "for, worktree-free. Each branch's ready-state is resolved from a local "
+        "worktree's pr-workflow.json when present, else the relay ref. With no "
+        "branch arguments, the local-worktree flow runs unchanged.",
+    )
     parser.add_argument(
         "--issue", default=None, help="Issue reference: number or owner/repo#number"
     )
@@ -144,12 +168,12 @@ def _push_branch(branch: str) -> None:
         raise SystemExit(msg) from exc
 
 
-def _create_pr(*, target_branch: str, title: str, pr_body: str) -> str:
+def _create_pr(*, target_branch: str, title: str, pr_body: str, head: str | None = None) -> str:
     with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
         f.write(pr_body)
         tmp_path = f.name
     try:
-        pr_url = github.create_pr(base=target_branch, title=title, body_file=tmp_path)
+        pr_url = github.create_pr(base=target_branch, title=title, body_file=tmp_path, head=head)
     finally:
         Path(tmp_path).unlink(missing_ok=True)
     return pr_url
@@ -569,47 +593,84 @@ def _push_create_record(
     return pr_url
 
 
-def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: bool) -> str:
-    """Read the worktree's PR fields, push, create the PR, record it, return URL.
+def _open_pr(
+    branch: str,
+    base: str,
+    metadata: dict[str, str],
+    *,
+    push: bool,
+    dry_run: bool = False,
+    assume_yes: bool = False,
+) -> str | None:
+    """Shared PR-open core: run the standards/provenance guards on the issue,
+    resolve the linkage, build the body, optionally push the branch, and open
+    the PR against *base*. Returns the PR URL (``None`` on a dry run).
 
-    Self-contained submit for one worktree, used by the batch orchestrator.
-    Propagates ``AlreadySubmittedError`` / ``FileNotFoundError`` /
-    ``WorkflowError`` from the field reader and raises ``SystemExit`` on a
-    forbidden linkage or a declined confirm. The per-PR
-    confirm is pre-answered when *assume_yes* — the batch path passes True so
-    the single up-front batch confirm is the only gate (issue #1673).
+    This is the seam both the local worktree batch and the worktree-free relay
+    path build on. It takes *branch* / *base* / *metadata* as given — it never
+    reads ``git.current_branch()`` nor looks a worktree up — so the relay path
+    can drive it for a branch that is not checked out anywhere locally. *push*
+    is the one behavioral fork: the local path pushes the branch first
+    (``push=True``); the relay path skips it (``push=False``) because the branch
+    is already on origin, and passes ``--head`` so ``gh`` opens the PR for the
+    right branch from outside its worktree.
+
+    Raises ``SystemExit`` on a forbidden linkage or a declined confirm.
     """
-    fields = submission.read_pr_fields(worktree_root)
-    issue_ref = resolve_issue_ref(fields["issue"])
+    issue_ref = resolve_issue_ref(metadata["issue"])
     _reject_if_cross_repo(issue_ref)
     _reject_if_epic_link(issue_ref)
     _reject_if_operational_task(issue_ref)
-    branch = git.current_branch()
-    target = _target_branch(base_override, fields.get("base"))
     try:
-        linkage, linkage_warning = normalize_linkage(fields.get("linkage", "Ref"))
+        linkage, linkage_warning = normalize_linkage(metadata.get("linkage", "Ref"))
     except ValueError as exc:
         raise SystemExit(f"vrg-submit-pr: {exc}") from exc
     if linkage_warning:
         print(f"vrg-submit-pr: {linkage_warning}", file=sys.stderr)
     linkage = _resolve_linkage(issue_ref, linkage)
     pr_body = build_pr_body(
-        summary=fields["summary"],
+        summary=metadata["summary"],
         linkage=linkage,
         issue_ref=issue_ref,
-        notes=fields.get("notes", ""),
+        notes=metadata.get("notes", ""),
     )
-    print(f"=== Submitting issue {issue_ref}: {fields['title']} ===")
-    print(f"    base {target}, branch {branch}")
+    print(f"=== Submitting issue {issue_ref}: {metadata['title']} ===")
+    print(f"    base {base}, branch {branch}")
+    print(f"\n=== Body Preview ===\n{pr_body}")
+    if dry_run:
+        return None
     if not confirm("\nSubmit this PR?", assume_yes=assume_yes):
         raise SystemExit("vrg-submit-pr: submission declined at the per-PR confirm")
-    return _push_create_record(
-        worktree_root=worktree_root,
-        branch=branch,
-        target=target,
-        title=fields["title"],
-        pr_body=pr_body,
-    )
+    if push:
+        print(f"Ensuring branch '{branch}' is pushed to origin...")
+        _push_branch(branch)
+    print("Creating PR...")
+    pr_url = _create_pr(target_branch=base, title=metadata["title"], pr_body=pr_body, head=branch)
+    print(f"PR created: {pr_url}")
+    return pr_url
+
+
+def _submit_one(worktree_root: Path, *, base_override: str | None, assume_yes: bool) -> str:
+    """Read the worktree's PR fields, push, create the PR, record it, return URL.
+
+    Self-contained submit for one worktree, used by the batch orchestrator. The
+    push/create/guard flow is the shared :func:`_open_pr` core (``push=True``);
+    this wrapper adds the worktree-specific parts — reading the fields and
+    recording the submission on the local state file. Propagates
+    ``AlreadySubmittedError`` / ``FileNotFoundError`` / ``WorkflowError`` from the
+    field reader and raises ``SystemExit`` on a forbidden linkage or a declined
+    confirm. The per-PR confirm is pre-answered when *assume_yes* — the batch
+    path passes True so the single up-front batch confirm is the only gate
+    (issue #1673).
+    """
+    fields = submission.read_pr_fields(worktree_root)
+    branch = git.current_branch()
+    target = _target_branch(base_override, fields.get("base"))
+    pr_url = _open_pr(branch, target, fields, push=True, assume_yes=assume_yes)
+    if pr_url is None:  # pragma: no cover - the batch path never dry-runs
+        raise SystemExit("vrg-submit-pr: internal error: _open_pr returned no URL")
+    submission.record_submission(worktree_root, pr_url=pr_url)
+    return pr_url
 
 
 def _run_template_mode(args: argparse.Namespace) -> int:
@@ -718,8 +779,120 @@ def _run_template_mode(args: argparse.Namespace) -> int:
     return 0
 
 
+def _metadata_from_state(state: WorkflowState, branch: str) -> dict[str, str]:
+    """Extract the PR-body metadata from a ready ``WorkflowState``.
+
+    Mirrors ``submission.read_pr_fields`` but reads from an in-memory state
+    (which the relay path may have fetched from the ref rather than a local
+    file). Raises ``SystemExit`` when the state carries no PR metadata yet — the
+    USER agent must ``report-ready`` before the branch can be relayed.
+    """
+    meta = state.pr_metadata
+    if meta is None:
+        raise SystemExit(
+            f"vrg-submit-pr: branch '{branch}' has no PR metadata yet; run "
+            "`report-ready` before relaying it."
+        )
+    return {
+        "issue": state.issue,
+        "title": meta["title"],
+        "summary": meta["summary"],
+        "notes": meta.get("notes", ""),
+        "linkage": meta.get("linkage", "Ref"),
+    }
+
+
+def _resolve_ready_state(root: Path, branch: str) -> WorkflowState:
+    """Resolve *branch*'s ready-state for the relay path.
+
+    Prefers a local worktree's ``pr-workflow.json`` when a worktree is checked
+    out on *branch* and carries state; otherwise reads the relay ref
+    (``GitHubTransport``). Raises ``SystemExit`` with an actionable message when
+    neither source has a ready-state.
+    """
+    for wt in worktrees.list_worktrees(root):
+        if wt.branch == branch:
+            local = LocalFileTransport(wt.path).read()
+            if local is not None:
+                return local
+            break
+    remote = GitHubTransport(branch).read()
+    if remote is None:
+        raise SystemExit(
+            f"vrg-submit-pr: no ready-state for branch '{branch}' — no local "
+            "worktree pr-workflow.json and no relay ref on origin. Run "
+            "`report-ready` first."
+        )
+    return remote
+
+
+def _verify_origin_tip(branch: str, state: WorkflowState) -> None:
+    """Refuse to relay unless origin's tip of *branch* matches the ready-state.
+
+    The relay path never pushes — it trusts that origin already carries exactly
+    the commit ``report-ready`` recorded. If the branch moved on origin since
+    then (or was never pushed), the recorded metadata no longer describes the
+    tip, so the submission would be stale. Fail loudly rather than open a PR for
+    the wrong commit.
+    """
+    expected = state.git.get("head_sha")
+    listing = git.read_output("ls-remote", "origin", f"refs/heads/{branch}")
+    if not listing:
+        raise SystemExit(
+            f"vrg-submit-pr: branch '{branch}' is not on origin; a relay submit "
+            "needs the branch already pushed."
+        )
+    origin_sha = listing.split()[0]
+    if origin_sha != expected:
+        raise SystemExit(
+            f"vrg-submit-pr: origin/{branch} tip ({origin_sha[:12]}) does not "
+            f"match the ready-state head_sha ({str(expected)[:12]}). The branch "
+            "moved since `report-ready`; re-run `report-ready` on the current tip "
+            "(or fetch and reconcile) before relaying."
+        )
+
+
+def _run_relay(branches: list[str], args: argparse.Namespace) -> int:
+    """Open PRs for each already-pushed *branch* without a local worktree.
+
+    For every branch: resolve its ready-state (local file preferred, else the
+    relay ref), verify origin's tip matches the recorded ``head_sha``, and drive
+    the shared :func:`_open_pr` core with ``push=False``. Branches already
+    carrying a submitted PR are reported and skipped. Standards/provenance run
+    against the resolved GitHub-carried metadata, exactly as the local path runs
+    them against the worktree's file.
+    """
+    root = Path(git.repo_root())
+    opened = 0
+    for branch in branches:
+        state = _resolve_ready_state(root, branch)
+        if state.submitted is not None:
+            pr_url = state.submitted.get("pr_url", "")
+            print(
+                f"vrg-submit-pr: branch '{branch}' already has a submitted PR ({pr_url}); skipping."
+            )
+            continue
+        metadata = _metadata_from_state(state, branch)
+        base = _target_branch(args.base, state.base)
+        if not args.dry_run:
+            _verify_origin_tip(branch, state)
+        pr_url = _open_pr(
+            branch, base, metadata, push=False, dry_run=args.dry_run, assume_yes=args.yes
+        )
+        if pr_url is None:
+            continue
+        opened += 1
+        print(f"Done. PR URL: {pr_url}")
+        _print_pr_watch(pr_url)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    # Capture the cascade intent before normalization mutates the flags — the
+    # relay path guard below needs to know what the caller actually passed.
+    cascade_requested = args.finalize or args.release or args.install
 
     # --install extends the cascade one link past --release, which itself
     # implies --finalize; normalize once (install ⇒ release ⇒ finalize) so
@@ -736,6 +909,34 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+
+    if args.branches:
+        # Relay path: branches identify the submit. It is deliberately narrow —
+        # it opens PRs worktree-free and hands off to pr-watch, with none of the
+        # local batch's worktree selection or finalize/release cascade.
+        if args.all_worktrees or args.select is not None:
+            print(
+                "vrg-submit-pr: branch arguments select the submit directly and "
+                "cannot be combined with --all/--select.",
+                file=sys.stderr,
+            )
+            return 1
+        if args.issue is not None or args.summary is not None or args.title is not None:
+            print(
+                "vrg-submit-pr: branch arguments cannot be combined with "
+                "--issue/--summary/--title (those drive the single-PR CLI path).",
+                file=sys.stderr,
+            )
+            return 1
+        if cascade_requested:
+            print(
+                "vrg-submit-pr: the relay branch path does not run the "
+                "--finalize/--release/--install cascade; open the PR, then run "
+                "the cascade separately.",
+                file=sys.stderr,
+            )
+            return 1
+        return _run_relay(args.branches, args)
 
     cli_fields = [args.issue, args.summary, args.title]
     has_any = any(f is not None for f in cli_fields)

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -453,9 +453,19 @@ def delete_if_exists(endpoint: str) -> bool:
     return "404" not in first_line
 
 
-def create_pr(*, base: str, title: str, body_file: str) -> str:
-    """Create a pull request and return its URL."""
-    return read_output("pr", "create", "--base", base, "--title", title, "--body-file", body_file)
+def create_pr(*, base: str, title: str, body_file: str, head: str | None = None) -> str:
+    """Create a pull request and return its URL.
+
+    *head* names the source branch explicitly (``gh pr create --head``). It is
+    required when the PR is opened from outside the branch's worktree — the
+    worktree-free relay path in ``vrg-submit-pr`` runs from the main worktree, so
+    ``gh``'s default "current branch" head would be wrong. The in-worktree paths
+    leave it ``None`` and rely on the checked-out branch, unchanged.
+    """
+    args = ["pr", "create", "--base", base, "--title", title, "--body-file", body_file]
+    if head is not None:
+        args += ["--head", head]
+    return read_output(*args)
 
 
 def create_issue(

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -62,9 +62,25 @@ def test_current_org_returns_remote_owner() -> None:
 
 
 def test_create_pr_returns_url() -> None:
-    with patch("vergil_tooling.lib.github.read_output", return_value="https://github.com/pr/1"):
+    with patch(
+        "vergil_tooling.lib.github.read_output", return_value="https://github.com/pr/1"
+    ) as mock_read:
         url = github.create_pr(base="main", title="title", body_file="body.md")
     assert url == "https://github.com/pr/1"
+    assert "--head" not in mock_read.call_args.args
+
+
+def test_create_pr_passes_head_when_given() -> None:
+    """The relay path opens a PR from outside the branch's worktree, so it must
+    pass --head to name the source branch explicitly."""
+    with patch(
+        "vergil_tooling.lib.github.read_output", return_value="https://github.com/pr/2"
+    ) as mock_read:
+        url = github.create_pr(base="main", title="title", body_file="body.md", head="feature/x")
+    assert url == "https://github.com/pr/2"
+    args = mock_read.call_args.args
+    assert "--head" in args
+    assert args[args.index("--head") + 1] == "feature/x"
 
 
 def test_create_issue_returns_url_and_builds_command() -> None:

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -10,25 +10,32 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
+    _metadata_from_state,
+    _open_pr,
     _push_branch,
     _reject_if_cross_repo,
     _reject_if_epic_link,
     _reject_if_operational_task,
     _resolve_linkage,
+    _resolve_ready_state,
     _run_submit_batch,
     _select_batch_worktrees,
     _submit_one,
     _target_branch,
     _task_linkage,
+    _verify_origin_tip,
     main,
     parse_args,
 )
 from vergil_tooling.lib import epics, worktrees
+from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
 from vergil_tooling.lib.worktrees import Worktree
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
 _MOD = "vergil_tooling.bin.vrg_submit_pr"
 
@@ -1547,7 +1554,9 @@ def test_submit_one_strips_issue_number_from_linkage_and_warns(
         patch(_MOD + ".git.current_branch", return_value="feature/1-x"),
         patch(_MOD + ".build_pr_body", return_value="BODY") as build,
         patch(_MOD + ".confirm", return_value=True),
-        patch(_MOD + "._push_create_record", return_value="https://example/pull/1"),
+        patch(_MOD + "._push_branch"),
+        patch(_MOD + "._create_pr", return_value="https://example/pull/1"),
+        patch(_MOD + ".submission.record_submission"),
     ):
         url = _submit_one(Path("/r"), base_override=None, assume_yes=True)
     assert url == "https://example/pull/1"
@@ -1795,3 +1804,365 @@ def test_reject_if_epic_link_noop_when_repo_unresolvable() -> None:
     # A bare ref with no resolvable default repo is skipped, not an error.
     with patch(f"{_MOD}.github.current_repo", return_value=""):
         _reject_if_epic_link("#42")
+
+
+# -- shared _open_pr core + worktree-free relay branch path (issue #2368) ------
+
+
+def _ready_state(
+    *,
+    issue: str = "42",
+    branch: str = "feature/x",
+    base: str = "develop",
+    head_sha: str = "abc123def456",
+    title: str = "fix: bug",
+    summary: str = "Fix the bug",
+    notes: str = "Verified",
+    linkage: str = "Ref",
+    submitted: dict[str, str] | None = None,
+) -> WorkflowState:
+    """Build a report-ready ``WorkflowState`` for the relay tests."""
+    now = "2026-06-08T00:00:00Z"
+    state = engine.init_state(
+        issue=issue, branch=branch, base=base, head_sha=head_sha, base_sha="b0", now=now
+    )
+    engine.apply_report_ready(
+        state,
+        title=title,
+        summary=summary,
+        notes=notes,
+        linkage=linkage,
+        head_sha=head_sha,
+        now=now,
+    )
+    if submitted is not None:
+        state.submitted = submitted
+    return state
+
+
+def test_open_pr_relay_opens_without_pushing() -> None:
+    """push=False opens the PR with --head and never pushes the branch."""
+    metadata = {"issue": "42", "title": "fix: bug", "summary": "s", "notes": "", "linkage": "Ref"}
+    with (
+        patch(_MOD + ".resolve_issue_ref", return_value="#42"),
+        patch(_MOD + ".build_pr_body", return_value="BODY"),
+        patch(_MOD + "._push_branch") as push,
+        patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/9") as create,
+    ):
+        url = _open_pr("feature/x", "develop", metadata, push=False, assume_yes=True)
+    assert url == "https://github.com/pr/9"
+    push.assert_not_called()
+    assert create.call_args.kwargs["head"] == "feature/x"
+    assert create.call_args.kwargs["base"] == "develop"
+
+
+def test_open_pr_local_pushes_before_creating() -> None:
+    """push=True pushes the branch first, then opens the PR."""
+    metadata = {"issue": "42", "title": "fix: bug", "summary": "s", "notes": "", "linkage": "Ref"}
+    with (
+        patch(_MOD + ".resolve_issue_ref", return_value="#42"),
+        patch(_MOD + ".build_pr_body", return_value="BODY"),
+        patch(_MOD + "._push_branch") as push,
+        patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/9"),
+    ):
+        url = _open_pr("feature/x", "develop", metadata, push=True, assume_yes=True)
+    assert url == "https://github.com/pr/9"
+    push.assert_called_once_with("feature/x")
+
+
+def test_open_pr_dry_run_previews_without_opening() -> None:
+    metadata = {"issue": "42", "title": "fix: bug", "summary": "s", "notes": "", "linkage": "Ref"}
+    with (
+        patch(_MOD + ".resolve_issue_ref", return_value="#42"),
+        patch(_MOD + ".build_pr_body", return_value="BODY"),
+        patch(_MOD + "._push_branch") as push,
+        patch(_MOD + ".github.create_pr") as create,
+    ):
+        url = _open_pr("feature/x", "develop", metadata, push=False, dry_run=True)
+    assert url is None
+    push.assert_not_called()
+    create.assert_not_called()
+
+
+def test_metadata_from_state_extracts_fields() -> None:
+    state = _ready_state(issue="7", title="T", summary="S", notes="N", linkage="Closes")
+    meta = _metadata_from_state(state, "feature/x")
+    assert meta == {"issue": "7", "title": "T", "summary": "S", "notes": "N", "linkage": "Closes"}
+
+
+def test_metadata_from_state_errors_without_pr_metadata() -> None:
+    now = "2026-06-08T00:00:00Z"
+    state = engine.init_state(
+        issue="7", branch="feature/x", base="develop", head_sha="h", base_sha="b", now=now
+    )
+    with pytest.raises(SystemExit, match="no PR metadata yet"):
+        _metadata_from_state(state, "feature/x")
+
+
+def test_resolve_ready_state_prefers_local_worktree_file() -> None:
+    """A branch with a local worktree resolves via the file — the ref is untouched."""
+    wt = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+    state = _ready_state()
+    local = MagicMock()
+    local.read.return_value = state
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[wt]),
+        patch(_MOD + ".LocalFileTransport", return_value=local) as local_cls,
+        patch(_MOD + ".GitHubTransport") as gh_cls,
+    ):
+        out = _resolve_ready_state(Path("/repo"), "feature/x")
+    assert out is state
+    local_cls.assert_called_once_with(wt.path)
+    gh_cls.assert_not_called()
+
+
+def test_resolve_ready_state_falls_back_to_relay_ref() -> None:
+    """A worktree list with no branch match → read the relay ref via GitHubTransport."""
+    other = Worktree(path=Path("/repo/.worktrees/issue-99-y"), branch="feature/other")
+    state = _ready_state()
+    transport = MagicMock()
+    transport.read.return_value = state
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[other]),
+        patch(_MOD + ".GitHubTransport", return_value=transport) as gh_cls,
+    ):
+        out = _resolve_ready_state(Path("/repo"), "feature/x")
+    assert out is state
+    gh_cls.assert_called_once_with("feature/x")
+
+
+def test_resolve_ready_state_worktree_without_file_falls_back_to_ref() -> None:
+    """A worktree on the branch but with no state file falls through to the ref."""
+    wt = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+    state = _ready_state()
+    local = MagicMock()
+    local.read.return_value = None
+    transport = MagicMock()
+    transport.read.return_value = state
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[wt]),
+        patch(_MOD + ".LocalFileTransport", return_value=local),
+        patch(_MOD + ".GitHubTransport", return_value=transport),
+    ):
+        out = _resolve_ready_state(Path("/repo"), "feature/x")
+    assert out is state
+
+
+def test_resolve_ready_state_errors_when_no_source() -> None:
+    transport = MagicMock()
+    transport.read.return_value = None
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+        patch(_MOD + ".GitHubTransport", return_value=transport),
+        pytest.raises(SystemExit, match="no ready-state for branch"),
+    ):
+        _resolve_ready_state(Path("/repo"), "feature/x")
+
+
+def test_verify_origin_tip_passes_on_match() -> None:
+    state = _ready_state(head_sha="abc123")
+    with patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"):
+        _verify_origin_tip("feature/x", state)  # no raise
+
+
+def test_verify_origin_tip_errors_on_mismatch() -> None:
+    state = _ready_state(head_sha="abc123")
+    with (
+        patch(_MOD + ".git.read_output", return_value="deadbeef\trefs/heads/feature/x"),
+        pytest.raises(SystemExit, match="does not"),
+    ):
+        _verify_origin_tip("feature/x", state)
+
+
+def test_verify_origin_tip_errors_when_branch_absent_on_origin() -> None:
+    state = _ready_state(head_sha="abc123")
+    with (
+        patch(_MOD + ".git.read_output", return_value=""),
+        pytest.raises(SystemExit, match="not on origin"),
+    ):
+        _verify_origin_tip("feature/x", state)
+
+
+class TestRelayBranchPath:
+    """`vrg-submit-pr <branch>` opens a PR worktree-free (issue #2368)."""
+
+    @pytest.fixture(autouse=True)
+    def _human_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VRG_IDENTITY_MODE", raising=False)
+        monkeypatch.delenv("VRG_APP_ID", raising=False)
+
+    def test_relay_opens_pr_without_pushing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch") as push,
+            patch(_MOD + ".git.run") as git_run,
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/5") as create,
+        ):
+            rc = main(["feature/x", "--yes"])
+        assert rc == 0
+        push.assert_not_called()
+        assert not any(c.args and c.args[0] == "push" for c in git_run.call_args_list)
+        assert create.call_args.kwargs["head"] == "feature/x"
+        assert "/vergil:pr-watch https://github.com/pr/5" in capsys.readouterr().out
+
+    def test_relay_prefers_local_file_over_ref(self) -> None:
+        wt = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        local = MagicMock()
+        local.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[wt]),
+            patch(_MOD + ".LocalFileTransport", return_value=local),
+            patch(_MOD + ".GitHubTransport") as gh_cls,
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch"),
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/5"),
+        ):
+            rc = main(["feature/x", "--yes"])
+        assert rc == 0
+        gh_cls.assert_not_called()
+
+    def test_relay_head_sha_mismatch_errors(self) -> None:
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="deadbeef\trefs/heads/feature/x"),
+            patch(_MOD + ".github.create_pr") as create,
+            pytest.raises(SystemExit, match="does not"),
+        ):
+            main(["feature/x", "--yes"])
+        create.assert_not_called()
+
+    def test_relay_missing_ready_state_errors(self) -> None:
+        transport = MagicMock()
+        transport.read.return_value = None
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            pytest.raises(SystemExit, match="no ready-state for branch"),
+        ):
+            main(["feature/x", "--yes"])
+
+    def test_relay_skips_already_submitted_branch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        state = _ready_state(
+            branch="feature/x",
+            submitted={"pr_url": "https://github.com/o/r/pull/12", "pr_number": "12"},
+        )
+        transport = MagicMock()
+        transport.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".github.create_pr") as create,
+        ):
+            rc = main(["feature/x", "--yes"])
+        assert rc == 0
+        create.assert_not_called()
+        assert "already has a submitted PR" in capsys.readouterr().out
+
+    def test_relay_batches_two_branches(self) -> None:
+        states = {
+            "feature/a": _ready_state(issue="1", branch="feature/a", head_sha="sha_a"),
+            "feature/b": _ready_state(issue="2", branch="feature/b", head_sha="sha_b"),
+        }
+
+        def fake_read_output(*args: str) -> str:
+            branch = args[-1].removeprefix("refs/heads/")
+            return f"sha_{branch[-1]}\t{args[-1]}"
+
+        def fake_transport(branch: str) -> MagicMock:
+            t = MagicMock()
+            t.read.return_value = states[branch]
+            return t
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", side_effect=fake_transport),
+            patch(_MOD + ".git.read_output", side_effect=fake_read_output),
+            patch(_MOD + "._push_branch") as push,
+            patch(
+                _MOD + ".github.create_pr",
+                side_effect=["https://github.com/pr/1", "https://github.com/pr/2"],
+            ) as create,
+        ):
+            rc = main(["feature/a", "feature/b", "--yes"])
+        assert rc == 0
+        assert create.call_count == 2
+        push.assert_not_called()
+        heads = [c.kwargs["head"] for c in create.call_args_list]
+        assert heads == ["feature/a", "feature/b"]
+
+    def test_relay_dry_run_skips_verify_and_create(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        state = _ready_state(branch="feature/x")
+        transport = MagicMock()
+        transport.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output") as read_output,
+            patch(_MOD + ".github.create_pr") as create,
+        ):
+            rc = main(["feature/x", "--dry-run"])
+        assert rc == 0
+        create.assert_not_called()
+        read_output.assert_not_called()  # no ls-remote verification on dry-run
+        assert "fix: bug" in capsys.readouterr().out
+
+    def test_relay_rejects_all_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["feature/x", "--all"])
+        assert rc == 1
+        assert "--all/--select" in capsys.readouterr().err
+
+    def test_relay_rejects_cli_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["feature/x", "--issue", "42", "--summary", "s", "--title", "t"])
+        assert rc == 1
+        assert "--issue/--summary/--title" in capsys.readouterr().err
+
+    def test_relay_rejects_cascade_flags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["feature/x", "--finalize"])
+        assert rc == 1
+        assert "cascade" in capsys.readouterr().err
+
+    def test_relay_blocked_for_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VRG_IDENTITY_MODE", "user")
+        with patch(_MOD + ".github.create_pr") as create:
+            rc = main(["feature/x"])
+        assert rc != 0
+        create.assert_not_called()
+
+
+def test_no_arg_local_path_unchanged_regression(tmp_path: Path) -> None:
+    """Regression guard for issue #2368: extracting the shared _open_pr core must
+    leave the no-arg local worktree path byte-for-byte behaviorally unchanged —
+    it force-with-lease pushes the branch, opens the PR, and marks the local
+    state file submitted."""
+    _write_workflow_state(tmp_path, title="fix: bug", summary="Fix")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        patch(_MOD + ".git.run") as git_run,
+        patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/1") as create,
+        patch("builtins.input", return_value="y"),
+    ):
+        rc = main([])
+    assert rc == 0
+    git_run.assert_called_once_with("push", "--force-with-lease", "-u", "origin", "feature/x")
+    create.assert_called_once()
+    assert _state_submitted(tmp_path)


### PR DESCRIPTION
# Pull Request

## Summary

- Extract a shared _open_pr core and add a positional branches relay path that opens PRs worktree-free from already-pushed branches.

## Issue Linkage

- Closes #2368

## Notes

- Extracted _open_pr(branch, base, metadata, *, push) as the shared PR-open core (guards/linkage/body/optional-push/create). The local batch path (_submit_one) now delegates to it; the no-arg local template path is behaviorally unchanged and locked by a regression test. New relay path (positional branches): resolves each branch's ready-state (local worktree pr-workflow.json preferred, else GitHubTransport ref), verifies origin tip == recorded head_sha, and calls _open_pr(push=False) with no current_branch/worktree lookup/push. Added github.create_pr(head=...) so gh opens the PR for the right branch from outside its worktree. Relay refuses --all/--select, --issue/--summary/--title, and the finalize/release/install cascade; skips already-submitted branches. Validation green at 100% coverage (4324 passed).