### PR TITLE
fix(vm-cloud): create host-path prefix and symlink under sudo

### DIFF
--- a/src/vergil_tooling/lib/vm_cloud.py
+++ b/src/vergil_tooling/lib/vm_cloud.py
@@ -576,14 +576,24 @@ def ensure_host_path(transport: Transport, host_projects_dir: str, org: str, rep
     and returns the host-equivalent absolute path so the caller can open the
     session there.
 
-    Idempotent: ``mkdir -p`` is a no-op when the parent already exists, and
-    ``ln -sfn`` re-points an existing link rather than nesting a new one inside
-    it. Follows the ``link_cloud_claude_dirs`` bash-over-transport idiom.
+    Both steps run under ``sudo``. The host prefix (e.g. ``/Users``) sits under
+    root-owned ``/``, so an unprivileged ``mkdir -p /Users/...`` fails with
+    "Permission denied" and aborts the session before it opens (regression
+    #2431). The guest has passwordless sudo (already used for the cloud-init log
+    tail), so ``sudo`` creates the prefix and the symlink; a root-owned symlink
+    is fully traversable and its ``/vergil`` target stays ``ubuntu``-owned, so
+    the session reads and writes the checkout normally.
+
+    Idempotent: ``sudo mkdir -p`` is a no-op when the parent already exists, and
+    ``sudo ln -sfn`` re-points an existing link rather than nesting a new one
+    inside it. Follows the ``link_cloud_claude_dirs`` bash-over-transport idiom.
     """
     checkout = f"{_CLOUD_PROJECTS_VOLUME}/{org}/{repo}"
     host_path = f"{host_projects_dir}/{org}/{repo}"
     host_parent = f"{host_projects_dir}/{org}"
-    transport.run("bash", "-c", f"mkdir -p {host_parent} && ln -sfn {checkout} {host_path}")
+    transport.run(
+        "bash", "-c", f"sudo mkdir -p {host_parent} && sudo ln -sfn {checkout} {host_path}"
+    )
     return host_path
 
 

--- a/tests/vergil_tooling/test_vm_cloud.py
+++ b/tests/vergil_tooling/test_vm_cloud.py
@@ -818,9 +818,12 @@ class TestEnsureHostPath:
         assert path == "/Users/me/dev/projects/vergil-project/vergil-tooling"
         # transport.run("bash", "-c", <script>) — the script is the last positional arg
         script = transport.run.call_args.args[-1]
-        assert "mkdir -p /Users/me/dev/projects/vergil-project" in script
+        # #2431: the host prefix lives under root-owned /, so both steps run
+        # under sudo — an unprivileged mkdir -p /Users/... fails and aborts the
+        # session. Guard both the mkdir and the ln against a non-sudo regression.
+        assert "sudo mkdir -p /Users/me/dev/projects/vergil-project" in script
         assert (
-            "ln -sfn /vergil/projects/vergil-project/vergil-tooling "
+            "sudo ln -sfn /vergil/projects/vergil-project/vergil-tooling "
             "/Users/me/dev/projects/vergil-project/vergil-tooling" in script
         )
 


### PR DESCRIPTION
# Pull Request

## Summary

- Showstopper fix: ensure_host_path ran an unprivileged mkdir -p /Users/... in the cloud guest, which failed (root-owned /) and aborted every cloud vrg-vm session. Now runs the mkdir and ln under the guest's passwordless sudo; the root-owned symlink is traversable and its /vergil target stays ubuntu-owned.

## Issue Linkage

- Closes #2431

## Notes

- Regression from #2410. Host-side vrg-vm change only — reinstalling the host tool fixes existing VMs with no rebuild. Validation green, vm_cloud.py 100% coverage, 4408 tests. Test asserts both mkdir and ln are sudo (regression guard).