### PR TITLE
fix(github-config): support cpp for CodeQL + repo-init

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -228,6 +228,9 @@ _CODEQL_SUPPORTED_LANGUAGES = frozenset(
         "java",
         "ruby",
         "rust",
+        # cpp aligns this list with repo_init._CODEQL_LANGUAGES, which already
+        # lists cpp — the two must agree (epic vergil-project/.github#207 T7).
+        "cpp",
     }
 )
 

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -396,10 +396,39 @@ def render_gitignore() -> str:
     )
 
 
-def _container_suffix(language: str | None) -> str:
-    """Map primary language to dev container image suffix."""
+def _cpp_family_and_version(versions: list[str] | None) -> tuple[str, str] | None:
+    """Parse the primary cpp compiler family and version from ``[ci].versions``.
+
+    C++ carries its compiler family × version axis on ``[ci].versions`` as a
+    ``clang-``/``gcc-`` prefixed tag (e.g. ``clang-20``), per spec
+    vergil-project/.github#207 §6. The first entry is the representative
+    primary that drives the single top-level ``container-suffix``/
+    ``container-tag`` in generated CI. Returns ``(family, version)`` — e.g.
+    ``("clang", "20")`` — or ``None`` when the primary entry carries no
+    recognized prefix.
+    """
+    if not versions:
+        return None
+    primary = versions[0]
+    for family in ("clang", "gcc"):
+        prefix = f"{family}-"
+        if primary.startswith(prefix):
+            return family, primary[len(prefix) :]
+    return None
+
+
+def _container_suffix(language: str | None, versions: list[str] | None = None) -> str:
+    """Map primary language to dev container image suffix.
+
+    C++ is compiler-family-aware: the suffix resolves to ``cpp-clang`` /
+    ``cpp-gcc`` from the ``clang-``/``gcc-`` prefix on the primary
+    ``[ci].versions`` entry (vergil-project/.github#207 §6).
+    """
     if language is None:
         return "base"
+    if language == "cpp":
+        parsed = _cpp_family_and_version(versions)
+        return f"cpp-{parsed[0]}" if parsed else "base"
     suffix_map = {
         "python": "python",
         "go": "go",
@@ -429,7 +458,16 @@ def _cd_release_secrets(language: str | None) -> list[str]:
 
 
 def _container_tag(language: str | None, versions: list[str]) -> str:
-    """Derive the container tag from language and versions."""
+    """Derive the container tag from language and versions.
+
+    C++ tags carry only the numeric version — the compiler family rides the
+    image *suffix* (``cpp-clang`` / ``cpp-gcc``), so ``clang-20`` resolves to
+    ``prod-cpp-clang:20`` (vergil-project/.github#207 §6). The primary is the
+    first ``[ci].versions`` entry.
+    """
+    if language == "cpp":
+        parsed = _cpp_family_and_version(versions)
+        return parsed[1] if parsed else "latest"
     if language == "python" and versions:
         return versions[-1]
     return "latest"
@@ -460,7 +498,7 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
     # `language: {empty}` leaves a trailing space that fails yamllint
     # trailing-spaces (issue #1993).
     lang_line = f"      language: {lang_yaml}\n" if lang_yaml else "      language:\n"
-    suffix = _container_suffix(ctx.primary_language)
+    suffix = _container_suffix(ctx.primary_language, ctx.ci_versions)
     tag = _container_tag(ctx.primary_language, ctx.ci_versions)
     versions_json = json.dumps(ctx.ci_versions)
 
@@ -628,7 +666,7 @@ def render_cd_workflow(ctx: RepoInitContext) -> str:
         )
 
     if ctx.publish_release:
-        suffix = _container_suffix(ctx.primary_language)
+        suffix = _container_suffix(ctx.primary_language, ctx.ci_versions)
         tag = _container_tag(ctx.primary_language, ctx.ci_versions)
         lines.append("\n")
         lines.extend(
@@ -815,6 +853,11 @@ def _default_ci_versions(language: str | None) -> str:
         "java": "21",
         "ruby": "3.3",
         "rust": "stable",
+        # C++ carries the compiler family × version axis here as a
+        # ``clang-``/``gcc-`` prefixed tag (vergil-project/.github#207 §6); the
+        # default seeds a single primary Clang image, matching the primary
+        # major built in vergil-containers.
+        "cpp": "clang-20",
     }
     return defaults.get(language, "latest")
 

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -287,6 +287,16 @@ def test_ci_gates_codeql_for_supported_language() -> None:
     assert "CodeQL" in names
 
 
