### PR TITLE
feat(epic-audit): add machine-readable epic sub-issue enumeration

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_audit.py
+++ b/src/vergil_tooling/bin/vrg_epic_audit.py
@@ -61,6 +61,21 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help=(f"How many days back to scan for merged PRs (default: {_DEFAULT_WINDOW_DAYS})."),
     )
     parser.add_argument(
+        "--epic",
+        metavar="REF",
+        help=(
+            "Enumerate a single epic's child tasks as machine-readable JSON "
+            "instead of running the drift audit. REF is an epic ref "
+            "('owner/repo#N', or a bare '#N' resolved against the current repo). "
+            'Emits {"epic": <slug>, "children": [{repo, number, title, '
+            "state}, ...]} — a stable array of objects (native sub-issues, with "
+            "the portable Parent: reflink fallback), so "
+            "'.children[] | select(.state==\"OPEN\")' lists the open children "
+            "without brittle jq against GitHub's raw subIssues shape. Read-only; "
+            "ignores the drift-audit flags."
+        ),
+    )
+    parser.add_argument(
         "--repo",
         help=(
             "Audit a single repo's resolved epic home ('owner/repo') instead of "
@@ -85,6 +100,25 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    # Epic-scoped enumeration is a distinct, read-only mode: resolve the epic ref
+    # and emit its children (with states) as machine-readable JSON, bypassing the
+    # drift-audit path entirely (issue #2538). Parse + validate directly rather
+    # than via resolve_epic_ref so the read-only 'adhoc' sentinel (which *creates*
+    # an epic) is not reachable from an enumeration.
+    if args.epic is not None:
+        try:
+            epic = epics.parse_issue_ref(args.epic, default_repo=github.current_repo())
+        except ValueError as exc:
+            print(f"vrg-epic-audit: {exc}", file=sys.stderr)
+            return 1
+        if not epics.is_epic(epic):
+            print(
+                f"vrg-epic-audit: {epic.slug} is not an epic (missing the 'epic' label)",
+                file=sys.stderr,
+            )
+            return 1
+        print(epic_audit.render_epic_children(epic, epics.child_states(epic)))
+        return 0
     # Gate the write path before any network work so a rejected agent run is
     # cheap and unambiguous. A human may close interactively; the scheduled
     # reconciliation sweep (ops-epic-sweep) closes via the _SWEEP_ENV signal.

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -9,6 +9,7 @@ by the caller.
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from dataclasses import dataclass
@@ -349,6 +350,37 @@ def closed_epic_open_child(org: str, *, home: str | None = None) -> list[EpicOpe
         if open_kids:
             violations.append((epic, open_kids))
     return violations
+
+
+def render_epic_children(epic: epics.IssueRef, children: list[epics.ChildState]) -> str:
+    """Machine-readable JSON enumeration of *epic*'s children with their state.
+
+    Emits a stable, trivially-parseable object — the epic slug plus a ``children``
+    array whose entries each carry ``repo`` (``owner/name``), ``number``,
+    ``title``, and ``state`` (``"OPEN"``/``"CLOSED"``). This is the sanctioned
+    replacement for the brittle ``gh issue view <epic> --json subIssues --jq`` path
+    that failed with ``expected an object but got: array`` (issue #2538): callers
+    filter ``.children[] | select(.state=="OPEN")`` over a proper array of objects
+    instead of GitHub's raw sub-issue shape, and get each child's repo/number/title
+    without a second per-issue lookup. *children* is the output of
+    :func:`epics.child_states` (native sub-issues, reflink fallback), so the native
+    vs portable mechanism is transparent to the caller. Entries are sorted by
+    (owner, repo, number) so the output is deterministic across runs.
+    """
+    ordered = sorted(children, key=lambda c: (c.ref.owner, c.ref.repo, c.ref.number))
+    payload = {
+        "epic": epic.slug,
+        "children": [
+            {
+                "repo": f"{child.ref.owner}/{child.ref.repo}",
+                "number": child.ref.number,
+                "title": child.title,
+                "state": child.state,
+            }
+            for child in ordered
+        ],
+    }
+    return json.dumps(payload, indent=2)
 
 
 def render(

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -36,10 +36,16 @@ class IssueRef:
 
 @dataclass(frozen=True)
 class ChildState:
-    """A child task and whether it is open or closed."""
+    """A child task: its ref, open/closed state, and title.
+
+    ``title`` is descriptive metadata for machine-readable enumeration (issue
+    #2538); it defaults to ``""`` so state-only consumers construct a
+    ``ChildState`` without supplying it.
+    """
 
     ref: IssueRef
     state: str  # "OPEN" | "CLOSED"
+    title: str = ""
 
 
 _PARENT_RE = re.compile(
@@ -95,7 +101,7 @@ query($id: ID!) {
   node(id: $id) {
     ... on Issue {
       subIssues(first: 100) {
-        nodes { number state repository { name owner { login } } }
+        nodes { number state title repository { name owner { login } } }
       }
     }
   }
@@ -154,7 +160,12 @@ def _ref_from_node(node: Any) -> IssueRef:
 def _native_child_states(epic: IssueRef) -> list[ChildState]:
     data: Any = github.graphql(_SUBISSUES_QUERY, id=_node_id(epic))
     nodes = (((data or {}).get("node") or {}).get("subIssues") or {}).get("nodes") or []
-    return [ChildState(ref=_ref_from_node(n), state=str(n["state"]).upper()) for n in nodes]
+    return [
+        ChildState(
+            ref=_ref_from_node(n), state=str(n["state"]).upper(), title=str(n.get("title") or "")
+        )
+        for n in nodes
+    ]
 
 
 def _body_declares_parent(body: str, epic: IssueRef) -> bool:
@@ -185,7 +196,7 @@ def _reflink_child_states(epic: IssueRef) -> list[ChildState]:
         "--owner",
         epic.owner,
         "--json",
-        "number,state,repository,body",
+        "number,state,title,repository,body",
     )
     states: list[ChildState] = []
     for item in results if isinstance(results, list) else []:
@@ -199,6 +210,7 @@ def _reflink_child_states(epic: IssueRef) -> list[ChildState]:
             ChildState(
                 ref=IssueRef(owner=owner, repo=name, number=int(item["number"])),
                 state=str(item["state"]).upper(),
+                title=str(item.get("title") or ""),
             )
         )
     return states

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -695,3 +696,45 @@ def test_epic_drift_scopes_to_home() -> None:
 def test_render_banner_names_home_when_repo_scoped() -> None:
     out = epic_audit.render([], [], org="org", window_days=30, home="org/lab")
     assert "**org/lab**" in out  # banner names the scoped home, not the org
+
+
+# -- render_epic_children (machine-readable enumeration, issue #2538) ---------
+
+
+def test_render_epic_children_lists_children_with_states() -> None:
+    epic = epics.IssueRef("vergil-project", ".github", 201)
+    children = [
+        epics.ChildState(
+            epics.IssueRef("vergil-project", "vergil-tooling", 2538), "OPEN", "Harden enumeration"
+        ),
+        epics.ChildState(
+            epics.IssueRef("vergil-project", "vergil-tooling", 2500), "CLOSED", "Earlier task"
+        ),
+    ]
+    out = json.loads(epic_audit.render_epic_children(epic, children))
+    assert out["epic"] == "vergil-project/.github#201"
+    # Deterministic order (owner, repo, number): 2500 sorts before 2538.
+    assert out["children"] == [
+        {
+            "repo": "vergil-project/vergil-tooling",
+            "number": 2500,
+            "title": "Earlier task",
+            "state": "CLOSED",
+        },
+        {
+            "repo": "vergil-project/vergil-tooling",
+            "number": 2538,
+            "title": "Harden enumeration",
+            "state": "OPEN",
+        },
+    ]
+    # Open children are trivially selectable from a proper array of objects — the
+    # brittle-jq failure mode this replaces (issue #2538).
+    open_children = [c for c in out["children"] if c["state"] == "OPEN"]
+    assert [c["number"] for c in open_children] == [2538]
+
+
+def test_render_epic_children_empty_when_no_children() -> None:
+    epic = epics.IssueRef("vergil-project", ".github", 201)
+    out = json.loads(epic_audit.render_epic_children(epic, []))
+    assert out == {"epic": "vergil-project/.github#201", "children": []}

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.lib import epics, github
-from vergil_tooling.lib.epics import ChildState, IssueRef
+from vergil_tooling.lib.epics import _SUBISSUES_QUERY, ChildState, IssueRef
 
 EPIC = IssueRef("org", ".github", 40)
 TASK = IssueRef("org", "repo-a", 101)
@@ -86,6 +86,64 @@ def test_child_states_reflink_fallback_when_native_empty() -> None:
     assert "Parent: org/.github#40" in mock_search.call_args.args
     assert "--owner" in mock_search.call_args.args
     assert "org" in mock_search.call_args.args
+
+
+def test_child_states_native_carries_title() -> None:
+    # The native traversal requests and propagates each child's title (issue #2538).
+    data = {
+        "node": {
+            "subIssues": {
+                "nodes": [
+                    {
+                        "number": 101,
+                        "state": "CLOSED",
+                        "title": "First task",
+                        "repository": _repo_node("org", "repo-a"),
+                    },
+                    {
+                        "number": 102,
+                        "state": "OPEN",
+                        "title": "Second task",
+                        "repository": _repo_node("org", "repo-b"),
+                    },
+                ]
+            }
+        }
+    }
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=data),
+    ):
+        result = epics.child_states(EPIC)
+    assert result == [
+        ChildState(IssueRef("org", "repo-a", 101), "CLOSED", "First task"),
+        ChildState(IssueRef("org", "repo-b", 102), "OPEN", "Second task"),
+    ]
+    # The GraphQL query asks GitHub for the title field.
+    assert "title" in _SUBISSUES_QUERY
+
+
+def test_child_states_reflink_carries_title() -> None:
+    # The portable Parent: reflink fallback also requests and propagates title.
+    empty = {"node": {"subIssues": {"nodes": []}}}
+    search = [
+        {
+            "number": 41,
+            "state": "OPEN",
+            "title": "Fallback task",
+            "repository": {"nameWithOwner": "org/.github"},
+            "body": "Parent: org/.github#40",
+        }
+    ]
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=empty),
+        patch("vergil_tooling.lib.github.read_json", return_value=search) as mock_search,
+    ):
+        result = epics.child_states(EPIC)
+    assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN", "Fallback task")]
+    # The search requests the title field so the fallback listing is complete.
+    assert "number,state,title,repository,body" in mock_search.call_args.args
 
 
 # -- parent_of ---------------------------------------------------------------

