### PR TITLE
feat(submit-pr): run the finalize/release/install cascade on the relay branch path

### DIFF
--- a/docs/site/docs/reference/dev/submit-pr.md
+++ b/docs/site/docs/reference/dev/submit-pr.md
@@ -96,6 +96,28 @@ The relay ref is cleaned up by [`vrg-finalize-pr`](finalize-pr.md), which
 deletes it alongside the branch on merge and sweeps any orphaned relay ref
 whose branch no longer exists.
 
+### Cascade on the relay path (`--finalize`/`--release`/`--install`)
+
+The relay path runs the full cascade too (issue #2398): the cascade is a
+**local macOS** action, so it does not matter whether the branch was
+implemented on the Mac or on a cloud VM. Once the PR is open, finalizing,
+releasing, and installing operate on the PR and the remote — the branch does
+not need to be checked out locally (`vrg-finalize-pr` already merges and
+cleans up a branch with no local worktree).
+
+```bash
+# Open PRs for both cloud-implemented branches, then merge, release, and
+# install — all locally, in one command.
+vrg-submit-pr --install feature/123-x feature/124-y
+```
+
+It uses the same batch semantics as the worktree batch (`--all` / `--select`):
+each PR is finalized in turn, then — only if every branch merged — a single
+end-of-batch validation runs, followed by **one** `vrg-release` (never one per
+branch). A branch that already carries a submitted PR is fail-fast in the
+cascade (finalize it directly with `vrg-finalize-pr <url>`); without a cascade
+flag it is simply reported and skipped, as before.
+
 ## Arguments
 
 | Argument | Required (CLI mode) | Description |

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -14,7 +14,11 @@ Supports three modes:
   ``head_sha`` and the PR is opened **without** pushing (``--head`` names
   the source branch). This is the Mac-side of the cloud→Mac relay handoff:
   the branch and its metadata already rode GitHub, so no worktree, no
-  ``git.current_branch()``, and no push are involved.
+  ``git.current_branch()``, and no push are involved. With a cascade flag
+  (``--finalize``/``--release``/``--install``) it also carries the branches
+  through the cascade locally, using the same batch semantics as the local
+  worktree batch — finalize each PR, then a single validation and **one**
+  release (issue #2398).
 
 The template and CLI modes push the branch using the human's host
 credentials before creating the PR. Because the human is the superset
@@ -852,6 +856,33 @@ def _verify_origin_tip(branch: str, state: WorkflowState) -> None:
         )
 
 
+def _relay_open(
+    root: Path, branch: str, args: argparse.Namespace, *, assume_yes: bool
+) -> tuple[str | None, str | None]:
+    """Resolve, verify, and open the relay PR for one already-pushed *branch*.
+
+    Returns ``(pr_url, submitted_url)``: exactly one is non-``None`` on a live
+    run — the new PR URL when the branch was opened, or the already-submitted
+    PR's URL when the branch already carries one. A dry run returns
+    ``(None, None)`` (``_open_pr`` previewed without opening). Resolves the
+    ready-state (local file preferred, else the relay ref), verifies origin's
+    tip matches the recorded ``head_sha``, and drives the shared :func:`_open_pr`
+    core with ``push=False``. Shared by the plain relay loop and the relay
+    cascade so both classify an already-submitted branch identically.
+    """
+    state = _resolve_ready_state(root, branch)
+    if state.submitted is not None:
+        return None, state.submitted.get("pr_url", "")
+    metadata = _metadata_from_state(state, branch)
+    base = _target_branch(args.base, state.base)
+    if not args.dry_run:
+        _verify_origin_tip(branch, state)
+    pr_url = _open_pr(
+        branch, base, metadata, push=False, dry_run=args.dry_run, assume_yes=assume_yes
+    )
+    return pr_url, None
+
+
 def _run_relay(branches: list[str], args: argparse.Namespace) -> int:
     """Open PRs for each already-pushed *branch* without a local worktree.
 
@@ -860,31 +891,108 @@ def _run_relay(branches: list[str], args: argparse.Namespace) -> int:
     the shared :func:`_open_pr` core with ``push=False``. Branches already
     carrying a submitted PR are reported and skipped. Standards/provenance run
     against the resolved GitHub-carried metadata, exactly as the local path runs
-    them against the worktree's file.
+    them against the worktree's file. The finalize/release/install cascade is
+    handled separately by :func:`_run_relay_cascade`.
     """
     root = Path(git.repo_root())
-    opened = 0
     for branch in branches:
-        state = _resolve_ready_state(root, branch)
-        if state.submitted is not None:
-            pr_url = state.submitted.get("pr_url", "")
+        pr_url, submitted_url = _relay_open(root, branch, args, assume_yes=args.yes)
+        if submitted_url is not None:
             print(
-                f"vrg-submit-pr: branch '{branch}' already has a submitted PR ({pr_url}); skipping."
+                f"vrg-submit-pr: branch '{branch}' already has a submitted PR "
+                f"({submitted_url}); skipping."
             )
             continue
-        metadata = _metadata_from_state(state, branch)
-        base = _target_branch(args.base, state.base)
-        if not args.dry_run:
-            _verify_origin_tip(branch, state)
-        pr_url = _open_pr(
-            branch, base, metadata, push=False, dry_run=args.dry_run, assume_yes=args.yes
-        )
-        if pr_url is None:
+        if pr_url is None:  # dry run — _open_pr previewed only
             continue
-        opened += 1
         print(f"Done. PR URL: {pr_url}")
         _print_pr_watch(pr_url)
     return 0
+
+
+def _run_relay_cascade(
+    branches: list[str], args: argparse.Namespace, *, release: bool, install: bool
+) -> int:
+    """Relay-submit *branches* and run the finalize (→ release → install) cascade.
+
+    The worktree-free counterpart of :func:`_run_submit_batch`, and it borrows
+    the same batch semantics because they are the *correct* ones for multiple
+    PRs: each branch is opened and finalized (``vrg-finalize-pr <url>
+    --skip-post-checks``) in turn, then — only if every branch merged — a single
+    end-of-batch validation runs, followed by **one** ``vrg-release`` (never one
+    per branch). It differs from ``_run_submit_batch`` only in the parts a
+    worktree provided: there is no local branch to rebase, and the PR is opened
+    via the relay core (``push=False``) rather than from a checked-out worktree.
+    ``vrg-finalize-pr`` already merges and cleans up a branch that is not checked
+    out locally — the cloud→Mac case the relay exists for — so no local fetch is
+    needed here.
+
+    Reached only when a cascade flag was passed (``--finalize`` is implied by
+    ``--release``/``--install``), so finalize always runs.
+    """
+    root = Path(git.repo_root())
+    main_root = git.main_worktree_root()
+
+    # Dry run: preview every PR and name the cascade, without touching origin.
+    if args.dry_run:
+        for branch in branches:
+            _relay_open(root, branch, args, assume_yes=args.yes)
+        print(_dry_run_chain_note(release=release, install=install))
+        return 0
+
+    def _process(branch: str) -> None:
+        pr_url, submitted_url = _relay_open(root, branch, args, assume_yes=True)
+        if submitted_url is not None:
+            raise batch.BatchAbortError(
+                f"branch already has a submitted PR ({submitted_url}); "
+                f"finalize it directly with: vrg-finalize-pr {submitted_url}"
+            )
+        # A live, non-submitted relay open always yields a URL (never a dry run);
+        # the guard narrows the type and defends the invariant.
+        if pr_url is None:  # pragma: no cover - unreachable on a live relay open
+            raise SystemExit("vrg-submit-pr: internal error: relay open returned no PR URL")
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", pr_url, "--skip-post-checks"),  # noqa: S607
+            cwd=main_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise batch.BatchAbortError(
+                f"vrg-finalize-pr {pr_url} --skip-post-checks exited {result.returncode}"
+            )
+
+    def _validate() -> None:
+        result = subprocess.run(  # noqa: S603
+            ("vrg-finalize-pr", "--cleanup-only"),  # noqa: S607
+            cwd=main_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise batch.BatchAbortError(f"end-of-batch validation exited {result.returncode}")
+
+    def _release() -> None:
+        cmd = ("vrg-release", "--install") if install else ("vrg-release",)
+        result = subprocess.run(cmd, cwd=main_root, check=False)  # noqa: S603,S607
+        if result.returncode != 0:
+            raise batch.BatchAbortError(f"{' '.join(cmd)} exited {result.returncode}")
+
+    post_steps: list[batch.PostStep] = [batch.PostStep("validation", _validate)]
+    if release:
+        post_steps.append(batch.PostStep("release", _release))
+
+    plan = [f"relay-submit + finalize {branch}" for branch in branches]
+    plan.append("then: validate develop once" + (", then release" if release else ""))
+
+    report = batch.run_batch(
+        branches,
+        _process,
+        label=lambda branch: branch,
+        plan=plan,
+        assume_yes=args.yes,
+        post_steps=post_steps,
+    )
+    print(batch.format_report(report))
+    return 0 if report.all_merged and report.post_failure is None else 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -911,9 +1019,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if args.branches:
-        # Relay path: branches identify the submit. It is deliberately narrow —
-        # it opens PRs worktree-free and hands off to pr-watch, with none of the
-        # local batch's worktree selection or finalize/release cascade.
+        # Relay path: branches identify the submit. It opens PRs worktree-free
+        # (from the branch's relayed ready-state), and — when a cascade flag is
+        # passed — carries them through finalize/release/install locally, exactly
+        # like the local worktree batch (issue #2398). It still rejects the
+        # worktree-selection and single-PR CLI flags, which name a different path.
         if args.all_worktrees or args.select is not None:
             print(
                 "vrg-submit-pr: branch arguments select the submit directly and "
@@ -929,13 +1039,9 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
         if cascade_requested:
-            print(
-                "vrg-submit-pr: the relay branch path does not run the "
-                "--finalize/--release/--install cascade; open the PR, then run "
-                "the cascade separately.",
-                file=sys.stderr,
+            return _run_relay_cascade(
+                args.branches, args, release=args.release, install=args.install
             )
-            return 1
         return _run_relay(args.branches, args)
 
     cli_fields = [args.issue, args.summary, args.title]

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -2135,10 +2135,245 @@ class TestRelayBranchPath:
         assert rc == 1
         assert "--issue/--summary/--title" in capsys.readouterr().err
 
-    def test_relay_rejects_cascade_flags(self, capsys: pytest.CaptureFixture[str]) -> None:
-        rc = main(["feature/x", "--finalize"])
+    def test_relay_cascade_finalizes_each_and_releases_once(self) -> None:
+        """--release relays both branches, finalizes each with --skip-post-checks,
+        then validates once and releases exactly once — not once per branch
+        (issue #2398)."""
+        states = {
+            "feature/a": _ready_state(issue="1", branch="feature/a", head_sha="sha_a"),
+            "feature/b": _ready_state(issue="2", branch="feature/b", head_sha="sha_b"),
+        }
+
+        def fake_read_output(*args: str) -> str:
+            branch = args[-1].removeprefix("refs/heads/")
+            return f"sha_{branch[-1]}\t{args[-1]}"
+
+        def fake_transport(branch: str) -> MagicMock:
+            t = MagicMock()
+            t.read.return_value = states[branch]
+            return t
+
+        calls: list[tuple[str, ...]] = []
+
+        def fake_run(cmd: tuple[str, ...], **_kwargs: object) -> MagicMock:
+            calls.append(tuple(cmd))
+            return MagicMock(returncode=0)
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", side_effect=fake_transport),
+            patch(_MOD + ".git.read_output", side_effect=fake_read_output),
+            patch(_MOD + "._push_branch"),
+            patch(
+                _MOD + ".github.create_pr",
+                side_effect=["https://x/pull/1", "https://x/pull/2"],
+            ),
+            patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        ):
+            rc = main(["feature/a", "feature/b", "--release", "--yes"])
+        assert rc == 0
+        assert ("vrg-finalize-pr", "https://x/pull/1", "--skip-post-checks") in calls
+        assert ("vrg-finalize-pr", "https://x/pull/2", "--skip-post-checks") in calls
+        assert ("vrg-finalize-pr", "--cleanup-only") in calls
+        # Released once for the whole batch, never per-branch.
+        assert calls.count(("vrg-release",)) == 1
+
+    def test_relay_cascade_finalize_only_skips_release(self) -> None:
+        """--finalize (no --release) finalizes each PR and validates once, but
+        never releases."""
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+        calls: list[tuple[str, ...]] = []
+
+        def fake_run(cmd: tuple[str, ...], **_kwargs: object) -> MagicMock:
+            calls.append(tuple(cmd))
+            return MagicMock(returncode=0)
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch"),
+            patch(_MOD + ".github.create_pr", return_value="https://x/pull/1"),
+            patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        ):
+            rc = main(["feature/x", "--finalize", "--yes"])
+        assert rc == 0
+        assert ("vrg-finalize-pr", "https://x/pull/1", "--skip-post-checks") in calls
+        assert ("vrg-finalize-pr", "--cleanup-only") in calls
+        assert not any(cmd and cmd[0] == "vrg-release" for cmd in calls)
+
+    def test_relay_cascade_install_passes_through(self) -> None:
+        """--install runs the release step as `vrg-release --install`."""
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+        calls: list[tuple[str, ...]] = []
+
+        def fake_run(cmd: tuple[str, ...], **_kwargs: object) -> MagicMock:
+            calls.append(tuple(cmd))
+            return MagicMock(returncode=0)
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch"),
+            patch(_MOD + ".github.create_pr", return_value="https://x/pull/1"),
+            patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        ):
+            rc = main(["feature/x", "--install", "--yes"])
+        assert rc == 0
+        assert ("vrg-release", "--install") in calls
+        assert ("vrg-release",) not in calls
+
+    def test_relay_cascade_already_submitted_branch_aborts(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """In the cascade, an already-submitted branch is fail-fast: it cannot be
+        finalized via relay, so the batch stops and the rest are not started."""
+        states = {
+            "feature/a": _ready_state(
+                issue="1",
+                branch="feature/a",
+                submitted={"pr_url": "https://x/pull/9", "pr_number": "9"},
+            ),
+            "feature/b": _ready_state(issue="2", branch="feature/b", head_sha="sha_b"),
+        }
+
+        def fake_transport(branch: str) -> MagicMock:
+            t = MagicMock()
+            t.read.return_value = states[branch]
+            return t
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", side_effect=fake_transport),
+            patch(_MOD + ".git.read_output", return_value="sha_b\trefs/heads/feature/b"),
+            patch(_MOD + ".github.create_pr") as create,
+            patch(_MOD + ".subprocess.run") as run,
+        ):
+            rc = main(["feature/a", "feature/b", "--finalize", "--yes"])
         assert rc == 1
-        assert "cascade" in capsys.readouterr().err
+        create.assert_not_called()
+        run.assert_not_called()
+        out = capsys.readouterr().out
+        assert "already has a submitted PR" in out
+        assert "https://x/pull/9" in out
+
+    def test_relay_cascade_dry_run_previews_without_side_effects(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--finalize --dry-run previews each PR and names the cascade, opening no
+        PR and running no finalize/release subprocess."""
+        state = _ready_state(branch="feature/x")
+        transport = MagicMock()
+        transport.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output") as read_output,
+            patch(_MOD + ".github.create_pr") as create,
+            patch(_MOD + ".subprocess.run") as run,
+        ):
+            rc = main(["feature/x", "--finalize", "--dry-run"])
+        assert rc == 0
+        create.assert_not_called()
+        run.assert_not_called()
+        read_output.assert_not_called()
+        assert "would chain into" in capsys.readouterr().out
+
+    def test_relay_cascade_finalize_failure_stops_and_reports(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A per-PR finalize failure fails the batch and is reported."""
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+
+        def fake_run(cmd: tuple[str, ...], **_kwargs: object) -> MagicMock:
+            # Fail the per-PR finalize; the end-of-batch validation must not run.
+            return MagicMock(returncode=1)
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch"),
+            patch(_MOD + ".github.create_pr", return_value="https://x/pull/1"),
+            patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        ):
+            rc = main(["feature/x", "--finalize", "--yes"])
+        assert rc == 1
+        assert "Failed" in capsys.readouterr().out
+
+    def test_relay_cascade_validation_failure_reported(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Every PR finalizes, but the end-of-batch validation fails: reported as a
+        post-step failure with a non-zero exit."""
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+
+        def fake_run(cmd: tuple[str, ...], **_kwargs: object) -> MagicMock:
+            # Per-PR finalize passes; the --cleanup-only validation fails.
+            failed = tuple(cmd) == ("vrg-finalize-pr", "--cleanup-only")
+            return MagicMock(returncode=1 if failed else 0)
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch"),
+            patch(_MOD + ".github.create_pr", return_value="https://x/pull/1"),
+            patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        ):
+            rc = main(["feature/x", "--finalize", "--yes"])
+        assert rc == 1
+        assert "Post-step failed: validation" in capsys.readouterr().out
+
+    def test_relay_cascade_release_failure_reported(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Finalize and validation pass, but the single release fails: reported as a
+        post-step failure."""
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        transport = MagicMock()
+        transport.read.return_value = state
+
+        def fake_run(cmd: tuple[str, ...], **_kwargs: object) -> MagicMock:
+            # Only vrg-release fails.
+            return MagicMock(returncode=1 if tuple(cmd)[0] == "vrg-release" else 0)
+
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+            patch(_MOD + ".GitHubTransport", return_value=transport),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch"),
+            patch(_MOD + ".github.create_pr", return_value="https://x/pull/1"),
+            patch(_MOD + ".subprocess.run", side_effect=fake_run),
+        ):
+            rc = main(["feature/x", "--release", "--yes"])
+        assert rc == 1
+        assert "Post-step failed: release" in capsys.readouterr().out
 
     def test_relay_blocked_for_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VRG_IDENTITY_MODE", "user")


### PR DESCRIPTION
# Pull Request

## Summary

- Let vrg-submit-pr's relay/positional-branch path run the --finalize/--release/--install cascade locally, instead of refusing it, so a batch of cloud-prepared branches can be submitted and flow through finalize/release/install in one command.

## Issue Linkage

- Closes #2398

## Notes

- Removes the artificial refusal on the relay path and routes it through the same batch semantics as the local worktree batch: finalize each opened PR with --skip-post-checks, then (only if every branch merged) one end-of-batch validation and a single vrg-release — never one release per branch, which is the key correctness point for multi-branch cascades. vrg-finalize-pr already merges/cleans up a branch with no local worktree (the cloud-to-Mac case), so no local fetch is added. A branch already carrying a submitted PR is fail-fast in the cascade; the non-cascade relay path still reports and skips it. Dry-run previews each PR and names the cascade without side effects. Adds 8 tests (finalize-only, release-once, install passthrough, already-submitted abort, dry-run, and validation/release post-step failures) and documents the relay cascade in the submit-pr reference.