+def test_ci_gates_codeql_for_cpp() -> None:
+    # cpp is CodeQL-supported (epic vergil-project/.github#207 T7): the
+    # github_config list must stay aligned with repo_init._CODEQL_LANGUAGES,
+    # which already lists cpp.
+    r = desired_ci_gates_ruleset(_project(language="cpp"), _ci(versions=["clang-20"]), ghas=True)
+    names = _check_names(r)
+    assert "security / codeql" in names
+    assert "CodeQL" in names
+
+
 def test_ci_gates_no_codeql_without_language() -> None:
     r = desired_ci_gates_ruleset(_project(language=None), _ci(), ghas=True)
     names = _check_names(r)

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -15,6 +15,7 @@ from vergil_tooling.lib.repo_init import (
     _cd_release_secrets,
     _check_remote_steps,
     _container_suffix,
+    _container_tag,
     _default_ci_versions,
     _load_existing_config,
     _remote_branch_exists,
@@ -390,6 +391,18 @@ class TestRenderCiWorkflow:
         assert "ci-version-bump.yml@v2.1" in content
         assert "run-codeql: false" not in content
 
+    def test_cpp_workflow(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "cpp"
+        ctx.ci_versions = ["clang-20", "clang-19"]
+        ctx.release_model = "tagged-release"
+        content = render_ci_workflow(ctx)
+        # Compiler-family-aware suffix + numeric tag → prod-cpp-clang:20.
+        assert "container-suffix: cpp-clang" in content
+        assert "container-tag: '20'" in content
+        # cpp is CodeQL-supported, so run-codeql must NOT be disabled.
+        assert "run-codeql: false" not in content
+
     def test_no_language_workflow(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
         ctx.ci_versions = ["latest"]
@@ -487,6 +500,43 @@ class TestContainerHelpers:
 
     def test_default_ci_versions_none_returns_latest(self) -> None:
         assert _default_ci_versions(None) == "latest"
+
+    def test_container_suffix_cpp_clang(self) -> None:
+        # cpp is compiler-family-aware: the family rides the image suffix,
+        # parsed from the clang-/gcc- prefix on the primary [ci].versions entry
+        # (epic vergil-project/.github#207 §6).
+        assert _container_suffix("cpp", ["clang-20"]) == "cpp-clang"
+
+    def test_container_suffix_cpp_gcc(self) -> None:
+        assert _container_suffix("cpp", ["gcc-15"]) == "cpp-gcc"
+
+    def test_container_suffix_cpp_uses_first_entry_as_primary(self) -> None:
+        # A mixed-family matrix takes its representative top-level suffix from
+        # the first entry.
+        assert _container_suffix("cpp", ["gcc-15", "clang-20"]) == "cpp-gcc"
+
+    def test_container_suffix_cpp_unparseable_falls_back_to_base(self) -> None:
+        assert _container_suffix("cpp", ["latest"]) == "base"
+        assert _container_suffix("cpp", []) == "base"
+
+    def test_container_tag_cpp_is_numeric_version(self) -> None:
+        # The tag carries only the numeric version; family lives in the suffix,
+        # so clang-20 resolves to prod-cpp-clang:20.
+        assert _container_tag("cpp", ["clang-20"]) == "20"
+        assert _container_tag("cpp", ["gcc-15"]) == "15"
+
+    def test_container_tag_cpp_unparseable_falls_back_to_latest(self) -> None:
+        assert _container_tag("cpp", ["latest"]) == "latest"
+        assert _container_tag("cpp", []) == "latest"
+
+    def test_default_ci_versions_cpp_seeds_clang_primary(self) -> None:
+        # The cpp default must be a clang-/gcc- prefixed tag so the derived
+        # suffix/tag are family-aware; a bare "latest" would render a base image.
+        default = _default_ci_versions("cpp")
+        assert default == "clang-20"
+        versions = [v.strip() for v in default.split(",")]
+        assert _container_suffix("cpp", versions) == "cpp-clang"
+        assert _container_tag("cpp", versions) == "20"
 
 
 class TestRenderCdWorkflow:


### PR DESCRIPTION
# Pull Request

## Summary

- Add cpp to the CodeQL-supported languages so a cpp repo gets the CodeQL CI gate, and make repo-init container scaffolding compiler-family-aware (cpp-clang/cpp-gcc suffix + numeric tag) with a clang-20 default.

## Issue Linkage

- Closes #2556

## Notes

- T7 of epic vergil-project/.github#207. Two changes: (1) github_config._CODEQL_SUPPORTED_LANGUAGES gains cpp, aligning it with repo_init._CODEQL_LANGUAGES (already had cpp) and fixing the confirmed discrepancy. (2) repo_init._container_suffix/_container_tag parse the clang-/gcc- prefix on the primary [ci].versions entry into the family-aware suffix cpp-clang/cpp-gcc plus numeric tag (clang-20 -> prod-cpp-clang:20), per spec .github#207 section 6; _default_ci_versions seeds cpp with clang-20 so scaffolding renders a family-aware image instead of a bare base image. No _LANGUAGE_ACTION_PATTERNS entry was needed (vergil-actions cpp CI uses no marketplace actions beyond the base allowlist). Builds on merged T4; independent of T5. Validation green (4521 tests, 100% coverage).