### PR TITLE
feat(repo-init): expose every wizard prompt as a CLI flag for non-interactive repo creation

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_init.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_init.py
@@ -5,12 +5,24 @@ from __future__ import annotations
 import argparse
 import sys
 
+from vergil_tooling.lib.config import _ENUMS
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
     prompt_choice,
     prompt_free_text,
     prompt_yes_no,
     run_wizard,
+)
+
+# Flags that a --non-interactive new-repo run must supply: the prompts that have
+# no sensible default (issue #2382). Everything else falls back to its
+# documented default. (attr, flag) pairs; attr is the argparse dest.
+_REQUIRED_NON_INTERACTIVE = (
+    ("description", "--description"),
+    ("repository_type", "--repository-type"),
+    ("branching_model", "--branching-model"),
+    ("versioning_scheme", "--versioning-scheme"),
+    ("release_model", "--release-model"),
 )
 
 
@@ -33,7 +45,82 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--visibility",
         choices=("public", "private"),
-        help="Repository visibility (new repos only)",
+        help="Repository visibility, new repos only (default: public)",
+    )
+
+    # Wizard-prompt flags. Each overrides the matching interactive prompt exactly
+    # as --visibility already does; supplying all of them runs the tool with zero
+    # prompts (issue #2382).
+    parser.add_argument(
+        "--description",
+        help="Project description (one paragraph)",
+    )
+    parser.add_argument(
+        "--repository-type",
+        choices=sorted(_ENUMS["repository-type"]),
+        help="Repository type",
+    )
+    parser.add_argument(
+        "--language",
+        choices=sorted(_ENUMS["primary-language"]),
+        help="Primary language (omit for a language-less repo)",
+    )
+    parser.add_argument(
+        "--branching-model",
+        choices=sorted(_ENUMS["branching-model"]),
+        help="Branching model",
+    )
+    parser.add_argument(
+        "--versioning-scheme",
+        choices=sorted(_ENUMS["versioning-scheme"]),
+        help="Versioning scheme",
+    )
+    parser.add_argument(
+        "--release-model",
+        choices=sorted(_ENUMS["release-model"]),
+        help="Release model",
+    )
+    parser.add_argument(
+        "--versions",
+        help="CI versions, comma-separated (default: language-derived)",
+    )
+    parser.add_argument(
+        "--integration-tests",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable integration tests (default: no)",
+    )
+    parser.add_argument(
+        "--publish-release",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Publish releases (default: derived from --release-model)",
+    )
+    parser.add_argument(
+        "--publish-docs",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Publish docs (default: yes)",
+    )
+    parser.add_argument(
+        "--vergil-version",
+        help="Vergil dependency version (default: v2.1)",
+    )
+    parser.add_argument(
+        "--license",
+        choices=("MIT", "GPL-3.0", "Apache-2.0", "none"),
+        help="License (default: MIT)",
+    )
+    parser.add_argument(
+        "--initial-version",
+        help="Initial version (default: 0.1.0)",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        "--yes",
+        action="store_true",
+        dest="non_interactive",
+        help="Run with no prompts; fail loud on any missing required flag",
     )
 
     args = parser.parse_args(argv)
@@ -46,6 +133,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     if args.repo and "/" not in args.repo:
         parser.error("repo must be in ORG/NAME format")
+
+    # A --non-interactive new-repo run must supply every no-default prompt.
+    # Adopt runs draw those from the existing vergil.toml, so they are validated
+    # later once that config is loaded (repo_init.step_generate_config).
+    if args.non_interactive and not args.adopt:
+        missing = [flag for attr, flag in _REQUIRED_NON_INTERACTIVE if getattr(args, attr) is None]
+        if missing:
+            parser.error(
+                "--non-interactive requires these flags for a new repo: " + ", ".join(missing)
+            )
 
     return args
 
@@ -66,17 +163,23 @@ def main(argv: list[str] | None = None) -> int:
             ".claude/hooks/guard.sh, LICENSE, README.md, .gitignore, CI/CD workflows,\n"
             "docs site config, GitHub settings, rulesets, and labels."
         )
-        if not prompt_yes_no("Continue?", default=False):
+        # Under --non-interactive/--yes the destructive confirmation is
+        # auto-accepted (issue #2382).
+        if not args.non_interactive and not prompt_yes_no("Continue?", default=False):
             print("Aborted.")
             return 1
 
         ctx = RepoInitContext(org=org, name=name, adopt=True)
