### PR TITLE
feat(vm-memory): project host memory into cloud session at matching slug

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -30,7 +30,7 @@ from vergil_tooling.bin.vrg_vm_resolve import (
     name_by_session,
     projects_glob,
 )
-from vergil_tooling.lib import progress, vm_cloud
+from vergil_tooling.lib import progress, vm_cloud, vm_memory
 from vergil_tooling.lib.config import ConfigError, VmStanza, read_config
 from vergil_tooling.lib.identity import (
     Identity,
@@ -2429,6 +2429,12 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
     assert target.org is not None  # noqa: S101 — dedicated cloud target always carries org/repo
     assert target.repo is not None  # noqa: S101
     workdir = vm_cloud.ensure_host_path(transport, identity.projects_dir, target.org, target.repo)
+    # #2411 (Component 3): project this repo's memory subset (per-repo memory/ +
+    # MEMORY.md) and the global CLAUDE.md from the host into the guest at the
+    # matching slug, so the cloud session reads canonical host memory rather than a
+    # divergent (or empty) cloud copy. The read-only lock is applied separately
+    # (#2412); this copies the files only.
+    vm_memory.project_memory(transport, claude_dir=claude_dir, host_workdir=workdir)
     print("  -> opening the session", file=sys.stderr, flush=True)
     workspace_abs = os.path.normpath(resolve_workspace(args.workspace, identity.projects_dir))
     rel_path = os.path.relpath(workspace_abs, identity.projects_dir)

--- a/src/vergil_tooling/lib/vm_memory.py
+++ b/src/vergil_tooling/lib/vm_memory.py
@@ -1,0 +1,90 @@
+"""Project host agent memory into a cloud guest as a read-only cache.
+
+Net-new logic for the cloud-memory-projection epic (vergil-project/.github#156,
+spec Component 3). The physical host is the single source of truth for agent
+memory; a cloud VM is a projection of it. Before a cloud session opens, the host
+copies that repo's memory subset — the per-repo ``memory/`` directory (including
+``MEMORY.md``) — plus the global ``~/.claude/CLAUDE.md`` into the guest at the
+slug Claude derives from the host project path, file-by-file over the
+established ``transport.pipe`` (``cat > <dest>``) idiom (the same mechanism
+``copy_claude_config`` uses; there is no ``rsync`` over the transport).
+
+The read-only lock that freezes this projection is applied separately by
+``lock_projection`` (issue #2412); this module only *copies* the files.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from vergil_tooling.lib.vm_transport import Transport
+
+# The guest ``~/.claude`` root. ``~`` is deliberately left unquoted so the guest
+# shell expands it, matching the ``copy_claude_config`` idiom (``cat > ~/.claude/…``).
+_GUEST_CLAUDE_DIR = "~/.claude"
+
+
+def host_slug(host_workdir: str) -> str:
+    """Return Claude's memory slug for an absolute path.
+
+    Claude derives ``~/.claude/projects/<slug>`` from the session's starting
+    working directory by replacing every ``/`` with ``-`` (so an absolute path
+    keeps its leading ``-``). Matching that convention is what lets the projected
+    memory be *found* under the guest's ``~/.claude/projects/<host-slug>/`` once
+    the session starts at the host-equivalent path (spec Component 2a).
+    """
+    return host_workdir.replace("/", "-")
+
+
+def host_memory_dir(claude_dir: Path, slug: str) -> Path:
+    """Return the host memory dir for a slug: ``<claude_dir>/projects/<slug>/memory``."""
+    return claude_dir / "projects" / slug / "memory"
+
+
+def project_memory(transport: Transport, *, claude_dir: Path, host_workdir: str) -> None:
+    """Copy the host memory subset and global ``CLAUDE.md`` into the cloud guest.
+
+    Resolves the host memory slug from ``host_workdir``, ensures the guest memory
+    directory exists, then copies — file-by-file over ``transport.pipe`` — every
+    file under the host ``memory/`` directory (including ``MEMORY.md``) to the
+    matching guest path under ``~/.claude/projects/<slug>/memory/`` and the global
+    ``~/.claude/CLAUDE.md``. Each pipe clears any prior read-only lock
+    (``chmod u+w`` before ``cat >``) so a re-projection can overwrite a locked
+    cache. If the host has no memory directory for this repo yet, the guest memory
+    directory is still created and the memory copy is skipped (not an error — a
+    repo may have no memory yet); the global ``CLAUDE.md`` is projected regardless.
+
+    The read-only lock is **not** applied here — ``lock_projection`` (issue #2412)
+    owns that and will be inserted at the end of this function once it lands.
+    """
+    slug = host_slug(host_workdir)
+    guest_memory_dir = f"{_GUEST_CLAUDE_DIR}/projects/{slug}/memory"
+
+    src_memory_dir = host_memory_dir(claude_dir, slug)
+    src_files = (
+        sorted(p for p in src_memory_dir.rglob("*") if p.is_file())
+        if src_memory_dir.is_dir()
+        else []
+    )
+
+    # Create the guest memory dir (and any nested subdirs the source carries) up
+    # front, over the ``bash -c`` idiom so the guest shell expands ``~``.
+    guest_dirs = {guest_memory_dir}
+    copies: list[tuple[str, Path]] = []
+    for src in src_files:
+        rel = src.relative_to(src_memory_dir).as_posix()
+        dest = f"{guest_memory_dir}/{rel}"
+        guest_dirs.add(dest.rsplit("/", 1)[0])
+        copies.append((dest, src))
+    transport.run("bash", "-c", f"mkdir -p {' '.join(sorted(guest_dirs))}")
+
+    for dest, src in copies:
+        transport.pipe(f"chmod u+w {dest} 2>/dev/null; cat > {dest}", src.read_text())
+
+    global_claude_md = claude_dir / "CLAUDE.md"
+    if global_claude_md.exists():
+        dest = f"{_GUEST_CLAUDE_DIR}/CLAUDE.md"
+        transport.pipe(f"chmod u+w {dest} 2>/dev/null; cat > {dest}", global_claude_md.read_text())

--- a/tests/vergil_tooling/test_vm_memory.py
+++ b/tests/vergil_tooling/test_vm_memory.py
@@ -1,0 +1,115 @@
+"""Tests for host->guest memory projection (vm_memory)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from vergil_tooling.lib import vm_memory
+
+_SLUG = "-Users-me-dev-projects-org-repo"
+_WORKDIR = "/Users/me/dev/projects/org/repo"
+
+
+def test_host_slug_matches_claude_convention() -> None:
+    assert vm_memory.host_slug(_WORKDIR) == _SLUG
+
+
+def test_host_memory_dir() -> None:
+    d = vm_memory.host_memory_dir(Path("/Users/me/.claude"), _SLUG)
+    assert d == Path(f"/Users/me/.claude/projects/{_SLUG}/memory")
+
+
+def _seed_memory(claude: Path) -> Path:
+    """Create a host memory dir with MEMORY.md and return the memory dir path."""
+    memory = claude / "projects" / _SLUG / "memory"
+    memory.mkdir(parents=True)
+    (memory / "MEMORY.md").write_text("m")
+    return memory
+
+
+def test_project_memory_copies_memory_and_claude_md(tmp_path: Path) -> None:
+    transport = MagicMock()
+    claude = tmp_path / ".claude"
+    _seed_memory(claude)
+    (claude / "CLAUDE.md").write_text("global")
+
+    vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
+
+    piped = [c.args[0] for c in transport.pipe.call_args_list]
+    # copy_claude_config idiom: pipe a ``cat > <dest>`` for each file, prefixed
+    # with a chmod that clears any prior read-only lock before overwrite.
+    assert any("cat > " in cmd and "/memory/MEMORY.md" in cmd for cmd in piped)
+    assert any("cat > " in cmd and cmd.endswith("/CLAUDE.md") for cmd in piped)
+    assert all(cmd.startswith("chmod u+w ") for cmd in piped)
+    # The memory content is piped as the input payload.
+    contents = [c.args[1] for c in transport.pipe.call_args_list]
+    assert "m" in contents
+    assert "global" in contents
+
+
+def test_project_memory_mkdirs_guest_memory_dir(tmp_path: Path) -> None:
+    transport = MagicMock()
+    claude = tmp_path / ".claude"
+    _seed_memory(claude)
+
+    vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
+
+    # The guest memory dir is created up front over the ``bash -c`` idiom so ``~``
+    # expands in the guest shell (a bare ``mkdir`` arg would not expand it).
+    script = transport.run.call_args.args[-1]
+    assert transport.run.call_args.args[0] == "bash"
+    assert f"mkdir -p ~/.claude/projects/{_SLUG}/memory" in script
+
+
+def test_project_memory_copies_nested_memory_file(tmp_path: Path) -> None:
+    transport = MagicMock()
+    claude = tmp_path / ".claude"
+    memory = _seed_memory(claude)
+    nested = memory / "notes"
+    nested.mkdir()
+    (nested / "topic.md").write_text("n")
+
+    vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
+
+    # Nested subdir is created (its parent added to the mkdir set) and the file
+    # is projected at the matching relative path.
+    script = transport.run.call_args.args[-1]
+    assert f"~/.claude/projects/{_SLUG}/memory/notes" in script
+    piped = [c.args[0] for c in transport.pipe.call_args_list]
+    assert any("/memory/notes/topic.md" in cmd for cmd in piped)
+
+
+def test_project_memory_without_host_memory_dir_still_seeds_and_copies_claude_md(
+    tmp_path: Path,
+) -> None:
+    transport = MagicMock()
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    (claude / "CLAUDE.md").write_text("global")
+    # No projects/<slug>/memory dir on the host.
+
+    vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
+
+    # The guest memory (slug) dir is still created — no error — and the global
+    # CLAUDE.md is projected regardless of per-repo memory.
+    script = transport.run.call_args.args[-1]
+    assert f"mkdir -p ~/.claude/projects/{_SLUG}/memory" in script
+    piped = [c.args[0] for c in transport.pipe.call_args_list]
+    assert any(cmd.endswith("/CLAUDE.md") for cmd in piped)
+    # No memory files were copied.
+    assert not any("/memory/" in cmd for cmd in piped)
+
+
+def test_project_memory_without_global_claude_md(tmp_path: Path) -> None:
+    transport = MagicMock()
+    claude = tmp_path / ".claude"
+    _seed_memory(claude)
+    # No global CLAUDE.md on the host.
+
+    vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
+
+    piped = [c.args[0] for c in transport.pipe.call_args_list]
+    # Memory is copied; CLAUDE.md is not (it does not exist on the host).
+    assert any("/memory/MEMORY.md" in cmd for cmd in piped)
+    assert not any(cmd.endswith("/CLAUDE.md") for cmd in piped)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -3732,6 +3732,7 @@ class _CloudPatches:
             "vergil_tooling.bin.vrg_vm.vm_cloud.ensure_host_path",
             return_value="/Users/me/dev/projects/lmf/cloud",
         )
+        _patch("vergil_tooling.bin.vrg_vm.vm_memory.project_memory")
         _patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.preflight")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.destroy_vm")
