### PR TITLE
feat(vm-cloud): align cloud session workdir to host project path for memory-slug parity

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2422,6 +2422,13 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
     claude_dir = Path.home() / ".claude"
     copy_claude_config(transport, claude_dir)
     vm_cloud.link_cloud_claude_dirs(transport)
+    # #2410 (Component 2a): start the session at the host-equivalent project path so
+    # Claude derives the host's memory slug and finds the projected memory under
+    # ~/.claude/projects/<host-slug>/. A symlink from that path onto the /vergil
+    # checkout makes the host path resolve in the guest.
+    assert target.org is not None  # noqa: S101 — dedicated cloud target always carries org/repo
+    assert target.repo is not None  # noqa: S101
+    workdir = vm_cloud.ensure_host_path(transport, identity.projects_dir, target.org, target.repo)
     print("  -> opening the session", file=sys.stderr, flush=True)
     workspace_abs = os.path.normpath(resolve_workspace(args.workspace, identity.projects_dir))
     rel_path = os.path.relpath(workspace_abs, identity.projects_dir)
@@ -2433,7 +2440,6 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
         resolve_session_stale_days(config, identity),
         resolve_session_archive_days(config, identity),
     )
-    workdir = f"/vergil/projects/{target.org}/{target.repo}"
     transport.exec_session(workdir=workdir, inner=inner)
     return 0  # unreachable, keeps the type checker happy
 

--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -561,6 +561,32 @@ def link_cloud_claude_dirs(transport: Transport) -> None:
     transport.run("bash", "-c", " ; ".join(parts))
 
 
+_CLOUD_PROJECTS_VOLUME = "/vergil/projects"
+
+
+def ensure_host_path(transport: Transport, host_projects_dir: str, org: str, repo: str) -> str:
+    """Symlink the host-equivalent project path onto the ``/vergil`` checkout.
+
+    A cloud session must *start* at the host project path
+    (``<host_projects_dir>/<org>/<repo>``) so Claude Code derives the same memory
+    slug as the physical host and finds the projected memory under the guest's
+    ``~/.claude/projects/<host-slug>/`` (spec Component 2a). The guest checkout
+    lives at ``/vergil/projects/<org>/<repo>``; this creates the host path as a
+    symlink onto it — ``mkdir -p`` the parent first, then ``ln -sfn`` the leaf —
+    and returns the host-equivalent absolute path so the caller can open the
+    session there.
+
+    Idempotent: ``mkdir -p`` is a no-op when the parent already exists, and
+    ``ln -sfn`` re-points an existing link rather than nesting a new one inside
+    it. Follows the ``link_cloud_claude_dirs`` bash-over-transport idiom.
+    """
+    checkout = f"{_CLOUD_PROJECTS_VOLUME}/{org}/{repo}"
+    host_path = f"{host_projects_dir}/{org}/{repo}"
+    host_parent = f"{host_projects_dir}/{org}"
+    transport.run("bash", "-c", f"mkdir -p {host_parent} && ln -sfn {checkout} {host_path}")
+    return host_path
+
+
 # --- OpenTofu two-state runner -----------------------------------------------
 #
 # The cloud backend keeps the volume and the VM in *separate* tofu states under

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -805,6 +805,26 @@ class TestCloudClaudeLayout:
         assert ".credentials.json" not in joined
 
 
