### PR TITLE
feat(github-config): add per-repo allowed-actions override in vergil.toml

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -40,7 +40,17 @@ _REQUIRED_PROJECT_FIELDS = (
 _PROJECT_FIELDS = (*_REQUIRED_PROJECT_FIELDS, "primary-language", "ghas")
 
 _KNOWN_SECTIONS = frozenset(
-    {"project", "dependencies", "markdownlint", "ci", "publish", "container", "validation", "vm"},
+    {
+        "project",
+        "dependencies",
+        "markdownlint",
+        "ci",
+        "publish",
+        "container",
+        "validation",
+        "actions",
+        "vm",
+    },
 )
 
 _KNOWN_KEYS: dict[str, frozenset[str]] = {
@@ -51,6 +61,7 @@ _KNOWN_KEYS: dict[str, frozenset[str]] = {
     "publish": frozenset({"release", "docs", "consumer-refresh"}),
     "container": frozenset({"env-prefixes"}),
     "validation": frozenset({"container-command"}),
+    "actions": frozenset({"extra-allowed-patterns"}),
 }
 
 
@@ -97,6 +108,15 @@ class ValidationConfig:
 
 
 @dataclass
+class ActionsConfig:
+    # Extra allowed-action patterns unioned into the repo's GitHub Actions
+    # allowed-actions policy, on top of the base + per-language defaults in
+    # github_config.desired_actions_permissions. Least-privilege by convention:
+    # name the specific action (``owner/repo@*``), not the whole org (``owner/*``).
+    extra_allowed_patterns: list[str]
+
+
+@dataclass
 class VergilConfig:
     project: ProjectConfig
     dependencies: dict[str, str]
@@ -105,6 +125,7 @@ class VergilConfig:
     publish: PublishConfig
     container: ContainerConfig
     validation: ValidationConfig
+    actions: ActionsConfig = field(default_factory=lambda: ActionsConfig(extra_allowed_patterns=[]))
     vm: VmStanza | None = None
 
 
@@ -440,6 +461,18 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
     else:
         validation = ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND)
 
+    actions_raw = raw.get("actions")
+    if actions_raw is not None:
+        extra_patterns = actions_raw.get("extra-allowed-patterns", [])
+        if not isinstance(extra_patterns, list) or not all(
+            isinstance(p, str) for p in extra_patterns
+        ):
+            msg = f"{source}: [actions].extra-allowed-patterns must be a list of strings"
+            raise ConfigError(msg)
+        actions = ActionsConfig(extra_allowed_patterns=extra_patterns)
+    else:
+        actions = ActionsConfig(extra_allowed_patterns=[])
+
     project = ProjectConfig(
         repository_type=project_raw["repository-type"],
         versioning_scheme=project_raw["versioning-scheme"],
@@ -456,6 +489,7 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
         publish=publish,
         container=container,
         validation=validation,
+        actions=actions,
         vm=parse_vm_stanza(raw, source),
     )
 

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -154,9 +154,11 @@ def desired_security_settings(*, ghas: bool) -> DesiredSecuritySettings:
     )
 
 
-def desired_actions_permissions(primary_language: str | None) -> DesiredActionsPermissions:
+def desired_actions_permissions(
+    primary_language: str | None, extra_patterns: list[str] | None = None
+) -> DesiredActionsPermissions:
     lang_patterns = _LANGUAGE_ACTION_PATTERNS.get(primary_language, []) if primary_language else []
-    patterns = sorted(set(_BASE_ACTION_PATTERNS) | set(lang_patterns))
+    patterns = sorted(set(_BASE_ACTION_PATTERNS) | set(lang_patterns) | set(extra_patterns or []))
     return DesiredActionsPermissions(
         default_workflow_permissions="read",
         can_approve_pull_request_reviews=False,
@@ -439,7 +441,9 @@ def compute_desired_state(
     return DesiredState(
         repo_settings=desired_repo_settings(is_org=is_org, visibility=visibility),
         security=desired_security_settings(ghas=ghas),
-        actions_permissions=desired_actions_permissions(config.project.primary_language),
+        actions_permissions=desired_actions_permissions(
+            config.project.primary_language, config.actions.extra_allowed_patterns
+        ),
         rulesets=rulesets,
         publish=publish,
     )

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -99,6 +99,28 @@ def test_read_config_valid(tmp_path: Path) -> None:
     assert cfg.dependencies["vergil"] == "v2.0"
 
 
+def test_read_config_actions_extra_allowed_patterns(tmp_path: Path) -> None:
+    toml = (
+        _VALID_TOML + '\n[actions]\nextra-allowed-patterns = ["dataaxiom/ghcr-cleanup-action@*"]\n'
+    )
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.actions.extra_allowed_patterns == ["dataaxiom/ghcr-cleanup-action@*"]
+
+
+def test_read_config_no_actions_section_defaults_empty(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.actions.extra_allowed_patterns == []
+
+
+def test_read_config_actions_extra_allowed_patterns_not_a_list(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '\n[actions]\nextra-allowed-patterns = "nope"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[actions\]\.extra-allowed-patterns must be a list"):
+        read_config(tmp_path)
+
+
 def test_read_config_missing_file(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match="vergil.toml"):
         read_config(tmp_path)

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -134,6 +134,38 @@ def test_desired_actions_permissions_python() -> None:
     ]
 
 
+def test_desired_actions_permissions_extra_patterns() -> None:
+    a = desired_actions_permissions("go", ["dataaxiom/ghcr-cleanup-action@*"])
+    assert a.patterns_allowed == [
+        "actions/*",
+        "dataaxiom/ghcr-cleanup-action@*",
+        "docker/*",
+        "github/*",
+        "vergil-project/*",
+    ]
+
+
+def test_desired_actions_permissions_extra_patterns_unioned_not_duplicated() -> None:
+    # An extra pattern that overlaps a language default is unioned, not duplicated.
+    a = desired_actions_permissions("python", ["astral-sh/*", "dataaxiom/ghcr-cleanup-action@*"])
+    assert a.patterns_allowed == [
+        "actions/*",
+        "astral-sh/*",
+        "dataaxiom/ghcr-cleanup-action@*",
+        "docker/*",
+        "github/*",
+        "pypa/*",
+        "vergil-project/*",
+    ]
+
+
+def test_compute_desired_state_threads_extra_action_patterns() -> None:
+    cfg = _vergil_config()
+    cfg.actions.extra_allowed_patterns = ["dataaxiom/ghcr-cleanup-action@*"]
+    state = compute_desired_state(cfg, visibility="public", is_org=True)
+    assert "dataaxiom/ghcr-cleanup-action@*" in state.actions_permissions.patterns_allowed
+
+
 def test_branch_protection_ruleset() -> None:
     r = desired_branch_protection_ruleset()
     assert r.name == "Branch protection"


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a [actions].extra-allowed-patterns list that is unioned into a repo's GitHub Actions allowed-actions policy, so one repo can permit a specific third-party action without a global pattern or a manual UI change the config audit would revert.

## Issue Linkage

- Closes #2524

## Notes

- Threaded through desired_actions_permissions(primary_language, extra_patterns) and compute_desired_state. Missing [actions] section is a no-op (default empty); a non-list value raises ConfigError. Least-privilege by convention: name owner/repo@*, not owner/*. Unblocks vergil-containers#449 (declares dataaxiom/ghcr-cleanup-action@*) and epic #155's validation #436. Full validation green: 4465 passed, 100% coverage.