### PR TITLE
feat(vrg-gh): add read-only release subcommand to the allowlist

### DIFF
--- a/src/vergil_tooling/bin/vrg_gh.py
+++ b/src/vergil_tooling/bin/vrg_gh.py
@@ -17,6 +17,11 @@ _ALLOWED: dict[str, set[str]] = {
     "pr": {"view", "checks", "list", "diff", "comment", "edit", "review", "merge"},
     "run": {"list", "view", "watch"},
     "repo": {"view", "list"},
+    # `release` is read-only here: only `list` and `view` are permitted so
+    # release facts can be queried directly. Write actions (create/edit/
+    # delete/upload/download) are denied by the action-level allowlist's
+    # deny-by-default. See issue #2539.
+    "release": {"list", "view"},
     "label": {"list", "create"},
     # `gh search` is read-only across all its subcommands (code/commits/
     # issues/prs/repos), so it fits the wrapper's no-mutation safety model.

--- a/tests/vergil_tooling/test_vrg_gh.py
+++ b/tests/vergil_tooling/test_vrg_gh.py
@@ -64,6 +64,8 @@ _ALLOWED_PAIRS: list[tuple[str, str]] = [
     ("run", "watch"),
     ("repo", "view"),
     ("repo", "list"),
+    ("release", "list"),
+    ("release", "view"),
     ("label", "list"),
     ("label", "create"),
     ("search", "code"),
@@ -121,6 +123,26 @@ def test_search_has_no_write_subcommands() -> None:
     from vergil_tooling.bin.vrg_gh import _ALLOWED
 
     assert _ALLOWED["search"] == {"code", "commits", "issues", "prs", "repos"}
+
+
+# -- release (read-only) -----------------------------------------------------
+
+
+def test_release_is_read_only() -> None:
+    # Guard against widening `release` beyond the read-only actions. Only
+    # `list`/`view` may ever be permitted (issue #2539).
+    from vergil_tooling.bin.vrg_gh import _ALLOWED
+
+    assert _ALLOWED["release"] == {"list", "view"}
+
+
+@pytest.mark.parametrize("sub", ["create", "edit", "delete", "upload", "download"])
+def test_release_write_actions_rejected(sub: str, capsys: pytest.CaptureFixture[str]) -> None:
+    # Write/mutating release actions are not on the allowlist and are rejected
+    # by the action-level deny-by-default (issue #2539).
+    assert main(["release", sub]) != 0
+    err = capsys.readouterr().err
+    assert sub in err
 
 
 # -- unrecognized subcommands ------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Adds release (list/view) to the vrg-gh subcommand allowlist so release facts can be queried directly instead of inferred.

## Issue Linkage

- Closes #2539

## Notes

- Read-only only: release list/view permitted; write actions (create/edit/delete/upload/download) rejected by the action-level deny-by-default. Mirrors existing read-only entries. Tests: added release list/view to the allowed-pairs matrix, a guard asserting _ALLOWED['release'] == {list, view}, and a parametrized test that write actions are rejected. Validation green (4472 tests, 100% coverage).