### PR TITLE
feat(config): add cpp primary-language + [cpp] block

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -27,8 +27,19 @@ _ENUMS: dict[str, set[str]] = {
     "versioning-scheme": {"library", "semver", "application", "none"},
     "branching-model": {"library-release", "application-promotion", "docs-single-branch"},
     "release-model": {"artifact-publishing", "tagged-release", "environment-promotion", "none"},
-    "primary-language": {"python", "go", "java", "ruby", "rust"},
+    "primary-language": {"python", "go", "java", "ruby", "rust", "cpp"},
 }
+
+# The [cpp] block (epic vergil-project/.github#207 §3.3). The compiler family ×
+# version axis rides [ci].versions (the ``clang-``/``gcc-`` tag prefix); the two
+# cheap in-build axes are single-valued [cpp] keys. v1 pins std = c++20 and
+# stdlib = libstdc++; the wider std set is accepted since it is a free build
+# flag, while libc++ stays on the spec §9 deferral ledger (ledger #2) and is
+# therefore rejected, not silently ignored.
+DEFAULT_CPP_STD = "c++20"
+DEFAULT_CPP_STDLIB = "libstdc++"
+_CPP_STD_VALUES = frozenset({"c++17", "c++20", "c++23"})
+_CPP_STDLIB_VALUES = frozenset({"libstdc++"})
 
 _REQUIRED_PROJECT_FIELDS = (
     "repository-type",
@@ -49,6 +60,7 @@ _KNOWN_SECTIONS = frozenset(
         "container",
         "validation",
         "actions",
+        "cpp",
         "vm",
     },
 )
@@ -62,6 +74,7 @@ _KNOWN_KEYS: dict[str, frozenset[str]] = {
     "container": frozenset({"env-prefixes"}),
     "validation": frozenset({"container-command"}),
     "actions": frozenset({"extra-allowed-patterns"}),
+    "cpp": frozenset({"std", "stdlib"}),
 }
 
 
@@ -108,6 +121,16 @@ class ValidationConfig:
 
 
 @dataclass
+class CppConfig:
+    # The two cheap in-build C++ axes (epic vergil-project/.github#207 §3.3):
+    # ``std`` is the ``-std=`` flag, ``stdlib`` selects the standard library.
+    # Both are single string values in v1; compiler family × version is carried
+    # by [ci].versions, not here.
+    std: str
+    stdlib: str
+
+
+@dataclass
 class ActionsConfig:
     # Extra allowed-action patterns unioned into the repo's GitHub Actions
     # allowed-actions policy, on top of the base + per-language defaults in
@@ -126,6 +149,9 @@ class VergilConfig:
     container: ContainerConfig
     validation: ValidationConfig
     actions: ActionsConfig = field(default_factory=lambda: ActionsConfig(extra_allowed_patterns=[]))
+    cpp: CppConfig = field(
+        default_factory=lambda: CppConfig(std=DEFAULT_CPP_STD, stdlib=DEFAULT_CPP_STDLIB)
+    )
     vm: VmStanza | None = None
 
 
@@ -343,6 +369,39 @@ def parse_vm_stanza(raw: dict[str, Any], source: str = CONFIG_FILE) -> VmStanza 
     )
 
 
