### PR TITLE
feat(whoami): add empirical fail-closed platform resolver (--platform)

### DIFF
--- a/src/vergil_tooling/bin/vrg_whoami.py
+++ b/src/vergil_tooling/bin/vrg_whoami.py
@@ -13,9 +13,15 @@ Modes:
 - ``vrg-whoami`` / ``vrg-whoami --mode`` — print the resolved role as a
   single token (``human`` | ``user`` | ``audit``), suitable for
   ``export VRG_IDENTITY_MODE="$(vrg-whoami --mode)"``.
+- ``vrg-whoami --platform`` — print the resolved platform as a single
+  token (``physical-host`` | ``local-vm`` | ``cloud-vm``), from the
+  empirical, fail-closed resolver in
+  :mod:`vergil_tooling.lib.platform_env`.
 - ``vrg-whoami --explain`` — print the resolved role, the signal it
-  resolved from, and every signal's state; warn on stderr when present
-  signals disagree (the condition that precedes a misread).
+  resolved from, and every signal's state, plus the resolved platform
+  and its signals; warn on stderr when present identity signals disagree
+  or when the platform and identity correlate poorly (the conditions
+  that precede a misread).
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ import argparse
 import sys
 
 from vergil_tooling.lib.identity_mode import Resolution, Signal, resolve