+        if args.description is not None:
+            ctx.description = args.description
     else:
         org, name = args.repo.split("/", 1)
         ctx = RepoInitContext(org=org, name=name)
 
         if args.visibility:
             ctx.visibility = args.visibility
+        elif args.non_interactive:
+            ctx.visibility = "public"
         else:
             ctx.visibility = prompt_choice(
                 "Repository visibility",
@@ -84,7 +187,30 @@ def main(argv: list[str] | None = None) -> int:
                 default="public",
             )
 
-        ctx.description = prompt_free_text("Project description (one paragraph)")
+        # --description is a required flag under --non-interactive (validated in
+        # parse_args), so it is always present there; the else is reached only by
+        # an interactive run, which prompts.
+        if args.description is not None:
+            ctx.description = args.description
+        else:
+            ctx.description = prompt_free_text("Project description (one paragraph)")
+
+    # Carry the remaining wizard-prompt flags into the context; the wizard
+    # resolves each (flag override > non-interactive default > prompt).
+    ctx.non_interactive = args.non_interactive
+    ctx.opt_description = args.description
+    ctx.opt_repository_type = args.repository_type
+    ctx.opt_primary_language = args.language
+    ctx.opt_branching_model = args.branching_model
+    ctx.opt_versioning_scheme = args.versioning_scheme
+    ctx.opt_release_model = args.release_model
+    ctx.opt_ci_versions = args.versions
+    ctx.opt_integration_tests = args.integration_tests
+    ctx.opt_publish_release = args.publish_release
+    ctx.opt_publish_docs = args.publish_docs
+    ctx.opt_vergil_version = args.vergil_version
+    ctx.opt_license_type = args.license
+    ctx.opt_initial_version = args.initial_version
 
     run_wizard(ctx)
     return 0

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -9,7 +9,10 @@ import subprocess
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from vergil_tooling.lib import git, github, repo_config
 from vergil_tooling.lib.config import _ENUMS
@@ -43,6 +46,28 @@ class RepoInitContext:
     vergil_version: str = "v2.1"
     license_type: str = "MIT"
     initial_version: str = "0.1.0"
+
+    # Non-interactive mode (issue #2382): resolve every value from a flag and
+    # never prompt. The wizard fails loud on a missing required value rather
+    # than silently defaulting.
+    non_interactive: bool = False
+
+    # Flag overrides carried into the wizard. ``None`` means the flag was not
+    # supplied on the CLI — distinct from a value that merely equals a default —
+    # so a resolver can tell "not provided" from "provided as the default".
+    opt_description: str | None = None
+    opt_repository_type: str | None = None
+    opt_primary_language: str | None = None
+    opt_branching_model: str | None = None
+    opt_versioning_scheme: str | None = None
+    opt_release_model: str | None = None
+    opt_ci_versions: str | None = None
+    opt_integration_tests: bool | None = None
+    opt_publish_release: bool | None = None
+    opt_publish_docs: bool | None = None
+    opt_vergil_version: str | None = None
+    opt_license_type: str | None = None
+    opt_initial_version: str | None = None
 
     @property
     def repo(self) -> str:
@@ -172,6 +197,29 @@ def prompt_free_text(
         if not required:
             return ""
         print("  This field is required.")
+
+
+def _resolve[T](
+    override: T | None,
+    *,
+    non_interactive: bool,
+    default: T,
+    prompt: Callable[[], T],
+) -> T:
+    """Resolve a wizard value: flag override, else default (non-interactive),
+    else prompt.
+
+    An explicit flag override always wins. With no override, a
+    ``--non-interactive`` run takes the documented default (which mirrors the
+    interactive default exactly), while an interactive run prompts. Required
+    values that have no sensible default are validated up front — see
+    ``parse_args`` and ``step_generate_config`` (issue #2382).
+    """
+    if override is not None:
+        return override
+    if non_interactive:
+        return default
+    return prompt()
 
 
 def _load_data_file(filename: str) -> str:
@@ -685,7 +733,8 @@ def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
         return
 
     resolved = target.resolve()
-    if not prompt_yes_no(f"Step 2: Clone to {resolved}?", default=True):
+    # Under --non-interactive/--yes the clone confirmation is auto-accepted.
+    if not ctx.non_interactive and not prompt_yes_no(f"Step 2: Clone to {resolved}?", default=True):
         print("Aborted. Re-run from the directory where you want the clone.")
         raise SystemExit(1)
 
@@ -734,61 +783,143 @@ def step_generate_config(ctx: RepoInitContext) -> None:
     pub_raw = existing.get("publish", {}) if existing else {}
     deps = existing.get("dependencies", {}) if existing else {}
 
-    ctx.repository_type = prompt_choice(
-        "Repository type",
-        sorted(_ENUMS["repository-type"]),
-        default=project.get("repository-type", ""),
+    ni = ctx.non_interactive
+
+    repo_type_default = project.get("repository-type", "")
+    ctx.repository_type = _resolve(
+        ctx.opt_repository_type,
+        non_interactive=ni,
+        default=repo_type_default,
+        prompt=lambda: prompt_choice(
+            "Repository type",
+            sorted(_ENUMS["repository-type"]),
+            default=repo_type_default,
+        ),
     )
 
     # Primary language is prompted on its own — "no language" is the absence of
     # a language, presented as a separate "none of the above" choice, not a
-    # sixth enum value (issue #1579).
-    ctx.primary_language = prompt_language(default=project.get("primary-language", ""))
+    # sixth enum value (issue #1579). Its documented default is "no language",
+    # so omitting --language under --non-interactive yields a language-less repo.
+    lang_default = project.get("primary-language", "")
+    ctx.primary_language = _resolve(
+        ctx.opt_primary_language,
+        non_interactive=ni,
+        default=lang_default,
+        prompt=lambda: prompt_language(default=lang_default),
+    )
 
-    enum_fields = [
-        ("branching_model", "branching-model", "Branching model"),
-        ("versioning_scheme", "versioning-scheme", "Versioning scheme"),
-        ("release_model", "release-model", "Release model"),
-    ]
-    for attr, toml_key, label in enum_fields:
-        options = sorted(_ENUMS[toml_key])
-        default = project.get(toml_key, "")
-        value = prompt_choice(label, options, default=default)
-        setattr(ctx, attr, value)
+    branching_default = project.get("branching-model", "")
+    ctx.branching_model = _resolve(
+        ctx.opt_branching_model,
+        non_interactive=ni,
+        default=branching_default,
+        prompt=lambda: prompt_choice(
+            "Branching model", sorted(_ENUMS["branching-model"]), default=branching_default
+        ),
+    )
+
+    versioning_default = project.get("versioning-scheme", "")
+    ctx.versioning_scheme = _resolve(
+        ctx.opt_versioning_scheme,
+        non_interactive=ni,
+        default=versioning_default,
+        prompt=lambda: prompt_choice(
+            "Versioning scheme", sorted(_ENUMS["versioning-scheme"]), default=versioning_default
+        ),
+    )
+
+    release_model_default = project.get("release-model", "")
+    ctx.release_model = _resolve(
+        ctx.opt_release_model,
+        non_interactive=ni,
+        default=release_model_default,
+        prompt=lambda: prompt_choice(
+            "Release model", sorted(_ENUMS["release-model"]), default=release_model_default
+        ),
+    )
+
+    # No silent failure (issue #2382): a --non-interactive run must resolve every
+    # required enum to a real value. New-repo runs are gated up front in
+    # parse_args; this catches the adopt path when an existing vergil.toml (or a
+    # missing one) leaves a required field empty and no flag supplied it.
+    if ni:
+        missing = [
+            flag
+            for value, flag in (
+                (ctx.repository_type, "--repository-type"),
+                (ctx.branching_model, "--branching-model"),
+                (ctx.versioning_scheme, "--versioning-scheme"),
+                (ctx.release_model, "--release-model"),
+            )
+            if not value
+        ]
+        if missing:
+            raise SystemExit(
+                "error: --non-interactive is missing required values: " + ", ".join(missing)
+            )
 
     default_versions = _default_ci_versions(ctx.primary_language)
     existing_versions = ", ".join(ci_raw.get("versions", []))
-    raw_versions = prompt_free_text(
-        "CI versions (comma-separated)",
-        default=existing_versions or default_versions,
+    versions_default = existing_versions or default_versions
+    raw_versions = _resolve(
+        ctx.opt_ci_versions,
+        non_interactive=ni,
+        default=versions_default,
+        prompt=lambda: prompt_free_text(
+            "CI versions (comma-separated)",
+            default=versions_default,
+        ),
     )
     ctx.ci_versions = [v.strip() for v in raw_versions.split(",")]
 
-    ctx.integration_tests = prompt_yes_no(
-        "Integration tests?",
-        default=ci_raw.get("integration-tests", False),
+    it_default = ci_raw.get("integration-tests", False)
+    ctx.integration_tests = _resolve(
+        ctx.opt_integration_tests,
+        non_interactive=ni,
+        default=it_default,
+        prompt=lambda: prompt_yes_no("Integration tests?", default=it_default),
     )
 
     release_default = ctx.release_model != "none"
-    ctx.publish_release = prompt_yes_no(
-        "Publish releases?",
-        default=pub_raw.get("release", release_default),
+    pr_default = pub_raw.get("release", release_default)
+    ctx.publish_release = _resolve(
+        ctx.opt_publish_release,
+        non_interactive=ni,
+        default=pr_default,
+        prompt=lambda: prompt_yes_no("Publish releases?", default=pr_default),
     )
 
-    ctx.publish_docs = prompt_yes_no(
-        "Publish docs?",
-        default=pub_raw.get("docs", True),
+    pd_default = pub_raw.get("docs", True)
+    ctx.publish_docs = _resolve(
+        ctx.opt_publish_docs,
+        non_interactive=ni,
+        default=pd_default,
+        prompt=lambda: prompt_yes_no("Publish docs?", default=pd_default),
     )
 
-    ctx.vergil_version = prompt_free_text(
-        "Vergil dependency version",
-        default=deps.get("vergil", "v2.1"),
+    vv_default = deps.get("vergil", "v2.1")
+    ctx.vergil_version = _resolve(
+        ctx.opt_vergil_version,
+        non_interactive=ni,
+        default=vv_default,
+        prompt=lambda: prompt_free_text("Vergil dependency version", default=vv_default),
     )
 
     license_options = ["MIT", "GPL-3.0", "Apache-2.0", "none"]
-    ctx.license_type = prompt_choice("License", license_options, default="MIT")
+    ctx.license_type = _resolve(
+        ctx.opt_license_type,
+        non_interactive=ni,
+        default="MIT",
+        prompt=lambda: prompt_choice("License", license_options, default="MIT"),
+    )
 
-    ctx.initial_version = prompt_free_text("Initial version", default="0.1.0")
+    ctx.initial_version = _resolve(
+        ctx.opt_initial_version,
+        non_interactive=ni,
+        default="0.1.0",
+        prompt=lambda: prompt_free_text("Initial version", default="0.1.0"),
+    )
 
     content = render_vergil_toml(ctx)
     if ctx.work_dir is None:  # pragma: no cover

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib.repo_init import (
     _default_ci_versions,
     _load_existing_config,
     _remote_branch_exists,
+    _resolve,
     _sync_labels,
     detect_completed_steps,
     prompt_choice,
@@ -131,6 +132,33 @@ class TestPromptFreeText:
         with patch("builtins.input", return_value=""):
             result = prompt_free_text("Optional", required=False)
         assert result == ""
+
+
+class TestResolve:
+    def test_override_wins(self) -> None:
+        called = False
+
+        def prompt() -> str:
+            nonlocal called
+            called = True
+            return "prompted"
+
+        result = _resolve("flag", non_interactive=False, default="dflt", prompt=prompt)
+        assert result == "flag"
+        assert called is False
+
+    def test_non_interactive_uses_default(self) -> None:
+        result = _resolve(None, non_interactive=True, default="dflt", prompt=lambda: "prompted")
+        assert result == "dflt"
+
+    def test_interactive_prompts_when_no_override(self) -> None:
+        result = _resolve(None, non_interactive=False, default="dflt", prompt=lambda: "prompted")
+        assert result == "prompted"
+
+    def test_false_boolean_override_is_respected(self) -> None:
+        # A False override must not be mistaken for "not supplied".
+        result = _resolve(False, non_interactive=True, default=True, prompt=lambda: True)
+        assert result is False
 
 
 class TestRepoInitContext:
@@ -634,6 +662,30 @@ class TestStepClone:
         ):
             step_clone(ctx, parent_dir=tmp_path)
 
+    def test_non_interactive_skips_clone_confirmation(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        ctx.non_interactive = True
+        target = tmp_path / "vergil-vm"
+
+        def mock_subprocess_run(cmd: Any, **kw: Any) -> None:
+            target.mkdir(exist_ok=True)
+            (target / ".git").mkdir()
+
+        with (
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=mock_subprocess_run,
+            ),
+            patch(
+                "vergil_tooling.lib.repo_init.prompt_yes_no",
+                side_effect=AssertionError("prompted in non-interactive mode"),
+            ),
+            patch("vergil_tooling.lib.repo_init.os.chdir"),
+        ):
+            step_clone(ctx, parent_dir=tmp_path)
+
+        assert ctx.work_dir == target
+
 
 class TestStepGenerateConfig:
     def test_prompts_and_writes_vergil_toml(self, tmp_path: Path) -> None:
@@ -797,6 +849,100 @@ class TestStepGenerateConfig:
 
         assert ctx.primary_language == "python"
         assert ctx.repository_type == "tooling"
+
+    def test_non_interactive_resolves_flags_without_prompting(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        ctx.work_dir = tmp_path
+        ctx.non_interactive = True
+        ctx.opt_repository_type = "tooling"
+        ctx.opt_primary_language = "python"
+        ctx.opt_branching_model = "library-release"
+        ctx.opt_versioning_scheme = "semver"
+        ctx.opt_release_model = "tagged-release"
+        ctx.opt_ci_versions = "3.12, 3.13"
+        ctx.opt_integration_tests = False
+        ctx.opt_publish_release = True
+        ctx.opt_publish_docs = False
+        ctx.opt_vergil_version = "v2.1"
+        ctx.opt_license_type = "Apache-2.0"
+        ctx.opt_initial_version = "1.0.0"
+
+        with (
+            patch(
+                "builtins.input",
+                side_effect=AssertionError("prompted in non-interactive mode"),
+            ),
+            patch("vergil_tooling.lib.repo_init.git.run"),
+        ):
+            step_generate_config(ctx)
+
+        assert ctx.repository_type == "tooling"
+        assert ctx.primary_language == "python"
+        assert ctx.branching_model == "library-release"
+        assert ctx.versioning_scheme == "semver"
+        assert ctx.release_model == "tagged-release"
+        assert ctx.ci_versions == ["3.12", "3.13"]
+        assert ctx.integration_tests is False
+        assert ctx.publish_release is True
+        assert ctx.publish_docs is False
+        assert ctx.license_type == "Apache-2.0"
+        assert ctx.initial_version == "1.0.0"
+        content = (tmp_path / "vergil.toml").read_text()
+        assert 'primary-language = "python"' in content
+        assert _parse_raw_config(tomllib.loads(content)).ci.versions == ["3.12", "3.13"]
+
+    def test_non_interactive_uses_documented_defaults_for_optional_flags(
+        self, tmp_path: Path
+    ) -> None:
+        # Required enums supplied; every optional flag omitted falls back to its
+        # documented default (matching the interactive default exactly).
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        ctx.work_dir = tmp_path
+        ctx.non_interactive = True
+        ctx.opt_repository_type = "tooling"
+        ctx.opt_branching_model = "library-release"
+        ctx.opt_versioning_scheme = "semver"
+        ctx.opt_release_model = "tagged-release"
+
+        with (
+            patch(
+                "builtins.input",
+                side_effect=AssertionError("prompted in non-interactive mode"),
+            ),
+            patch("vergil_tooling.lib.repo_init.git.run"),
+        ):
+            step_generate_config(ctx)
+
+        assert ctx.primary_language == ""  # no --language → language-less
+        assert ctx.integration_tests is False
+        assert ctx.publish_release is True  # release-model != none
+        assert ctx.publish_docs is True
+        assert ctx.vergil_version == "v2.1"
+        assert ctx.license_type == "MIT"
+        assert ctx.initial_version == "0.1.0"
+
+    def test_non_interactive_adopt_missing_required_enum_fails_loud(self, tmp_path: Path) -> None:
+        # Adopt with no existing vergil.toml and no flags: the required enums
+        # resolve empty, so the wizard must fail loud rather than write an
+        # invalid config (issue #2382, no silent failure).
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm", adopt=True)
+        ctx.work_dir = tmp_path
+        ctx.non_interactive = True
+
+        with (
+            patch(
+                "builtins.input",
+                side_effect=AssertionError("prompted in non-interactive mode"),
+            ),
+            patch("vergil_tooling.lib.repo_init.git.run"),
+            pytest.raises(SystemExit) as exc,
+        ):
+            step_generate_config(ctx)
+
+        message = str(exc.value)
+        assert "--repository-type" in message
+        assert "--branching-model" in message
+        assert not (tmp_path / "vergil.toml").exists()
 
 
 class TestStepScaffoldConfigFiles:

--- a/tests/vergil_tooling/test_vrg_github_repo_init.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_init.py
@@ -34,6 +34,121 @@ class TestParseArgs:
         with pytest.raises(SystemExit):
             parse_args([])
 
+    def test_wizard_flags_parse(self) -> None:
+        args = parse_args(
+            [
+                "org/repo",
+                "--description",
+                "A test repo",
+                "--repository-type",
+                "tooling",
+                "--language",
+                "python",
+                "--branching-model",
+                "library-release",
+                "--versioning-scheme",
+                "semver",
+                "--release-model",
+                "tagged-release",
+                "--versions",
+                "3.12,3.13",
+                "--integration-tests",
+                "--no-publish-release",
+                "--publish-docs",
+                "--vergil-version",
+                "v2.1",
+                "--license",
+                "Apache-2.0",
+                "--initial-version",
+                "1.0.0",
+            ]
+        )
+        assert args.description == "A test repo"
+        assert args.repository_type == "tooling"
+        assert args.language == "python"
+        assert args.branching_model == "library-release"
+        assert args.versioning_scheme == "semver"
+        assert args.release_model == "tagged-release"
+        assert args.versions == "3.12,3.13"
+        assert args.integration_tests is True
+        assert args.publish_release is False
+        assert args.publish_docs is True
+        assert args.vergil_version == "v2.1"
+        assert args.license == "Apache-2.0"
+        assert args.initial_version == "1.0.0"
+
+    def test_boolean_flags_default_none(self) -> None:
+        # Unset boolean flags stay None so the wizard can tell "not supplied"
+        # from an explicit true/false.
+        args = parse_args(["org/repo"])
+        assert args.integration_tests is None
+        assert args.publish_release is None
+        assert args.publish_docs is None
+        assert args.non_interactive is False
+
+    def test_yes_is_alias_for_non_interactive(self) -> None:
+        args = parse_args(["--adopt", "--yes"])
+        assert args.non_interactive is True
+
+    def test_invalid_enum_choice_rejected(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["org/repo", "--repository-type", "not-a-type"])
+
+    def test_non_interactive_requires_flags_for_new_repo(self) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["org/repo", "--non-interactive"])
+
+    def test_non_interactive_missing_flags_names_each(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(
+                [
+                    "org/repo",
+                    "--non-interactive",
+                    "--description",
+                    "d",
+                    "--repository-type",
+                    "tooling",
+                ]
+            )
+        err = capsys.readouterr().err
+        # Inspect the error message line, not the usage banner (which lists
+        # every flag).
+        message = next(line for line in err.splitlines() if "requires these flags" in line)
+        assert "--branching-model" in message
+        assert "--versioning-scheme" in message
+        assert "--release-model" in message
+        # Supplied flags are not reported as missing.
+        assert "--description" not in message
+        assert "--repository-type" not in message
+
+    def test_non_interactive_with_all_required_flags_ok(self) -> None:
+        args = parse_args(
+            [
+                "org/repo",
+                "--non-interactive",
+                "--description",
+                "d",
+                "--repository-type",
+                "tooling",
+                "--branching-model",
+                "library-release",
+                "--versioning-scheme",
+                "semver",
+                "--release-model",
+                "tagged-release",
+            ]
+        )
+        assert args.non_interactive is True
+
+    def test_adopt_non_interactive_needs_no_required_flags(self) -> None:
+        # Adopt draws the required values from the existing vergil.toml, so
+        # parse_args does not demand them.
+        args = parse_args(["--adopt", "--non-interactive"])
+        assert args.non_interactive is True
+        assert args.adopt is True
+
 
 class TestMain:
     def test_adopt_mode_success(self) -> None:
@@ -87,3 +202,109 @@ class TestMain:
         assert result == 0
         ctx = mock_wizard.call_args[0][0]
         assert ctx.visibility == "public"
+
+    def test_non_interactive_new_repo_threads_flags_without_prompting(self) -> None:
+        argv = [
+            "org/repo",
+            "--non-interactive",
+            "--description",
+            "A scripted repo",
+            "--repository-type",
+            "tooling",
+            "--language",
+            "python",
+            "--branching-model",
+            "library-release",
+            "--versioning-scheme",
+            "semver",
+            "--release-model",
+            "tagged-release",
+            "--visibility",
+            "private",
+            "--no-integration-tests",
+            "--publish-release",
+            "--no-publish-docs",
+            "--vergil-version",
+            "v2.1",
+            "--license",
+            "Apache-2.0",
+            "--initial-version",
+            "1.2.3",
+        ]
+        with (
+            patch("builtins.input", side_effect=AssertionError("prompted in non-interactive mode")),
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(argv)
+
+        assert result == 0
+        ctx = mock_wizard.call_args[0][0]
+        assert ctx.non_interactive is True
+        assert ctx.visibility == "private"
+        assert ctx.description == "A scripted repo"
+        assert ctx.opt_repository_type == "tooling"
+        assert ctx.opt_primary_language == "python"
+        assert ctx.opt_branching_model == "library-release"
+        assert ctx.opt_versioning_scheme == "semver"
+        assert ctx.opt_release_model == "tagged-release"
+        assert ctx.opt_integration_tests is False
+        assert ctx.opt_publish_release is True
+        assert ctx.opt_publish_docs is False
+        assert ctx.opt_vergil_version == "v2.1"
+        assert ctx.opt_license_type == "Apache-2.0"
+        assert ctx.opt_initial_version == "1.2.3"
+
+    def test_non_interactive_defaults_visibility_public(self) -> None:
+        argv = [
+            "org/repo",
+            "--non-interactive",
+            "--description",
+            "d",
+            "--repository-type",
+            "tooling",
+            "--branching-model",
+            "library-release",
+            "--versioning-scheme",
+            "semver",
+            "--release-model",
+            "tagged-release",
+        ]
+        with (
+            patch("builtins.input", side_effect=AssertionError("prompted in non-interactive mode")),
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(argv)
+
+        assert result == 0
+        ctx = mock_wizard.call_args[0][0]
+        assert ctx.visibility == "public"
+
+    def test_adopt_yes_skips_continue_prompt(self) -> None:
+        with (
+            patch("vergil_tooling.lib.github.current_repo", return_value="org/repo"),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.prompt_yes_no",
+                side_effect=AssertionError("prompted under --yes"),
+            ),
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(["--adopt", "--yes"])
+
+        assert result == 0
+        ctx = mock_wizard.call_args[0][0]
+        assert ctx.non_interactive is True
+
+    def test_adopt_description_flag_overrides_empty_default(self) -> None:
+        with (
+            patch("vergil_tooling.lib.github.current_repo", return_value="org/repo"),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.prompt_yes_no",
+                return_value=True,
+            ),
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(["--adopt", "--description", "Adopted repo"])
+
+        assert result == 0
+        ctx = mock_wizard.call_args[0][0]
+        assert ctx.description == "Adopted repo"


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a CLI flag for every vrg-github-repo-init wizard prompt plus a --non-interactive/--yes mode, so scripted repo creation runs start-to-finish with zero prompts and fails loud on any missing required value.

## Issue Linkage

- Closes #2382

## Notes

- Flags override prompts exactly as --visibility already did; omitting them preserves today's interactive behaviour unchanged (all prior tests still pass). Required-flag enforcement is two-layered: parse_args names each missing no-default flag up front for a new repo (zero side effects), and step_generate_config catches the adopt path where an existing or absent vergil.toml leaves a required enum empty (before writing vergil.toml) — no silent defaulting. Optional prompts fall back to their documented interactive defaults; --language omitted yields a language-less repo, matching the interactive default. Booleans use argparse.BooleanOptionalAction with default=None so the wizard distinguishes 'not supplied' from an explicit true/false. --help documents every flag. vrg-validate green (lint, typecheck, tests, 100% coverage).