### PR TITLE
feat(repo_init): emit language-aware explicit secrets map in cd.yml

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -410,6 +410,24 @@ def _container_suffix(language: str | None) -> str:
     return suffix_map.get(language, "base")
 
 
+def _cd_release_secrets(language: str | None) -> list[str]:
+    """Secrets ``cd-release.yml`` consumes per ecosystem (least-privilege).
+
+    Mirrors exactly what the reusable release workflow reads for each
+    ecosystem, so a generated ``cd.yml`` forwards only what its publisher
+    needs instead of the blanket ``secrets: inherit`` (epic
+    vergil-project/.github#189). python (OIDC trusted publishing) and go
+    (no token) — and any non-listed / non-publishing language — need no
+    repo secret, so they get an empty list and no ``secrets:`` block.
+    """
+    secrets_map = {
+        "rust": ["CARGO_REGISTRY_TOKEN"],
+        "ruby": ["RUBYGEMS_API_KEY"],
+        "java": ["CENTRAL_USERNAME", "CENTRAL_TOKEN", "GPG_PRIVATE_KEY", "GPG_PASSPHRASE"],
+    }
+    return secrets_map.get(language or "", [])
+
+
 def _container_tag(language: str | None, versions: list[str]) -> str:
     """Derive the container tag from language and versions."""
     if language == "python" and versions:
@@ -621,9 +639,16 @@ def render_cd_workflow(ctx: RepoInitContext) -> str:
                 "    with:\n",
                 f"      language: {suffix}\n",
                 f'      container-tag: "{tag}"\n',
-                "    secrets: inherit\n",
             ]
         )
+        # Forward only the secrets this ecosystem's publisher needs, keyed on
+        # the primary language, instead of a blanket `secrets: inherit`
+        # (epic vergil-project/.github#189). python (OIDC) / go (none) forward
+        # nothing, so no `secrets:` block is emitted at all.
+        secret_names = _cd_release_secrets(ctx.primary_language)
+        if secret_names:
+            lines.append("    secrets:\n")
+            lines.extend(f"      {name}: ${{{{ secrets.{name} }}}}\n" for name in secret_names)
 
     return "".join(lines)
 

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -12,6 +12,7 @@ import pytest
 from vergil_tooling.lib.config import _parse_raw_config
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
+    _cd_release_secrets,
     _check_remote_steps,
     _container_suffix,
     _default_ci_versions,
@@ -515,7 +516,10 @@ class TestRenderCdWorkflow:
         assert "if: github.ref == 'refs/heads/main'" in content
         assert "language: python" in content
         assert 'container-tag: "3.14"' in content
-        assert "secrets: inherit" in content
+        # python publishes via OIDC trusted publishing — no repo secret, and
+        # the blanket `secrets: inherit` must never be emitted (epic .github#189).
+        assert "secrets: inherit" not in content
+        assert "secrets:" not in content
         assert "attestations: write" in content
         assert "id-token: write" in content
         assert "pull-requests: write" in content
@@ -545,6 +549,57 @@ class TestRenderCdWorkflow:
         assert "language: go" in content
         assert 'container-tag: "latest"' in content
         assert "attestations: write" in content
+        # go needs no publishing token — no secrets block, never blanket inherit.
+        assert "secrets: inherit" not in content
+        assert "secrets:" not in content
+
+    def test_release_rust_explicit_secrets(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.publish_docs = False
+        ctx.publish_release = True
+        ctx.primary_language = "rust"
+        content = render_cd_workflow(ctx)
+        assert "secrets: inherit" not in content
+        assert "    secrets:\n" in content
+        assert "      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}\n" in content
+
+    def test_release_ruby_explicit_secrets(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.publish_docs = False
+        ctx.publish_release = True
+        ctx.primary_language = "ruby"
+        content = render_cd_workflow(ctx)
+        assert "secrets: inherit" not in content
+        assert "    secrets:\n" in content
+        assert "      RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}\n" in content
+
+    def test_release_java_explicit_secrets(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.publish_docs = False
+        ctx.publish_release = True
+        ctx.primary_language = "java"
+        content = render_cd_workflow(ctx)
+        assert "secrets: inherit" not in content
+        assert "    secrets:\n" in content
+        assert "      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}\n" in content
+        assert "      CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}\n" in content
+        assert "      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}\n" in content
+        assert "      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}\n" in content
+
+    def test_cd_release_secrets_helper(self) -> None:
+        # python/go/unlisted → no secrets; publishers → their exact secret set.
+        assert _cd_release_secrets("python") == []
+        assert _cd_release_secrets("go") == []
+        assert _cd_release_secrets(None) == []
+        assert _cd_release_secrets("elixir") == []
+        assert _cd_release_secrets("rust") == ["CARGO_REGISTRY_TOKEN"]
+        assert _cd_release_secrets("ruby") == ["RUBYGEMS_API_KEY"]
+        assert _cd_release_secrets("java") == [
+            "CENTRAL_USERNAME",
+            "CENTRAL_TOKEN",
+            "GPG_PRIVATE_KEY",
+            "GPG_PASSPHRASE",
+        ]
 
 
 class TestRenderMkdocsYml:


### PR DESCRIPTION
# Pull Request

## Summary

- repo_init now emits a language-keyed least-privilege secrets: block in generated cd.yml instead of blanket secrets: inherit, forwarding only each ecosystem's publisher secrets to cd-release.yml.

## Issue Linkage

- Closes #2508

## Notes

- New helper _cd_release_secrets(language) is the single home for the per-ecosystem map: rust=CARGO_REGISTRY_TOKEN, ruby=RUBYGEMS_API_KEY, java=CENTRAL_USERNAME/CENTRAL_TOKEN/GPG_PRIVATE_KEY/GPG_PASSPHRASE; python (OIDC), go, and any unlisted language emit no secrets: line at all. TDD red-then-green; test_repo_init.py covers each language branch and asserts no secrets: inherit anywhere. Full gate green at 100% coverage.