### PR TITLE
feat(languages): C++ registry entry (clang/gcc)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ constraint-dependencies = ["msgpack>=1.2.1"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-vergil_tooling = ["data/*.json", "data/*.md", "data/*.sh", "data/licenses/*.txt", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml"]
+vergil_tooling = ["data/*.json", "data/*.md", "data/*.sh", "data/licenses/*.txt", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml", "configs/cpp/.clang-format", "configs/cpp/.clang-tidy", "configs/cpp/*.txt", "configs/cpp/*.cfg"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/vergil_tooling/bin/vrg_validate.py
+++ b/src/vergil_tooling/bin/vrg_validate.py
@@ -88,7 +88,14 @@ def _command_stage(label: str, cmds: list[list[str]], *, mode: StageMode) -> Sta
     return Stage(label, fn, mode=mode)
 
 
-def _build_stages(check: str | None, language: str | None, repo_root: Path) -> list[Stage]:
+def _build_stages(
+    check: str | None,
+    language: str | None,
+    repo_root: Path,
+    *,
+    cpp_std: str | None = None,
+    cpp_stdlib: str | None = None,
+) -> list[Stage]:
     stages: list[Stage] = []
 
     if check in (None, "common"):
@@ -103,10 +110,15 @@ def _build_stages(check: str | None, language: str | None, repo_root: Path) -> l
 
     if language is not None and check != "common":
         kinds = [kind for kind in _LANGUAGE_CHECK_ORDER if check is None or check == kind.value]
-        kind_cmds = [(kind, language_commands(language, kind)) for kind in kinds]
+        kind_cmds = [
+            (kind, language_commands(language, kind, cpp_std=cpp_std, cpp_stdlib=cpp_stdlib))
+            for kind in kinds
+        ]
         kind_cmds = [(kind, cmds) for kind, cmds in kind_cmds if cmds]
         if kind_cmds:
-            install_cmds = language_commands(language, CheckKind.INSTALL)
+            install_cmds = language_commands(
+                language, CheckKind.INSTALL, cpp_std=cpp_std, cpp_stdlib=cpp_stdlib
+            )
             if install_cmds:
                 stages.append(_command_stage("install", install_cmds, mode="fail_fast"))
             stages.extend(
@@ -162,16 +174,20 @@ def main(argv: list[str] | None = None) -> int:
 
     repo_root = git.repo_root()
 
+    cpp_std: str | None = None
+    cpp_stdlib: str | None = None
     try:
         vergil_config = config.read_config(repo_root)
         language = vergil_config.project.primary_language
+        cpp_std = vergil_config.cpp.std
+        cpp_stdlib = vergil_config.cpp.stdlib
     except FileNotFoundError:
         language = None
     except config.ConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    stages = _build_stages(args.check, language, repo_root)
+    stages = _build_stages(args.check, language, repo_root, cpp_std=cpp_std, cpp_stdlib=cpp_stdlib)
     if not stages:
         print(f"No {args.check} commands for language '{language or '<not set>'}'")
         return 0

--- a/src/vergil_tooling/configs/cpp/.clang-format
+++ b/src/vergil_tooling/configs/cpp/.clang-format
@@ -1,0 +1,24 @@
+# Packaged clang-format style for Vergil C++ repos
+# (epic vergil-project/.github#207, T5). Consumed via
+# `clang-format --style=file:{configs}/cpp/.clang-format`. The C++ standards
+# docs (T9) describe the house style this encodes.
+---
+Language: Cpp
+BasedOnStyle: LLVM
+Standard: c++20
+ColumnLimit: 100
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+PointerAlignment: Left
+DerivePointerAlignment: false
+AccessModifierOffset: -4
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Attach
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+IncludeBlocks: Regroup
+SortIncludes: CaseSensitive
+SpaceAfterCStyleCast: true
+...

--- a/src/vergil_tooling/configs/cpp/.clang-tidy
+++ b/src/vergil_tooling/configs/cpp/.clang-tidy
@@ -1,0 +1,27 @@
+# Packaged clang-tidy config for Vergil C++ repos
+# (epic vergil-project/.github#207, T5). Consumed via
+# `run-clang-tidy -p build -config-file={configs}/cpp/.clang-tidy`.
+#
+# WarningsAsErrors: '*' makes the LINT stage fail on any enabled diagnostic —
+# the "no standing suppression list" house rule applied to static analysis.
+# The check set is a curated, portable baseline (bugprone / performance /
+# portability / modernize / readability, minus noisy or opinionated checks);
+# the C++ standards docs (T9) describe the rationale.
+---
+Checks: >
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  portability-*,
+  modernize-*,
+  readability-*,
+  cppcoreguidelines-*,
+  -modernize-use-trailing-return-type,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+FormatStyle: file
+...

--- a/src/vergil_tooling/configs/cpp/cppcheck-suppressions.txt
+++ b/src/vergil_tooling/configs/cpp/cppcheck-suppressions.txt
@@ -1,0 +1,18 @@
+# Packaged cppcheck suppressions for Vergil C++ repos
+# (epic vergil-project/.github#207, T5). Consumed via
+# `cppcheck --enable=all --suppressions-list={configs}/cpp/cppcheck-suppressions.txt`.
+#
+# `--enable=all` turns on categories (information, missingInclude) that report
+# environmental noise rather than defects. These suppressions silence exactly
+# that noise so the gate flags real findings — they are NOT a standing
+# defect-suppression list (per-finding suppressions belong inline via
+# `--inline-suppr`).
+#
+# System headers cppcheck cannot resolve (deps live in the Conan cache, not on
+# cppcheck's include path).
+missingIncludeSystem
+# `--enable=all` implies checks whose config is absent in a bare invocation.
+unmatchedSuppression
+checkersReport
+# cppcheck cannot see across the CMake/Conan boundary for every TU.
+missingInclude

--- a/src/vergil_tooling/configs/cpp/gcovr.cfg
+++ b/src/vergil_tooling/configs/cpp/gcovr.cfg
@@ -1,0 +1,16 @@
+# Packaged gcovr config for Vergil C++ repos
+# (epic vergil-project/.github#207, T5). Consumed via
+# `gcovr --config {configs}/cpp/gcovr.cfg --fail-under-line 100`.
+#
+# The 100%-per-compiler line gate itself is passed on the command line
+# (--fail-under-line 100) so it stays visible in the registry command; this
+# file carries the non-compiler-specific search/filter settings. The gcov
+# executable is compiler-specific (gcov on GCC, `llvm-cov gcov` on Clang) and
+# is supplied by the container image's environment, not pinned here.
+root = .
+filter = src/
+exclude = .*/build.*/.*
+exclude = .*/tests?/.*
+exclude-unreachable-branches = yes
+exclude-throw-branches = yes
+print-summary = yes

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -131,6 +131,77 @@ _MAVEN_LICENSES_ALLOWLIST = "|".join(
     ]
 )
 
+# C++ license allowlist (epic vergil-project/.github#207 §4). C++/Conan has no
+# turnkey allowlist-enforcing gate the way pip-licenses / go-licenses do, so v1
+# license checking is *best-effort surfacing* (see the AUDIT commands below) and
+# hardened gating is deferred (spec §9 ledger #7). This constant is the reviewed
+# allowlist that the C++ standards docs (T9) reference and that a future hardened
+# gate will enforce; keeping it here alongside the other language allowlists
+# keeps the single-source-of-truth contract intact.
+_CPP_LICENSES_ALLOWLIST = ";".join(
+    [
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "BSL-1.0",
+        "ISC",
+        "MIT",
+        "MPL-2.0",
+        "Unlicense",
+        "Zlib",
+    ]
+)
+
+# -- C++ warning set (epic vergil-project/.github#207 §3.2, owned by T5) -------
+#
+# "Warnings to 11" resolved to a concrete, reviewable list. The floor is
+# ``-Wall -Wextra -Werror -Wpedantic``; the curated extras below extend it.
+#
+# **One portable set, on purpose.** TYPECHECK is a per-compiler×version stage,
+# but ``language_commands`` is version-agnostic — the *same* argv runs inside
+# every ``clang-*`` and ``gcc-*`` image, and the two-diagnostics win comes from
+# the two *compilers* interpreting these flags, not from two flag lists. Under
+# ``-Werror`` an option only one compiler recognizes is itself a hard error
+# (GCC rejects an unknown ``-W`` outright; Clang's ``-Werror`` promotes
+# ``-Wunknown-warning-option``), so every flag here is one **both** current
+# GCC (>=13) and Clang (>=18) accept. Compiler-exclusive gems (GCC's
+# ``-Wlogical-op`` / ``-Wduplicated-cond``, etc.) are therefore deliberately
+# out of the v1 set; adding a compiler-branched TYPECHECK command is a separate
+# change (would need the registry to gain a compiler dimension) and is noted for
+# the deferral ledger, not smuggled in here. T9 *documents* this set; it does
+# not re-choose it.
+_CPP_WARNING_FLAGS = [
+    # floor (spec §3.2)
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-Wpedantic",
+    # curated extras (spec §3.2 candidate baseline + closely-related companions)
+    "-Wshadow",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wcast-qual",
+    "-Wold-style-cast",
+    "-Wnon-virtual-dtor",
+    "-Woverloaded-virtual",
+    "-Wdouble-promotion",
+    "-Wformat=2",
+    "-Wimplicit-fallthrough",
+    "-Wnull-dereference",
+]
+# The warning flags are threaded into the build as one ``CMAKE_CXX_FLAGS`` cache
+# value (a single space-joined string), so the whole set lands on every
+# translation unit's compile line.
+_CPP_WARNINGS_CXX_FLAGS = " ".join(_CPP_WARNING_FLAGS)
+
+# CMake build directories. INSTALL configures ``build`` (its
+# ``compile_commands.json`` feeds the LINT clang-tidy pass); TYPECHECK reuses it
+# for the warnings build; TEST does its ASan/UBSan build out-of-tree in
+# ``build-sanitize`` so the sanitizer instrumentation never shares object files
+# with the coverage build (spec §4: "the instrumentations do not share a build").
+_CPP_BUILD_DIR = "build"
+_CPP_SANITIZE_BUILD_DIR = "build-sanitize"
+
 # -- Registry -----------------------------------------------------------------
 
 _REGISTRY: dict[str, Language] = {
@@ -262,6 +333,148 @@ _REGISTRY: dict[str, Language] = {
             publish_env_var="CRATES_IO_TOKEN",
         ),
     ),
+    # C++ (epic vergil-project/.github#207, T5). CMake + Conan 2; two co-equal
+    # open-source compilers (Clang primary, GCC secondary) run as independent
+    # diagnostic engines on the containerized multi-version model.
+    #
+    # **Cache-var contract.** vergil-tooling passes *intent* as CMake cache vars
+    # and the consuming project's ``CMakeLists.txt`` translates them
+    # per-compiler (this keeps every command portable across both families —
+    # e.g. libc++'s ``-stdlib`` is Clang-only, so it must not be a raw flag
+    # here):
+    #   ``VERGIL_CPP_STD``      — the ``[cpp].std`` value (e.g. ``c++20``)
+    #   ``VERGIL_CPP_STDLIB``   — the ``[cpp].stdlib`` value (e.g. ``libstdc++``)
+    #   ``VERGIL_CPP_COVERAGE`` — ``ON`` selects coverage instrumentation
+    #   ``VERGIL_CPP_SANITIZE`` — sanitizer list (``address,undefined``)
+    # ``{std}`` / ``{stdlib}`` are expanded by ``language_commands`` from the
+    # parsed ``[cpp]`` block (defaulting to the v1 pins ``c++20`` / ``libstdc++``).
+    "cpp": Language(
+        name="cpp",
+        checks={
+            CheckKind.INSTALL: [
+                ["conan", "install", ".", "--build=missing"],
+                [
+                    "cmake",
+                    "-S",
+                    ".",
+                    "-B",
+                    _CPP_BUILD_DIR,
+                    "-DCMAKE_BUILD_TYPE=Debug",
+                    "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                    "-DVERGIL_CPP_STD={std}",
+                    "-DVERGIL_CPP_STDLIB={stdlib}",
+                ],
+            ],
+            # LINT runs *once* on the primary Clang image (§3.6). No shell is
+            # available (commands exec directly), so each tool self-discovers:
+            # cppcheck walks ``.``; run-clang-tidy reads the compile DB; only
+            # clang-format needs a file list, so it uses an explicit ``sh -c``
+            # find/xargs driver.
+            CheckKind.LINT: [
+                [
+                    "sh",
+                    "-c",
+                    "find . -path ./build -prune -o -path ./build-sanitize -prune -o "
+                    '-type f \\( -name "*.cpp" -o -name "*.cxx" -o -name "*.cc" '
+                    '-o -name "*.hpp" -o -name "*.hxx" -o -name "*.hh" '
+                    '-o -name "*.h" \\) -print0 '
+                    "| xargs -0 -r clang-format --dry-run --Werror "
+                    "--style=file:{configs}/cpp/.clang-format",
+                ],
+                [
+                    "run-clang-tidy",
+                    "-p",
+                    _CPP_BUILD_DIR,
+                    "-quiet",
+                    "-config-file={configs}/cpp/.clang-tidy",
+                ],
+                [
+                    "cppcheck",
+                    "--enable=all",
+                    "--error-exitcode=1",
+                    "--inline-suppr",
+                    "--std={std}",
+                    "--suppressions-list={configs}/cpp/cppcheck-suppressions.txt",
+                    ".",
+                ],
+            ],
+            # TYPECHECK is "the compiler" — the warnings-to-11 build, per
+            # compiler×version. The curated warning set (§3.2) lives here, on
+            # the configure line, as one CMAKE_CXX_FLAGS cache value.
+            CheckKind.TYPECHECK: [
+                [
+                    "cmake",
+                    "-S",
+                    ".",
+                    "-B",
+                    _CPP_BUILD_DIR,
+                    "-DCMAKE_BUILD_TYPE=Debug",
+                    "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                    "-DVERGIL_CPP_STD={std}",
+                    "-DVERGIL_CPP_STDLIB={stdlib}",
+                    f"-DCMAKE_CXX_FLAGS={_CPP_WARNINGS_CXX_FLAGS}",
+                ],
+                ["cmake", "--build", _CPP_BUILD_DIR, "--parallel"],
+            ],
+            # TEST is per compiler×version: a coverage-instrumented build+run
+            # held to 100% line via gcovr (image sets the gcov executable —
+            # ``gcov`` on GCC, ``llvm-cov gcov`` on Clang), then a *separate*
+            # ASan+UBSan build+run (distinct build dir — the instrumentations
+            # do not share a build, §4).
+            CheckKind.TEST: [
+                [
+                    "cmake",
+                    "-S",
+                    ".",
+                    "-B",
+                    _CPP_BUILD_DIR,
+                    "-DCMAKE_BUILD_TYPE=Debug",
+                    "-DVERGIL_CPP_STD={std}",
+                    "-DVERGIL_CPP_STDLIB={stdlib}",
+                    "-DVERGIL_CPP_COVERAGE=ON",
+                ],
+                ["cmake", "--build", _CPP_BUILD_DIR, "--parallel"],
+                ["ctest", "--test-dir", _CPP_BUILD_DIR, "--output-on-failure"],
+                ["gcovr", "--config", "{configs}/cpp/gcovr.cfg", "--fail-under-line", "100"],
+                [
+                    "cmake",
+                    "-S",
+                    ".",
+                    "-B",
+                    _CPP_SANITIZE_BUILD_DIR,
+                    "-DCMAKE_BUILD_TYPE=Debug",
+                    "-DVERGIL_CPP_STD={std}",
+                    "-DVERGIL_CPP_STDLIB={stdlib}",
+                    "-DVERGIL_CPP_SANITIZE=address,undefined",
+                ],
+                ["cmake", "--build", _CPP_SANITIZE_BUILD_DIR, "--parallel"],
+                ["ctest", "--test-dir", _CPP_SANITIZE_BUILD_DIR, "--output-on-failure"],
+            ],
+            # AUDIT runs *once* (§3.6). ``conan audit`` scans the dependency
+            # graph for CVEs; its provider/token setup is verified live in T11
+            # (spec §4 acceptance), and if it cannot be shown to *detect* a
+            # known-vulnerable pin the objective trigger is to switch to the
+            # OSV-Scanner-over-``conan.lock`` contingency. License checking is
+            # best-effort surfacing in v1 (no turnkey Conan allowlist gate);
+            # hardened gating against ``_CPP_LICENSES_ALLOWLIST`` is ledger #7.
+            CheckKind.AUDIT: [
+                ["conan", "audit", "scan", "."],
+                ["conan", "graph", "info", ".", "--format=json"],
+            ],
+        },
+        ecosystem=EcosystemInfo(
+            build_cmd=["cmake", "--build", _CPP_BUILD_DIR],
+            publish_cmd=None,
+            publish_env_var=None,
+        ),
+        # LINT + AUDIT are compiler-agnostic → one gate each (§3.6). TYPECHECK
+        # and TEST are the two-diagnostics engine → per compiler×version, which
+        # is the PER_VERSION default, so they are intentionally omitted here.
+        cardinality={
+            CheckKind.LINT: Cardinality.ONCE,
+            CheckKind.AUDIT: Cardinality.ONCE,
+        },
+    ),
 }
 
 
@@ -277,24 +490,47 @@ def ecosystem_metadata(language: str) -> EcosystemInfo:
     return entry.ecosystem
 
 
-def language_commands(language: str | None, kind: CheckKind) -> list[list[str]]:
+def language_commands(
+    language: str | None,
+    kind: CheckKind,
+    *,
+    cpp_std: str | None = None,
+    cpp_stdlib: str | None = None,
+) -> list[list[str]]:
     """Return the canonical commands for a language and check kind.
 
     Returns an empty list if the language is not in the registry or
     has no entry for the given check kind.
 
-    Any argument containing ``{configs}`` is expanded to the resolved
-    path of the ``vergil_tooling.configs`` package directory.
+    Placeholder expansion applied to every argument:
+
+    - ``{configs}`` → the resolved ``vergil_tooling.configs`` package dir.
+    - ``{std}`` / ``{stdlib}`` → the C++ ``[cpp]`` ``std`` / ``stdlib`` values,
+      threaded into the CMake cache vars. ``cpp_std`` / ``cpp_stdlib`` default to
+      the v1 pins (``config.DEFAULT_CPP_STD`` / ``DEFAULT_CPP_STDLIB``) when not
+      supplied, so the two-argument call still yields fully-resolved argv.
     """
     if language is None:
         return []
     entry = _REGISTRY.get(language)
     if entry is None:
         return []
-    configs_dir = str(files("vergil_tooling.configs"))
-    return [
-        [arg.replace("{configs}", configs_dir) for arg in cmd] for cmd in entry.checks.get(kind, [])
-    ]
+    # Local import keeps this module a leaf in the import graph (the same
+    # cycle-avoidance idiom used by github_config/repo_init for languages).
+    from vergil_tooling.lib.config import DEFAULT_CPP_STD, DEFAULT_CPP_STDLIB
+
+    replacements = {
+        "{configs}": str(files("vergil_tooling.configs")),
+        "{std}": cpp_std if cpp_std is not None else DEFAULT_CPP_STD,
+        "{stdlib}": cpp_stdlib if cpp_stdlib is not None else DEFAULT_CPP_STDLIB,
+    }
+
+    def _expand(arg: str) -> str:
+        for token, value in replacements.items():
+            arg = arg.replace(token, value)
+        return arg
+
+    return [[_expand(arg) for arg in cmd] for cmd in entry.checks.get(kind, [])]
 
 
 def check_cardinality(language: str | None, kind: CheckKind) -> Cardinality:

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -272,6 +272,143 @@ def test_rust_audit_commands() -> None:
     assert "cargo deny check" in joined
 
 
+# -- C++ (epic vergil-project/.github#207, T5) --------------------------------
+
+
+def test_cpp_is_supported() -> None:
+    assert "cpp" in supported_languages()
+
+
+def test_cpp_install_commands() -> None:
+    joined = _joined(language_commands("cpp", CheckKind.INSTALL))
+    assert "conan install . --build=missing" in joined
+    # cmake configure exports the compile DB that feeds clang-tidy and threads
+    # the [cpp] std/stdlib in as cache vars.
+    cmake_cmd = [c for c in language_commands("cpp", CheckKind.INSTALL) if c[0] == "cmake"]
+    assert len(cmake_cmd) == 1
+    assert "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" in cmake_cmd[0]
+    assert "-DVERGIL_CPP_STD=c++20" in cmake_cmd[0]
+    assert "-DVERGIL_CPP_STDLIB=libstdc++" in cmake_cmd[0]
+
+
+def test_cpp_lint_commands() -> None:
+    cmds = language_commands("cpp", CheckKind.LINT)
+    joined = _joined(cmds)
+    assert any("clang-format" in c and "--dry-run --Werror" in c for c in joined)
+    assert any("run-clang-tidy" in c for c in joined)
+    assert any(
+        "cppcheck" in c and "--enable=all" in c and "--error-exitcode=1" in c for c in joined
+    )
+
+
+def test_cpp_lint_uses_packaged_configs() -> None:
+    """Every LINT tool points at a packaged {configs}/cpp/* file that exists."""
+    cmds = language_commands("cpp", CheckKind.LINT)
+    flat = [arg for cmd in cmds for arg in cmd]
+    # No unresolved placeholder survives expansion.
+    assert all("{configs}" not in arg for arg in flat)
+    # clang-format, clang-tidy and cppcheck each reference a real packaged file.
+    referenced = [arg for arg in flat if "/cpp/" in arg]
+    for arg in referenced:
+        # Extract the path token (may be embedded in a --flag=path or sh script).
+        for token in arg.split():
+            if "/cpp/" in token:
+                path = token.split("=", 1)[-1].split(":")[-1]
+                assert Path(path).exists(), f"packaged config missing: {path}"
+
+
+def test_cpp_typecheck_is_the_warnings_build() -> None:
+    cmds = language_commands("cpp", CheckKind.TYPECHECK)
+    joined = _joined(cmds)
+    # A configure carrying the warning flags, then a build.
+    assert any(c.startswith("cmake -S . -B build") for c in joined)
+    assert any("cmake --build build" in c for c in joined)
+
+
+def test_cpp_typecheck_carries_curated_warning_set() -> None:
+    """The floor + curated extras all land on one CMAKE_CXX_FLAGS cache value."""
+    cmds = language_commands("cpp", CheckKind.TYPECHECK)
+    cxx_flags = [arg for cmd in cmds for arg in cmd if arg.startswith("-DCMAKE_CXX_FLAGS=")]
+    assert len(cxx_flags) == 1
+    flags = cxx_flags[0].split("=", 1)[1].split()
+    # Floor (spec §3.2).
+    for floor in ("-Wall", "-Wextra", "-Werror", "-Wpedantic"):
+        assert floor in flags, f"missing floor flag {floor}"
+    # Curated extras owned + tested by this task (T5); T9 only documents them.
+    for extra in (
+        "-Wshadow",
+        "-Wconversion",
+        "-Wsign-conversion",
+        "-Wcast-qual",
+        "-Wold-style-cast",
+        "-Wnon-virtual-dtor",
+        "-Woverloaded-virtual",
+        "-Wdouble-promotion",
+        "-Wformat=2",
+        "-Wimplicit-fallthrough",
+        "-Wnull-dereference",
+    ):
+        assert extra in flags, f"missing curated extra {extra}"
+
+
+def test_cpp_test_commands_coverage_ctest_and_sanitizers() -> None:
+    cmds = language_commands("cpp", CheckKind.TEST)
+    joined = _joined(cmds)
+    # CTest as the framework-agnostic runner.
+    assert any(c.startswith("ctest") and "--output-on-failure" in c for c in joined)
+    # Coverage held to 100% line via gcovr.
+    assert any("gcovr" in c and "--fail-under-line 100" in c for c in joined)
+    # A separate ASan+UBSan build+run in its own build dir.
+    assert any("-DVERGIL_CPP_SANITIZE=address,undefined" in c for c in joined)
+    assert any("cmake --build build-sanitize" in c for c in joined)
+    assert any("ctest --test-dir build-sanitize" in c for c in joined)
+
+
+def test_cpp_audit_commands() -> None:
+    joined = _joined(language_commands("cpp", CheckKind.AUDIT))
+    # conan audit is the CVE scan (provider verified live in T11, spec §4).
+    assert any("conan audit" in c for c in joined)
+    # Best-effort license-metadata surfacing (hardened gating deferred, §9 #7).
+    assert any("conan graph info" in c for c in joined)
+
+
+def test_cpp_ecosystem_metadata() -> None:
+    info = ecosystem_metadata("cpp")
+    assert info.build_cmd == ["cmake", "--build", "build"]
+    # C++ has no v1 publish target (non-goal §8).
+    assert info.publish_cmd is None
+    assert info.publish_env_var is None
+
+
+def test_cpp_cardinality_lint_and_audit_run_once() -> None:
+    assert check_cardinality("cpp", CheckKind.LINT) is Cardinality.ONCE
+    assert check_cardinality("cpp", CheckKind.AUDIT) is Cardinality.ONCE
+
+
+def test_cpp_cardinality_typecheck_and_test_are_per_version() -> None:
+    assert check_cardinality("cpp", CheckKind.TYPECHECK) is Cardinality.PER_VERSION
+    assert check_cardinality("cpp", CheckKind.TEST) is Cardinality.PER_VERSION
+
+
+def test_cpp_std_stdlib_default_to_v1_pins() -> None:
+    """The two-argument call resolves {std}/{stdlib} to the v1 pins."""
+    for kind in (CheckKind.INSTALL, CheckKind.TYPECHECK, CheckKind.TEST, CheckKind.LINT):
+        for cmd in language_commands("cpp", kind):
+            for arg in cmd:
+                assert "{std}" not in arg and "{stdlib}" not in arg
+
+
+def test_cpp_std_stdlib_are_threaded_from_config() -> None:
+    """An explicit [cpp] std/stdlib overrides the pins in the cache vars."""
+    cmds = language_commands("cpp", CheckKind.INSTALL, cpp_std="c++17", cpp_stdlib="libstdc++")
+    cmake_cmd = [c for c in cmds if c[0] == "cmake"][0]
+    assert "-DVERGIL_CPP_STD=c++17" in cmake_cmd
+    # cppcheck --std is threaded too.
+    lint = language_commands("cpp", CheckKind.LINT, cpp_std="c++17")
+    cppcheck_cmd = [c for c in lint if c[0] == "cppcheck"][0]
+    assert "--std=c++17" in cppcheck_cmd
+
+
 # -- Edge cases ---------------------------------------------------------------
 
 
@@ -312,9 +449,9 @@ def test_configs_placeholder_resolves_to_existing_directory() -> None:
 # -- New API ------------------------------------------------------------------
 
 
-def test_supported_languages_returns_five() -> None:
+def test_supported_languages_includes_cpp() -> None:
     langs = supported_languages()
-    assert langs == frozenset({"python", "go", "java", "ruby", "rust"})
+    assert langs == frozenset({"python", "go", "java", "ruby", "rust", "cpp"})
 
 
 def test_supported_languages_is_frozen() -> None:
@@ -357,13 +494,15 @@ def test_language_commands_still_works_for_unknown() -> None:
 # -- Check cardinality --------------------------------------------------------
 
 
-def test_existing_languages_default_to_per_version_cardinality() -> None:
-    """Every existing language defaults to per-version for every check kind.
+def test_single_image_languages_default_to_per_version_cardinality() -> None:
+    """Every single-image language defaults to per-version for every check kind.
 
     This backward-compatibility guarantee is what keeps their generated CI
-    gates byte-identical after the cardinality concept was introduced.
+    gates byte-identical after the cardinality concept was introduced. C++ is
+    the one matrix language that legitimately declares ONCE kinds, so it is
+    excluded here and covered by the C++-specific cardinality tests.
     """
-    for lang in supported_languages():
+    for lang in supported_languages() - {"cpp"}:
         for kind in CheckKind:
             assert check_cardinality(lang, kind) is Cardinality.PER_VERSION
 

--- a/tests/vergil_tooling/test_vrg_validate.py
+++ b/tests/vergil_tooling/test_vrg_validate.py
@@ -58,7 +58,7 @@ def test_build_stages_full_run_order() -> None:
         patch(_MOD + ".language_commands") as m_cmds,
         patch(_MOD + "._find_custom_validator", return_value=None),
     ):
-        m_cmds.side_effect = lambda lang, kind: [["echo", kind.value]]
+        m_cmds.side_effect = lambda lang, kind, **_kw: [["echo", kind.value]]
         stages = _build_stages(None, "python", Path("/tmp/r"))  # noqa: S108
     assert [s.name for s in stages] == [
         "common",
@@ -77,7 +77,7 @@ def test_build_stages_full_run_includes_custom() -> None:
         patch(_MOD + ".language_commands") as m_cmds,
         patch(_MOD + "._find_custom_validator", return_value="/path/to/custom"),
     ):
-        m_cmds.side_effect = lambda lang, kind: [["echo", kind.value]]
+        m_cmds.side_effect = lambda lang, kind, **_kw: [["echo", kind.value]]
         stages = _build_stages(None, "python", Path("/tmp/r"))  # noqa: S108
     assert stages[-1].name == "custom"
     assert stages[-1].mode == "fail_defer"
@@ -90,14 +90,14 @@ def test_build_stages_check_common_only() -> None:
 
 def test_build_stages_check_lint_runs_install_then_lint() -> None:
     with patch(_MOD + ".language_commands") as m_cmds:
-        m_cmds.side_effect = lambda lang, kind: [["echo", kind.value]]
+        m_cmds.side_effect = lambda lang, kind, **_kw: [["echo", kind.value]]
         stages = _build_stages("lint", "python", Path("/tmp/r"))  # noqa: S108
     assert [s.name for s in stages] == ["install", "lint"]
     assert stages[0].mode == "fail_fast"
 
 
 def test_build_stages_check_lint_no_install_commands() -> None:
-    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+    def mock_lang_cmds(lang: str, kind: CheckKind, **_kwargs: object) -> list[list[str]]:
         if kind == CheckKind.INSTALL:
             return []
         if kind == CheckKind.LINT:
@@ -197,7 +197,7 @@ def test_run_all_executes_stages_in_order(tmp_path: Path) -> None:
         order.append(cmd[-1])
         return 0
 
-    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+    def mock_lang_cmds(lang: str, kind: CheckKind, **_kwargs: object) -> list[list[str]]:
         return [["echo", kind.value]]
 
     with (
@@ -233,7 +233,7 @@ def test_run_all_language_failure_does_not_stop_later_checks(tmp_path: Path) -> 
     _write_config(tmp_path, "python")
     ran: list[str] = []
 
-    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+    def mock_lang_cmds(lang: str, kind: CheckKind, **_kwargs: object) -> list[list[str]]:
         return [["echo", kind.value]]
 
     def mock_run(cmd: list[str], *, check: bool = True) -> int:
@@ -258,7 +258,7 @@ def test_run_all_install_failure_stops_later_checks(tmp_path: Path) -> None:
     _write_config(tmp_path, "python")
     ran: list[str] = []
 
-    def mock_lang_cmds(lang: str, kind: CheckKind) -> list[list[str]]:
+    def mock_lang_cmds(lang: str, kind: CheckKind, **_kwargs: object) -> list[list[str]]:
         return [["echo", kind.value]]
 
     def mock_run(cmd: list[str], *, check: bool = True) -> int:


### PR DESCRIPTION
# Pull Request

## Summary

- Add the C++ Language entry to the languages registry — INSTALL/LINT/TYPECHECK/TEST/AUDIT commands, EcosystemInfo, per-kind cardinality (LINT+AUDIT once, TYPECHECK+TEST per-version), packaged clang-format/clang-tidy/cppcheck/gcovr configs, {std}/{stdlib} threading, and a C++ license allowlist — building on the merged T3 cardinality concept and T4 [cpp] schema (epic vergil-project/.github#207, T5).

## Issue Linkage

- Closes #2554

## Notes

- Owns and unit-tests the concrete curated warning set (floor -Wall -Wextra -Werror -Wpedantic plus -Wshadow -Wconversion -Wsign-conversion -Wcast-qual -Wold-style-cast -Wnon-virtual-dtor -Woverloaded-virtual -Wdouble-promotion -Wformat=2 -Wimplicit-fallthrough -Wnull-dereference); T9 documents it. One portable set on purpose: language_commands is version-agnostic so the same TYPECHECK argv runs in every clang-/gcc- image, and under -Werror a compiler-exclusive -W flag is itself a hard error, so every flag is one both current GCC and Clang accept (GCC-only gems deliberately deferred). Commands run shell-free via subprocess, so tools self-discover: cppcheck walks '.', run-clang-tidy reads the compile DB, clang-format uses an sh -c find/xargs driver. std/stdlib are passed as VERGIL_CPP_* CMake cache vars (not raw flags) so the consuming project translates them per-compiler; the sample project's CMakeLists in T11 provides that. conan audit scan and the best-effort conan graph info license surfacing are encoded as chosen; their exact provider/CLI is verified live in T11 (spec section 4) with the OSV-Scanner contingency if it cannot detect a known CVE. Full vrg-validate is green (4525 tests, 100% coverage). Two pre-existing sibling tests updated: the supported-languages set (now 6) and the per-version cardinality sweep (excludes cpp, which legitimately declares ONCE).