### PR TITLE
docs(cloud-relay): reflect shipped cloud PR relay in contract and site docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,32 +187,52 @@ of the tree.
 
 ### Cloud session prompt contract (off-platform VMs)
 
-The PR handoff above assumes the agent and the human share one
-filesystem — true on the Mac (Lima), where the agent's worktree and the
-local `.vergil/pr-workflow.json` are visible to the human running
-`vrg-submit-pr`. **Cloud x86 VMs have no shared filesystem with the
-Mac**, so that handoff does not yet work there. Until the GitHub-relay
-transport lands (issue
-[#1858](https://github.com/vergil-project/vergil-tooling/issues/1858),
-Deliverable B), a cloud session must observe this boundary:
+The PR handoff above no longer needs a shared filesystem. `report-ready`
+**always** mirrors the recorded ready-state onto a reserved git ref,
+`refs/vergil/pr-workflow/<branch>` (the *relay ref*), in addition to the
+local `.vergil/pr-workflow.json`. The push is unconditional — no config
+key, no off-platform detection — so a cloud x86 VM's `report-ready` is
+visible to the Mac even though the two never share a disk. The write is a
+pure ref update built out-of-band with git plumbing; it never advances the
+feature branch, so it stays freeze-neutral (the post-`report-ready` freeze
+still holds).
 
-- **Cloud x86 VMs are for runtime verification, builds,
-  triage/debugging, and issue registration — not PR-development.** The
-  MQ x86 work and other native-x86 / Red Hat stacks that cannot run
-  under Lima are exercised on a cloud VM for triage only.
-- **The GitHub issue is the cloud→Mac message bus.** A cloud triage
-  agent writes structured findings, repro steps, and diagnosis as
-  comments on the tracking issue (via `vrg-gh`); a Mac development agent
-  picks the issue up through the normal flow and does the PR-development
-  there via Lima, where the shared filesystem and `vrg-submit-pr` work
-  unchanged.
+Because the metadata now rides GitHub, **a cloud VM can do PR-development
+end-to-end** — not just triage. A cloud agent implements the issue,
+commits, pushes the feature branch to origin, and runs `report-ready`,
+exactly as it would under Lima. The old "cloud x86 VMs are triage-only /
+not for PR-development" boundary is retired, along with the "until the
+relay lands" framing — the relay
+([#1858](https://github.com/vergil-project/vergil-tooling/issues/1858),
+Deliverable B) shipped.
 
-This is a **best-effort advisory, not a hard guard.** The session layer
-(not `vrg-pr-workflow` itself) knows it is on a cloud VM, so the
-convention is carried here in the prompt contract. It extends the
-"agents must not run `vrg-submit-pr`" policy upstream: cloud agents do
-not do PR-development at all. If you find yourself about to prepare a PR
-in a cloud context, stop and hand the issue back to the Mac instead.
+**Only submission and merge stay human-on-Mac.** From the Mac's main
+worktree, the human runs `vrg-submit-pr` **worktree-free** with an explicit
+branch list:
+
+```text
+vrg-submit-pr <branch> [<branch> …]
+```
+
+Each branch's ready-state is resolved from a local worktree's
+`pr-workflow.json` when one exists, else fetched from the relay ref; the
+tip of `origin/<branch>` is verified against the recorded `head_sha`, and
+the PR is opened **without pushing** (the branch already rode GitHub, so
+`--head` just names it). Merge and cleanup stay human actions:
+`vrg-finalize-pr` deletes the branch's relay ref alongside the branch on
+cleanup, and a swept safety net prunes any relay ref whose branch no longer
+exists, so a cloud-handoff ref never outlives its work.
+
+**The relay ref is world-readable on a public repo.** Anyone can read
+`refs/vergil/pr-workflow/<branch>`, so the `report-ready` `--title`,
+`--summary`, and `--notes` must carry **no secrets** — treat them as public
+the moment they are recorded.
+
+This does not loosen the "agents must not run `vrg-submit-pr`" policy: the
+cloud agent stops at `report-ready`, exactly like a Lima agent, and the
+human submits and merges on the Mac. What changed is only *where the
+development can happen* — the relay removed the shared-disk requirement, so
+a cloud VM is now a full PR-development environment, not a triage-only one.
 
 ## Project Overview
 

--- a/docs/site/docs/guides/git-workflow.md
+++ b/docs/site/docs/guides/git-workflow.md
@@ -166,6 +166,17 @@ See the [vrg-submit-pr reference](../reference/dev/submit-pr.md).
     `vrg-pr-workflow unfreeze`. See the tool's entry in the
     [CLI Tools Overview](../reference/cli-tools-overview.md#vrg-pr-workflow).
 
+!!! note "Cloud (off-platform) agents: same handoff, over GitHub"
+    A cloud x86 VM shares no disk with the Mac, so `report-ready`
+    **always** also mirrors the ready-state onto the reserved relay ref
+    `refs/vergil/pr-workflow/<branch>`. A cloud agent therefore does
+    PR-development end-to-end — implement, push the branch, `report-ready`
+    — exactly like a Lima agent, and the human submits from the Mac
+    worktree-free with `vrg-submit-pr <branch> [<branch> …]` (see the
+    [reference](../reference/dev/submit-pr.md#relay-branch-mode-cloud-to-mac-handoff)).
+    The relay ref is world-readable on a public repo, so keep secrets out
+    of the `report-ready` title/summary/notes.
+
 ### 4. Wait for review, merge manually
 
 Once CI is green and a reviewer approves, merge through the GitHub
@@ -182,8 +193,11 @@ This:
 
 - Switches back to the integration branch (`develop`).
 - Pulls the latest.
-- Deletes the merged local feature branch and removes its worktree.
-- Prunes stale remote-tracking refs.
+- Deletes the merged local feature branch and removes its worktree,
+  along with the branch's PR-workflow relay ref
+  (`refs/vergil/pr-workflow/<branch>`).
+- Prunes stale remote-tracking refs and sweeps any orphaned relay ref
+  whose branch is gone.
 - Runs post-merge validation via `vrg-container-run` to catch any
   regression introduced by the merge.
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -28,15 +28,21 @@ worktree convention).
 
 ### vrg-submit-pr
 
-Create standards-compliant pull requests. Pushes the current branch
-and opens a PR with a populated template body.
+Create standards-compliant pull requests. Template mode pushes the
+current branch and opens a PR from `.vergil/pr-workflow.json`. **Relay
+branch mode** (positional `<branch> [<branch> …]`) opens PRs
+**worktree-free** for branches already on origin — the Mac side of the
+cloud→Mac handoff: each branch's ready-state comes from a local
+worktree's `pr-workflow.json` when present, else the relay ref
+`refs/vergil/pr-workflow/<branch>`; origin's tip is checked against the
+recorded `head_sha` and the PR opens with `--head` **without pushing**.
 
 | Attribute | Value |
 |---|---|
 | Source | `vergil_tooling.bin.vrg_submit_pr` |
-| Args | `--issue` (required), `--summary` (required), `--linkage` (default: Ref; `vrg-submit-pr` auto-selects `Closes` for a managed task — `Fixes`/`Resolves` are banned), `--notes`, `--title`, `--dry-run` |
-| Preconditions | Git repo, `gh` CLI on PATH |
-| Failure mode | Subprocess error from `git push` or `gh pr create` |
+| Args | positional `branches` (relay mode); or `--issue` (required), `--summary` (required), `--linkage` (default: Ref; `vrg-submit-pr` auto-selects `Closes` for a managed task — `Fixes`/`Resolves` are banned), `--notes`, `--title`, `--dry-run` |
+| Preconditions | Git repo, `gh` CLI on PATH; relay mode: named branches on origin with a resolvable ready-state and matching `head_sha` |
+| Failure mode | Subprocess error from `git push` or `gh pr create`; relay mode: loud failure on a missing ready-state or `head_sha` drift |
 | Exit codes | 0 success |
 | Status | Active |
 
@@ -63,13 +69,22 @@ Record and manage the PR handoff state in `.vergil/pr-workflow.json` —
 the oracle `vrg-submit-pr` reads. `report-ready` writes the PR metadata
 (`--issue/--title/--summary/--notes`, optional `--linkage`) and marks the
 branch **ready**; it is idempotent — re-running overwrites the recorded
-prose (correcting the title/summary/notes is always allowed). Reaching
-**ready** *freezes* the branch: `vrg-commit` and the `vrg-git` push path
-then refuse further commits/pushes, because a task is exactly one PR and
-more work is a new follow-up issue (epic #146). `unfreeze` is the only
-sanctioned way to reopen a still-unsubmitted branch — it drops the state
-back to `implementing` while keeping the metadata; an already-submitted
-branch cannot be unfrozen. `status` prints the current state.
+prose (correcting the title/summary/notes is always allowed).
+`report-ready` **always** also mirrors the ready-state onto the reserved
+relay ref `refs/vergil/pr-workflow/<branch>` (unconditional — no config,
+no off-platform detection), so a cloud VM's report-ready reaches the Mac
+that later runs `vrg-submit-pr <branch>` even though the two never share a
+disk. The relay push is a pure ref write built with git plumbing; it never
+advances the branch, so it stays **freeze-neutral**. A push failure is
+loud on stderr but never rolls back the durable local file. Because the
+ref is world-readable on a public repo, keep secrets out of
+`--title/--summary/--notes`. Reaching **ready** *freezes* the branch:
+`vrg-commit` and the `vrg-git` push path then refuse further
+commits/pushes, because a task is exactly one PR and more work is a new
+follow-up issue (epic #146). `unfreeze` is the only sanctioned way to
+reopen a still-unsubmitted branch — it drops the state back to
+`implementing` while keeping the metadata; an already-submitted branch
+cannot be unfrozen. `status` prints the current state.
 
 | Attribute | Value |
 |---|---|
@@ -115,8 +130,11 @@ Claude plugin, VERSION file) to find the version.
 Finalize a pull request. Given a PR, runs the provenance check, merges
 it, then cleans up; with no PR, runs cleanup only. Cleanup switches to
 the target branch, fast-forward pulls, deletes merged local branches
-(auto-removing worktrees inside `.worktrees/` when necessary), prunes
-remotes, runs validation, and checks the CD workflow status. A
+(auto-removing worktrees inside `.worktrees/` when necessary), deletes
+each merged branch's PR-workflow relay ref
+(`refs/vergil/pr-workflow/<branch>`) and sweeps any orphaned relay ref
+whose branch is gone (issue #2369), prunes remotes, runs validation, and
+checks the CD workflow status. A
 merged/closed worktree the sweep cannot remove — a dirty tree, or a
 reused branch name with unmerged commits (issue #1719) — is surfaced
 **prominently after the pipeline** rather than buried in the stage log;

--- a/docs/site/docs/reference/dev/finalize-pr.md
+++ b/docs/site/docs/reference/dev/finalize-pr.md
@@ -94,7 +94,11 @@ would do.
 The just-merged PR branch and its `.worktrees/` worktree are deleted
 by name. The default squash strategy rewrites history onto the
 target, so the branch is never an ancestor and the merged-branch
-sweep below cannot see it.
+sweep below cannot see it. The branch's PR-workflow relay ref
+(`refs/vergil/pr-workflow/<branch>`, pushed by `report-ready`) is
+deleted alongside it, so a cloud-handoff ref never outlives its
+branch (issue #2369). Deleting a relay ref that was never pushed is a
+no-op.
 
 ### 2. Switch to Target Branch
 
@@ -175,7 +179,11 @@ Eternal branches are protected based on the `branching_model`:
 ### 5. Prune Remote References
 
 Runs `git remote prune origin` to clean up stale remote-tracking
-branches.
+branches. As a swept safety net, any PR-workflow relay ref
+(`refs/vergil/pr-workflow/*`) whose branch no longer exists on origin
+is pruned too, so a relay ref stranded by a branch deleted outside
+finalize (or by an earlier failed run) is never left behind
+(issue #2369).
 
 ### 6. Working-Tree Cleanliness Gate
 

--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -5,12 +5,22 @@
 **Source:** `src/vergil_tooling/bin/vrg_submit_pr.py`
 
 Wrapper that creates standards-compliant pull requests with
-proper issue linkage. Has two modes:
+proper issue linkage. Has three modes:
 
 - **Template mode** (no arguments) — the normal path. Reads
   `.vergil/pr-workflow.json` (the oracle state file the agent records via
   `vrg-pr-workflow`), shows a preview, asks for confirmation, pushes the
   branch, creates the PR, and emits the `/vergil:pr-watch` handoff line.
+- **Relay branch mode** (positional `<branch> [<branch> …]`) — the Mac
+  side of the cloud→Mac relay handoff (issue #2368). Opens PRs for
+  branches that are **already on origin, worktree-free**: each branch's
+  ready-state is resolved from a local worktree's `pr-workflow.json` when
+  one exists, else fetched from the relay ref
+  `refs/vergil/pr-workflow/<branch>` that `report-ready` always pushes.
+  Origin's tip is verified against the recorded `head_sha` and the PR is
+  opened **without pushing** (`--head` names the source branch). No
+  worktree, no `git.current_branch()`, and no push are involved — the
+  branch and its metadata already rode GitHub.
 - **CLI mode** (`--issue/--summary/--title`) — direct invocation for
   human emergency use.
 
@@ -32,6 +42,9 @@ container.
 # Template mode (normal): from the repo root or inside the worktree
 vrg-submit-pr
 
+# Relay branch mode (cloud handoff): worktree-free, from the main worktree
+vrg-submit-pr <branch> [<branch> …]
+
 # CLI mode (emergency): from inside the worktree
 vrg-submit-pr --issue NUMBER --summary TEXT --title TEXT [options]
 ```
@@ -51,6 +64,37 @@ resolves the target worktree itself:
 Run from inside a worktree, behavior is unchanged. The tool is
 interactive by design — it is a human touch point of the workflow and
 requires a terminal; root launches fail fast when stdin is not a TTY.
+
+## Relay branch mode (cloud-to-Mac handoff)
+
+Passing one or more branch names opens PRs **worktree-free** for work an
+off-platform (cloud x86) agent implemented and pushed. It is the Mac side
+of the GitHub relay: the cloud VM and the Mac never share a disk, so the
+agent's `report-ready` mirrors its ready-state onto the reserved ref
+`refs/vergil/pr-workflow/<branch>` in addition to the local
+`.vergil/pr-workflow.json`. Run from the **main worktree**:
+
+```bash
+vrg-submit-pr feature/123-x feature/124-y
+```
+
+For each branch, the tool:
+
+1. resolves the ready-state from a local worktree's `pr-workflow.json`
+   when one exists, else fetches it from the relay ref;
+2. verifies the tip of `origin/<branch>` matches the recorded `head_sha`
+   (a mismatch fails loudly — the metadata is for a different commit);
+3. opens the PR with `--head <branch>` and **does not push** — the branch
+   is already on origin.
+
+!!! warning "The relay ref is world-readable"
+    On a public repo, anyone can read `refs/vergil/pr-workflow/<branch>`.
+    Keep secrets out of the `report-ready` `--title`, `--summary`, and
+    `--notes` — they are public the moment they are recorded.
+
+The relay ref is cleaned up by [`vrg-finalize-pr`](finalize-pr.md), which
+deletes it alongside the branch on merge and sweeps any orphaned relay ref
+whose branch no longer exists.
 
 ## Arguments
 
@@ -74,6 +118,9 @@ requires a terminal; root launches fail fast when stdin is not a TTY.
 ```bash
 # Normal flow: resolve the worktree, preview, confirm
 vrg-submit-pr
+
+# Relay branch mode: open PRs for cloud-implemented branches, worktree-free
+vrg-submit-pr feature/123-x feature/124-y
 
 # Preview without submitting
 vrg-submit-pr --dry-run


### PR DESCRIPTION
# Pull Request

## Summary

- Rewrite the CLAUDE.md cloud-session contract and update site docs to reflect the shipped GitHub PR relay: cloud can now do PR-development end-to-end, only submission/merge stay human-on-Mac.

## Issue Linkage

- Closes #2364

## Notes

- Grounded in merged code (report-ready unconditional relay-ref push, vrg-submit-pr branch-list relay mode, vrg-finalize-pr relay-ref delete + orphan sweep) released in v2.1.143. Removes the retired cloud-is-triage-only boundary and the until-the-relay-lands framing; adds the world-readable relay-ref no-secrets caveat. Specs under docs/specs left as historical records.