### PR TITLE
refactor(container): retire .venv-host dual-venv model in favor of single .venv

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,19 +260,17 @@ repository under `docs/`.
 Host-side `vrg-*` tools are installed via `uv tool install` (see
 [Consumption Model](#consumption-model)). For developing
 vergil-tooling itself, there is also a **dev-tree override** using
-a local `.venv-host`:
-
-- **`.venv`** — Created inside dev containers. Shebang paths reference
-  `/workspace/.venv/...` and do not work on the host.
-- **`.venv-host`** — Dev-tree override venv for testing unreleased
-  code on the host. Not the normal install mechanism.
+a local `.venv` for testing unreleased code on the host:
 
 ```bash
 # Dev-tree override (vergil-tooling development only)
-UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
-export PATH="$(pwd)/.venv-host/bin:$PATH"
+uv sync --group dev
+export PATH="$(pwd)/.venv/bin:$PATH"
 
 ```
+
+A single `.venv` is safe because the dev container never touches the
+host `.venv` — it is masked by an anonymous volume (#2486).
 
 After host tools are available, use `vrg-container-run` to run all
 commands inside the dev container. See [Validation](#validation)

--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -82,7 +82,7 @@ def _find_yaml_files(repo_root: Path) -> list[str]:
     (.markdownlint.yaml etc.), `.github/` tree (workflows, issue
     templates), and `docs/site/mkdocs.yml`.
 
-    Vendored paths (`.worktrees`, `.venv`, `.venv-host`,
+    Vendored paths (`.worktrees`, `.venv`,
     `node_modules`) are excluded by construction — discovery only
     walks the listed locations, never venv/worktree subtrees.
     """

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -388,7 +388,7 @@ def render_gitignore() -> str:
         "Thumbs.db\n"
         "\n"
         "# Vergil\n"
-        ".venv-host/\n"
+        ".venv/\n"
         ".worktrees/\n"
         ".vergil/\n"
         ".superpowers/\n"

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -344,7 +344,8 @@ class TestRenderGitignore:
         content = render_gitignore()
         assert ".DS_Store" in content
         assert ".worktrees/" in content
-        assert ".venv-host/" in content
+        assert ".venv/" in content
+        assert ".venv-host/" not in content
 
     def test_contains_vergil_workflow_patterns(self) -> None:
         content = render_gitignore()

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -419,7 +419,7 @@ def test_find_yaml_files_mkdocs(tmp_path: Path) -> None:
 
 
 def test_find_yaml_files_skips_worktrees_and_venv(tmp_path: Path) -> None:
-    for skip in (".worktrees", ".venv", ".venv-host", "node_modules"):
+    for skip in (".worktrees", ".venv", "node_modules"):
         nested = tmp_path / skip / ".github" / "workflows"
         nested.mkdir(parents=True)
         (nested / "ci.yml").write_text("name: CI\n")


### PR DESCRIPTION
# Pull Request

## Summary

- Retire the .venv-host dual-venv workaround now that the dev container structurally masks .venv with an anonymous volume (#2486/T2), so the host dev tree is safe using a single plain .venv.

## Issue Linkage

- Closes #2487

## Notes

- T3 of epic vergil-project/.github#179; T2 (#2486) is merged. Changes: repo_init render_gitignore now emits .venv/ instead of .venv-host/ (closing a real gap — the template never ignored consumers' host .venv); validate_common _find_yaml_files docstring drops .venv-host; CLAUDE.md Environment Setup collapsed to the single-.venv host model with a note that the container never touches the host .venv. Tests updated (test_repo_init baseline patterns, test_validate_common skip tuple). The repo's own .gitignore already covered .venv/ and .superpowers/, so no edit was needed there (acceptance is state-based). Out of scope per the plan: docs/specs/host-level-tool.md and versioned site docs (handled by doc-review #2477). Full gate green: 4437 tests, 100% branch coverage.