+def _parse_cpp_str_value(
+    raw: dict[str, Any], key: str, allowed: frozenset[str], default: str, source: str
+) -> str:
+    """Return a validated single-string [cpp] value, or its default when absent.
+
+    Raises ConfigError if present but non-string, or if it is not one of the
+    ``allowed`` values (rejection, not a silent fallback — a bogus std/stdlib
+    would otherwise be dropped into the build unnoticed).
+    """
+    if key not in raw:
+        return default
+    value = raw[key]
+    if not isinstance(value, str):
+        msg = f"{source}: [cpp].{key} must be a string (got {type(value).__name__})"
+        raise ConfigError(msg)
+    if value not in allowed:
+        allowed_str = ", ".join(sorted(allowed))
+        msg = f"{source}: invalid [cpp].{key} '{value}' (allowed: {allowed_str})"
+        raise ConfigError(msg)
+    return value
+
+
+def _parse_cpp_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> CppConfig:
+    """Parse the ``[cpp]`` block, defaulting to the v1 pins when it is absent."""
+    cpp_raw = raw.get("cpp", {})
+    return CppConfig(
+        std=_parse_cpp_str_value(cpp_raw, "std", _CPP_STD_VALUES, DEFAULT_CPP_STD, source),
+        stdlib=_parse_cpp_str_value(
+            cpp_raw, "stdlib", _CPP_STDLIB_VALUES, DEFAULT_CPP_STDLIB, source
+        ),
+    )
+
+
 def _warn_unrecognized_keys(raw: dict[str, Any], source: str = CONFIG_FILE) -> None:
     for section in raw:
         if section not in _KNOWN_SECTIONS:
@@ -490,6 +549,7 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
         container=container,
         validation=validation,
         actions=actions,