+from vergil_tooling.lib.platform_env import PlatformResolution, resolve_platform
 
 _SIGNAL_LABELS = {
     Signal.ENV_VAR: "environment variable",
@@ -43,6 +50,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--mode",
         action="store_true",
         help="Emit only the role token (machine-readable; the default already does this).",
+    )
+    group.add_argument(
+        "--platform",
+        action="store_true",
+        help="Emit only the platform token (physical-host | local-vm | cloud-vm).",
     )
     group.add_argument(
         "--explain",
@@ -86,12 +98,38 @@ def _explain(resolution: Resolution) -> int:
     return 0
 
 
+def _explain_platform(platform: PlatformResolution) -> None:
+    print(f"platform:      {platform.platform.value}")
+    print(f"resolved from: {platform.resolved_from}")
+    print("platform signals:")
+    for name, state in platform.signals.items():
+        print(f"  {name}: {state}")
+
+    if platform.disagreement:
+        print(
+            f"WARNING: platform and identity signals disagree "
+            f"(platform={platform.platform.value}, "
+            f"identity={platform.signals['identity']}); the expected "
+            "correlation is host<->human, VM<->agent. Reconcile the signals "
+            "— disagreement is the condition that precedes a misread.",
+            file=sys.stderr,
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+
+    if args.platform:
+        print(resolve_platform().platform.value)
+        return 0
+
     resolution = resolve()
 
     if args.explain:
-        return _explain(resolution)
+        rc = _explain(resolution)
+        print()
+        _explain_platform(resolve_platform())
+        return rc
 
     print(resolution.mode.value)
     return 0

--- a/src/vergil_tooling/lib/platform_env.py
+++ b/src/vergil_tooling/lib/platform_env.py
@@ -1,0 +1,197 @@
+"""Empirical, fail-closed platform detection.
+
+A single platform-awareness signal distinguishes three states along two
+axes — *sandbox* (in a VM) vs. *host* (not a VM), and *cloud* vs. *local*:
+
+- ``physical-host`` — not a VM; the human's machine and the single source
+  of truth for canonical agent data.
+- ``local-vm`` — a Lima VM whose writes reach the live host store through
+  path-preserved mounts (durable).
+- ``cloud-vm`` — an off-platform x86 VM whose data disk is ephemeral; its
+  copy of canonical data is a read-only cache.
+
+The resolver derives the platform from **empirical heuristics — there is
+no written marker file.** Candidate signals, in precedence order:
+
+1. macOS (``platform.system() == "Darwin"``) and no ``/vergil`` mount ⇒
+   ``PHYSICAL_HOST``.
+2. ``/vergil`` mount present ⇒ in a VM. A reachable cloud metadata
+   endpoint ⇒ ``CLOUD_VM``; else Lima markers ⇒ ``LOCAL_VM``.
+3. **Fail closed:** any VM signal present (or a box that cannot be
+   positively confirmed as the physical host) that is not positively
+   confirmed ``LOCAL_VM`` ⇒ ``CLOUD_VM``. The resolver never falls
+   through to ``PHYSICAL_HOST`` from an unconfirmed box.
+
+Fail-open — silently deciding "host" and re-enabling futile writes — is
+the exact failure the read-only cloud-memory control exists to kill, and
+is prohibited here regardless of detection mechanism.
+
+The platform axis is distinct from the identity axis
+(:mod:`vergil_tooling.lib.identity_mode`) but correlates with it
+(host → human, any VM → agent). The resolver keeps them separate and
+*reports* the correlation via :attr:`PlatformResolution.disagreement`
+rather than conflating them.
+
+This mirrors the dataclass / ``disagreement`` shape of
+:mod:`vergil_tooling.lib.identity_mode`.
+"""
+
+from __future__ import annotations
+
+import enum
+import platform as _platform_mod
+import socket
+from dataclasses import dataclass
+
+from vergil_tooling.lib import identity_mode
+
+
+class Platform(enum.Enum):
+    PHYSICAL_HOST = "physical-host"
+    LOCAL_VM = "local-vm"
+    CLOUD_VM = "cloud-vm"
+
+
+# Signal names recorded in :attr:`PlatformResolution.signals`.
+_SIGNAL_OS = "os"
+_SIGNAL_VERGIL = "vergil-mount"
+_SIGNAL_CLOUD_METADATA = "cloud-metadata"
+_SIGNAL_LIMA_MARKER = "lima-marker"
+_SIGNAL_IDENTITY = "identity"
+
+# Provenance tokens for how the platform was resolved.
+_FROM_DARWIN_NO_VERGIL = "darwin-no-vergil"
+_FROM_CLOUD_METADATA = "cloud-metadata"
+_FROM_LIMA_MARKER = "lima-marker"
+_FROM_FAIL_CLOSED = "fail-closed"
+
+# The link-local metadata address shared by the major cloud providers
+# (GCP metadata.google.internal, Azure IMDS, AWS IMDS all answer here).
+_METADATA_HOST = "169.254.169.254"
+_METADATA_PORT = 80
+_METADATA_TIMEOUT_S = 0.25
+
+_VERGIL_MOUNT = "/vergil"
+_LIMA_MARKERS = ("/mnt/lima", "/dev/virtio-ports/lima")
+
+
+@dataclass(frozen=True)
+class PlatformResolution:
+    """The resolved platform plus the evidence it was resolved from."""
+
+    platform: Platform
+    resolved_from: str
+    signals: dict[str, str]
+    disagreement: bool
+
+
+def _vergil_mount_present() -> bool:
+    """True when the ``/vergil`` data disk is present (a VM signal)."""
+    from pathlib import Path
+
+    return Path(_VERGIL_MOUNT).exists()
+
+
+def _cloud_metadata_reachable() -> bool:
+    """True when a cloud metadata endpoint answers a short-timeout probe.
+
+    A TCP connect to the link-local metadata address succeeds only inside
+    a cloud VM; on a physical host or a Lima VM the address is unrouted
+    and the connect fails fast. Never raises — any failure means "not
+    reachable."
+    """
+    try:
+        with socket.create_connection(
+            (_METADATA_HOST, _METADATA_PORT), timeout=_METADATA_TIMEOUT_S
+        ):
+            return True
+    except OSError:
+        return False
+
+
+def _lima_marker_present() -> bool:
+    """True when a Lima-specific marker is present (a local-VM signal)."""
+    from pathlib import Path
+
+    return any(Path(marker).exists() for marker in _LIMA_MARKERS)
+
+
+def _identity_is_agent() -> bool:
+    """True when the resolved identity is an agent (corroboration only)."""
+    return identity_mode.is_agent()
+
+
+def resolve_platform() -> PlatformResolution:
+    """Resolve the platform empirically and record the evidence.
+
+    This is the single source of truth for platform resolution; both
+    :func:`current_platform` and the ``vrg-whoami`` CLI consult it. See
+    the module docstring for the precedence and the fail-closed rule.
+    """
+    is_darwin = _platform_mod.system() == "Darwin"
+    vergil = _vergil_mount_present()
+    is_agent = _identity_is_agent()
+
+    signals = {
+        _SIGNAL_OS: _platform_mod.system(),
+        _SIGNAL_VERGIL: "present" if vergil else "absent",
+        _SIGNAL_CLOUD_METADATA: "not-probed",
+        _SIGNAL_LIMA_MARKER: "not-probed",
+        _SIGNAL_IDENTITY: "agent" if is_agent else "human",
+    }
+
+    if is_darwin and not vergil:
+        platform_val = Platform.PHYSICAL_HOST
+        resolved_from = _FROM_DARWIN_NO_VERGIL
+    else:
+        # In a VM, or a box we cannot positively confirm as the physical
+        # host. Distinguish cloud from local; anything not positively
+        # confirmed local fails closed to cloud (never PHYSICAL_HOST).
+        cloud_reachable = _cloud_metadata_reachable()
+        signals[_SIGNAL_CLOUD_METADATA] = "reachable" if cloud_reachable else "unreachable"
+        if cloud_reachable:
+            platform_val = Platform.CLOUD_VM
+            resolved_from = _FROM_CLOUD_METADATA
+        else:
+            lima = _lima_marker_present()
+            signals[_SIGNAL_LIMA_MARKER] = "present" if lima else "absent"
+            if lima:
+                platform_val = Platform.LOCAL_VM
+                resolved_from = _FROM_LIMA_MARKER
+            else:
+                platform_val = Platform.CLOUD_VM
+                resolved_from = _FROM_FAIL_CLOSED
+
+    disagreement = _correlation_disagrees(platform_val, is_agent)
+    return PlatformResolution(
+        platform=platform_val,
+        resolved_from=resolved_from,
+        signals=signals,
+        disagreement=disagreement,
+    )
+
+
+def _correlation_disagrees(platform_val: Platform, is_agent: bool) -> bool:
+    """Flag a platform/identity mismatch against the expected correlation.
+
+    The expected correlation is host ↔ human, any VM ↔ agent. An agent on
+    the physical host, or a human inside a VM, is a mismatch worth
+    surfacing — it is the condition that precedes a misread.
+    """
+    is_host = platform_val is Platform.PHYSICAL_HOST
+    if is_host:
+        return is_agent
+    return not is_agent
+
+
+def current_platform() -> Platform:
+    """Return the resolved platform.
+
+    Thin wrapper over :func:`resolve_platform`; see it for the order.
+    """
+    return resolve_platform().platform
+
+
+def is_cloud() -> bool:
+    """Return True only on a ``cloud-vm`` (where the memory control activates)."""
+    return current_platform() is Platform.CLOUD_VM

--- a/tests/vergil_tooling/test_platform_env.py
+++ b/tests/vergil_tooling/test_platform_env.py
@@ -1,0 +1,164 @@
+"""Tests for the empirical, fail-closed platform resolver."""
+
+from __future__ import annotations
+
+import pytest
+
+from vergil_tooling.lib import platform_env
+from vergil_tooling.lib.platform_env import (
+    Platform,
+    current_platform,
+    is_cloud,
+    resolve_platform,
+)
+
+# Capture the real probe before the autouse fixture replaces the module
+# attribute, so the low-level helper tests exercise the actual body.
+_REAL_CLOUD_METADATA_REACHABLE = platform_env._cloud_metadata_reachable
+
+
+@pytest.fixture(autouse=True)
+def _neutral_signals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every empirical signal to a benign value.
+
+    Individual tests override exactly the signals they exercise, so an
+    unmocked probe can never reach the real host and make a test depend
+    on where it runs.
+    """
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._lima_marker_present", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: False)
+
+
+def test_darwin_no_vergil_is_physical_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    assert resolve_platform().platform is Platform.PHYSICAL_HOST
+
+
+def test_vergil_plus_cloud_metadata_is_cloud_vm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: True)
+    assert resolve_platform().platform is Platform.CLOUD_VM
+
+
+def test_vergil_plus_lima_marker_is_local_vm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._lima_marker_present", lambda: True)
+    assert resolve_platform().platform is Platform.LOCAL_VM
+
+
+def test_vm_without_local_confirmation_fails_closed_to_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._lima_marker_present", lambda: False)
+    assert resolve_platform().platform is Platform.CLOUD_VM  # never PHYSICAL_HOST
+
+
+def test_non_darwin_no_vergil_fails_closed_to_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A box we cannot positively confirm as the physical host must never
+    # be reported as PHYSICAL_HOST (fail closed for the memory control).
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    assert resolve_platform().platform is not Platform.PHYSICAL_HOST
+
+
+def test_darwin_with_vergil_is_treated_as_vm(monkeypatch: pytest.MonkeyPatch) -> None:
+    # /vergil present dominates the OS signal: presence of the mount means
+    # a VM, and without local confirmation it fails closed to cloud.
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._lima_marker_present", lambda: False)
+    assert resolve_platform().platform is Platform.CLOUD_VM
+
+
+def test_cloud_metadata_wins_over_lima_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A reachable cloud metadata endpoint is the stronger cloud signal.
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._lima_marker_present", lambda: True)
+    assert resolve_platform().platform is Platform.CLOUD_VM
+
+
+def test_agent_identity_on_physical_host_flags_disagreement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: True)
+    assert resolve_platform().disagreement is True
+
+
+def test_human_identity_in_vm_flags_disagreement(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The correlation is host<->human, VM<->agent; a human on a VM is a
+    # mismatch worth surfacing.
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: False)
+    assert resolve_platform().disagreement is True
+
+
+def test_no_disagreement_when_identity_matches_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Human on the physical host: the expected correlation, no warning.
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: False)
+    assert resolve_platform().disagreement is False
+
+
+def test_resolution_records_signals_and_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    resolution = resolve_platform()
+    assert resolution.resolved_from  # non-empty provenance token
+    assert isinstance(resolution.signals, dict)
+    assert resolution.signals  # every signal recorded
+
+
+def test_current_platform_returns_enum(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    assert current_platform() is Platform.PHYSICAL_HOST
+
+
+def test_is_cloud_true_only_on_cloud_vm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: True)
+    assert is_cloud() is True
+
+
+def test_is_cloud_false_on_physical_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+    assert is_cloud() is False
+
+
+class _FakeConn:
+    def __enter__(self) -> _FakeConn:
+        return self
+
+    def __exit__(self, *_: object) -> bool:
+        return False
+
+
+def test_cloud_metadata_reachable_true_on_successful_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("socket.create_connection", lambda *a, **k: _FakeConn())
+    assert _REAL_CLOUD_METADATA_REACHABLE() is True
+
+
+def test_cloud_metadata_reachable_false_on_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> object:
+        raise OSError("unreachable")
+
+    monkeypatch.setattr("socket.create_connection", _boom)
+    assert _REAL_CLOUD_METADATA_REACHABLE() is False

--- a/tests/vergil_tooling/test_platform_env.py
+++ b/tests/vergil_tooling/test_platform_env.py
@@ -12,9 +12,10 @@ from vergil_tooling.lib.platform_env import (
     resolve_platform,
 )
 
-# Capture the real probe before the autouse fixture replaces the module
-# attribute, so the low-level helper tests exercise the actual body.
+# Capture the real probes before the autouse fixture replaces the module
+# attributes, so the low-level helper tests exercise the actual bodies.
 _REAL_CLOUD_METADATA_REACHABLE = platform_env._cloud_metadata_reachable
+_REAL_LIMA_MARKER_PRESENT = platform_env._lima_marker_present
 
 
 @pytest.fixture(autouse=True)
@@ -162,3 +163,17 @@ def test_cloud_metadata_reachable_false_on_oserror(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr("socket.create_connection", _boom)
     assert _REAL_CLOUD_METADATA_REACHABLE() is False
+
+
+def test_lima_marker_present_true_when_a_marker_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    # __file__ is a real, existing path, so the any(...) predicate is True.
+    monkeypatch.setattr("vergil_tooling.lib.platform_env._LIMA_MARKERS", (__file__,))
+    assert _REAL_LIMA_MARKER_PRESENT() is True
+
+
+def test_lima_marker_present_false_when_no_marker_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "vergil_tooling.lib.platform_env._LIMA_MARKERS",
+        ("/nonexistent/vrg-lima-marker-should-not-exist",),
+    )
+    assert _REAL_LIMA_MARKER_PRESENT() is False

--- a/tests/vergil_tooling/test_vrg_whoami.py
+++ b/tests/vergil_tooling/test_vrg_whoami.py
@@ -124,3 +124,57 @@ class TestExplain:
 def test_mode_and_explain_are_mutually_exclusive() -> None:
     with pytest.raises(SystemExit):
         main(["--mode", "--explain"])
+
+
+class TestPlatform:
+    def test_platform_flag_prints_token(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+        assert main(["--platform"]) == 0
+        assert capsys.readouterr().out == "physical-host\n"
+
+    def test_platform_token_reports_cloud_vm(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: True)
+        monkeypatch.setattr(
+            "vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: True
+        )
+        assert main(["--platform"]) == 0
+        assert capsys.readouterr().out.strip() == "cloud-vm"
+
+    def test_platform_is_mutually_exclusive_with_mode(self) -> None:
+        with pytest.raises(SystemExit):
+            main(["--platform", "--mode"])
+
+    def test_explain_includes_platform_section(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: False)
+        assert main(["--explain"]) == 0
+        out = capsys.readouterr().out
+        assert "platform:      physical-host" in out
+        assert "platform signals:" in out
+
+    def test_explain_warns_on_platform_disagreement(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Agent identity on the physical host is a platform/identity mismatch.
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: True)
+        assert main(["--explain"]) == 0
+        assert "WARNING: platform and identity signals disagree" in capsys.readouterr().err
+
+    def test_explain_no_platform_warning_when_correlated(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
+        monkeypatch.setattr("vergil_tooling.lib.platform_env._identity_is_agent", lambda: False)
+        assert main(["--explain"]) == 0
+        assert "platform and identity signals disagree" not in capsys.readouterr().err


### PR DESCRIPTION
# Pull Request

## Summary

- Add a platform_env resolver that derives physical-host/local-vm/cloud-vm from empirical signals with no marker file, failing closed to cloud-vm when a VM cannot be positively confirmed local, and surface it via vrg-whoami --platform and an --explain platform section.

## Issue Linkage

- Closes #2408

## Notes

- Task 2 of epic vergil-project/.github#156 (Component 1). New src/vergil_tooling/lib/platform_env.py mirrors identity_mode.py's dataclass/disagreement shape (Platform enum, PlatformResolution, resolve_platform/current_platform/is_cloud). Precedence: Darwin + no /vergil => physical-host; /vergil present + reachable cloud metadata endpoint => cloud-vm; else Lima markers => local-vm; any unconfirmed VM => cloud-vm (fail closed, never physical-host). Corroborates against identity_mode.is_agent and flags host<->human / VM<->agent mismatches as disagreement. vrg_whoami.py gains a --platform token (mutually exclusive with --mode/--explain) and a platform block in --explain that warns on disagreement. TDD: 19 resolver tests + 7 whoami platform tests; 100% coverage on both files; vrg-validate green.