### PR TITLE
feat(vm-memory): apply surgical read-only lock to projected memory and CLAUDE.md

### DIFF
--- a/src/vergil_tooling/lib/vm_memory.py
+++ b/src/vergil_tooling/lib/vm_memory.py
@@ -9,8 +9,10 @@ slug Claude derives from the host project path, file-by-file over the
 established ``transport.pipe`` (``cat > <dest>``) idiom (the same mechanism
 ``copy_claude_config`` uses; there is no ``rsync`` over the transport).
 
-The read-only lock that freezes this projection is applied separately by
-``lock_projection`` (issue #2412); this module only *copies* the files.
+Once the copy completes, the projection is frozen read-only by
+``lock_projection`` (issue #2412), which ``project_memory`` calls at the end so a
+futile cloud write fails loudly with ``EACCES`` instead of succeeding-then-
+vanishing (spec §Component 3, §Error handling).
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from vergil_tooling.lib.vm_transport import Transport
@@ -57,8 +60,9 @@ def project_memory(transport: Transport, *, claude_dir: Path, host_workdir: str)
     directory is still created and the memory copy is skipped (not an error — a
     repo may have no memory yet); the global ``CLAUDE.md`` is projected regardless.
 
-    The read-only lock is **not** applied here — ``lock_projection`` (issue #2412)
-    owns that and will be inserted at the end of this function once it lands.
+    After the copy, ``lock_projection`` freezes the projected canonical set
+    read-only. Re-projection is safe: each pipe above clears the lock
+    (``chmod u+w``) before overwriting, and the lock is re-applied here.
     """
     slug = host_slug(host_workdir)
     guest_memory_dir = f"{_GUEST_CLAUDE_DIR}/projects/{slug}/memory"
@@ -88,3 +92,60 @@ def project_memory(transport: Transport, *, claude_dir: Path, host_workdir: str)
     if global_claude_md.exists():
         dest = f"{_GUEST_CLAUDE_DIR}/CLAUDE.md"
         transport.pipe(f"chmod u+w {dest} 2>/dev/null; cat > {dest}", global_claude_md.read_text())
+
+    # Freeze the projection read-only. ``$HOME`` (not ``~``) is used because the
+    # lock paths are double-quoted to survive the slug's characters, and ``~``
+    # does not expand inside double quotes whereas ``$HOME`` does. The only extra
+    # beyond the memory subtree is the global ``CLAUDE.md`` (the Task-1 audit's
+    # locked set: vergil-project/.github#161); ``settings.json`` is deliberately
+    # NOT locked — provisioning and the Claude runtime both write it.
+    lock_projection(
+        transport,
+        claude_dir_guest="$HOME/.claude",
+        slug=slug,
+        locked_set=["$HOME/.claude/CLAUDE.md"],
+    )
+
+
+def lock_projection(
+    transport: Transport,
+    *,
+    claude_dir_guest: str,
+    slug: str,
+    locked_set: Sequence[str],
+) -> None:
+    """Apply a surgical read-only lock to the projected canonical memory set.
+
+    ``chmod`` read-only exactly the projected canonical data so a futile cloud
+    write fails loudly with ``EACCES`` rather than succeeding-then-vanishing
+    (spec §Component 3): the per-repo ``memory`` subtree
+    (``<claude_dir_guest>/projects/<slug>/memory``, recursively), its
+    ``MEMORY.md``, and every path in ``locked_set`` (the Task-1 audit's extras,
+    i.e. the global ``CLAUDE.md``).
+
+    **Surgical.** The ``projects/<slug>/`` directory co-mingles the durable
+    ``memory/`` subtree with the session-transcript ``.jsonl`` files Claude writes
+    continuously, so this **never** blanket-``chmod``s ``projects/<slug>/`` itself
+    — a recursive lock there would break session logging with ``EACCES``. Only
+    ``memory/`` and the enumerated files are frozen; the transcripts stay
+    writable. ``settings.json`` is likewise never in the locked set (provisioning
+    and the runtime both write it).
+
+    Each ``chmod`` is guarded by an ``[ -e ]`` existence test so a missing
+    optional file is a no-op, not an error, and the ``if … then … fi`` form always
+    exits 0 (re-locking after a re-projection is safe — ``project_memory``
+    ``chmod u+w``s before overwriting).
+    """
+    memory_dir = f'"{claude_dir_guest}/projects/{slug}/memory"'
+    memory_md = f'"{claude_dir_guest}/projects/{slug}/memory/MEMORY.md"'
+
+    targets: list[tuple[str, str]] = [
+        (memory_dir, f"chmod -R a-w {memory_dir}"),
+        (memory_md, f"chmod a-w {memory_md}"),
+    ]
+    for path in locked_set:
+        quoted = f'"{path}"'
+        targets.append((quoted, f"chmod a-w {quoted}"))
+
+    script = "\n".join(f"if [ -e {target} ]; then {chmod}; fi" for target, chmod in targets)
+    transport.run("bash", "-c", script)

--- a/tests/vergil_tooling/test_vm_memory.py
+++ b/tests/vergil_tooling/test_vm_memory.py
@@ -46,6 +46,13 @@ def test_project_memory_copies_memory_and_claude_md(tmp_path: Path) -> None:
     contents = [c.args[1] for c in transport.pipe.call_args_list]
     assert "m" in contents
     assert "global" in contents
+    # The projection is locked read-only *after* the copy: the final transport
+    # command is the surgical lock (a chmod of the memory subtree + CLAUDE.md).
+    last_run = transport.run.call_args_list[-1].args
+    assert last_run[0] == "bash"
+    assert "chmod -R a-w" in last_run[-1]
+    assert f'"$HOME/.claude/projects/{_SLUG}/memory"' in last_run[-1]
+    assert '"$HOME/.claude/CLAUDE.md"' in last_run[-1]
 
 
 def test_project_memory_mkdirs_guest_memory_dir(tmp_path: Path) -> None:
@@ -56,9 +63,10 @@ def test_project_memory_mkdirs_guest_memory_dir(tmp_path: Path) -> None:
     vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
 
     # The guest memory dir is created up front over the ``bash -c`` idiom so ``~``
-    # expands in the guest shell (a bare ``mkdir`` arg would not expand it).
-    script = transport.run.call_args.args[-1]
-    assert transport.run.call_args.args[0] == "bash"
+    # expands in the guest shell (a bare ``mkdir`` arg would not expand it). The
+    # mkdir is the *first* transport.run call (the last is now the lock).
+    script = transport.run.call_args_list[0].args[-1]
+    assert transport.run.call_args_list[0].args[0] == "bash"
     assert f"mkdir -p ~/.claude/projects/{_SLUG}/memory" in script
 
 
@@ -73,8 +81,8 @@ def test_project_memory_copies_nested_memory_file(tmp_path: Path) -> None:
     vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
 
     # Nested subdir is created (its parent added to the mkdir set) and the file
-    # is projected at the matching relative path.
-    script = transport.run.call_args.args[-1]
+    # is projected at the matching relative path. The mkdir is the first run call.
+    script = transport.run.call_args_list[0].args[-1]
     assert f"~/.claude/projects/{_SLUG}/memory/notes" in script
     piped = [c.args[0] for c in transport.pipe.call_args_list]
     assert any("/memory/notes/topic.md" in cmd for cmd in piped)
@@ -92,8 +100,8 @@ def test_project_memory_without_host_memory_dir_still_seeds_and_copies_claude_md
     vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
 
     # The guest memory (slug) dir is still created — no error — and the global
-    # CLAUDE.md is projected regardless of per-repo memory.
-    script = transport.run.call_args.args[-1]
+    # CLAUDE.md is projected regardless of per-repo memory. mkdir is the first run.
+    script = transport.run.call_args_list[0].args[-1]
     assert f"mkdir -p ~/.claude/projects/{_SLUG}/memory" in script
     piped = [c.args[0] for c in transport.pipe.call_args_list]
     assert any(cmd.endswith("/CLAUDE.md") for cmd in piped)
@@ -113,3 +121,60 @@ def test_project_memory_without_global_claude_md(tmp_path: Path) -> None:
     # Memory is copied; CLAUDE.md is not (it does not exist on the host).
     assert any("/memory/MEMORY.md" in cmd for cmd in piped)
     assert not any(cmd.endswith("/CLAUDE.md") for cmd in piped)
+
+
+def test_lock_projection_locks_memory_not_transcripts() -> None:
+    transport = MagicMock()
+    vm_memory.lock_projection(
+        transport,
+        claude_dir_guest="$HOME/.claude",
+        slug=_SLUG,
+        locked_set=["$HOME/.claude/CLAUDE.md"],
+    )
+
+    assert transport.run.call_args.args[0] == "bash"
+    script = transport.run.call_args.args[-1]
+    # The memory subtree is locked recursively; MEMORY.md and CLAUDE.md are locked.
+    assert f'chmod -R a-w "$HOME/.claude/projects/{_SLUG}/memory"' in script
+    assert f'chmod a-w "$HOME/.claude/projects/{_SLUG}/memory/MEMORY.md"' in script
+    assert 'chmod a-w "$HOME/.claude/CLAUDE.md"' in script
+    # SURGICAL: every reference to the slug dir is under /memory/ — the slug dir
+    # itself is never chmod'd, so the session-transcript .jsonl files it holds
+    # stay writable. (A blanket recursive chmod would break session logging.)
+    slug_lines = [ln for ln in script.splitlines() if f"projects/{_SLUG}" in ln]
+    assert slug_lines
+    assert all("/memory" in ln for ln in slug_lines)
+    assert f'chmod -R a-w "$HOME/.claude/projects/{_SLUG}"' not in script
+    assert f'chmod a-w "$HOME/.claude/projects/{_SLUG}"' not in script
+
+
+def test_lock_projection_guards_each_path_with_existence_test() -> None:
+    transport = MagicMock()
+    vm_memory.lock_projection(
+        transport,
+        claude_dir_guest="$HOME/.claude",
+        slug=_SLUG,
+        locked_set=["$HOME/.claude/CLAUDE.md"],
+    )
+
+    script = transport.run.call_args.args[-1]
+    # Each chmod is guarded by an ``[ -e ]`` test so a missing optional file is a
+    # no-op, not an error — and the guarded form always exits 0.
+    assert f'[ -e "$HOME/.claude/projects/{_SLUG}/memory" ]' in script
+    assert f'[ -e "$HOME/.claude/projects/{_SLUG}/memory/MEMORY.md" ]' in script
+    assert '[ -e "$HOME/.claude/CLAUDE.md" ]' in script
+
+
+def test_lock_projection_locks_each_extra_in_locked_set() -> None:
+    transport = MagicMock()
+    vm_memory.lock_projection(
+        transport,
+        claude_dir_guest="$HOME/.claude",
+        slug=_SLUG,
+        locked_set=["$HOME/.claude/CLAUDE.md", "$HOME/.claude/extra.md"],
+    )
+
+    script = transport.run.call_args.args[-1]
+    # Every path in the audited locked_set is chmod'd read-only, guarded.
+    assert 'chmod a-w "$HOME/.claude/CLAUDE.md"' in script
+    assert 'chmod a-w "$HOME/.claude/extra.md"' in script


### PR DESCRIPTION
# Pull Request

## Summary

- Add lock_projection to vm_memory and call it at the end of project_memory so each cloud-session memory projection is frozen read-only, making a futile cloud write fail loudly with EACCES.

## Issue Linkage

- Closes #2412

## Notes

- Plan Task 5 / spec Component 3 for epic vergil-project/.github#156. lock_projection chmods read-only exactly the per-repo memory/ subtree (recursive), memory/MEMORY.md, and each path in locked_set — project_memory passes locked_set=["$HOME/.claude/CLAUDE.md"], the audit's (#161) only extra beyond the memory subtree. Lock is SURGICAL: it never blanket-chmods projects/<slug>/ itself, so the session-transcript .jsonl files there stay writable; each chmod is guarded by an if [ -e ] test (missing optional file is a no-op) and uses $HOME (not ~) because the paths are double-quoted. settings.json is explicitly NOT locked (provisioning + runtime both write it). Re-locking is safe: project_memory chmod u+w's before overwriting on the next session. Validation green: 4408 passed, 100% branch coverage.