### PR TITLE
feat(vrg-gh): allow read-only 'gh search' in the wrapper allowlist

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -18,6 +18,10 @@ _ALLOWED: dict[str, set[str]] = {
     "run": {"list", "view", "watch"},
     "repo": {"view", "list"},
     "label": {"list", "create"},
+    # `gh search` is read-only across all its subcommands (code/commits/
+    # issues/prs/repos), so it fits the wrapper's no-mutation safety model.
+    # Enables cross-org GitHub code search for fleet-wide sweeps (#2505).
+    "search": {"code", "commits", "issues", "prs", "repos"},
 }
 
 _ALLOWED_AUDIT: dict[str, set[str]] = {

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -66,6 +66,11 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
     ("repo", "list"),
     ("label", "list"),
     ("label", "create"),
+    ("search", "code"),
+    ("search", "commits"),
+    ("search", "issues"),
+    ("search", "prs"),
+    ("search", "repos"),
 ]
 
 
@@ -85,6 +90,37 @@ def test_allowed_pair_passes(top: str, sub: str) -> None:
     assert args[0] == "gh"
     assert args[1] == top
     assert args[2] == sub
+
+
+# -- search (read-only, cross-org code search) -------------------------------
+
+
+def test_search_code_with_query_and_owner_passes_through() -> None:
+    # Acceptance: `vrg-gh search code '<query>' --owner <org>` runs read-only
+    # for cross-org fleet sweeps (issue #2505). The query and flags forward
+    # unchanged.
+    with (
+        patch(
+            "vergil_tooling.bin.vrg_gh.github.get_installation_token",
+            return_value=None,
+        ),
+        patch("vergil_tooling.lib.retry.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = _completed()
+        rc = main(["search", "code", "secrets: inherit", "--owner", "vergil-project"])
+    assert rc == 0
+    args = mock_run.call_args[0][0]
+    assert args[:4] == ["gh", "search", "code", "secrets: inherit"]
+    assert "--owner" in args
+    assert "vergil-project" in args
+
+
+def test_search_has_no_write_subcommands() -> None:
+    # Guard against accidentally widening `search` beyond gh's read-only
+    # subcommands (code/commits/issues/prs/repos).
+    from vergil_tooling.bin.vrg_gh import _ALLOWED
+
+    assert _ALLOWED["search"] == {"code", "commits", "issues", "prs", "repos"}
 
 
 # -- unrecognized subcommands ------------------------------------------------
@@ -675,6 +711,7 @@ class TestAuditAllowlist:
             ("run", "list"),
             ("repo", "view"),
             ("label", "list"),
+            ("search", "code"),
         ],
     )
     def test_audit_non_pr_denied(


### PR DESCRIPTION
# Pull Request

## Summary

- Add read-only `gh search` (code/commits/issues/prs/repos) to the vrg-gh subcommand allowlist so cross-org GitHub code search works for fleet-wide sweeps.

## Issue Linkage

- Closes #2505

## Notes

- Read-only addition only — no write capability. `gh search` mutates nothing, so it fits the wrapper's safety model. Scoped to the human/user identities; the audit identity stays barred (search absent from its allowlist, per least privilege). Tests: parametrized allowed-pair coverage for all five search subcommands, a dedicated acceptance test for `search code '<query>' --owner <org>` passthrough, a guard asserting the search subcommand set contains no write actions, and an audit-denied case. Full gate green (4459 passed, 100% coverage).