### PR TITLE
fix(vm-guest): make copy_claude_config tolerate the read-only projected CLAUDE.md

### DIFF
--- a/src/vergil_tooling/lib/vm_guest.py
+++ b/src/vergil_tooling/lib/vm_guest.py
@@ -425,7 +425,16 @@ _CLAUDE_CONFIG_FILES = ("CLAUDE.md", "settings.json")
 
 
 def copy_claude_config(transport: Transport, claude_dir: Path) -> None:
-    """Copy CLAUDE.md and settings.json from host into the VM."""
+    """Copy CLAUDE.md and settings.json from host into the VM.
+
+    Each target is made writable (``chmod u+w``) before the overwrite: on a
+    cloud VM the memory projection locks ``~/.claude/CLAUDE.md`` read-only at the
+    end of a session (``lock_projection``, #2412), so a later session's plain
+    ``cat >`` would fail with "permission denied" (#2436). The ``chmod u+w``
+    clears any prior lock first; it is a harmless no-op on Lima (never locked)
+    and on a fresh file (guarded with ``2>/dev/null``). Mirrors the same guard in
+    ``vm_memory.project_memory``.
+    """
     if not claude_dir.is_dir():
         return
     transport.run("bash", "-c", "mkdir -p ~/.claude")
@@ -434,7 +443,7 @@ def copy_claude_config(transport: Transport, claude_dir: Path) -> None:
         if source.exists():
             content = source.read_text()
             transport.pipe(
-                f"cat > ~/.claude/{filename}",
+                f"chmod u+w ~/.claude/{filename} 2>/dev/null; cat > ~/.claude/{filename}",
                 content,
             )
 

--- a/tests/vergil_tooling/test_vm_guest.py
+++ b/tests/vergil_tooling/test_vm_guest.py
@@ -428,6 +428,18 @@ class TestCopyClaudeConfig:
         assert "settings.json" in settings_call[0][0]
         assert '"key"' in settings_call[0][1]
 
+        # #2436: the target must be made writable before the overwrite, because
+        # the cloud memory projection locks CLAUDE.md read-only (#2412) — a plain
+        # `cat >` on a later session would fail with "permission denied". Guard
+        # both files against a non-chmod regression.
+        assert (
+            "chmod u+w ~/.claude/CLAUDE.md 2>/dev/null; cat > ~/.claude/CLAUDE.md" in md_call[0][0]
+        )
+        assert (
+            "chmod u+w ~/.claude/settings.json 2>/dev/null; cat > ~/.claude/settings.json"
+            in settings_call[0][0]
+        )
+
     def test_skips_missing_files(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()


### PR DESCRIPTION
# Pull Request

## Summary

- Second showstopper in the memory-projection rollout: lock_projection (#2412) makes ~/.claude/CLAUDE.md read-only, so a later cloud session's copy_claude_config (which runs first, before project_memory) failed its plain 'cat >' with permission denied and aborted the session. copy_claude_config now chmod u+w's each target before the cat, mirroring project_memory's guard.

## Issue Linkage

- Closes #2436

## Notes

- Regression surfaced by #2412. Host-side vrg-vm change only — reinstall fixes existing VMs with no rebuild. Validation green, vm_guest.py 100% coverage, 4408 tests. Test asserts the chmod u+w guard on both CLAUDE.md and settings.json.