@@ -4072,6 +4073,28 @@ class TestCloudSession:
         order = [name for name, _, _ in manager.mock_calls]
         # host-path indirection is built after the volume relink, before the exec
         assert order.index("link") < order.index("ensure") < order.index("exec")
+
+    def test_cloud_session_projects_host_memory(self, _cloud_repo: Path, tmp_path: Path) -> None:
+        # #2411 (Component 3): _cloud_session must project the host memory subset
+        # (per-repo memory/ + MEMORY.md) and the global CLAUDE.md into the guest at
+        # the host slug, AFTER building the host-path indirection (so the slug is
+        # known) and BEFORE the process-replacing exec_session.
+        transport = MagicMock()
+        with _CloudPatches(tmp_path / "state") as m:
+            m["transport"].return_value = transport
+            manager = MagicMock()
+            manager.attach_mock(m["ensure_host_path"], "ensure")
+            manager.attach_mock(m["project_memory"], "project")
+            manager.attach_mock(transport.exec_session, "exec")
+            main(["session", "lmf/cloud", "--config", str(_cloud_repo)])
+        m["project_memory"].assert_called_once()
+        assert m["project_memory"].call_args.args[0] is transport
+        kwargs = m["project_memory"].call_args.kwargs
+        assert kwargs["host_workdir"] == m["ensure_host_path"].return_value
+        assert kwargs["claude_dir"] == Path.home() / ".claude"
+        order = [name for name, _, _ in manager.mock_calls]
+        # projection runs after the host-path indirection, before the exec
+        assert order.index("ensure") < order.index("project") < order.index("exec")
 
     def test_cloud_session_seeds_claude_config(self, _cloud_repo: Path, tmp_path: Path) -> None:
         # #1999 (Fix A): the cloud session path must seed the operator's ~/.claude


### PR DESCRIPTION
# Pull Request

## Summary

- Add src/vergil_tooling/lib/vm_memory.py and wire it into _cloud_session so a cloud VM session projects the host's per-repo memory/ (incl. MEMORY.md) and global CLAUDE.md into the guest at the host-derived slug over the transport.pipe cat idiom.

## Issue Linkage

- Closes #2411

## Notes

- Plan Task 4 / spec Component 3 for epic vergil-project/.github#156. New helpers host_slug() and host_memory_dir(); project_memory(transport, *, claude_dir, host_workdir) mkdirs the guest memory dir over a bash -c so ~ expands, then pipes each memory file and the global CLAUDE.md with a chmod u+w guard before cat >. Missing host memory dir still seeds the slug dir and copies CLAUDE.md (no error). Read-only lock is deliberately NOT added here: lock_projection is issue #2412's deliverable per the plan task split. Wired after ensure_host_path and before exec_session. Validation green, 100% coverage.