### PR TITLE
fix(repo-init): reflow generated README description under markdownlint MD013

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import textwrap
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
@@ -305,12 +306,36 @@ def render_claude_md(ctx: RepoInitContext) -> str:
     )
 
 
+def _reflow_prose(text: str, width: int = 100) -> str:
+    """Reflow a free-text paragraph to lines no longer than ``width``.
+
+    The user-supplied description is one paragraph of arbitrary length; emitted
+    verbatim it routinely exceeds the bundled markdownlint MD013 limit (100),
+    so a freshly-created repo's first ``vrg-validate`` fails on generated
+    content (issue #2393). Wrap on word boundaries, paragraph by paragraph, so
+    blank-line-separated paragraphs survive. ``break_long_words``/
+    ``break_on_hyphens`` are off so a single long token (e.g. a URL) is never
+    mangled — it stays on its own line rather than being split.
+    """
+    paragraphs = re.split(r"\n\s*\n", text.strip())
+    wrapped = [
+        textwrap.fill(
+            para.strip(),
+            width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+        for para in paragraphs
+    ]
+    return "\n\n".join(wrapped)
+
+
 def render_readme(ctx: RepoInitContext) -> str:
     """Render README.md from wizard context."""
     lines = [
         f"# {ctx.name}\n",
         "\n",
-        f"{ctx.description}\n",
+        f"{_reflow_prose(ctx.description)}\n",
         "\n",
         "## Table of Contents\n",
         "\n",

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -309,6 +309,35 @@ class TestRenderReadme:
         assert "See [LICENSE](LICENSE).\n" in content
         assert "GPL" not in content
 
+    def test_long_description_reflowed_under_md013(self) -> None:
+        # A long one-paragraph description must be wrapped to <=100-char lines so
+        # the generated README passes the bundled markdownlint MD013 limit — the
+        # first vrg-validate of every new repo lints it (issue #2393).
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        ctx.description = (
+            "A resilience and observability toolkit for message queues that "
+            "provides retry policies, dead-letter handling, structured tracing, "
+            "and Prometheus metrics across RabbitMQ and Kafka backends, with "
+            "sensible defaults for production deployments."
+        )
+        ctx.license_type = "MIT"
+        ctx.publish_docs = True
+        content = render_readme(ctx)
+        assert all(len(line) <= 100 for line in content.splitlines())
+        # Content is preserved — every word from the description survives the wrap.
+        collapsed = " ".join(content.split())
+        for word in ctx.description.split():
+            assert word in collapsed
+
+    def test_description_paragraphs_preserved(self) -> None:
+        # Blank-line-separated paragraphs survive the reflow as separate blocks.
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+        ctx.description = "First paragraph.\n\nSecond paragraph."
+        ctx.license_type = "MIT"
+        ctx.publish_docs = True
+        content = render_readme(ctx)
+        assert "First paragraph.\n\nSecond paragraph.\n" in content
+
 
 class TestRenderGitignore:
     def test_contains_baseline_patterns(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Reflow the user-supplied description paragraph in the generated README.md to <=100-char lines so a freshly-scaffolded repo passes vrg-validate's bundled markdownlint MD013 check with no manual edit.

## Issue Linkage

- Closes #2393

## Notes

- Before, the description was emitted verbatim as one line; a typical paragraph exceeds MD013's 100-char limit, and since vrg-validate lints README.md the first PR of every new repo failed on generated content. The wrap is paragraph-aware (word boundaries; long tokens like URLs are never split; blank-line-separated paragraphs preserved). Tests assert no README line exceeds 100 chars for a long description, that all words survive the wrap, and that multi-paragraph descriptions stay separated.