### PR TITLE
feat(github-config): per-kind CI-gate cardinality

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -292,17 +292,30 @@ def desired_ci_gates_ruleset(
         checks.append(_make_check("security / codeql"))
         checks.append(_make_ghas_check("CodeQL"))
 
-    # Versioned checks — only emitted when the language has
-    # a command registry entry for the check
+    # Versioned checks — only emitted when the language has a command registry
+    # entry for the check. Each kind's cardinality decides how many gates it
+    # yields: a ``per-version`` kind emits one gate per configured version,
+    # while a ``once`` kind emits a single gate keyed to the primary version
+    # (``ci.versions[0]``) — so a matrix language's run-once stages become one
+    # required check instead of N redundant, merge-blocking ones. Existing
+    # single-image languages declare no ``once`` kinds, so their emitted gates
+    # are byte-identical to the pre-cardinality behavior.
+    from vergil_tooling.lib.languages import Cardinality, CheckKind, check_cardinality
+
+    primary_version = ci.versions[0] if ci.versions else None
+    versioned_kinds: tuple[tuple[str, CheckKind, str], ...] = (
+        ("lint", CheckKind.LINT, "quality / lint / {version}"),
+        ("typecheck", CheckKind.TYPECHECK, "quality / typecheck / {version}"),
+        ("unit", CheckKind.TEST, "test / unit / {version}"),
+        ("dependencies", CheckKind.AUDIT, "audit / dependencies / {version}"),
+    )
     for version in ci.versions:
-        if _lang_has_check(lang, "lint"):
-            checks.append(_make_check(f"quality / lint / {version}"))
-        if _lang_has_check(lang, "typecheck"):
-            checks.append(_make_check(f"quality / typecheck / {version}"))
-        if _lang_has_check(lang, "unit"):
-            checks.append(_make_check(f"test / unit / {version}"))
-        if _lang_has_check(lang, "dependencies"):
-            checks.append(_make_check(f"audit / dependencies / {version}"))
+        for check_key, kind, template in versioned_kinds:
+            if not _lang_has_check(lang, check_key):
+                continue
+            if check_cardinality(lang, kind) is Cardinality.ONCE and version != primary_version:
+                continue
+            checks.append(_make_check(template.format(version=version)))
 
     # Integration tests per version (when enabled)
     if ci.integration_tests:

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -10,7 +10,7 @@ Replaces the former ``validate_commands`` module.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from importlib.resources import files
 
@@ -21,6 +21,21 @@ class CheckKind(Enum):
     TYPECHECK = "typecheck"
     TEST = "test"
     AUDIT = "audit"
+
+
+class Cardinality(Enum):
+    """How many CI gates a check kind yields across the version matrix.
+
+    ``PER_VERSION`` — one required check per configured version (the
+    default, matching every single-image language's historical behavior).
+    ``ONCE`` — a single required check keyed to the primary version, for
+    stages that run once per language rather than once per compiler×version
+    (e.g. a matrix language's lint/audit). This keeps run-once stages from
+    accumulating N redundant, merge-blocking checks in branch protection.
+    """
+
+    PER_VERSION = "per-version"
+    ONCE = "once"
 
 
 @dataclass(frozen=True)
@@ -35,6 +50,12 @@ class Language:
     name: str
     checks: dict[CheckKind, list[list[str]]]
     ecosystem: EcosystemInfo
+    # Per-kind gate cardinality. A kind absent from this mapping defaults to
+    # ``PER_VERSION`` — so the existing single-image languages, which declare
+    # nothing here, keep emitting one gate per version exactly as before. A
+    # matrix language (e.g. C++) declares ``ONCE`` for the kinds it runs a
+    # single time across the compiler×version matrix.
+    cardinality: dict[CheckKind, Cardinality] = field(default_factory=dict)
 
 
 # -- Machine-readable report paths --------------------------------------------
@@ -274,3 +295,18 @@ def language_commands(language: str | None, kind: CheckKind) -> list[list[str]]:
     return [
         [arg.replace("{configs}", configs_dir) for arg in cmd] for cmd in entry.checks.get(kind, [])
     ]
+
+
+def check_cardinality(language: str | None, kind: CheckKind) -> Cardinality:
+    """Return the gate cardinality for a language's check kind.
+
+    Defaults to :attr:`Cardinality.PER_VERSION` when the language is unknown,
+    ``None``, or declares no explicit cardinality for the kind — preserving the
+    historical one-gate-per-version behavior for every existing language.
+    """
+    if language is None:
+        return Cardinality.PER_VERSION
+    entry = _REGISTRY.get(language)
+    if entry is None:
+        return Cardinality.PER_VERSION
+    return entry.cardinality.get(kind, Cardinality.PER_VERSION)

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -362,6 +362,94 @@ def test_lang_has_check_returns_false_for_unknown_check() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-kind cardinality tests (issue #2552)
+# ---------------------------------------------------------------------------
+
+
+def test_ci_gates_per_version_kind_emits_one_gate_per_version() -> None:
+    """A per-version kind (the default) yields N gates across N versions."""
+    ci = _ci(versions=["3.12", "3.13", "3.14"])
+    r = desired_ci_gates_ruleset(_project(), ci, ghas=True)
+    lint = [n for n in _check_names(r) if n.startswith("quality / lint")]
+    assert lint == [
+        "quality / lint / 3.12",
+        "quality / lint / 3.13",
+        "quality / lint / 3.14",
+    ]
+
+
+def test_ci_gates_once_kind_emits_single_gate_keyed_to_primary_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run-once kind yields exactly one gate, keyed to the primary version.
+
+    Cardinality is language-agnostic infra: no shipping language declares a
+    ``once`` kind yet (that arrives with the C++ registry entry), so the
+    behavior is exercised by declaring LINT run-once for the duration of the
+    test. TYPECHECK stays per-version to prove the two coexist.
+    """
+    from vergil_tooling.lib import languages
+
+    def fake_cardinality(language: str | None, kind: languages.CheckKind) -> languages.Cardinality:
+        if kind is languages.CheckKind.LINT:
+            return languages.Cardinality.ONCE
+        return languages.Cardinality.PER_VERSION
+
+    monkeypatch.setattr(languages, "check_cardinality", fake_cardinality)
+
+    ci = _ci(versions=["3.12", "3.13", "3.14"])
+    r = desired_ci_gates_ruleset(_project(), ci, ghas=True)
+    names = _check_names(r)
+
+    lint = [n for n in names if n.startswith("quality / lint")]
+    assert lint == ["quality / lint / 3.12"]  # single gate, keyed to versions[0]
+
+    typecheck = [n for n in names if n.startswith("quality / typecheck")]
+    assert typecheck == [
+        "quality / typecheck / 3.12",
+        "quality / typecheck / 3.13",
+        "quality / typecheck / 3.14",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Regression snapshot — existing languages' gates must stay byte-identical
+# ---------------------------------------------------------------------------
+#
+# The cardinality refactor (issue #2552) restructured the versioned-gate loop.
+# Every existing language defaults to per-version cardinality, so its generated
+# gates must be byte-identical to the pre-refactor output. This snapshot pins
+# the exact ordered check list for each of the five languages; any drift in the
+# order, naming, or count of the existing languages' gates fails here.
+
+_EXPECTED_GATES_TWO_VERSIONS = [
+    "quality / common",
+    "security / trivy",
+    "security / semgrep",
+    "Trivy",
+    "Semgrep OSS",
+    "security / codeql",
+    "CodeQL",
+    "quality / lint / v1",
+    "quality / typecheck / v1",
+    "test / unit / v1",
+    "audit / dependencies / v1",
+    "quality / lint / v2",
+    "quality / typecheck / v2",
+    "test / unit / v2",
+    "audit / dependencies / v2",
+    "version / version-bump",
+]
+
+
+@pytest.mark.parametrize("language", ["python", "go", "java", "ruby", "rust"])
+def test_ci_gates_existing_languages_snapshot(language: str) -> None:
+    ci = _ci(versions=["v1", "v2"])
+    r = desired_ci_gates_ruleset(_project(language=language), ci, ghas=True)
+    assert _check_names(r) == _EXPECTED_GATES_TWO_VERSIONS
+
+
+# ---------------------------------------------------------------------------
 # compute_desired_state tests
 # ---------------------------------------------------------------------------
 

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -10,8 +10,11 @@ from vergil_tooling.lib.languages import (
     LICENSES_REPORT,
     PIP_AUDIT_REPORT,
     PYTHON_REPORT_FILES,
+    Cardinality,
     CheckKind,
     EcosystemInfo,
+    Language,
+    check_cardinality,
     ecosystem_metadata,
     language_commands,
     supported_languages,
@@ -349,3 +352,51 @@ def test_ecosystem_metadata_unknown_raises() -> None:
 def test_language_commands_still_works_for_unknown() -> None:
     cmds = language_commands("unknown", CheckKind.LINT)
     assert cmds == []
+
+
+# -- Check cardinality --------------------------------------------------------
+
+
+def test_existing_languages_default_to_per_version_cardinality() -> None:
+    """Every existing language defaults to per-version for every check kind.
+
+    This backward-compatibility guarantee is what keeps their generated CI
+    gates byte-identical after the cardinality concept was introduced.
+    """
+    for lang in supported_languages():
+        for kind in CheckKind:
+            assert check_cardinality(lang, kind) is Cardinality.PER_VERSION
+
+
+def test_check_cardinality_unknown_language_defaults_per_version() -> None:
+    assert check_cardinality("unknown", CheckKind.LINT) is Cardinality.PER_VERSION
+
+
+def test_check_cardinality_none_language_defaults_per_version() -> None:
+    assert check_cardinality(None, CheckKind.LINT) is Cardinality.PER_VERSION
+
+
+def test_language_cardinality_defaults_to_empty_mapping() -> None:
+    """A Language that declares no cardinality carries an empty mapping."""
+    lang = Language(
+        name="x",
+        checks={},
+        ecosystem=EcosystemInfo(build_cmd=None, publish_cmd=None, publish_env_var=None),
+    )
+    assert lang.cardinality == {}
+
+
+def test_language_may_declare_once_cardinality() -> None:
+    """A language can declare a kind as run-once (e.g. a matrix language)."""
+    lang = Language(
+        name="x",
+        checks={},
+        ecosystem=EcosystemInfo(build_cmd=None, publish_cmd=None, publish_env_var=None),
+        cardinality={CheckKind.LINT: Cardinality.ONCE},
+    )
+    assert lang.cardinality[CheckKind.LINT] is Cardinality.ONCE
+
+
+def test_cardinality_enum_values() -> None:
+    assert Cardinality.PER_VERSION.value == "per-version"
+    assert Cardinality.ONCE.value == "once"


### PR DESCRIPTION
# Pull Request

## Summary

- Add a language-agnostic per-kind gate cardinality concept (per-version vs once) so desired_ci_gates_ruleset can emit run-once check kinds as a single required check keyed to the primary version while per-version kinds stay one-per-version.

## Issue Linkage

- Closes #2552

## Notes

- T3 of epic vergil-project/.github#207 (C++ language support); unblocks T5/T8/T11. Language-agnostic infra only: all five existing languages default to per-version, so their generated gates are byte-identical (proven by a parametrized snapshot test). No shipping language declares a once kind yet, so the once path is exercised via a monkeypatched cardinality in the unit test. Validation green: vrg-container-run -- vrg-validate, 4497 passed, 100% coverage.