### PR TITLE
fix(container): reclaim anonymous venv mask volume on cache-build cleanup

### DIFF
--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -302,7 +302,7 @@ def _build_cached_image(
         )
     finally:
         subprocess.run(  # noqa: S603
-            [rt, "rm", container_id],  # noqa: S607
+            [rt, "rm", "-v", container_id],  # noqa: S607
             capture_output=True,
         )
 

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -410,6 +410,30 @@ def test_build_cached_image_success(tmp_path: Path) -> None:
     assert result == "img:1--branch--hash"
 
 
+def test_build_cached_image_cleanup_reclaims_anonymous_volumes(tmp_path: Path) -> None:
+    """Cleanup `rm` must pass `-v` so the anonymous venv mask volume is reclaimed.
+
+    Without `-v`, `nerdctl volume ls` grows by one per cold build because the
+    `/workspace/.venv` mask volume orphans (issue #2500).
+    """
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    create_result = MagicMock(returncode=0, stdout="abc123\n")
+    rm_cmd: list[str] = []
+
+    def mock_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[1] == "create":
+            return create_result
+        if cmd[1] == "rm":
+            rm_cmd.extend(cmd)
+        return MagicMock(returncode=0)
+
+    with patch("vergil_tooling.lib.container_cache.subprocess.run", side_effect=mock_run):
+        _build_cached_image(tmp_path, "go", "img:1", "img:1--branch--hash", runtime="docker")
+
+    assert rm_cmd[:3] == ["docker", "rm", "-v"]
+    assert "abc123" in rm_cmd
+
+
 def test_build_cached_image_includes_platform(tmp_path: Path) -> None:
     (tmp_path / "vergil.toml").write_text(_VALID_TOML)
     create_result = MagicMock(returncode=0, stdout="abc123\n")


### PR DESCRIPTION
# Pull Request

## Summary

- Add -v to the cache-build cleanup rm in container_cache.py so the anonymous /workspace/.venv mask volume (introduced in #2495) is reclaimed instead of orphaned, stopping the per-cold-build volume leak.

## Issue Linkage

- Closes #2500

## Notes

- One-line fix plus a TDD unit test. Root cause: the create/commit/rm cache-build path removed the build container with rm but no -v, leaking one anonymous venv mask volume per cold build (nerdctl volume ls grew 0->2 over two cold builds); the run path is unaffected since it uses run --rm. New test test_build_cached_image_cleanup_reclaims_anonymous_volumes asserts the cleanup rm includes -v via the existing subprocess.run mock harness (verified red before / green after). Full vrg-validate green: 4442 passed, 100% branch coverage. Live leak-free re-validation (cold build, nerdctl volume ls unchanged) is the epic's T4 re-validation (#2488), not this task.