### PR TITLE
fix(repo-init): add actions:read to generated cd.yml release permissions

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -546,7 +546,14 @@ def render_cd_workflow(ctx: RepoInitContext) -> str:
     """Render .github/workflows/cd.yml."""
     permissions = ["  contents: write\n"]
     if ctx.publish_release:
+        # The release job inherits these top-level permissions (it sets no block
+        # of its own). cd-release.yml@v2.1 requests actions:read; GitHub validates
+        # reusable-workflow permissions at parse time, so omitting it fails the
+        # whole CD run with startup_failure on every push — even though the job is
+        # if:main-gated (if is evaluated after parse). Keep actions:read here in
+        # sync with whatever cd-release.yml requires (issue #2392).
         permissions = [
+            "  actions: read\n",
             "  attestations: write\n",
             "  contents: write\n",
             "  id-token: write\n",

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -489,7 +489,19 @@ class TestRenderCdWorkflow:
         assert "attestations: write" in content
         assert "id-token: write" in content
         assert "pull-requests: write" in content
+        # cd-release.yml@v2.1 requests actions:read; without it the reusable
+        # workflow startup-fails at parse time on every CD run (issue #2392).
+        assert "actions: read" in content
         assert "cd-docs" not in content
+
+    def test_release_omits_actions_read_when_no_release(self) -> None:
+        # actions:read is only needed by the release job; a docs-only CD must
+        # not carry it (no cd-release call to satisfy).
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.publish_docs = True
+        ctx.publish_release = False
+        content = render_cd_workflow(ctx)
+        assert "actions: read" not in content
 
     def test_docs_and_release(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")


### PR DESCRIPTION
# Pull Request

## Summary

- Add actions:read to the generated cd.yml top-level permissions for publish.release=true repos so the inherited release-job permissions satisfy cd-release.yml@v2.1, fixing the startup_failure that broke CD on every push in freshly-scaffolded repos.

## Issue Linkage

- Closes #2392

## Notes

- Root cause: the caller set an explicit top-level permissions block (attestations/contents/id-token/pull-requests) but omitted actions; the release job inherits it and calls cd-release.yml@v2.1, which requests actions:read. Explicit block means unlisted scopes default to none, and GitHub validates reusable-workflow permissions at parse time, so the whole CD workflow startup-failed on every push to develop and main despite the if:main gate (evaluated after parse). Fix adds actions:read to the top-level block, kept in alphabetical order. Tests assert actions:read is present for a release repo and absent for a docs-only CD.