### PR TITLE
feat(finalize): provision the dev image explicitly before validation

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -54,7 +54,8 @@ from vergil_tooling.lib import (
     worktrees,
 )
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
-from vergil_tooling.lib.container_cache import clean_branch_images
+from vergil_tooling.lib.container import detect_language
+from vergil_tooling.lib.container_cache import clean_branch_images, provision_dev_image
 from vergil_tooling.lib.pr_workflow import batch, github_transport
 from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.repo_init import prompt_choice
@@ -809,6 +810,32 @@ def _stage_cleanup(ctx: FinalizeContext) -> None:
     )
 
 
+def _stage_provision(ctx: FinalizeContext) -> None:
+    """Provision the target-branch dev image up front, before validation.
+
+    ``_stage_cleanup`` has just advanced the target branch — the one
+    deterministic reason its cached image needs rebuilding. Warm it here, once,
+    so the validation stage (and the next PR's work) reuse a warm image instead
+    of triggering a cold rebuild *inside* an operation. That lazy just-in-time
+    rebuild — late, and possibly under parallel load — is what let a build-time
+    glitch masquerade as "validation failed after a clean merge" (issue #2462).
+    """
+    args = ctx.args
+    if args.dry_run:
+        print("  [dry-run] provision dev image for the target branch")
+        return
+    print("Provisioning dev image for post-finalization validation...")
+    lang = detect_language(ctx.root)
+    try:
+        image, source = provision_dev_image(ctx.root, lang)
+    except RuntimeError as exc:
+        raise FinalizeError(f"dev-image provisioning failed: {exc}") from exc
+    if source == "env":
+        print(f"  Using DOCKER_DEV_IMAGE override: {image}")
+    else:
+        print(f"  Image ready: {image}")
+
+
 def _stage_validation(ctx: FinalizeContext) -> None:
     """Run canonical validation to catch problems on the target branch
     before the next PR is created.
@@ -861,10 +888,11 @@ def build_stages(*, include_pr: bool, include_post_checks: bool = True) -> tuple
     """Assemble the pipeline for the resolved mode.
 
     provenance/merge run only when a PR was given or inferred; cleanup always