+class TestEnsureHostPath:
+    def test_symlinks_onto_volume(self) -> None:
+        # Component 2a (#2410): the host-equivalent project path is created as a
+        # symlink onto the /vergil checkout so Claude, started there, derives the
+        # host's memory slug.
+        transport = MagicMock()
+        transport.run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        path = vm_cloud.ensure_host_path(
+            transport, "/Users/me/dev/projects", "vergil-project", "vergil-tooling"
+        )
+        assert path == "/Users/me/dev/projects/vergil-project/vergil-tooling"
+        # transport.run("bash", "-c", <script>) — the script is the last positional arg
+        script = transport.run.call_args.args[-1]
+        assert "mkdir -p /Users/me/dev/projects/vergil-project" in script
+        assert (
+            "ln -sfn /vergil/projects/vergil-project/vergil-tooling "
+            "/Users/me/dev/projects/vergil-project/vergil-tooling" in script
+        )
+
+
 def _tofu_output_json(values: dict[str, str]) -> str:
     return json.dumps({k: {"value": v} for k, v in values.items()})
 

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3728,6 +3728,10 @@ class _CloudPatches:
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.await_readiness")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.bootstrap_volume")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.link_cloud_claude_dirs")
+        _patch(
+            "vergil_tooling.bin.vrg_vm.vm_cloud.ensure_host_path",
+            return_value="/Users/me/dev/projects/lmf/cloud",
+        )
         _patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.preflight")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.destroy_vm")
@@ -4037,8 +4041,37 @@ class TestCloudSession:
         m["preflight"].assert_called_once()
         transport.exec_session.assert_called_once()
         kwargs = transport.exec_session.call_args.kwargs
-        assert kwargs["workdir"] == "/vergil/projects/lmf/cloud"
+        # #2410: the session now starts at the host-equivalent project path (the
+        # ensure_host_path return), not the /vergil literal, so Claude derives the
+        # host memory slug.
+        assert kwargs["workdir"] == "/Users/me/dev/projects/lmf/cloud"
         assert "vrg-vm-resolve-session" in kwargs["inner"]
+
+    def test_cloud_session_aligns_workdir_to_host_path(
+        self, _cloud_repo: Path, tmp_path: Path
+    ) -> None:
+        # #2410 (Component 2a): _cloud_session must build the host-path indirection
+        # (after relinking the volume dirs) and pass the host-equivalent path as the
+        # session workdir, so the memory slug matches the physical host.
+        transport = MagicMock()
+        with _CloudPatches(tmp_path / "state") as m:
+            m["transport"].return_value = transport
+            manager = MagicMock()
+            manager.attach_mock(m["link_cloud_claude_dirs"], "link")
+            manager.attach_mock(m["ensure_host_path"], "ensure")
+            manager.attach_mock(transport.exec_session, "exec")
+            main(["session", "lmf/cloud", "--config", str(_cloud_repo)])
+        m["ensure_host_path"].assert_called_once()
+        ensure_args = m["ensure_host_path"].call_args.args
+        assert ensure_args[0] is transport
+        assert ensure_args[1].endswith("/projects")  # identity.projects_dir
+        assert ensure_args[2] == "lmf"
+        assert ensure_args[3] == "cloud"
+        kwargs = transport.exec_session.call_args.kwargs
+        assert kwargs["workdir"] == m["ensure_host_path"].return_value
+        order = [name for name, _, _ in manager.mock_calls]
+        # host-path indirection is built after the volume relink, before the exec
+        assert order.index("link") < order.index("ensure") < order.index("exec")
 
     def test_cloud_session_seeds_claude_config(self, _cloud_repo: Path, tmp_path: Path) -> None:
         # #1999 (Fix A): the cloud session path must seed the operator's ~/.claude


### PR DESCRIPTION
# Pull Request

## Summary

- Cloud sessions now start at the host-equivalent project path via a new vm_cloud.ensure_host_path symlink onto the /vergil checkout, so Claude derives the physical host's memory slug instead of the /vergil literal.

## Issue Linkage

- Closes #2410

## Notes

- Epic vergil-project/.github#156, plan Task 3 / spec Component 2a. Adds ensure_host_path(transport, host_projects_dir, org, repo) following the link_cloud_claude_dirs bash-over-transport idiom (mkdir -p parent, ln -sfn leaf, idempotent) and wires it into _cloud_session, replacing the hardcoded /vergil/projects literal workdir. Dedicated unit test in test_vm_cloud.py covers the full helper body for deterministic coverage; wiring tests in test_vrg_vm.py assert call order (link -> ensure -> exec) and that the host path becomes the session workdir. Per the merged audit (#161), no Component 2b path rewrites are needed. Validation green at 100% coverage.