### PR TITLE
feat(repo-init): fail loud when vrg-github-repo-init is run without human credentials

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_init.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
+from vergil_tooling.lib import identity_mode
 from vergil_tooling.lib.config import _ENUMS
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
@@ -149,6 +150,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    # `gh repo create` and the org-level branch/label/Pages setup this command
+    # drives require human GitHub credentials. Under an agent identity those
+    # credentials are absent, and without this guard the failure surfaces deep in
+    # the call stack as an opaque `gh auth login` traceback (issue #2391). Refuse
+    # up front with one clear message — mirroring the identity check in
+    # vrg-submit-pr / vrg-release — before any side effect. This command is
+    # human-credential-only until that boundary moves.
+    if identity_mode.is_agent():
+        print(
+            "vrg-github-repo-init must be run by a human with an authenticated gh. "
+            "It runs `gh repo create` and other org-level operations that the "
+            "agent-credential path cannot perform, so it is human-credential-only "
+            "until that boundary moves.\n"
+            "Remedy: run it in a human shell.",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.adopt:
         from vergil_tooling.lib import github

--- a/tests/vergil_tooling/test_vrg_github_repo_init.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_init.py
@@ -151,6 +151,46 @@ class TestParseArgs:
 
 
 class TestMain:
+    def test_aborts_under_agent_identity(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # gh repo create + org-level setup need human credentials; an agent
+        # identity must hard-abort with a clear message before any side effect,
+        # not crash deep in the call stack (issue #2391).
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.identity_mode.is_agent",
+                return_value=True,
+            ),
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+            patch("vergil_tooling.lib.github.current_repo") as mock_current_repo,
+        ):
+            result = main(["org/repo"])
+
+        assert result == 1
+        mock_wizard.assert_not_called()
+        mock_current_repo.assert_not_called()
+        err = capsys.readouterr().err
+        assert "human" in err.lower()
+        assert "gh repo create" in err
+
+    def test_agent_refusal_precedes_adopt_side_effects(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The refusal fires before adopt resolves the repo or prompts, so an
+        # agent hits it in every mode.
+        with (
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.identity_mode.is_agent",
+                return_value=True,
+            ),
+            patch("vergil_tooling.lib.github.current_repo") as mock_current_repo,
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(["--adopt"])
+
+        assert result == 1
+        mock_current_repo.assert_not_called()
+        mock_wizard.assert_not_called()
+
     def test_adopt_mode_success(self) -> None:
         with (
             patch("vergil_tooling.lib.github.current_repo", return_value="org/repo"),


### PR DESCRIPTION
# Pull Request

## Summary

- Add an up-front identity check to vrg-github-repo-init that refuses under an agent identity with one clear message, instead of crashing deep in the call stack with an opaque gh auth login traceback.

## Issue Linkage

- Closes #2391

## Notes

- Reuses identity_mode.is_agent() — the same template as vrg-submit-pr and vrg-release — and fires before any side effect (no repo resolution, no prompts, no wizard). The message names the human-credential-only boundary and the remedy (run in a human shell). Behaviour with human credentials is unchanged. Adds two tests covering the agent refusal for both the new-repo and --adopt paths.