### PR TITLE
fix(container): pin UV_LINK_MODE=copy to silence uv hardlink-fallback warning

### DIFF
--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -170,6 +170,15 @@ def build_container_args(
             if name.startswith(prefixes):
                 container_args.extend(["-e", name])
 
+    # uv's cache (`/root/.cache/uv`, container overlay fs) and the venv target
+    # (`/workspace/.venv`, the bind-mounted repo) live on different filesystems,
+    # so uv cannot hardlink and falls back to a full copy, printing a warning on
+    # every install in every run. Pin the link mode to copy to suppress that
+    # noise — uv already copies here, so this changes no behaviour. An explicit
+    # host UV_LINK_MODE wins, so an operator can still override it. (#2461)
+    uv_link_mode = os.environ.get("UV_LINK_MODE", "copy")
+    container_args.extend(["-e", f"UV_LINK_MODE={uv_link_mode}"])
+
     # Mount host git config so git identity is available in the container.
     gitconfig = Path.home() / ".gitconfig"
     if gitconfig.exists():

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -184,6 +184,29 @@ def test_build_container_args_nerdctl(tmp_path: Path) -> None:
     assert args[0:3] == ["nerdctl", "run", "--rm"]
 
 
+def _env_value(args: list[str], name: str) -> str | None:
+    """Return the value passed via ``-e NAME=value``, or None if absent."""
+    for i, a in enumerate(args):
+        if a == "-e" and i + 1 < len(args) and args[i + 1].startswith(f"{name}="):
+            return args[i + 1].split("=", 1)[1]
+    return None
+
+
+def test_build_container_args_defaults_uv_link_mode_copy(tmp_path: Path) -> None:
+    # The uv cache and the /workspace venv target are on different filesystems,
+    # so uv falls back to copy; we pin it to copy to silence the warning (#2461).
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(args, "UV_LINK_MODE") == "copy"
+
+
+def test_build_container_args_respects_host_uv_link_mode(tmp_path: Path) -> None:
+    # An operator's explicit UV_LINK_MODE wins over the copy default.
+    with patch.dict("os.environ", {"UV_LINK_MODE": "hardlink"}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(args, "UV_LINK_MODE") == "hardlink"
+
+
 def test_build_docker_args_basic(tmp_path: Path) -> None:
     with patch.dict("os.environ", {}, clear=True):
         args = build_docker_args(tmp_path, "img:1", ["echo", "hello"])


### PR DESCRIPTION
# Pull Request

## Summary

- Set UV_LINK_MODE=copy in the vrg-container-run environment so uv stops printing the hardlink-fallback warning on every install (cache and venv target are on different filesystems); uv already copies here, so behaviour is unchanged and an explicit host value still wins.

## Issue Linkage

- Ref #2461

## Notes

- Zero-behaviour-change noise suppression. Not the cure for the ansible-lint/Python-3.14 common flake (that is vergil-containers#446) nor the lazy-rebuild fix (#2462). New tests cover the copy default and host-override-wins. Full vrg-validate green (4415 passed, 100% coverage, common stage clean).