### PR TITLE
fix(vrg-git): demote workflow-file push refusal to a warning + success

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from vergil_tooling.lib import github, identity_mode
+from vergil_tooling.lib import github
 from vergil_tooling.lib.git import _git_auth_env, main_worktree_root
 from vergil_tooling.lib.pr_workflow import freeze
 
@@ -410,12 +410,16 @@ def _check_frozen_push() -> str | None:
 
 
 def _print_workflow_push_guidance() -> None:
-    mode = identity_mode.current_mode()
     print(
-        f"\nvrg-git: Push rejected — workflow file changes require elevated permissions.\n"
-        f"  Your identity ({mode.value}) is not permitted to push workflow file changes.\n"
-        f"  Stop and escalate to a human maintainer. Do not attempt to work around\n"
-        f"  this failure (e.g., by removing workflow files from the commit).",
+        "\nvrg-git: warning: push skipped for workflow-file changes — this is"
+        " EXPECTED and NOT an error.\n"
+        "  This branch touches .github/workflows/**, which an agent is not"
+        " permitted to push;\n"
+        "  it does not need an agent push. The human's vrg-submit-pr pushes"
+        " the branch at\n"
+        "  submit time. PROCEED AS USUAL — run `vrg-pr-workflow report-ready`"
+        " to hand off.\n"
+        "  Do NOT remove the workflow files from the commit to force a push.",
         file=sys.stderr,
     )
 
@@ -552,7 +556,13 @@ def main(argv: list[str] | None = None) -> int:
         if push_result.stderr:
             sys.stderr.write(push_result.stderr)
         if push_result.returncode != 0 and _WORKFLOW_PERMISSION_RE.search(push_result.stderr or ""):
+            # A workflow-file push refusal is expected and routine: the agent
+            # never pushes a workflow branch — the human's vrg-submit-pr does,
+            # at submit time. Warn and report success so the agent proceeds to
+            # report-ready instead of mistreating a normal case as a failure
+            # (#2540). Any other push failure keeps its original returncode.
             _print_workflow_push_guidance()
+            return 0
         return push_result.returncode
 
     result = subprocess.run(["git", *argv], check=False, env=env)  # noqa: S603, S607

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -779,16 +779,17 @@ class TestRemoteTokenInjection:
 
 
 class TestPushWorkflowErrorDetection:
-    """vrg-git push detects workflow permission errors and provides guidance."""
+    """vrg-git push treats a workflow-permission refusal as an expected, non-error case."""
 
     _WORKFLOW_ERR = (
         "refusing to allow a GitHub App to create or update workflow "
         "`.github/workflows/ci.yml` without `workflows` permission"
     )
 
-    def test_workflow_error_detected_and_guidance_printed(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_workflow_error_warns_and_succeeds(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # A workflow-permission refusal is EXPECTED: the agent never pushes a
+        # workflow branch; the human's vrg-submit-pr pushes it at submit time.
+        # So it exits 0 (success) with a warning, not a non-zero error (#2540).
         with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=["git", "push"],
@@ -797,11 +798,15 @@ class TestPushWorkflowErrorDetection:
                 stderr=self._WORKFLOW_ERR,
             )
             rc = main(["push", "origin", "feature/x"])
-        assert rc == 1
+        assert rc == 0
         err = capsys.readouterr().err
+        assert "warning" in err.lower()
         assert "workflow" in err.lower()
-        assert "escalate" in err.lower()
-        assert "human maintainer" in err.lower()
+        assert "expected" in err.lower()
+        assert "report-ready" in err.lower()
+        # The old error framing is gone.
+        assert "escalate" not in err.lower()
+        assert "human maintainer" not in err.lower()
 
     def test_workflow_error_shows_original_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
@@ -818,6 +823,8 @@ class TestPushWorkflowErrorDetection:
     def test_non_workflow_push_error_passes_through(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
+        # A push failure that is NOT a workflow-permission refusal keeps its
+        # original non-zero returncode unchanged (#2540).
         with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=["git", "push"],
@@ -829,7 +836,7 @@ class TestPushWorkflowErrorDetection:
         assert rc == 1
         err = capsys.readouterr().err
         assert "fatal: remote rejected" in err
-        assert "escalate" not in err.lower()
+        assert "warning" not in err.lower()
 
     def test_successful_push_unchanged(self) -> None:
         with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:


### PR DESCRIPTION
# Pull Request

## Summary

- A vrg-git push refused because the branch touches .github/workflows/** is now treated as an expected, routine outcome rather than a hard error. The push handler returns success (exit 0) with a warning that tells the agent to proceed and run report-ready, instead of a non-zero error with escalation wording. Any other push failure keeps its original non-zero returncode.

## Issue Linkage

- Closes #2540

## Notes

- The agent never pushes a workflow branch; the human's vrg-submit-pr pushes it at submit time, so the refusal is normal. The warning keeps a short caution against stripping the workflow files from the commit to force a push. Tests updated to assert the new contract: workflow-permission failure -> exit 0 + warning wording (no 'escalate'/'human maintainer'), and a non-workflow failure preserves its original non-zero code. Full vrg-validate passes at 100% coverage.