### PR TITLE
fix(container): mask host venv on cache-build path too (#2495)

### DIFF
--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -137,6 +137,18 @@ def worktree_parent_gitdir(repo_root: Path) -> Path | None:
     return gitdir.parent.parent
 
 
+def workspace_mount_args(repo_root: Path) -> list[str]:
+    """Return the workspace bind-mount + working dir, plus a fresh anonymous
+    volume masking the venv for Python repos so in-container uv never rewrites
+    the bind-mounted host .venv (#2473/#2495). Used by BOTH the run path and
+    the cache-build path — one source of truth so a new mount site can't
+    silently reintroduce the corruption."""
+    args = ["-v", f"{repo_root}:/workspace", "-w", "/workspace"]
+    if detect_language(repo_root) == "python":
+        args += ["-v", "/workspace/.venv"]
+    return args
+
+
 def build_container_args(
     repo_root: Path,
     image: str,
@@ -152,21 +164,11 @@ def build_container_args(
     container_args = [runtime, "run", "--rm", f"--platform={container_platform()}"]
     if pull_policy != "never":
         container_args.append("--pull=always")
-    container_args.extend(
-        [
-            "-v",
-            f"{repo_root}:/workspace",
-            "-w",
-            "/workspace",
-        ]
-    )
 
-    # Mask the bind-mounted host `.venv` with a fresh anonymous volume so an
-    # in-container `uv sync` builds a throwaway venv at the default path and can
-    # never corrupt the host venv. This is structural isolation — no env-var
-    # propagation. Gated to Python repos, the only ones with a `.venv` (#2486).
-    if detect_language(repo_root) == "python":
-        container_args.extend(["-v", "/workspace/.venv"])
+    # The workspace bind-mount, working dir, and the Python-gated `.venv` mask
+    # come from one shared helper so the run path and the cache-build path
+    # (container_cache.py) can never drift on venv protection (#2486/#2495).
+    container_args.extend(workspace_mount_args(repo_root))
 
     # When repo_root is a git worktree, the worktree's `.git` is a file
     # pointing at <parent>/.git/worktrees/<name>. Mount the parent .git

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -10,7 +10,12 @@ import sys
 from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.config import primary_ci_version, vrg_install_tag
-from vergil_tooling.lib.container import container_platform, default_image, detect_runtime
+from vergil_tooling.lib.container import (
+    container_platform,
+    default_image,
+    detect_runtime,
+    workspace_mount_args,
+)
 from vergil_tooling.lib.languages import CheckKind, language_commands
 
 if TYPE_CHECKING:
@@ -253,24 +258,26 @@ def _build_cached_image(
     if warmup:
         print(f"  Warmup:  {warmup}")
 
+    create_args = [
+        rt,
+        "create",
+        f"--platform={container_platform()}",
+        # Use the freshly-pulled base (resolve_base_digest pulled it). Only pull
+        # here if it is somehow absent locally; never --pull=always, which would
+        # fail an offline build that has a usable local copy.
+        "--pull=missing",
+        # Shared with the run path (container.py): the workspace bind-mount, the
+        # working dir, and the Python-gated `.venv` mask. Masking the host `.venv`
+        # here too keeps the cache-build (cold-rebuild) `setup` step from
+        # corrupting the bind-mounted host venv — the mount site #2486 missed (#2495).
+        *workspace_mount_args(repo_root),
+        base_image,
+        "bash",
+        "-c",
+        setup,
+    ]
     cid_result = subprocess.run(  # noqa: S603
-        [  # noqa: S607
-            rt,
-            "create",
-            f"--platform={container_platform()}",
-            # Use the freshly-pulled base (resolve_base_digest pulled it). Only pull
-            # here if it is somehow absent locally; never --pull=always, which would
-            # fail an offline build that has a usable local copy.
-            "--pull=missing",
-            "-v",
-            f"{repo_root}:/workspace",
-            "-w",
-            "/workspace",
-            base_image,
-            "bash",
-            "-c",
-            setup,
-        ],
+        create_args,
         capture_output=True,
         text=True,
     )

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib.container import (
     detect_language,
     detect_runtime,
     docker_platform,
+    workspace_mount_args,
     worktree_parent_gitdir,
 )
 
@@ -189,6 +190,26 @@ def test_default_image_no_language_falls_back_despite_declared_version() -> None
 
 def test_default_image_no_language_no_fallback_ignores_version() -> None:
     assert default_image("", version="latest") == ""
+
+
+# -- workspace_mount_args -----------------------------------------------------
+
+
+def test_workspace_mount_args_python_masks_venv(tmp_path: Path) -> None:
+    # A Python repo gets the bind mount, workdir, AND the anonymous `.venv`
+    # mask together — one source of truth shared by the run and cache-build
+    # paths so a mount site can't reintroduce host-venv corruption (#2495).
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    args = workspace_mount_args(tmp_path)
+    assert args == ["-v", f"{tmp_path}:/workspace", "-w", "/workspace", "-v", "/workspace/.venv"]
+
+
+def test_workspace_mount_args_non_python_omits_venv_mask(tmp_path: Path) -> None:
+    # A non-Python repo has no `.venv` to protect, so no mask is added (#2495).
+    (tmp_path / "go.mod").write_text("module example\n")
+    args = workspace_mount_args(tmp_path)
+    assert args == ["-v", f"{tmp_path}:/workspace", "-w", "/workspace"]
+    assert "/workspace/.venv" not in args
 
 
 # -- build_container_args -----------------------------------------------------

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -427,6 +427,44 @@ def test_build_cached_image_includes_platform(tmp_path: Path) -> None:
     assert any(a.startswith("--platform=linux/") for a in create_cmd)
 
 
+def _capture_create_cmd(tmp_path: Path, lang: str) -> list[str]:
+    """Run _build_cached_image and return the `create` command it issued."""
+    create_result = MagicMock(returncode=0, stdout="abc123\n")
+    ok = MagicMock(returncode=0)
+    create_cmd: list[str] = []
+
+    def mock_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[1] == "create":
+            create_cmd.extend(cmd)
+            return create_result
+        return ok
+
+    with patch("vergil_tooling.lib.container_cache.subprocess.run", side_effect=mock_run):
+        _build_cached_image(tmp_path, lang, "img:1", "img:1--branch--hash", runtime="docker")
+    return create_cmd
+
+
+def test_build_cached_image_masks_venv_for_python(tmp_path: Path) -> None:
+    # The cache-build (cold-rebuild) path masks the bind-mounted host `.venv`
+    # for a Python repo, so its `setup` step can never corrupt the host venv —
+    # the second mount site the run-path mask (#2486) missed (#2495).
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    create_cmd = _capture_create_cmd(tmp_path, "python")
+    assert "/workspace/.venv" in create_cmd
+    idx = create_cmd.index("/workspace/.venv")
+    assert create_cmd[idx - 1] == "-v"
+
+
+def test_build_cached_image_omits_venv_mask_for_non_python(tmp_path: Path) -> None:
+    # A non-Python repo has no host `.venv`, so the cache-build create args
+    # add no mask (#2495).
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    (tmp_path / "go.mod").write_text("module example\n")
+    create_cmd = _capture_create_cmd(tmp_path, "go")
+    assert "/workspace/.venv" not in create_cmd
+
+
 def test_build_cached_image_create_fails(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=1, stderr="no space")


### PR DESCRIPTION
# Pull Request

## Summary

- Extract a shared workspace_mount_args() helper and use it at both the run mount and the cache-build create mount so cold rebuilds no longer corrupt the bind-mounted host .venv.

## Issue Linkage

- Closes #2495

## Notes

- The T2 mask (#2486) covered only container.py's run path; container_cache.py's cache-build create mount was unmasked, so cache-miss (cold) rebuilds' setup step corrupted the host .venv — the failure T4 (#2488) caught. Fix centralizes the -v {repo}:/workspace, -w /workspace, and the Python-gated -v /workspace/.venv mask in one workspace_mount_args(repo_root) helper called from BOTH build_container_args and the refactored create_args local. Unit tests cover the helper directly (Python vs non-Python) and the cache-build create args (mask present for Python, absent otherwise); build_container_args behaviour is unchanged. Cold-build live re-validation is epic T4 (#2488), not this task. Full gate green: 4441 passed, 100% coverage.