--- a/tests/vergil_tooling/test_vrg_epic_audit.py
+++ b/tests/vergil_tooling/test_vrg_epic_audit.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_epic_audit import main
+from vergil_tooling.lib.epics import ChildState, IssueRef
 
 _MOD = "vergil_tooling.bin.vrg_epic_audit"
 
@@ -36,6 +38,47 @@ def test_main_repo_malformed_errors(capsys: pytest.CaptureFixture[str]) -> None:
     rc = main(["--repo", "noslash"])
     assert rc == 1
     assert "owner/repo" in capsys.readouterr().err
+
+
+def test_main_epic_enumerates_children_as_json(capsys: pytest.CaptureFixture[str]) -> None:
+    # --epic emits the epic's children (mixed open/closed) as machine-readable
+    # JSON, bypassing the drift audit (issue #2538).
+    children = [
+        ChildState(IssueRef("vergil-project", "vergil-tooling", 2538), "OPEN", "Open child"),
+        ChildState(IssueRef("vergil-project", "vergil-tooling", 2500), "CLOSED", "Closed child"),
+    ]
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="vergil-project/.github"),
+        patch(f"{_MOD}.epics.is_epic", return_value=True),
+        patch(f"{_MOD}.epics.child_states", return_value=children) as cs,
+    ):
+        rc = main(["--epic", "vergil-project/.github#201"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["epic"] == "vergil-project/.github#201"
+    states = {c["number"]: c["state"] for c in payload["children"]}
+    assert states == {2500: "CLOSED", 2538: "OPEN"}
+    # child_states is asked about the resolved epic ref.
+    assert cs.call_args.args[0] == IssueRef("vergil-project", ".github", 201)
+
+
+def test_main_epic_rejects_non_epic_ref(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="vergil-project/.github"),
+        patch(f"{_MOD}.epics.is_epic", return_value=False),
+        patch(f"{_MOD}.epics.child_states") as cs,
+    ):
+        rc = main(["--epic", "vergil-project/vergil-tooling#2538"])
+    assert rc == 1
+    assert "is not an epic" in capsys.readouterr().err
+    cs.assert_not_called()
+
+
+def test_main_epic_rejects_malformed_ref(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(f"{_MOD}.github.current_repo", return_value="vergil-project/.github"):
+        rc = main(["--epic", "not-a-ref"])
+    assert rc == 1
+    assert "not an issue ref" in capsys.readouterr().err
 
 
 def test_main_prints_audit(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a read-only vrg-epic-audit --epic <ref> mode that emits an epic's children with repo/number/title/state as stable JSON, replacing the brittle subIssues jq path.

## Issue Linkage

- Closes #2538

## Notes

- Root cause: gh issue view <epic> --json subIssues returns a raw array shape that broke the naive select() jq. The reliable traversal (epics.child_states via GraphQL sub-issues + Parent: reflink fallback) already existed; this surfaces it as machine-readable output and adds title to ChildState. Output shape: {"epic": <slug>, "children": [{repo, number, title, state}, ...]}, sorted by (owner, repo, number). --epic parses+validates the ref directly (not resolve_epic_ref) so the write-side 'adhoc' sentinel is unreachable from a read. Validation green: 4471 passed, 100% coverage.