### PR TITLE
feat(finalize-pr): delete the relay ref on branch cleanup

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -55,7 +55,7 @@ from vergil_tooling.lib import (
 )
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.container_cache import clean_branch_images
-from vergil_tooling.lib.pr_workflow import batch
+from vergil_tooling.lib.pr_workflow import batch, github_transport
 from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.repo_init import prompt_choice
 
@@ -272,6 +272,42 @@ def _worktree_is_dirty(wt_path: Path) -> bool:
     return bool(result.stdout.strip())
 
 
+def _delete_relay_ref(branch: str, *, dry_run: bool) -> None:
+    """Drop *branch*'s pr-workflow relay ref alongside the branch (issue #2369).
+
+    ``report-ready`` on a cloud VM parks the PR-handoff payload at
+    ``refs/vergil/pr-workflow/<branch>`` (epic #146). Once the branch is
+    cleaned up that ref is orphaned, so delete it here. ``delete()`` is a
+    no-op when the ref is absent — the common Mac case, where the local-file
+    transport was used and no relay ref was ever pushed — so calling it
+    unconditionally is safe.
+    """
+    if dry_run:
+        print(f"  [dry-run] delete relay ref for {branch}")
+        return
+    github_transport.GitHubTransport(branch).delete()
+
+
+def _prune_orphan_relay_refs(*, dry_run: bool) -> None:
+    """Prune relay refs whose branch no longer exists (issue #2369).
+
+    The per-branch cleanup already drops the relay ref alongside the branch it
+    deletes. This is the swept safety net: a relay ref whose branch was removed
+    out-of-band — merged and branch-pruned on the remote, or abandoned — would
+    otherwise linger forever in the reserved namespace. Both reads are
+    read-only ``ls-remote`` calls; under ``--dry-run`` no ref is touched.
+    """
+    if dry_run:
+        print("  [dry-run] prune orphaned pr-workflow relay refs")
+        return
+    live = git.remote_branches()
+    for branch in github_transport.list_relay_branches():
+        if branch in live:
+            continue
+        print(f"  Deleting orphaned relay ref for {branch} (branch no longer exists)")
+        github_transport.GitHubTransport(branch).delete()
+
+
 def _delete_branch_and_worktree(
     branch: str, root: Path, *, dry_run: bool, force: bool = False
 ) -> bool:
@@ -316,6 +352,9 @@ def _delete_branch_and_worktree(
         removed = clean_branch_images(branch)
         if removed:
             print(f"  Cleaned {removed} cached container image(s) for {branch}")
+    # Drop the branch's relay ref too, so a cloud-handoff ref never outlives the
+    # branch it belonged to (issue #2369). Shared by both cleanup paths.
+    _delete_relay_ref(branch, dry_run=dry_run)
     return True
 
 
@@ -735,6 +774,9 @@ def _stage_cleanup(ctx: FinalizeContext) -> None:
             continue
         if _delete_branch_and_worktree(branch, root, dry_run=args.dry_run):
             deleted.append(branch)
+
+    print("Checking for orphaned pr-workflow relay refs...")
+    _prune_orphan_relay_refs(dry_run=args.dry_run)
 
     print("Pruning stale remote-tracking references...")
     if args.dry_run:

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -172,6 +172,22 @@ def commits_ahead(base: str, branch: str) -> int:
     return int(read_output("rev-list", "--count", f"{base}..{branch}"))
 
 
+def remote_branches(remote: str = "origin") -> set[str]:
+    """Return the branch names present on *remote* (via ``ls-remote --heads``).
+
+    Strips the ``refs/heads/`` prefix, so a nested name like ``feature/123-x``
+    comes back whole. Used to tell whether a branch still exists on the remote
+    when deciding if a reserved ref keyed to it has been orphaned (#2369).
+    """
+    prefix = "refs/heads/"
+    names: set[str] = set()
+    for line in read_output("ls-remote", "--heads", remote).splitlines():
+        _sha, _tab, ref = line.partition("\t")
+        if ref.startswith(prefix):
+            names.add(ref[len(prefix) :])
+    return names
+
+
 def working_tree_status() -> str:
     """Return ``git status --porcelain`` output (empty string when clean)."""
     return read_output("status", "--porcelain")

--- a/src/vergil_tooling/lib/pr_workflow/github_transport.py
+++ b/src/vergil_tooling/lib/pr_workflow/github_transport.py
@@ -30,6 +30,24 @@ _COMMIT_MESSAGE = "vergil: pr-workflow relay"
 _BLOB_MODE = "100644"
 
 
+def list_relay_branches(remote: str = "origin") -> list[str]:
+    """Return every branch that has a relay ref on *remote*.
+
+    Lists ``refs/vergil/pr-workflow/*`` off *remote* and strips the namespace
+    prefix, yielding the branch names whose pr-workflow payload is currently
+    parked on the relay. The ``*`` glob spans slashes, so a nested branch name
+    (``feature/123-x``) is matched in full. Used by the finalize sweep to find
+    relay refs whose branch no longer exists so they can be pruned (#2369).
+    """
+    prefix = f"{_REF_PREFIX}/"
+    branches: list[str] = []
+    for line in git.read_output("ls-remote", remote, f"{prefix}*").splitlines():
+        _sha, _tab, ref = line.partition("\t")
+        if ref.startswith(prefix):
+            branches.append(ref[len(prefix) :])
+    return branches
+
+
 class GitHubTransport(Transport):
     """Relay the workflow state over ``refs/vergil/pr-workflow/<branch>``."""
 

--- a/tests/vergil_tooling/pr_workflow/test_github_transport.py
+++ b/tests/vergil_tooling/pr_workflow/test_github_transport.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 
 import subprocess
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
-from vergil_tooling.lib.pr_workflow.github_transport import GitHubTransport
+from vergil_tooling.lib.pr_workflow.github_transport import (
+    GitHubTransport,
+    list_relay_branches,
+)
 from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
 if TYPE_CHECKING:
@@ -114,6 +118,26 @@ def test_delete_is_a_noop_when_ref_absent(clone: Path) -> None:
     # No ref was ever written; delete must not raise.
     GitHubTransport(_BRANCH).delete()
     assert GitHubTransport(_BRANCH).read() is None
+
+
+def test_list_relay_branches_returns_branches_with_refs(clone: Path) -> None:
+    # The ``*`` glob spans slashes, so nested branch names round-trip whole.
+    GitHubTransport("feature/1-a").write(_state())
+    GitHubTransport("feature/2-b").write(_state())
+    assert sorted(list_relay_branches()) == ["feature/1-a", "feature/2-b"]
+
+
+def test_list_relay_branches_empty_when_none(clone: Path) -> None:
+    assert list_relay_branches() == []
+
+
+def test_list_relay_branches_ignores_malformed_lines() -> None:
+    output = "sha\trefs/vergil/pr-workflow/feature/9-y\nnot-a-ref-line"
+    with patch(
+        "vergil_tooling.lib.pr_workflow.github_transport.git.read_output",
+        return_value=output,
+    ):
+        assert list_relay_branches() == ["feature/9-y"]
 
 
 def test_head_sha_returns_current_head(clone: Path) -> None:

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -214,6 +214,23 @@ def test_merged_branches_empty() -> None:
     assert result == []
 
 
+def test_remote_branches_parses_heads() -> None:
+    output = (
+        "sha1\trefs/heads/develop\n"
+        "sha2\trefs/heads/feature/12-x\n"
+        "sha3\trefs/tags/v1.0"  # not a head — must be ignored
+    )
+    with patch("vergil_tooling.lib.git.read_output", return_value=output) as mock:
+        result = git.remote_branches()
+    assert result == {"develop", "feature/12-x"}
+    mock.assert_called_once_with("ls-remote", "--heads", "origin")
+
+
+def test_remote_branches_empty() -> None:
+    with patch("vergil_tooling.lib.git.read_output", return_value=""):
+        assert git.remote_branches() == set()
+
+
 def test_working_tree_status_returns_porcelain_output() -> None:
     with patch("vergil_tooling.lib.git.read_output", return_value="?? orphan.md") as mock:
         result = git.working_tree_status()

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -16,8 +16,10 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     FinalizeContext,
     FinalizeError,
     _check_cd_workflow_status,
+    _delete_branch_and_worktree,
     _dirt_is_untracked_only,
     _parse_pr_list,
+    _prune_orphan_relay_refs,
     _resolve_open_prs,
     _resolve_strategy,
     _run_finalize_batch,
@@ -74,6 +76,24 @@ def _clean_working_tree() -> Iterator[None]:
     directly — the innermost patch wins.
     """
     with patch(_MOD + ".git.working_tree_status", return_value=""):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _relay_refs_inert() -> Iterator[None]:
+    """Default: relay-ref cleanup touches nothing (issue #2369).
+
+    Cleanup drops each deleted branch's pr-workflow relay ref and sweeps
+    orphaned refs; both do remote ls-remote/push. Stub the seams so the many
+    cleanup tests neither hit the network nor need to know about relay refs.
+    Tests that assert relay behavior re-patch these directly — the innermost
+    patch wins.
+    """
+    with (
+        patch(_MOD + ".github_transport.GitHubTransport"),
+        patch(_MOD + ".github_transport.list_relay_branches", return_value=[]),
+        patch(_MOD + ".git.remote_branches", return_value=set()),
+    ):
         yield
 
 
@@ -2205,3 +2225,142 @@ def test_main_comma_list_routes_to_batch() -> None:
 # vergil-project/.github#75): vrg-finalize-pr no longer closes tasks. The
 # former _close_managed_task tests were removed in T4; the closing keyword is
 # covered by the linkage/submit-pr tests and rollup by test_vrg_epic_rollup.
+
+
+# -- relay-ref cleanup (issue #2369) ---------------------------------------
+
+
+def test_delete_branch_and_worktree_prunes_relay_ref(tmp_path: Path) -> None:
+    """Both cleanup paths funnel through _delete_branch_and_worktree, so the
+    branch's pr-workflow relay ref is dropped alongside it (issue #2369)."""
+    with (
+        patch(_MOD + ".worktrees.worktree_for_branch", return_value=None),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+    ):
+        assert _delete_branch_and_worktree("feature/9-x", tmp_path, dry_run=False)
+    mock_transport.assert_called_once_with("feature/9-x")
+    mock_transport.return_value.delete.assert_called_once_with()
+
+
+def test_delete_branch_and_worktree_skips_relay_ref_on_dry_run(tmp_path: Path) -> None:
+    """--dry-run never pushes a ref deletion; it only announces it."""
+    with (
+        patch(_MOD + ".worktrees.worktree_for_branch", return_value=None),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+    ):
+        assert _delete_branch_and_worktree("feature/9-x", tmp_path, dry_run=True)
+    mock_transport.assert_not_called()
+
+
+def test_main_merged_branch_prunes_relay_ref(tmp_path: Path) -> None:
+    """Merged-PR path: the explicit-target cleanup drops the relay ref."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(f"{_MOD}.pr_provenance.check_pr", return_value=_clean()),
+        patch(f"{_MOD}.github.pr_state", return_value="MERGED"),
+        patch(f"{_MOD}.github.head_ref", return_value="feature/42-x"),
+        patch(f"{_MOD}.git.current_branch", return_value="develop"),
+        patch(f"{_MOD}.git.merged_branches", return_value=[]),
+        patch(f"{_MOD}.git.read_output", return_value="feature/42-x"),
+        patch(f"{_MOD}.git.run"),
+        patch(f"{_MOD}.worktrees.worktree_for_branch", return_value=None),
+        patch(f"{_MOD}.clean_branch_images", return_value=0),
+        patch(f"{_MOD}.git.repo_root", return_value=tmp_path),
+        patch(f"{_MOD}._check_cd_workflow_status", return_value=None),
+        patch(f"{_MOD}.github_transport.GitHubTransport") as mock_transport,
+    ):
+        result = main(["42"])
+    assert result == 0
+    mock_transport.assert_any_call("feature/42-x")
+    mock_transport.return_value.delete.assert_called_once_with()
+
+
+def test_main_closed_pr_cleanup_prunes_relay_ref(tmp_path: Path) -> None:
+    """Closed-PR path (ancestry sweep): each swept branch drops its relay ref."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        _sweep_guards_pass(),
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="feature/x"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=["feature/x", "develop"]),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".clean_branch_images", return_value=0),
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+    ):
+        result = main([])
+    assert result == 0
+    mock_transport.assert_any_call("feature/x")
+    mock_transport.return_value.delete.assert_called_once_with()
+
+
+def test_prune_orphan_relay_refs_deletes_dead_branch() -> None:
+    """A relay ref whose branch no longer exists on the remote is pruned."""
+    with (
+        patch(_MOD + ".git.remote_branches", return_value={"feature/live"}),
+        patch(
+            _MOD + ".github_transport.list_relay_branches",
+            return_value=["feature/dead", "feature/live"],
+        ),
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+    ):
+        _prune_orphan_relay_refs(dry_run=False)
+    mock_transport.assert_called_once_with("feature/dead")
+    mock_transport.return_value.delete.assert_called_once_with()
+
+
+def test_prune_orphan_relay_refs_keeps_live_branch() -> None:
+    """A relay ref whose branch still exists is left untouched (no-op)."""
+    with (
+        patch(_MOD + ".git.remote_branches", return_value={"feature/live"}),
+        patch(
+            _MOD + ".github_transport.list_relay_branches",
+            return_value=["feature/live"],
+        ),
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+    ):
+        _prune_orphan_relay_refs(dry_run=False)
+    mock_transport.assert_not_called()
+
+
+def test_prune_orphan_relay_refs_skipped_on_dry_run(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--dry-run neither reads the remote nor pushes any deletion."""
+    with (
+        patch(_MOD + ".git.remote_branches") as mock_remote,
+        patch(_MOD + ".github_transport.list_relay_branches") as mock_list,
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+    ):
+        _prune_orphan_relay_refs(dry_run=True)
+    mock_remote.assert_not_called()
+    mock_list.assert_not_called()
+    mock_transport.assert_not_called()
+    assert "[dry-run] prune orphaned" in capsys.readouterr().out
+
+
+def test_main_sweeps_orphan_relay_ref(tmp_path: Path) -> None:
+    """The cleanup stage sweeps a relay ref whose branch is gone (issue #2369)."""
+    _make_profile(tmp_path, "library-release")
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".git.current_branch", return_value="develop"),
+        patch(_MOD + ".git.run"),
+        patch(_MOD + ".git.merged_branches", return_value=[]),
+        patch(_MOD + ".git.remote_branches", return_value=set()),
+        patch(
+            _MOD + ".github_transport.list_relay_branches",
+            return_value=["feature/orphan"],
+        ),
+        patch(_MOD + ".github_transport.GitHubTransport") as mock_transport,
+        patch(_MOD + "._check_cd_workflow_status", return_value=None),
+    ):
+        result = main([])
+    assert result == 0
+    mock_transport.assert_any_call("feature/orphan")
+    mock_transport.return_value.delete.assert_called_once_with()


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-finalize-pr now deletes a branch's pr-workflow relay ref during cleanup and sweeps orphaned relay refs whose branch no longer exists.

## Issue Linkage

- Closes #2369

## Notes

- Both cleanup paths (merged and closed-PR) funnel through _delete_branch_and_worktree, which now calls GitHubTransport(branch).delete() (no-op when absent) after removing the branch. The cleanup stage gained a swept safety net, _prune_orphan_relay_refs, that deletes any refs/vergil/pr-workflow/<branch> whose branch is absent from the remote heads. New library helpers: git.remote_branches and github_transport.list_relay_branches. Validation green at 100% coverage (4312 passed). Epic vergil-project/.github#148, Task 5.