-    runs. validation and cd-check run unless *include_post_checks* is False
-    (the batch path defers them to one end-of-batch run, issue #1673); they
-    are fail_defer so a validation failure still surfaces the CD status —
-    matching the pre-pipeline control flow.
+    runs. provision, validation, and cd-check run unless *include_post_checks*
+    is False (the batch path defers them to one end-of-batch run, issue #1673).
+    provision warms the target-branch image (fail_fast, before it is used);
+    validation and cd-check are fail_defer so a validation failure still surfaces
+    the CD status — matching the pre-pipeline control flow.
     """
     stages: list[Stage] = []
     if include_pr:
@@ -872,6 +900,10 @@ def build_stages(*, include_pr: bool, include_post_checks: bool = True) -> tuple
         stages.append(Stage("merge", _stage_merge, "fail_fast"))
     stages.append(Stage("cleanup", _stage_cleanup, "fail_fast"))
     if include_post_checks:
+        # Provision the environment before it is used. fail_fast: if the image
+        # cannot be built there is no point running validation against a broken
+        # or absent one (issue #2462).
+        stages.append(Stage("provision", _stage_provision, "fail_fast"))
         stages.append(Stage("validation", _stage_validation, "fail_defer"))
         stages.append(Stage("cd-check", _stage_cd_check, "fail_defer"))
     return tuple(stages)

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -10,7 +10,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.config import vrg_install_tag
-from vergil_tooling.lib.container import container_platform, detect_runtime
+from vergil_tooling.lib.container import container_platform, default_image, detect_runtime
 from vergil_tooling.lib.languages import CheckKind, language_commands
 
 if TYPE_CHECKING:
@@ -236,6 +236,14 @@ def _build_cached_image(
         uv_install = f"uv tool install --quiet 'vergil-tooling @ git+{_VRG_GIT_URL}@{tag}'"
         setup = f"{uv_install} && {warmup}" if warmup else uv_install
 
+    # Attribute the build clearly as an environment-provisioning step. A rebuild
+    # can be triggered lazily by an operational command (the first vrg-container-run
+    # whose cache key no longer matches), and without this framing a build failure
+    # reads as a failure of whatever operation happened to trigger it — e.g. a
+    # cold build during vrg-finalize-pr's validation looking like "validation
+    # failed after a clean merge" (issue #2462). This banner keeps a provisioning
+    # failure attributable to provisioning, not to the caller's operation.
+    print("── Provisioning dev image (environment build — not part of your command) ──")
     print(f"Building cached image: {target_tag}")
     print(f"  Base:    {base_image}")
     if self_repo:
@@ -330,6 +338,37 @@ def ensure_cached_image(
 
     target_tag = cache_image_tag(base_image, branch, current_hash)
     return _build_cached_image(repo_root, lang, base_image, target_tag, runtime=rt)
+
+
+def provision_dev_image(
+    repo_root: Path,
+    lang: str,
+    *,
+    prefix: str = "prod",
+    runtime: str = "",
+) -> tuple[str, str]:
+    """Resolve the dev image for *repo_root*, building/warming it if needed.
+
+    This is the explicit provisioning seam: it names, as a single operation, the
+    image resolution that ``vrg-container-run`` performs lazily on every call.
+    ``vrg-finalize-pr`` calls it up front — right after develop advances — so the
+    target-branch image is warm before validation (or the next PR's work) uses
+    it, instead of triggering a cold rebuild mid-operation (issue #2462).
+
+    Returns ``(image, source)`` where *source* is ``"env"`` (a ``DOCKER_DEV_IMAGE``
+    override), ``"cached"`` (a per-branch cached image), or ``"default"`` (the base
+    image, when the repo declares no cache-sensitive files).
+
+    Kept in step with ``vrg_container_run.main``'s inline resolution: both honour
+    ``DOCKER_DEV_IMAGE`` first, then fall back to ``default_image`` +
+    ``ensure_cached_image``. Change the two together.
+    """
+    env_image = os.environ.get("DOCKER_DEV_IMAGE")
+    if env_image:
+        return env_image, "env"
+    base = default_image(lang, fallback=True, prefix=prefix)
+    image = ensure_cached_image(repo_root, lang, base, runtime=runtime)
+    return image, ("cached" if image != base else "default")
 
 
 def clean_branch_images(branch: str, *, runtime: str = "") -> int:

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -18,6 +18,7 @@ from vergil_tooling.lib.container_cache import (
     compute_cache_hash,
     ensure_cached_image,
     find_cached_image,
+    provision_dev_image,
     resolve_base_digest,
 )
 
@@ -286,6 +287,48 @@ def test_ensure_rebuilds_when_base_digest_changes(tmp_path: Path) -> None:
     mock_build.assert_called_once()
     # The stale image was removed.
     assert stale_tag in mock_run.call_args[0][0]
+
+
+# -- provision_dev_image ------------------------------------------------------
+
+
+def test_provision_uses_env_override(tmp_path: Path) -> None:
+    with (
+        patch.dict("os.environ", {"DOCKER_DEV_IMAGE": "custom:img"}, clear=True),
+        patch("vergil_tooling.lib.container_cache.ensure_cached_image") as ensure,
+    ):
+        image, source = provision_dev_image(tmp_path, "python")
+    assert (image, source) == ("custom:img", "env")
+    # The env override short-circuits — no image is built.
+    ensure.assert_not_called()
+
+
+def test_provision_returns_cached_when_built(tmp_path: Path) -> None:
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("vergil_tooling.lib.container_cache.default_image", return_value="base:1"),
+        patch(
+            "vergil_tooling.lib.container_cache.ensure_cached_image",
+            return_value="base:1--develop--abcd1234",
+        ),
+    ):
+        image, source = provision_dev_image(tmp_path, "python", runtime="docker")
+    assert (image, source) == ("base:1--develop--abcd1234", "cached")
+
+
+def test_provision_returns_default_when_no_cache_files(tmp_path: Path) -> None:
+    # ensure_cached_image returns the base unchanged when the repo declares no
+    # cache-sensitive files, so the source is the plain base image.
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("vergil_tooling.lib.container_cache.default_image", return_value="base:1"),
+        patch(
+            "vergil_tooling.lib.container_cache.ensure_cached_image",
+            return_value="base:1",
+        ),
+    ):
+        image, source = provision_dev_image(tmp_path, "python")
+    assert (image, source) == ("base:1", "default")
 
 
 # -- clean_branch_images ------------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -26,6 +26,7 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     _stage_cd_check,
     _stage_merge,
     _stage_provenance,
+    _stage_provision,
     _stage_validation,
     _worktree_is_dirty,
     build_stages,
@@ -106,6 +107,17 @@ def _validation_passes() -> Iterator[None]:
     innermost patch wins.
     """
     with patch(_MOD + ".progress.run", return_value=0):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _provisioning_passes() -> Iterator[None]:
+    """Default: the provision stage warms the image without touching docker.
+
+    The provision stage calls provision_dev_image (issue #2462); tests that
+    assert provisioning behavior re-patch it directly — the innermost patch wins.
+    """
+    with patch(_MOD + ".provision_dev_image", return_value=("img--develop--test", "cached")):
         yield
 
 
@@ -1450,12 +1462,17 @@ def test_stage_merge_dry_run_skips_engine() -> None:
 
 def test_build_stages_with_pr() -> None:
     names = [s.name for s in build_stages(include_pr=True)]
-    assert names == ["provenance", "merge", "cleanup", "validation", "cd-check"]
+    assert names == ["provenance", "merge", "cleanup", "provision", "validation", "cd-check"]
 
 
 def test_build_stages_without_pr() -> None:
     names = [s.name for s in build_stages(include_pr=False)]
-    assert names == ["cleanup", "validation", "cd-check"]
+    assert names == ["cleanup", "provision", "validation", "cd-check"]
+
+
+def test_build_stages_skips_post_checks() -> None:
+    names = [s.name for s in build_stages(include_pr=True, include_post_checks=False)]
+    assert names == ["provenance", "merge", "cleanup"]
 
 
 def test_build_stages_failure_modes() -> None:
@@ -1463,10 +1480,54 @@ def test_build_stages_failure_modes() -> None:
     assert modes["provenance"] == "fail_fast"
     assert modes["merge"] == "fail_fast"
     assert modes["cleanup"] == "fail_fast"
+    # Provisioning is a prerequisite: fail_fast so validation never runs against
+    # a broken or absent image (issue #2462).
+    assert modes["provision"] == "fail_fast"
     # fail_defer preserves current semantics: a validation failure still
     # runs the cd-check, and either failure exits 1.
     assert modes["validation"] == "fail_defer"
     assert modes["cd-check"] == "fail_defer"
+
+
+def test_stage_provision_warms_image(tmp_path: Path) -> None:
+    ctx = _stage_ctx([], root=tmp_path)
+    with (
+        patch(_MOD + ".detect_language", return_value="python"),
+        patch(
+            _MOD + ".provision_dev_image", return_value=("img--develop--abcd1234", "cached")
+        ) as prov,
+    ):
+        _stage_provision(ctx)
+    prov.assert_called_once_with(tmp_path, "python")
+
+
+def test_stage_provision_reports_env_override(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ctx = _stage_ctx([], root=tmp_path)
+    with (
+        patch(_MOD + ".detect_language", return_value="python"),
+        patch(_MOD + ".provision_dev_image", return_value=("custom:img", "env")),
+    ):
+        _stage_provision(ctx)
+    assert "DOCKER_DEV_IMAGE override" in capsys.readouterr().out
+
+
+def test_stage_provision_failure_raises(tmp_path: Path) -> None:
+    ctx = _stage_ctx([], root=tmp_path)
+    with (
+        patch(_MOD + ".detect_language", return_value="python"),
+        patch(_MOD + ".provision_dev_image", side_effect=RuntimeError("Cache build failed")),
+        pytest.raises(FinalizeError, match="dev-image provisioning failed"),
+    ):
+        _stage_provision(ctx)
+
+
+def test_stage_provision_dry_run_skips(tmp_path: Path) -> None:
+    ctx = _stage_ctx(["--dry-run"], root=tmp_path)
+    with patch(_MOD + ".provision_dev_image") as prov:
+        _stage_provision(ctx)
+    prov.assert_not_called()
 
 
 def test_stage_validation_streams_through_progress(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a fail_fast 'provision' stage to vrg-finalize-pr that warms the target-branch dev image up front (right after cleanup advances the branch) via a shared provision_dev_image helper, so validation reuses a warm image instead of cold-rebuilding mid-operation; environment builds now print an attributed banner so a provisioning failure never masquerades as an operation failure.

## Issue Linkage

- Closes #2462

## Notes

- Implements the explicit-provisioning half of the dev-environment work. Does NOT cure the ansible-lint/Python-3.14 metadata glitch (vergil-containers#446) — it removes the lazy mid-operation rebuild and the mis-attribution. Lazy auto-build is preserved (no hard user-facing gate), just made deterministic-early and visible. New tests cover provision_dev_image (env/cached/default), the provision stage (warm/env/failure/dry-run), and the updated stage list. Full vrg-validate green (4421 passed, 100% coverage, common clean).