### PR TITLE
feat(vm-memory): verify projection resolved and fail loudly on a broken indirection

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2435,6 +2435,11 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
     # divergent (or empty) cloud copy. The read-only lock is applied separately
     # (#2412); this copies the files only.
     vm_memory.project_memory(transport, claude_dir=claude_dir, host_workdir=workdir)
+    # #2413 (Component 6): verify the projection actually resolved in-guest before
+    # opening the session. A broken Component-2a host-path indirection would
+    # otherwise degrade *silently* to empty memory; verify_projection turns that
+    # into a loud ProjectionError that aborts the session (no silent continue).
+    vm_memory.verify_projection(transport, host_workdir=workdir, slug=vm_memory.host_slug(workdir))
     print("  -> opening the session", file=sys.stderr, flush=True)
     workspace_abs = os.path.normpath(resolve_workspace(args.workspace, identity.projects_dir))
     rel_path = os.path.relpath(workspace_abs, identity.projects_dir)

--- a/src/vergil_tooling/lib/vm_memory.py
+++ b/src/vergil_tooling/lib/vm_memory.py
@@ -17,6 +17,7 @@ vanishing (spec §Component 3, §Error handling).
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -149,3 +150,62 @@ def lock_projection(
 
     script = "\n".join(f"if [ -e {target} ]; then {chmod}; fi" for target, chmod in targets)
     transport.run("bash", "-c", script)
+
+
+class ProjectionError(RuntimeError):
+    """The projected memory failed its post-copy verification (spec §Component 6).
+
+    Raised — not swallowed — when an in-guest check shows the projection did not
+    resolve, so a broken host-path indirection aborts the cloud session *loudly*
+    instead of degrading silently to empty memory (the one silent-degradation risk
+    the epic exists to kill). Carries an actionable message naming the failed check
+    and the fix.
+    """
+
+
+def verify_projection(transport: Transport, *, host_workdir: str, slug: str) -> None:
+    """Verify, in-guest, that the memory projection actually resolved (fail loudly).
+
+    The one silent-degradation risk (spec §Component 6): if the Component-2a
+    host-path indirection is broken, Claude starts at a path whose slug diverges
+    from the host, reads *empty* memory, and reports no error. This turns that
+    silent failure into a loud one by asserting two things over the transport,
+    **after** ``project_memory`` has run:
+
+    1. ``host_workdir`` resolves to a directory in the guest — the ``ensure_host_path``
+       symlink exists and points at the ``/vergil`` checkout (a broken or missing
+       symlink fails ``test -d``, which follows the link to its target).
+    2. ``~/.claude/projects/<slug>/memory`` exists — the projected memory landed at
+       the slug Claude will derive from ``host_workdir``.
+
+    Both are read-only ``test -d`` checks, so they are safe against the read-only
+    lock ``lock_projection`` has already applied. A failed ``test`` surfaces as a
+    :class:`subprocess.CalledProcessError` over the transport; it is re-raised as a
+    :class:`ProjectionError` whose message names the failed check and the fix
+    (re-run the session, which rebuilds the indirection and re-projects; rebuild the
+    VM if it persists). The error is allowed to propagate so ``_cloud_session``
+    aborts before ``exec_session`` rather than opening a session on empty memory.
+    """
+    guest_memory_dir = f"{_GUEST_CLAUDE_DIR}/projects/{slug}/memory"
+    checks = (
+        (
+            host_workdir,
+            f"projection verification failed: the host project path {host_workdir!r} "
+            f"does not resolve in the guest — the host-path symlink (Component 2a) is "
+            f"missing or broken, so Claude would derive a divergent memory slug and "
+            f"read empty memory. Fix: re-run the cloud session (it rebuilds the "
+            f"symlink and re-projects); rebuild the VM if it persists.",
+        ),
+        (
+            guest_memory_dir,
+            f"projection verification failed: the projected memory directory "
+            f"{guest_memory_dir!r} is missing in the guest — the host->guest memory "
+            f"copy did not land at the expected slug. Fix: re-run the cloud session "
+            f"to re-project memory; rebuild the VM if it persists.",
+        ),
+    )
+    for target, message in checks:
+        try:
+            transport.run("bash", "-c", f"test -d {target}")
+        except subprocess.CalledProcessError as exc:
+            raise ProjectionError(message) from exc

--- a/tests/vergil_tooling/test_vm_memory.py
+++ b/tests/vergil_tooling/test_vm_memory.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from vergil_tooling.lib import vm_memory
 
@@ -178,3 +181,56 @@ def test_lock_projection_locks_each_extra_in_locked_set() -> None:
     # Every path in the audited locked_set is chmod'd read-only, guarded.
     assert 'chmod a-w "$HOME/.claude/CLAUDE.md"' in script
     assert 'chmod a-w "$HOME/.claude/extra.md"' in script
+
+
+def test_verify_projection_raises_when_host_path_missing() -> None:
+    # (Component 6) A broken Component-2a host-path indirection would otherwise
+    # degrade *silently* to empty memory. verify_projection turns the first failed
+    # in-guest ``test`` (a CalledProcessError over the transport) into a loud
+    # ProjectionError carrying an actionable message.
+    transport = MagicMock()
+    transport.run.side_effect = subprocess.CalledProcessError(1, "test")
+
+    with pytest.raises(vm_memory.ProjectionError) as excinfo:
+        vm_memory.verify_projection(transport, host_workdir=_WORKDIR, slug=_SLUG)
+
+    message = str(excinfo.value)
+    # The message names the failed check (the host path) and the fix (re-run/rebuild).
+    assert _WORKDIR in message
+    assert "re-run" in message.lower()
+    assert "rebuild" in message.lower()
+
+
+def test_verify_projection_raises_when_memory_dir_missing() -> None:
+    # The host path resolves (first ``test`` succeeds) but the projected memory dir
+    # is absent (second ``test`` fails) — still a loud ProjectionError naming the
+    # memory dir and the fix, not a silent empty read.
+    transport = MagicMock()
+    transport.run.side_effect = [
+        subprocess.CompletedProcess(args=["bash"], returncode=0),
+        subprocess.CalledProcessError(1, "test"),
+    ]
+
+    with pytest.raises(vm_memory.ProjectionError) as excinfo:
+        vm_memory.verify_projection(transport, host_workdir=_WORKDIR, slug=_SLUG)
+
+    message = str(excinfo.value)
+    assert f"projects/{_SLUG}/memory" in message
+    assert "re-run" in message.lower()
+
+
+def test_verify_projection_passes_when_both_checks_succeed() -> None:
+    # Both read-only ``test -d`` checks pass: the host path resolves and the slug
+    # memory dir exists, so verify returns without raising (and never mutates —
+    # safe against the read-only lock).
+    transport = MagicMock()
+    transport.run.return_value = subprocess.CompletedProcess(args=["bash"], returncode=0)
+
+    vm_memory.verify_projection(transport, host_workdir=_WORKDIR, slug=_SLUG)
+
+    # Exactly the two read-only ``test -d`` checks ran — the host path and the slug
+    # memory dir — and nothing else (no write, no chmod).
+    scripts = [c.args[-1] for c in transport.run.call_args_list]
+    assert any(f"test -d {_WORKDIR}" in s for s in scripts)
+    assert any(f"test -d ~/.claude/projects/{_SLUG}/memory" in s for s in scripts)
+    assert all("test -d " in s for s in scripts)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -45,7 +45,7 @@ from vergil_tooling.bin.vrg_vm import (
     resolve_borrow,
     warn_if_off_host,
 )
-from vergil_tooling.lib import vm_cloud
+from vergil_tooling.lib import vm_cloud, vm_memory
 from vergil_tooling.lib.identity import Identity, IdentityConfig
 from vergil_tooling.lib.vm_backend import select_backend
 from vergil_tooling.lib.vm_spec import ComposedSpec, SpecError
@@ -3733,6 +3733,7 @@ class _CloudPatches:
             return_value="/Users/me/dev/projects/lmf/cloud",
         )
         _patch("vergil_tooling.bin.vrg_vm.vm_memory.project_memory")
