### PR TITLE
feat(container): isolate container venv with anonymous mask over .venv

### DIFF
--- a/src/vergil_tooling/bin/vrg_validate.py
+++ b/src/vergil_tooling/bin/vrg_validate.py
@@ -151,8 +151,13 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    # Prepend `.venv/bin` unconditionally. Under the container's anonymous
+    # `.venv` mask the dir is empty at startup and populated by the install
+    # stage; PATH resolves at exec time, so prepending a not-yet-existent dir is
+    # harmless and required for later bare `ruff`/`mypy`/`pytest` to resolve
+    # (#2486).
     venv_bin = Path.cwd() / ".venv" / "bin"
-    if venv_bin.is_dir() and str(venv_bin) not in os.environ.get("PATH", "").split(os.pathsep):
+    if str(venv_bin) not in os.environ.get("PATH", "").split(os.pathsep):
         os.environ["PATH"] = f"{venv_bin}{os.pathsep}{os.environ.get('PATH', '')}"
 
     repo_root = git.repo_root()

--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -161,6 +161,13 @@ def build_container_args(
         ]
     )
 
+    # Mask the bind-mounted host `.venv` with a fresh anonymous volume so an
+    # in-container `uv sync` builds a throwaway venv at the default path and can
+    # never corrupt the host venv. This is structural isolation — no env-var
+    # propagation. Gated to Python repos, the only ones with a `.venv` (#2486).
+    if detect_language(repo_root) == "python":
+        container_args.extend(["-v", "/workspace/.venv"])
+
     # When repo_root is a git worktree, the worktree's `.git` is a file
     # pointing at <parent>/.git/worktrees/<name>. Mount the parent .git
     # at the same absolute path so the pointer resolves in-container.

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -234,6 +234,26 @@ def test_build_container_args_respects_host_uv_link_mode(tmp_path: Path) -> None
     assert _env_value(args, "UV_LINK_MODE") == "hardlink"
 
 
+def test_build_container_args_masks_venv_for_python(tmp_path: Path) -> None:
+    # A Python repo gets an anonymous volume masking the bind-mounted host
+    # `.venv`, so in-container `uv sync` builds a throwaway venv that cannot
+    # corrupt the host venv (#2486).
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert "/workspace/.venv" in args
+    idx = args.index("/workspace/.venv")
+    assert args[idx - 1] == "-v"
+
+
+def test_build_container_args_omits_venv_mask_for_non_python(tmp_path: Path) -> None:
+    # A non-Python repo has no `.venv` to protect, so no mask is added (#2486).
+    (tmp_path / "go.mod").write_text("module example\n")
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert "/workspace/.venv" not in args
+
+
 def test_build_docker_args_basic(tmp_path: Path) -> None:
     with patch.dict("os.environ", {}, clear=True):
         args = build_docker_args(tmp_path, "img:1", ["echo", "hello"])

--- a/tests/vergil_tooling/test_vrg_validate.py
+++ b/tests/vergil_tooling/test_vrg_validate.py
@@ -485,6 +485,27 @@ def test_venv_bin_prepended_to_path(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert str(venv_bin) in os.environ["PATH"].split(os.pathsep)
 
 
+def test_venv_bin_prepended_when_dir_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Under the container's anonymous `.venv` mask the dir is empty (does not
+    # yet contain `bin`) at startup; PATH resolves at exec time, so the add is
+    # unconditional and must not depend on the dir existing (#2486).
+    _write_config(tmp_path, "python")
+    venv_bin = tmp_path / ".venv" / "bin"
+    assert not venv_bin.exists()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    with (
+        patch(_MOD + ".git.repo_root", return_value=tmp_path),
+        patch(_MOD + ".progress.run", return_value=0),
+    ):
+        result = main(["--check", "lint"])
+    assert result == 0
+    assert str(venv_bin) in os.environ["PATH"].split(os.pathsep)
+
+
 def test_venv_bin_not_prepended_when_already_on_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Mask the bind-mounted host .venv with a fresh anonymous volume for Python repos so an in-container uv sync builds a throwaway venv and cannot corrupt the host venv, and prepend .venv/bin unconditionally in vrg-validate since the mask is empty at startup.

## Issue Linkage

- Closes #2486

## Notes

- Structural isolation only (no env-var propagation); mask gated to Python repos via detect_language; dropped the is_dir() guard because the masked dir is empty at startup and populated by the install stage (PATH resolves at exec time); UV_LINK_MODE=copy retained (cross-fs copy stays correct); definitive proof is the T4 validation (#2488); flag works under both docker and nerdctl.