### PR TITLE
fix(container): make repo's [ci].versions authoritative for local container selection

### DIFF
--- a/src/vergil_tooling/bin/vrg_container_cache.py
+++ b/src/vergil_tooling/bin/vrg_container_cache.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 
 from vergil_tooling.lib import git
+from vergil_tooling.lib.config import primary_ci_version
 from vergil_tooling.lib.container import (
     assert_runtime_available,
     default_image,
@@ -34,7 +35,7 @@ from vergil_tooling.lib.container_cache import (
 def _cmd_build(_args: argparse.Namespace, *, runtime: str) -> int:
     repo_root = git.repo_root()
     lang = detect_language(repo_root)
-    base = default_image(lang, fallback=True)
+    base = default_image(lang, fallback=True, version=primary_ci_version(repo_root))
     assert_runtime_available(runtime)
     image = ensure_cached_image(repo_root, lang, base, runtime=runtime)
     if image == base:
@@ -45,7 +46,7 @@ def _cmd_build(_args: argparse.Namespace, *, runtime: str) -> int:
 def _cmd_clean(_args: argparse.Namespace, *, runtime: str) -> int:
     repo_root = git.repo_root()
     lang = detect_language(repo_root)
-    base = default_image(lang, fallback=True)
+    base = default_image(lang, fallback=True, version=primary_ci_version(repo_root))
     branch = git.current_branch()
     existing = find_cached_image(base, branch, runtime=runtime)
     if existing is None:
@@ -62,7 +63,7 @@ def _cmd_clean(_args: argparse.Namespace, *, runtime: str) -> int:
 def _cmd_status(_args: argparse.Namespace, *, runtime: str) -> int:
     repo_root = git.repo_root()
     lang = detect_language(repo_root)
-    base = default_image(lang, fallback=True)
+    base = default_image(lang, fallback=True, version=primary_ci_version(repo_root))
     branch = git.current_branch()
     existing = find_cached_image(base, branch, runtime=runtime)
     files = cache_sensitive_files(repo_root, lang)

--- a/src/vergil_tooling/bin/vrg_container_run.py
+++ b/src/vergil_tooling/bin/vrg_container_run.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib import git
 from vergil_tooling.lib.config import (
     DEFAULT_VALIDATION_COMMAND,
     container_env_prefixes,
+    primary_ci_version,
     validation_container_command,
 )
 from vergil_tooling.lib.container import (
@@ -121,7 +122,20 @@ def main(argv: list[str] | None = None) -> int:
         image = env_image
         image_source = "env"
     else:
-        base = default_image(lang, fallback=True, prefix=prefix)
+        # The repo's declared [ci].versions is authoritative for the container
+        # version — never a hardcoded tooling-side default (issue #2468). Fall
+        # back to the built-in default only when the repo declares none, and say
+        # so loudly: a silent fallback is exactly how a default bump once flipped
+        # every repo's local build to a different interpreter.
+        declared_version = primary_ci_version(repo_root)
+        if declared_version is None and lang:
+            print(
+                f"WARNING: vergil.toml declares no [ci].versions; using the "
+                f"built-in default container for '{lang}'. Declare [ci].versions "
+                f"to pin the container version and keep local builds aligned with CI.",
+                file=sys.stderr,
+            )
+        base = default_image(lang, fallback=True, prefix=prefix, version=declared_version)
         image = ensure_cached_image(repo_root, lang, base, runtime=runtime)
         image_source = "cached" if image != base else "default"
 

--- a/src/vergil_tooling/bin/vrg_container_test.py
+++ b/src/vergil_tooling/bin/vrg_container_test.py
@@ -14,7 +14,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib import git
-from vergil_tooling.lib.config import container_env_prefixes
+from vergil_tooling.lib.config import container_env_prefixes, primary_ci_version
 from vergil_tooling.lib.container import (
     _DEFAULT_TEST_COMMANDS,
     build_container_args,
@@ -38,7 +38,9 @@ def build_test_container_args(
     env_prefixes: Sequence[str] = (),
 ) -> list[str]:
     """Build the container run argument list for test execution."""
-    image = os.environ.get("DOCKER_DEV_IMAGE") or default_image(lang)
+    image = os.environ.get("DOCKER_DEV_IMAGE") or default_image(
+        lang, version=primary_ci_version(repo_root)
+    )
     test_cmd = os.environ.get("DOCKER_TEST_CMD") or _DEFAULT_TEST_COMMANDS.get(lang, "")
     network = os.environ.get("DOCKER_NETWORK", "")
 

--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -489,6 +489,28 @@ def vrg_install_tag(repo_root: Path) -> str:
     return cfg.dependencies["vergil"]
 
 
+def primary_ci_version(repo_root: Path) -> str | None:
+    """Return the repo's primary declared version — ``[ci].versions[0]``.
+
+    This is authoritative for local container selection (issue #2468): the
+    dev/validate image tag is ``prod-<lang>:<version>``, and the repo's declared
+    version must win over the built-in ``_DEFAULT_VERSIONS`` so a tooling-side
+    default bump cannot silently change every consuming repo's local builds (or
+    skew them from CI, which runs the same ``[ci].versions``).
+
+    Returns ``None`` — the caller falls back to the built-in default — when the
+    repo has no ``vergil.toml``. A ``ConfigError`` from a malformed config
+    propagates, matching :func:`validation_container_command` and
+    :func:`container_env_prefixes`; the parser guarantees ``[ci].versions`` is a
+    non-empty list, so ``[0]`` is always valid once the read succeeds.
+    """
+    try:
+        cfg = read_config(repo_root)
+    except FileNotFoundError:
+        return None
+    return cfg.ci.versions[0]
+
+
 def container_env_prefixes(repo_root: Path) -> list[str]:
     """Return ``[container].env-prefixes`` from vergil.toml, or ``[]``."""
     try:

--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -80,18 +80,30 @@ def detect_language(repo_root: Path) -> str:
     return ""
 
 
-def default_image(lang: str, *, fallback: bool = False, prefix: str = _DEFAULT_PREFIX) -> str:
+def default_image(
+    lang: str,
+    *,
+    fallback: bool = False,
+    prefix: str = _DEFAULT_PREFIX,
+    version: str | None = None,
+) -> str:
     """Return the default container image for a language.
 
     When *fallback* is True, return the base image if no language
     matches instead of returning an empty string.
+
+    *version* overrides the built-in ``_DEFAULT_VERSIONS`` entry for *lang*
+    (issue #2468). Callers pass the repo's declared ``[ci].versions`` primary
+    (via :func:`config.primary_ci_version`) so the repo — not a tooling-side
+    constant — picks the container tag. When it is ``None`` (or empty), the
+    built-in default is used.
     """
-    version = _DEFAULT_VERSIONS.get(lang, "")
-    if not version and fallback:
+    resolved = version or _DEFAULT_VERSIONS.get(lang, "")
+    if not resolved and fallback:
         return _fallback_image(prefix)
-    if not version:
+    if not resolved:
         return ""
-    return f"{_GHCR}/{prefix}-{lang}:{version}"
+    return f"{_GHCR}/{prefix}-{lang}:{resolved}"
 
 
 def worktree_parent_gitdir(repo_root: Path) -> Path | None:

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING
 
-from vergil_tooling.lib.config import vrg_install_tag
+from vergil_tooling.lib.config import primary_ci_version, vrg_install_tag
 from vergil_tooling.lib.container import container_platform, default_image, detect_runtime
 from vergil_tooling.lib.languages import CheckKind, language_commands
 
@@ -366,7 +366,10 @@ def provision_dev_image(
     env_image = os.environ.get("DOCKER_DEV_IMAGE")
     if env_image:
         return env_image, "env"
-    base = default_image(lang, fallback=True, prefix=prefix)
+    # The repo's declared [ci].versions picks the container version, not a
+    # hardcoded default (issue #2468), so provisioning warms the same image
+    # vrg-container-run selects.
+    base = default_image(lang, fallback=True, prefix=prefix, version=primary_ci_version(repo_root))
     image = ensure_cached_image(repo_root, lang, base, runtime=runtime)
     return image, ("cached" if image != base else "default")
 

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -18,6 +18,7 @@ from vergil_tooling.lib.config import (
     _warn_unrecognized_keys,
     container_env_prefixes,
     parse_vm_stanza,
+    primary_ci_version,
     read_config,
     validation_container_command,
     vrg_install_tag,
@@ -107,6 +108,25 @@ def test_read_config_invalid_toml(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text("[invalid\n")
     with pytest.raises(ConfigError, match="not valid TOML"):
         read_config(tmp_path)
+
+
+def test_primary_ci_version_returns_first_declared(tmp_path: Path) -> None:
+    toml = _BASE_TOML + '\n[ci]\nversions = ["3.12", "3.13", "3.14"]\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    assert primary_ci_version(tmp_path) == "3.12"
+
+
+def test_primary_ci_version_none_when_no_config(tmp_path: Path) -> None:
+    # No vergil.toml: the caller falls back to the built-in default version.
+    assert primary_ci_version(tmp_path) is None
+
+
+def test_primary_ci_version_propagates_config_error(tmp_path: Path) -> None:
+    # A malformed config fails loudly rather than silently defaulting — matching
+    # validation_container_command / container_env_prefixes (issue #2468).
+    (tmp_path / "vergil.toml").write_text("[invalid\n")
+    with pytest.raises(ConfigError):
+        primary_ci_version(tmp_path)
 
 
 def test_read_config_missing_required_project_field(tmp_path: Path) -> None:

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -164,6 +164,20 @@ def test_docker_platform_alias() -> None:
     assert docker_platform is container_platform
 
 
+def test_default_image_version_override() -> None:
+    # The repo's declared [ci].versions primary wins over _DEFAULT_VERSIONS (#2468).
+    assert default_image("python", version="3.12") == "ghcr.io/vergil-project/prod-python:3.12"
+
+
+def test_default_image_version_none_uses_builtin_default() -> None:
+    assert default_image("python", version=None) == "ghcr.io/vergil-project/prod-python:3.14"
+
+
+def test_default_image_empty_version_uses_builtin_default() -> None:
+    # An empty string is "no declared version" (falsy), not a literal tag.
+    assert default_image("python", version="") == "ghcr.io/vergil-project/prod-python:3.14"
+
+
 # -- build_container_args -----------------------------------------------------
 
 

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -316,6 +316,21 @@ def test_provision_returns_cached_when_built(tmp_path: Path) -> None:
     assert (image, source) == ("base:1--develop--abcd1234", "cached")
 
 
+def test_provision_passes_declared_version(tmp_path: Path) -> None:
+    # The repo's declared [ci].versions primary threads into image selection so
+    # provisioning warms the same image vrg-container-run picks (issue #2468).
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("vergil_tooling.lib.container_cache.primary_ci_version", return_value="3.12"),
+        patch(
+            "vergil_tooling.lib.container_cache.default_image", return_value="base:1"
+        ) as default_img,
+        patch("vergil_tooling.lib.container_cache.ensure_cached_image", return_value="base:1"),
+    ):
+        provision_dev_image(tmp_path, "python", runtime="docker")
+    default_img.assert_called_once_with("python", fallback=True, prefix="prod", version="3.12")
+
+
 def test_provision_returns_default_when_no_cache_files(tmp_path: Path) -> None:
     # ensure_cached_image returns the base unchanged when the repo declares no
     # cache-sensitive files, so the source is the plain base image.

--- a/tests/vergil_tooling/test_vrg_container_run.py
+++ b/tests/vergil_tooling/test_vrg_container_run.py
@@ -369,6 +369,56 @@ def test_registry_image_uses_pull_always(tmp_path: Path) -> None:
     assert "--pull=always" in args
 
 
+# -- [ci].versions authoritative container selection (issue #2468) ------------
+
+
+def test_declared_ci_version_selects_container(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A repo declaring [ci].versions must drive the container version — not the
+    # hardcoded _DEFAULT_VERSIONS — and must not warn.
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.primary_ci_version", return_value="3.12"),
+        patch(
+            "vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="cached:img"
+        ) as mock_cache,
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp"),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "cmd"])
+    # ensure_cached_image(repo_root, lang, base, ...) — the base carries 3.12.
+    assert mock_cache.call_args[0][2] == "ghcr.io/vergil-project/prod-python:3.12"
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_no_declared_version_warns_and_uses_builtin_default(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # No declared version: fall back to the built-in default, but say so loudly.
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    env = {"GH_TOKEN": "tok"}
+    with (
+        patch("vergil_tooling.bin.vrg_container_run.git.repo_root", return_value=tmp_path),
+        patch("vergil_tooling.bin.vrg_container_run.assert_runtime_available"),
+        patch("vergil_tooling.bin.vrg_container_run.primary_ci_version", return_value=None),
+        patch(
+            "vergil_tooling.bin.vrg_container_run.ensure_cached_image", return_value="cached:img"
+        ) as mock_cache,
+        patch("vergil_tooling.bin.vrg_container_run.detect_runtime", return_value="docker"),
+        patch("vergil_tooling.bin.vrg_container_run.os.execvp"),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        main(["--", "cmd"])
+    assert mock_cache.call_args[0][2] == "ghcr.io/vergil-project/prod-python:3.14"
+    err = capsys.readouterr().err
+    assert "no [ci].versions" in err
+
+
 # -- validation-command override ([validation] in vergil.toml) ----------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-container-run (and provision/test/cache) now derive the dev container version from the repo's declared vergil.toml [ci].versions[0] instead of a hardcoded _DEFAULT_VERSIONS, falling back to the built-in default only when none is declared and warning loudly when it does, so a tooling-side default bump can no longer silently switch every repo's local builds or skew them from CI.

## Issue Linkage

- Ref #2468

## Notes

- Root-cause fix behind the #2460/#2461 saga (the silent 3.12->3.14 flip). New config.primary_ci_version + a version override on default_image; a malformed config still fails loudly (ConfigError propagates, matching the sibling config helpers). Full vrg-validate green (4432 passed, 100% coverage). Note: this makes the self-repo's local dev container follow its declared [ci].versions[0]=3.12, aligning local with CI.