+        cpp=_parse_cpp_config(raw, source),
         vm=parse_vm_stanza(raw, source),
     )
 

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -8,10 +8,13 @@ from unittest.mock import patch
 import pytest
 
 from vergil_tooling.lib.config import (
+    DEFAULT_CPP_STD,
+    DEFAULT_CPP_STDLIB,
     DEFAULT_VALIDATION_COMMAND,
     CiConfig,
     ConfigError,
     ContainerConfig,
+    CppConfig,
     MarkdownlintConfig,
     ValidationConfig,
     VmStanza,
@@ -225,6 +228,26 @@ def test_config_warns_on_claude_plugin_language(
     cfg = read_config(tmp_path)
     assert cfg.project.primary_language is None
     assert "unrecognized primary-language 'claude-plugin'" in capsys.readouterr().err
+
+
+def test_config_accepts_cpp_language(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``primary-language = "cpp"`` is a recognized language (no warning)."""
+    toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "cpp"')
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language == "cpp"
+    assert "unrecognized primary-language" not in capsys.readouterr().err
+
+
+def test_config_warns_on_unknown_language_after_cpp_added(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Adding cpp does not weaken the enum — an unknown value still warns."""
+    toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "cobol"')
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language is None
+    assert "unrecognized primary-language 'cobol'" in capsys.readouterr().err
 
 
 # -- [markdownlint] section ---------------------------------------------------
@@ -1089,3 +1112,106 @@ def test_parse_vm_stanza_rejects_instance_entry_not_a_table() -> None:
     raw = {"vm": {"vergil-user": {"instances": {"cloud-x86": "not-a-table"}}}}
     with pytest.raises(ConfigError, match="must be a table"):
         parse_vm_stanza(raw)
+
+
+# -- [cpp] section (epic vergil-project/.github#207, T4) -----------------------
+
+_CPP_BASE_TOML = """\
+[project]
+repository-type = "application"
+versioning-scheme = "semver"
+branching-model = "application-promotion"
+release-model = "environment-promotion"
+primary-language = "cpp"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["clang-20", "gcc-15"]
+"""
+
+
+def test_cpp_block_defaults_when_absent(tmp_path: Path) -> None:
+    """With no [cpp] block, std/stdlib fall back to the v1 pins."""
+    (tmp_path / "vergil.toml").write_text(_CPP_BASE_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.cpp == CppConfig(std=DEFAULT_CPP_STD, stdlib=DEFAULT_CPP_STDLIB)
+    assert cfg.cpp.std == "c++20"
+    assert cfg.cpp.stdlib == "libstdc++"
+
+
+def test_cpp_block_parsed(tmp_path: Path) -> None:
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstd = "c++23"\nstdlib = "libstdc++"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.cpp == CppConfig(std="c++23", stdlib="libstdc++")
+
+
+def test_cpp_block_std_only_stdlib_defaults(tmp_path: Path) -> None:
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstd = "c++17"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.cpp.std == "c++17"
+    assert cfg.cpp.stdlib == DEFAULT_CPP_STDLIB
+
+
+def test_cpp_block_stdlib_only_std_defaults(tmp_path: Path) -> None:
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstdlib = "libstdc++"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.cpp.std == DEFAULT_CPP_STD
+    assert cfg.cpp.stdlib == "libstdc++"
+
+
+@pytest.mark.parametrize("std", ["c++17", "c++20", "c++23"])
+def test_cpp_std_valid_values(tmp_path: Path, std: str) -> None:
+    toml = _CPP_BASE_TOML + f'\n[cpp]\nstd = "{std}"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    assert read_config(tmp_path).cpp.std == std
+
+
+def test_cpp_std_rejects_nonsense(tmp_path: Path) -> None:
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstd = "banana"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[cpp\]\.std 'banana'"):
+        read_config(tmp_path)
+
+
+def test_cpp_std_non_string_rejected(tmp_path: Path) -> None:
+    toml = _CPP_BASE_TOML + "\n[cpp]\nstd = 20\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[cpp\]\.std must be a string"):
+        read_config(tmp_path)
+
+
+def test_cpp_stdlib_rejects_nonsense(tmp_path: Path) -> None:
+    # libc++ is deferred (spec §9 ledger #2): not yet a valid value, so it is
+    # rejected rather than silently ignored.
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstdlib = "libc++"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[cpp\]\.stdlib 'libc\+\+'"):
+        read_config(tmp_path)
+
+
+def test_cpp_stdlib_non_string_rejected(tmp_path: Path) -> None:
+    toml = _CPP_BASE_TOML + "\n[cpp]\nstdlib = true\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[cpp\]\.stdlib must be a string"):
+        read_config(tmp_path)
+
+
+def test_warns_unrecognized_cpp_key(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstd = "c++20"\nabi = 1\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    read_config(tmp_path)
+    assert "unrecognized key 'abi' in [cpp]" in capsys.readouterr().err
+
+
+def test_cpp_block_not_flagged_as_unrecognized_section(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    toml = _CPP_BASE_TOML + '\n[cpp]\nstd = "c++20"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    read_config(tmp_path)
+    assert "unrecognized section [cpp]" not in capsys.readouterr().err

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -69,9 +69,9 @@ class TestPromptChoice:
 
 
 class TestPromptLanguage:
-    # Languages are listed sorted: go, java, python, ruby, rust (so index 3 is python).
+    # Languages are listed sorted: cpp, go, java, python, ruby, rust (index 4 is python).
     def test_selects_language(self) -> None:
-        with patch("builtins.input", return_value="3"):
+        with patch("builtins.input", return_value="4"):
             assert prompt_language() == "python"
 
     def test_none_of_the_above_returns_empty(self) -> None:
@@ -790,13 +790,14 @@ class TestStepGenerateConfig:
         ctx.work_dir = tmp_path
 
         # Indices are alphabetical within each sorted enum:
-        # repository-type: 5=tooling, primary-language: 3=python,
+        # repository-type: 5=tooling; primary-language: 4=python — sorted order
+        # is cpp, go, java, python, ruby, rust;
         # branching-model: 3=library-release, versioning-scheme: 4=semver,
         # release-model: 4=tagged-release
         inputs = iter(
             [
                 "5",  # repository-type: tooling
-                "3",  # primary-language: python
+                "4",  # primary-language: python
                 "3",  # branching-model: library-release
                 "4",  # versioning-scheme: semver
                 "4",  # release-model: tagged-release


### PR DESCRIPTION
# Pull Request

## Summary

- Add cpp to the primary-language enum and parse a validated [cpp] block (std, stdlib) with v1-pin defaults, implementing epic vergil-project/.github#207 task T4.

## Issue Linkage

- Closes #2553

## Notes

- std accepts c++17/c++20/c++23; stdlib accepts only libstdc++ (libc++ is on the spec deferral ledger and is rejected, not silently ignored). Defaults are c++20 / libstdc++ when the block is absent. Also updates repo-init menu-index tests since adding cpp shifts the alphabetical language ordering (python 3 to 4). Validated green via vrg-container-run -- vrg-validate (4499 tests, 100% coverage).