### PR TITLE
fix(container): fall back to base image for language-less repos regardless of declared version

### DIFF
--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -98,11 +98,14 @@ def default_image(
     constant — picks the container tag. When it is ``None`` (or empty), the
     built-in default is used.
     """
-    resolved = version or _DEFAULT_VERSIONS.get(lang, "")
-    if not resolved and fallback:
-        return _fallback_image(prefix)
-    if not resolved:
-        return ""
+    # A declared *version* overrides only for a language that has a per-language
+    # image. A language-less/unknown repo has no `prod-<lang>` image, so it always
+    # uses the base — a declared [ci].versions must not resurrect a malformed
+    # `prod-:<version>` tag (#2475, the #2468 regression).
+    default_version = _DEFAULT_VERSIONS.get(lang, "")
+    if not default_version:
+        return _fallback_image(prefix) if fallback else ""
+    resolved = version or default_version
     return f"{_GHCR}/{prefix}-{lang}:{resolved}"
 
 

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -178,6 +178,19 @@ def test_default_image_empty_version_uses_builtin_default() -> None:
     assert default_image("python", version="") == "ghcr.io/vergil-project/prod-python:3.14"
 
 
+def test_default_image_no_language_falls_back_despite_declared_version() -> None:
+    # A language-less repo (lang="") that declares [ci].versions must still fall
+    # back to the base image, not build a malformed prod-:<ver> tag (#2475: the
+    # declared version must not resurrect a per-language image when there is none).
+    assert default_image("", fallback=True, version="latest") == (
+        "ghcr.io/vergil-project/prod-base:latest"
+    )
+
+
+def test_default_image_no_language_no_fallback_ignores_version() -> None:
+    assert default_image("", version="latest") == ""
+
+
 # -- build_container_args -----------------------------------------------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Gate default_image's declared-version override on the language having a per-language image, so a language-less/unknown repo (detect_language()=='') always uses the base image instead of building a malformed prod-:<version> tag — fixing the #2468 regression that broke vrg-container-run in config/docs-only repos like .github.

## Issue Linkage

- Closes #2475

## Notes

- Blocking regression from #2468 (tail of the #2460->#2468 container saga), found on the first post-release vrg-validate in .github (versions=['latest'] -> prod-:latest -> invalid reference format). Two regression tests added (fallback + no-fallback with a declared version); full vrg-validate green. This unblocks the epic #176 docs PR, which validates in .github.