+        _patch("vergil_tooling.bin.vrg_vm.vm_memory.verify_projection")
         _patch("vergil_tooling.bin.vrg_vm.copy_claude_config")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.preflight")
         _patch("vergil_tooling.bin.vrg_vm.vm_cloud.destroy_vm")
@@ -4095,6 +4096,42 @@ class TestCloudSession:
         order = [name for name, _, _ in manager.mock_calls]
         # projection runs after the host-path indirection, before the exec
         assert order.index("ensure") < order.index("project") < order.index("exec")
+
+    def test_cloud_session_verifies_projection(self, _cloud_repo: Path, tmp_path: Path) -> None:
+        # #2413 (Component 6): _cloud_session must verify the projection resolved —
+        # AFTER project_memory (so there is something to verify) and BEFORE the
+        # process-replacing exec_session — so a broken host-path indirection aborts
+        # the session loudly instead of degrading to empty memory.
+        transport = MagicMock()
+        with _CloudPatches(tmp_path / "state") as m:
+            m["transport"].return_value = transport
+            manager = MagicMock()
+            manager.attach_mock(m["ensure_host_path"], "ensure")
+            manager.attach_mock(m["project_memory"], "project")
+            manager.attach_mock(m["verify_projection"], "verify")
+            manager.attach_mock(transport.exec_session, "exec")
+            main(["session", "lmf/cloud", "--config", str(_cloud_repo)])
+        m["verify_projection"].assert_called_once()
+        assert m["verify_projection"].call_args.args[0] is transport
+        kwargs = m["verify_projection"].call_args.kwargs
+        assert kwargs["host_workdir"] == m["ensure_host_path"].return_value
+        assert kwargs["slug"] == vm_memory.host_slug(m["ensure_host_path"].return_value)
+        order = [name for name, _, _ in manager.mock_calls]
+        # verification runs after the projection, before the exec
+        assert order.index("project") < order.index("verify") < order.index("exec")
+
+    def test_cloud_session_aborts_on_projection_error(
+        self, _cloud_repo: Path, tmp_path: Path
+    ) -> None:
+        # A ProjectionError from verify_projection must propagate and abort the
+        # session (no silent continue): exec_session is never reached.
+        transport = MagicMock()
+        with _CloudPatches(tmp_path / "state") as m:
+            m["transport"].return_value = transport
+            m["verify_projection"].side_effect = vm_memory.ProjectionError("broken projection")
+            with pytest.raises(vm_memory.ProjectionError):
+                main(["session", "lmf/cloud", "--config", str(_cloud_repo)])
+        transport.exec_session.assert_not_called()
 
     def test_cloud_session_seeds_claude_config(self, _cloud_repo: Path, tmp_path: Path) -> None:
         # #1999 (Fix A): the cloud session path must seed the operator's ~/.claude


### PR DESCRIPTION
# Pull Request

## Summary

- Add ProjectionError and verify_projection to vm_memory, wired into _cloud_session after project_memory and before exec_session, so a broken host-path indirection aborts the cloud session loudly instead of degrading silently to empty memory.

## Issue Linkage

- Closes #2413

## Notes

- Task 6 of epic vergil-project/.github#156 (spec Component 6). verify_projection runs two read-only in-guest test -d checks (host_workdir resolves via the ensure_host_path symlink; ~/.claude/projects/<slug>/memory exists); a failed check (CalledProcessError over the transport) becomes a ProjectionError naming the failed check and the fix (re-run session / rebuild VM). Checks are read-only so they are safe against the read-only lock. Tests: vm_memory raise-on-missing-host-path, raise-on-missing-memory-dir, pass-when-both-succeed; vrg_vm wiring asserts verify runs after project_memory and before exec, and that a ProjectionError aborts before exec_session. Validation green at 100% coverage.