### PR TITLE
feat(semgrep): add --exclude-rule; exempt github-actions-mutable-action-tag fleet-wide

### DIFF
--- a/src/vergil_tooling/bin/vrg_semgrep_scan.py
+++ b/src/vergil_tooling/bin/vrg_semgrep_scan.py
@@ -40,6 +40,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Additional semgrep config values",
     )
     parser.add_argument(
+        "--exclude-rule",
+        action="append",
+        default=[],
+        metavar="RULE_ID",
+        help=(
+            "Full semgrep rule id to exclude (repeatable). Added on top of the "
+            "fleet defaults in DEFAULT_EXCLUDED_RULES, which are always excluded."
+        ),
+    )
+    parser.add_argument(
         "--has-dockerfiles",
         action="store_true",
         help="Add Dockerfile-specific rulesets",
@@ -62,7 +72,12 @@ def main(argv: list[str] | None = None) -> int:
         emit_warning(f"no rulesets resolved for language: {args.language}")
         return 0
 
-    scan_result = run_scan(rulesets, args.target_dir, args.output)
+    scan_result = run_scan(
+        rulesets,
+        args.target_dir,
+        args.output,
+        exclude_rules=args.exclude_rule or None,
+    )
     write_output("scan_exit_code", str(scan_result.returncode))
 
     if scan_result.returncode > 1:

--- a/src/vergil_tooling/lib/semgrep.py
+++ b/src/vergil_tooling/lib/semgrep.py
@@ -17,6 +17,17 @@ _LANGUAGE_RULESETS: dict[str, str] = {
     "rust": "p/rust",
 }
 
+# Rules excluded from every fleet scan, by full semgrep rule id.
+#
+# github-actions-mutable-action-tag flags every `uses: …@vN` action ref. It is
+# exempted fleet-wide pending vergil-project/.github#194 (pin third-party action
+# SHAs once pin-advancement tooling exists); our own vergil-actions@v2.1 refs are
+# a permanent exception (our release line). All other rules stay enforced.
+DEFAULT_EXCLUDED_RULES: tuple[str, ...] = (
+    "yaml.github-actions.security.github-actions-mutable-action-tag"
+    ".github-actions-mutable-action-tag",
+)
+
 
 @dataclass(frozen=True)
 class ScanResult:
@@ -54,15 +65,28 @@ def run_scan(
     rulesets: list[str],
     target_dir: Path,
     output_path: Path,
+    *,
+    exclude_rules: list[str] | None = None,
 ) -> ScanResult:
     """Execute semgrep scan with the given rulesets.
 
     Semgrep exit codes: 0 = clean, 1 = findings, >1 = error.
     All three can produce valid SARIF output.
+
+    The fleet defaults in ``DEFAULT_EXCLUDED_RULES`` are always excluded via
+    ``--exclude-rule``; any ``exclude_rules`` the caller supplies are added on
+    top of (never in place of) the defaults.
     """
+    excluded: list[str] = list(DEFAULT_EXCLUDED_RULES)
+    for rule in exclude_rules or []:
+        if rule not in excluded:
+            excluded.append(rule)
+
     cmd: list[str] = ["semgrep", "scan", "--sarif", "--output", str(output_path)]
     for ruleset in rulesets:
         cmd.extend(["--config", ruleset])
+    for rule in excluded:
+        cmd.extend(["--exclude-rule", rule])
     cmd.append(str(target_dir))
 
     result = subprocess.run(cmd, capture_output=True)  # noqa: S603

--- a/tests/vergil_tooling/test_semgrep.py
+++ b/tests/vergil_tooling/test_semgrep.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from vergil_tooling.lib.semgrep import ScanResult, resolve_rulesets, run_scan
+from vergil_tooling.lib.semgrep import (
+    DEFAULT_EXCLUDED_RULES,
+    ScanResult,
+    resolve_rulesets,
+    run_scan,
+)
+
+_MUTABLE_ACTION_TAG_RULE = (
+    "yaml.github-actions.security.github-actions-mutable-action-tag"
+    ".github-actions-mutable-action-tag"
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -99,3 +109,52 @@ class TestRunScan:
         cmd = mock_run.call_args[0][0]
         config_indices = [i for i, v in enumerate(cmd) if v == "--config"]
         assert len(config_indices) == 2
+
+    @staticmethod
+    def _excluded_from(cmd: list[str]) -> list[str]:
+        return [cmd[i + 1] for i, v in enumerate(cmd) if v == "--exclude-rule"]
+
+    def test_mutable_action_tag_is_a_fleet_default(self) -> None:
+        assert _MUTABLE_ACTION_TAG_RULE in DEFAULT_EXCLUDED_RULES
+
+    def test_default_excludes_mutable_action_tag(self, tmp_path: Path) -> None:
+        output = tmp_path / "results.sarif"
+
+        with patch(f"{_MOD}.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan(["p/python"], tmp_path, output)
+
+        excluded = self._excluded_from(mock_run.call_args[0][0])
+        assert _MUTABLE_ACTION_TAG_RULE in excluded
+
+    def test_caller_supplied_added_to_defaults(self, tmp_path: Path) -> None:
+        output = tmp_path / "results.sarif"
+
+        with patch(f"{_MOD}.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan(
+                ["p/python"],
+                tmp_path,
+                output,
+                exclude_rules=["custom.rule.id"],
+            )
+
+        excluded = self._excluded_from(mock_run.call_args[0][0])
+        # Caller-supplied rule is added IN ADDITION to the fleet defaults.
+        assert "custom.rule.id" in excluded
+        assert _MUTABLE_ACTION_TAG_RULE in excluded
+
+    def test_caller_supplied_default_is_not_duplicated(self, tmp_path: Path) -> None:
+        output = tmp_path / "results.sarif"
+
+        with patch(f"{_MOD}.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            run_scan(
+                ["p/python"],
+                tmp_path,
+                output,
+                exclude_rules=[_MUTABLE_ACTION_TAG_RULE],
+            )
+
+        excluded = self._excluded_from(mock_run.call_args[0][0])
+        assert excluded.count(_MUTABLE_ACTION_TAG_RULE) == 1

--- a/tests/vergil_tooling/test_vrg_semgrep_scan.py
+++ b/tests/vergil_tooling/test_vrg_semgrep_scan.py
@@ -40,7 +40,7 @@ _FINDINGS_SARIF = {
 def test_clean_scan(tmp_path: Path) -> None:
     output = tmp_path / "results.sarif"
 
-    def _fake_scan(rulesets: list, target: object, out: object) -> ScanResult:
+    def _fake_scan(rulesets: list, target: object, out: object, **_kwargs: object) -> ScanResult:
         output.write_text(json.dumps(_CLEAN_SARIF))
         return ScanResult(returncode=0, sarif_produced=True)
 
@@ -55,7 +55,7 @@ def test_clean_scan(tmp_path: Path) -> None:
 def test_findings_scan(tmp_path: Path) -> None:
     output = tmp_path / "results.sarif"
 
-    def _fake_scan(rulesets: list, target: object, out: object) -> ScanResult:
+    def _fake_scan(rulesets: list, target: object, out: object, **_kwargs: object) -> ScanResult:
         output.write_text(json.dumps(_FINDINGS_SARIF))
         return ScanResult(returncode=1, sarif_produced=True)
 
@@ -122,7 +122,7 @@ def test_unknown_language(tmp_path: Path) -> None:
 def test_extra_config(tmp_path: Path) -> None:
     output = tmp_path / "results.sarif"
 
-    def _fake_scan(rulesets: list, target: object, out: object) -> ScanResult:
+    def _fake_scan(rulesets: list, target: object, out: object, **_kwargs: object) -> ScanResult:
         output.write_text(json.dumps(_CLEAN_SARIF))
         return ScanResult(returncode=0, sarif_produced=True)
 
@@ -145,10 +145,39 @@ def test_extra_config(tmp_path: Path) -> None:
     assert "p/custom" in rulesets
 
 
+def test_exclude_rule_threads_through(tmp_path: Path) -> None:
+    output = tmp_path / "results.sarif"
+
+    def _fake_scan(rulesets: list, target: object, out: object, **_kwargs: object) -> ScanResult:
+        output.write_text(json.dumps(_CLEAN_SARIF))
+        return ScanResult(returncode=0, sarif_produced=True)
+
+    with (
+        patch(f"{_MOD}.run_scan", side_effect=_fake_scan) as mock_scan,
+        patch(f"{_MOD}.write_output"),
+    ):
+        main(
+            [
+                "--language",
+                "python",
+                "--output",
+                str(output),
+                "--exclude-rule",
+                "custom.rule.a",
+                "--exclude-rule",
+                "custom.rule.b",
+            ]
+        )
+
+    exclude_rules = mock_scan.call_args.kwargs["exclude_rules"]
+    assert "custom.rule.a" in exclude_rules
+    assert "custom.rule.b" in exclude_rules
+
+
 def test_dockerfile_and_workflow_flags(tmp_path: Path) -> None:
     output = tmp_path / "results.sarif"
 
-    def _fake_scan(rulesets: list, target: object, out: object) -> ScanResult:
+    def _fake_scan(rulesets: list, target: object, out: object, **_kwargs: object) -> ScanResult:
         output.write_text(json.dumps(_CLEAN_SARIF))
         return ScanResult(returncode=0, sarif_produced=True)
 
@@ -175,7 +204,7 @@ def test_dockerfile_and_workflow_flags(tmp_path: Path) -> None:
 def test_outputs_finding_count(tmp_path: Path) -> None:
     output = tmp_path / "results.sarif"
 
-    def _fake_scan(rulesets: list, target: object, out: object) -> ScanResult:
+    def _fake_scan(rulesets: list, target: object, out: object, **_kwargs: object) -> ScanResult:
         output.write_text(json.dumps(_FINDINGS_SARIF))
         return ScanResult(returncode=1, sarif_produced=True)
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add a rule-exclusion capability to vrg-semgrep-scan (run_scan emits --exclude-rule per id, plus a repeatable --exclude-rule CLI arg) and use it to exempt github-actions-mutable-action-tag fleet-wide via a DEFAULT_EXCLUDED_RULES constant, unblocking CD PRs while every other rule stays enforced.

## Issue Linkage

- Closes #2513

## Notes

- Fleet default lives in DEFAULT_EXCLUDED_RULES in lib/semgrep.py, so no per-repo or action change is needed once released. Caller-supplied --exclude-rule ids are added on top of the defaults, never in place of them (deduped). Exemption is a deliberate interim pending vergil-project/.github#194 (pin third-party action SHAs once pin-advancement tooling exists); our own vergil-actions@v2.1 refs are a permanent exception. semgrep flag used: --exclude-rule <full-rule-id>. 100% branch coverage on both changed files; full vrg-validate green.