### PR TITLE
feat(vrg-issue-create): add --kind retrospective (PR-workable label + scaffold)

### DIFF
--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -33,10 +33,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--repo", help="Target repo owner/name (defaults to the current repo)")
     parser.add_argument(
         "--kind",
-        choices=("task", "validation", "deployment"),
+        choices=("task", "validation", "deployment", "retrospective"),
         default="task",
-        help="Issue kind; an operational kind (validation/deployment) stamps its "
-        "label and executable scaffold",
+        help="Issue kind; validation/deployment stamp an operational "
+        "(not-PR-workable) label + scaffold, retrospective stamps a PR-workable "
+        "epic-retrospective label + scaffold",
     )
     parser.add_argument(
         "--blocked-by",
@@ -53,20 +54,29 @@ def _issue_number_from_url(url: str) -> int:
     return int(url.rstrip("/").rsplit("/", 1)[-1])
 
 
-_OPERATIONAL_INTRO = {
+# The operational kinds — a not-PR-workable task run to completion and recorded
+# as a comment. Kept in sync with ``epics._OPERATIONAL_LABELS``. ``retrospective``
+# is deliberately NOT here: it is an ordinary PR-workable task whose docs PR
+# publishes ``retrospective.md``, so PR tooling must accept it.
+_OPERATIONAL_KINDS = ("validation", "deployment")
+
+_SCAFFOLD_INTRO = {
     "validation": "Post-merge validation task.",
     "deployment": "Deployment task.",
+    "retrospective": "Epic retrospective task.",
 }
 
 
-def _render_operational_body(*, kind: str, intro: str, deps: list[epics.IssueRef]) -> str:
-    """Build an operational-task body from the *kind*'s scaffold template.
+def _render_scaffold_body(*, kind: str, intro: str, deps: list[epics.IssueRef]) -> str:
+    """Build a scaffolded issue body from the *kind*'s template.
 
-    Each operational kind (validation, deployment) has its own
-    ``<kind>_task_body.md`` scaffold — a precondition self-check, the procedure,
-    acceptance criteria, and a SUCCESS/FAILURE results template. *deps* are
-    rendered as machine-parseable ``Blocked-by:`` reflinks under a Dependencies
-    heading (or omitted entirely when there are none).
+    Each scaffolded kind has its own ``<kind>_task_body.md`` template. The
+    operational kinds (validation, deployment) render a precondition self-check,
+    the procedure, acceptance criteria, and a SUCCESS/FAILURE results template;
+    ``retrospective`` renders the backward-looking epic-retrospective outline.
+    *deps* (operational only) are rendered as machine-parseable ``Blocked-by:``
+    reflinks under a Dependencies heading (or omitted entirely when there are
+    none); a template without a ``{blocked_by}`` field simply ignores them.
     """
     template = (
         resources.files("vergil_tooling.data")
@@ -76,7 +86,7 @@ def _render_operational_body(*, kind: str, intro: str, deps: list[epics.IssueRef
     blocked_by = ""
     if deps:
         blocked_by = "## Dependencies (merge-first)\n\n" + epics.render_blocked_by(deps) + "\n"
-    return template.format(intro=intro or _OPERATIONAL_INTRO[kind], blocked_by=blocked_by)
+    return template.format(intro=intro or _SCAFFOLD_INTRO[kind], blocked_by=blocked_by)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -101,13 +111,15 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
-    # Build the issue body/labels. An operational kind (validation/deployment)
-    # stamps its executable scaffold + its label and renders its Blocked-by
-    # reflinks; a plain task passes the caller's body/labels through unchanged.
+    # Build the issue body/labels. A scaffolded kind stamps its label + template
+    # body; an operational kind (validation/deployment) also renders its
+    # Blocked-by reflinks, while retrospective is a plain PR-workable task that
+    # merely carries a scaffold. A plain task passes the caller's body/labels
+    # through unchanged.
     labels = list(args.label)
     body = args.body
     body_file = args.body_file
-    if args.kind in ("validation", "deployment"):
+    if args.kind != "task":
         if args.body_file:
             print(
                 f"vrg-issue-create: --body-file is not compatible with --kind {args.kind} "
@@ -115,13 +127,24 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
-        try:
-            deps = [epics.parse_issue_ref(ref, default_repo=repo) for ref in args.blocked_by]
-        except ValueError as exc:
-            print(f"vrg-issue-create: invalid --blocked-by ref: {exc}", file=sys.stderr)
+        deps: list[epics.IssueRef] = []
+        if args.kind in _OPERATIONAL_KINDS:
+            try:
+                deps = [epics.parse_issue_ref(ref, default_repo=repo) for ref in args.blocked_by]
+            except ValueError as exc:
+                print(f"vrg-issue-create: invalid --blocked-by ref: {exc}", file=sys.stderr)
+                return 1
+        elif args.blocked_by:
+            # --blocked-by encodes an operational merge-first dependency; a
+            # retrospective is an ordinary PR-workable task and takes none.
+            print(
+                f"vrg-issue-create: --blocked-by is only valid for an operational kind "
+                f"(validation/deployment), not --kind {args.kind}",
+                file=sys.stderr,
+            )
             return 1
         labels.append(args.kind)
-        body = _render_operational_body(kind=args.kind, intro=args.body, deps=deps)
+        body = _render_scaffold_body(kind=args.kind, intro=args.body, deps=deps)
         body_file = None
 
     # Scope every App-token call below to the issue's owner, not the cwd org.

--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -16,7 +16,8 @@
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
     {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"},
     {"name": "validation", "color": "006b75", "description": "Post-merge validation: run the checklist, record PASS/FAIL as a comment; never auto-closed"},
-    {"name": "deployment", "color": "0052cc", "description": "Deployment task: install/sync merged changes so they are usable; never auto-closed"}
+    {"name": "deployment", "color": "0052cc", "description": "Deployment task: install/sync merged changes so they are usable; never auto-closed"},
+    {"name": "retrospective", "color": "c2e0c6", "description": "Epic retrospective bookend; PR-workable, its docs PR publishes retrospective.md"}
   ],
   "delete": ["enhancement", "standing"]
 }

--- a/src/vergil_tooling/data/retrospective_task_body.md
+++ b/src/vergil_tooling/data/retrospective_task_body.md
@@ -1,0 +1,25 @@
+{intro}
+
+This is a **retrospective task** — the backward-looking bookend of its epic,
+partnering the spec and plan. Unlike a validation or deployment task, it **is**
+PR-workable: its finalizing docs PR publishes the epic's `retrospective.md` and
+closes the epic. Author the retrospective, open the docs PR, and let it close
+this task.
+
+## What shipped
+
+- \<the epic's tasks and their outcomes\>
+
+## What went well
+
+- \<what worked; keep doing it\>
+
+## What we would do differently
+
+- \<friction, dead ends, rework; the lesson learned\>
+
+## Follow-ups
+
+- \<new tasks / bugs spun out of this retrospective, if any\>
+</content>
+</invoke>

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -406,7 +406,9 @@ def is_epic_linkage(ref: str, *, default_repo: str) -> bool:
 
 # Labels marking a not-PR-workable *operational task* — one that is run and whose
 # acceptance is a recorded ``Outcome:`` comment, not a merged PR. Extended as new
-# operational kinds are added (e.g. ``deployment``).
+# operational kinds are added (e.g. ``deployment``). NOTE: ``retrospective`` is a
+# labelled kind but is deliberately NOT operational — its acceptance IS a merged
+# docs PR (publishing ``retrospective.md``), so PR tooling must accept it.
 _OPERATIONAL_LABELS: set[str] = {"validation", "deployment"}
 
 

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -94,6 +94,19 @@ def test_registry_includes_deployment_label() -> None:
     assert entry["description"], "deployment label needs a description"
 
 
+def test_registry_includes_retrospective_label() -> None:
+    # Epic retrospective bookend (vergil-project/.github#201): a labelled kind
+    # that — unlike validation/deployment — IS PR-workable; its docs PR publishes
+    # the epic's retrospective.md. The label makes the bookend mechanical for the
+    # epic-retrospective preflight and vrg-epic-audit.
+    entry = next(
+        (label for label in load_labels()["labels"] if label["name"] == "retrospective"),
+        None,
+    )
+    assert entry is not None, "retrospective label missing from the registry"
+    assert entry["description"], "retrospective label needs a description"
+
+
 def test_label_descriptions_within_github_limit() -> None:
     # GitHub caps a label's description at 100 chars; a longer one fails
     # provisioning with HTTP 422 so vrg-ensure-label --sync cannot deploy it.

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -127,8 +127,9 @@ def test_main_sync_provisions_all_labels() -> None:
     assert result == 0
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
-    # 18 before retiring the deprecated 'standing' alias (retire-standing task).
-    assert len(label_calls) == 17
+    # 18 before retiring the deprecated 'standing' alias (retire-standing task);
+    # 18 again after adding the 'retrospective' kind label.
+    assert len(label_calls) == 18
 
 
 def test_main_sync_uses_force_with_color_description() -> None:

--- a/tests/vergil_tooling/test_vrg_issue_create.py
+++ b/tests/vergil_tooling/test_vrg_issue_create.py
@@ -103,6 +103,81 @@ def test_kind_deployment_applies_label_and_scaffold() -> None:
     assert kwargs["body_file"] is None
 
 
+def test_kind_retrospective_applies_label_and_scaffold() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(
+            ["--epic", "adhoc", "--kind", "retrospective", "--title", "Retrospective: the epic"]
+        )
+    assert rc == 0
+    kwargs = mock_create.call_args.kwargs
+    assert "retrospective" in kwargs["labels"]
+    body = kwargs["body"]
+    assert "retrospective task" in body.lower()  # scaffold rendered
+    assert "## What went well" in body
+    assert "PR-workable" in body  # scaffold states it is PR-workable
+    assert kwargs["body_file"] is None
+
+
+def test_kind_retrospective_is_not_operational() -> None:
+    # The critical distinction: retrospective is a labelled kind, but unlike
+    # validation/deployment it is PR-workable, so PR tooling (vrg-submit-pr /
+    # vrg-pr-workflow report-ready) must NOT refuse it. The single source of
+    # truth is epics._OPERATIONAL_LABELS — retrospective must be excluded.
+    assert "retrospective" not in epics.operational_labels()
+    assert "validation" in epics.operational_labels()  # sanity: set is populated
+
+
+def test_kind_retrospective_rejects_body_file(tmp_path: Path) -> None:
+    body_file = tmp_path / "b.md"
+    body_file.write_text("x")
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--kind",
+                "retrospective",
+                "--title",
+                "R",
+                "--body-file",
+                str(body_file),
+            ]
+        )
+    assert rc == 1
+    mock_create.assert_not_called()
+
+
+def test_kind_retrospective_rejects_blocked_by() -> None:
+    # --blocked-by encodes an operational merge-first dependency; a retrospective
+    # is an ordinary PR-workable task and must not accept it.
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--kind",
+                "retrospective",
+                "--title",
+                "R",
+                "--blocked-by",
+                "org/repo#5",
+            ]
+        )
+    assert rc == 1
+    mock_create.assert_not_called()
+
+
 def test_kind_validation_without_blockers_has_no_dependency_reflink() -> None:
     with (
         patch(f"{_MOD}.github.current_repo", return_value="org/repo"),


### PR DESCRIPTION
# Pull Request

## Summary

- Add a retrospective kind that stamps a retrospective label and a minimal scaffold while staying PR-workable (excluded from the operational refusal set).

## Issue Linkage

- Closes #2537

## Notes

- Mirrors validation/deployment machinery in vrg_issue_create.py but the retrospective label is deliberately NOT added to epics._OPERATIONAL_LABELS, so vrg-submit-pr / report-ready accept it. Adds the label to labels.json (+bumped the ensure-label sync count 17->18), a retrospective_task_body.md scaffold, and tests asserting label+scaffold, body-file/blocked-by rejection, and that retrospective is not operational.