### PR TITLE
fix(github-config): source vergil.toml from develop, never main

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_config.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_config.py
@@ -64,7 +64,7 @@ def _load_local_config(path: str) -> VergilConfig:
 
 # Canonical config branches, in resolution order: the released/stable branch
 # first, then the integration branch as a bootstrap fallback.
-_CONFIG_REFS = ("main", "develop")
+_DEFAULT_BRANCH = "develop"
 
 
 def _is_not_found(exc: github.GitHubAPIError) -> bool:
@@ -115,28 +115,40 @@ def _load_cwd_config() -> VergilConfig | None:
 
 
 def _resolve_config(repo: str) -> VergilConfig:
-    """Resolve the canonical vergil.toml for ``repo``.
+    """Resolve the canonical vergil.toml for ``repo`` from the default branch.
 
-    Resolution order: the ``main`` branch, then ``develop``, then the local
-    working-directory copy when the cwd is a checkout of ``repo``. The remote
-    branches are the canonical source; the local fallback makes bootstrapping
-    ergonomic — run ``apply`` from the repo root before the file has landed on
-    any canonical branch — and is safe under the trust model: agents may *write*
-    vergil.toml, but only a human runs ``apply`` and owns that action, so the
-    local copy can never be applied without human oversight. The fallback is
-    gated on the cwd matching the target repo so a ``--repo other/repo`` run can
-    never apply the current directory's unrelated config.
+    Resolution order: the ``develop`` branch (the fleet default branch), then
+    the local working-directory copy when the cwd is a checkout of ``repo``.
+    Config tracks the **default branch**: everything else GitHub does off a
+    repo — workflows above all — runs from the default branch, so a config
+    change merged to ``develop`` must apply immediately, the same paradigm.
+
+    ``main`` is deliberately NOT consulted. Under GitFlow, content reaches
+    ``main`` only by way of ``develop``, so ``main`` can never hold a
+    vergil.toml that ``develop`` lacks — a ``main`` fallback could only ever
+    return the same file or a staler one, never a uniquely-available one. And
+    reading ``main`` *first* was the original bug: it silently ignored a
+    merged-to-develop change until a release carried it to ``main``, and
+    ``main`` may not exist at all in a new or unreleased repo
+    (vergil-tooling#2530).
+
+    The local copy is the final bootstrap fallback — run ``apply`` from the
+    repo root before the file has landed on ``develop`` — safe under the trust
+    model: agents may *write* vergil.toml, but only a human runs ``apply`` and
+    owns that action, so the local copy can never be applied without human
+    oversight. The fallback is gated on the cwd matching the target repo so a
+    ``--repo other/repo`` run can never apply the current directory's unrelated
+    config.
     """
-    for ref in _CONFIG_REFS:
-        config = _fetch_config_from_ref(repo, ref)
-        if config is not None:
-            return config
+    config = _fetch_config_from_ref(repo, _DEFAULT_BRANCH)
+    if config is not None:
+        return config
     cwd_is_repo = _cwd_matches_repo(repo)
     if cwd_is_repo:
         local = _load_cwd_config()
         if local is not None:
             return local
-    locations = "the 'main' and 'develop' branches"
+    locations = "the 'develop' branch"
     if cwd_is_repo:
         locations += " and the current directory"
     msg = (

--- a/tests/vergil_tooling/test_vrg_github_repo_config.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_config.py
@@ -498,27 +498,18 @@ def _by_ref(results: dict[str, object]):
     return _fake
 
 
-def test_resolve_config_prefers_main() -> None:
+def test_resolve_config_resolves_from_develop() -> None:
     cfg = _make_config()
     with patch(
         f"{_MODULE}._fetch_config_from_ref",
-        side_effect=_by_ref({"main": cfg, "develop": None}),
+        side_effect=_by_ref({"develop": cfg}),
     ) as mock_fetch:
         result = _resolve_config("o/r")
     assert result is cfg
-    # develop is not consulted once main resolves.
+    # Only the default branch (develop) is consulted; main is never fetched —
+    # under GitFlow main can't hold a vergil.toml that develop lacks.
     assert mock_fetch.call_count == 1
-
-
-def test_resolve_config_falls_back_to_develop() -> None:
-    cfg = _make_config()
-    with patch(
-        f"{_MODULE}._fetch_config_from_ref",
-        side_effect=_by_ref({"main": None, "develop": cfg}),
-    ) as mock_fetch:
-        result = _resolve_config("o/r")
-    assert result is cfg
-    assert mock_fetch.call_count == 2
+    assert mock_fetch.call_args.args[1] == "develop"
 
 
 def test_resolve_config_falls_back_to_local_when_cwd_matches() -> None:
@@ -526,7 +517,7 @@ def test_resolve_config_falls_back_to_local_when_cwd_matches() -> None:
     with (
         patch(
             f"{_MODULE}._fetch_config_from_ref",
-            side_effect=_by_ref({"main": None, "develop": None}),
+            side_effect=_by_ref({"develop": None}),
         ),
         patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
         patch(f"{_MODULE}._load_cwd_config", return_value=cfg) as mock_local,
@@ -540,7 +531,7 @@ def test_resolve_config_no_local_fallback_when_cwd_mismatch() -> None:
     with (
         patch(
             f"{_MODULE}._fetch_config_from_ref",
-            side_effect=_by_ref({"main": None, "develop": None}),
+            side_effect=_by_ref({"develop": None}),
         ),
         patch(f"{_MODULE}._cwd_matches_repo", return_value=False),
         patch(f"{_MODULE}._load_cwd_config") as mock_local,
@@ -567,7 +558,7 @@ def test_resolve_config_errors_when_absent_everywhere() -> None:
     with (
         patch(
             f"{_MODULE}._fetch_config_from_ref",
-            side_effect=_by_ref({"main": None, "develop": None}),
+            side_effect=_by_ref({"develop": None}),
         ),
         patch(f"{_MODULE}._cwd_matches_repo", return_value=True),
         patch(f"{_MODULE}._load_cwd_config", return_value=None),
@@ -576,7 +567,7 @@ def test_resolve_config_errors_when_absent_everywhere() -> None:
         _resolve_config("o/r")
     message = str(excinfo.value)
     assert "o/r" in message
-    assert "main" in message
+    assert "develop" in message
     assert "develop" in message
     assert "--config" in message
 


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-github-repo-config now resolves the canonical vergil.toml from the develop default branch only (then the local bootstrap copy), instead of reading main first — so a config change merged to develop applies immediately, matching how GitHub runs everything else off the default branch.

## Issue Linkage

- Closes #2530

## Notes

- Root-caused while enabling the package-cleanup allowlist (vergil-containers#451): the [actions] override merged to develop but apply read main (no override) and reported 'compliant'. main is dropped entirely, not reordered — under GitFlow main can never hold a vergil.toml that develop lacks. Tests updated to develop-only; the main-fallback test is removed. Full validation green (100% coverage).