### PR TITLE
feat(container): resolve C++ container images and detect cpp projects

### DIFF
--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -21,6 +21,10 @@ _DEFAULT_VERSIONS: dict[str, str] = {
     "go": "1.26",
     "rust": "1.93",
     "java": "21",
+    # C++ carries its compiler family on the version tag (spec
+    # vergil-project/.github#207 §6). The built-in default is the primary Clang
+    # image, so default_image("cpp") resolves to prod-cpp-clang:20.
+    "cpp": "clang-20",
 }
 
 _DEFAULT_PREFIX = "prod"
@@ -31,6 +35,12 @@ _DEFAULT_TEST_COMMANDS: dict[str, str] = {
     "go": "go test ./...",
     "rust": "cargo test",
     "java": "./mvnw verify",
+    "cpp": (
+        "conan install . --build=missing "
+        "&& cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug "
+        "&& cmake --build build --parallel "
+        "&& ctest --test-dir build --output-on-failure"
+    ),
 }
 
 
@@ -77,6 +87,13 @@ def detect_language(repo_root: Path) -> str:
         return "rust"
     if (repo_root / "pom.xml").is_file() or (repo_root / "mvnw").is_file():
         return "java"
+    # C++ is identified by the pair: a CMakeLists.txt AND a Conan manifest
+    # (spec vergil-project/.github#207 §3.3). Either marker alone is
+    # insufficient — CMake is used far beyond Conan-managed C++ projects.
+    if (repo_root / "CMakeLists.txt").is_file() and (
+        (repo_root / "conanfile.py").is_file() or (repo_root / "conanfile.txt").is_file()
+    ):
+        return "cpp"
     return ""
 
 
@@ -106,6 +123,20 @@ def default_image(
     if not default_version:
         return _fallback_image(prefix) if fallback else ""
     resolved = version or default_version
+    # C++ carries its compiler family on the version tag: `clang-20` resolves to
+    # `prod-cpp-clang:20` — the family rides the image *suffix*, only the numeric
+    # major is the tag (spec vergil-project/.github#207 §6, matching the images
+    # T1/T2 build in vergil-containers). A malformed tag (no clang-/gcc- prefix)
+    # must not build a `prod-cpp-:<ver>` image, so it falls back like an
+    # unknown language.
+    if lang == "cpp":
+        from vergil_tooling.lib.languages import parse_cpp_version_tag
+
+        parsed = parse_cpp_version_tag(resolved)
+        if parsed is None:
+            return _fallback_image(prefix) if fallback else ""
+        family, ver = parsed
+        return f"{_GHCR}/{prefix}-cpp-{family}:{ver}"
     return f"{_GHCR}/{prefix}-{lang}:{resolved}"
 
 

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -202,6 +202,31 @@ _CPP_WARNINGS_CXX_FLAGS = " ".join(_CPP_WARNING_FLAGS)
 _CPP_BUILD_DIR = "build"
 _CPP_SANITIZE_BUILD_DIR = "build-sanitize"
 
+# Recognized C++ compiler families, in declared-primary precedence order. The
+# `[ci].versions` tags carry the compiler family as a `<family>-<version>`
+# prefix (e.g. ``clang-20``), per spec vergil-project/.github#207 §6.
+_CPP_FAMILIES = ("clang", "gcc")
+
+
+def parse_cpp_version_tag(tag: str) -> tuple[str, str] | None:
+    """Split a C++ compiler-family version tag into ``(family, version)``.
+
+    C++ carries its compiler-family × version axis on ``[ci].versions`` as a
+    ``clang-``/``gcc-`` prefixed tag (e.g. ``clang-20`` → ``("clang", "20")``,
+    ``gcc-15`` → ``("gcc", "15")``), per spec vergil-project/.github#207 §6.
+    Returns ``None`` when *tag* carries no recognized family prefix.
+
+    This is the single source of truth for the tag format, shared by the
+    container image-resolution path (:mod:`container`) and the CI scaffolding
+    path (:mod:`repo_init`) so the two can never drift on the naming.
+    """
+    for family in _CPP_FAMILIES:
+        prefix = f"{family}-"
+        if tag.startswith(prefix):
+            return family, tag[len(prefix) :]
+    return None
+
+
 # -- Registry -----------------------------------------------------------------
 
 _REGISTRY: dict[str, Language] = {

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -406,15 +406,19 @@ def _cpp_family_and_version(versions: list[str] | None) -> tuple[str, str] | Non
     ``container-tag`` in generated CI. Returns ``(family, version)`` — e.g.
     ``("clang", "20")`` — or ``None`` when the primary entry carries no
     recognized prefix.
+
+    The tag parse itself is delegated to
+    :func:`languages.parse_cpp_version_tag` — the single source of truth shared
+    with the container image-resolution path so scaffolding and image naming
+    can never drift.
     """
+    # Local import keeps languages a leaf in the import graph (the same
+    # cycle-avoidance idiom already used for language_commands below).
+    from vergil_tooling.lib.languages import parse_cpp_version_tag
+
     if not versions:
         return None
-    primary = versions[0]
-    for family in ("clang", "gcc"):
-        prefix = f"{family}-"
-        if primary.startswith(prefix):
-            return family, primary[len(prefix) :]
-    return None
+    return parse_cpp_version_tag(versions[0])
 
 
 def _container_suffix(language: str | None, versions: list[str] | None = None) -> str:

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vergil_tooling.lib.container import (
+    _DEFAULT_TEST_COMMANDS,
+    _DEFAULT_VERSIONS,
     assert_docker_available,
     build_container_args,
     build_docker_args,
@@ -86,6 +88,31 @@ def test_detect_ruby_priority(tmp_path: Path) -> None:
     (tmp_path / "Gemfile").write_text("")
     (tmp_path / "pyproject.toml").write_text("")
     assert detect_language(tmp_path) == "ruby"
+
+
+def test_detect_cpp_conanfile_py(tmp_path: Path) -> None:
+    # C++ needs BOTH a CMakeLists.txt and a conanfile — the pair is the marker.
+    (tmp_path / "CMakeLists.txt").write_text("")
+    (tmp_path / "conanfile.py").write_text("")
+    assert detect_language(tmp_path) == "cpp"
+
+
+def test_detect_cpp_conanfile_txt(tmp_path: Path) -> None:
+    (tmp_path / "CMakeLists.txt").write_text("")
+    (tmp_path / "conanfile.txt").write_text("")
+    assert detect_language(tmp_path) == "cpp"
+
+
+def test_detect_cpp_requires_cmakelists(tmp_path: Path) -> None:
+    # A conanfile alone (no CMakeLists.txt) is not enough to claim cpp.
+    (tmp_path / "conanfile.py").write_text("")
+    assert detect_language(tmp_path) == ""
+
+
+def test_detect_cpp_requires_conanfile(tmp_path: Path) -> None:
+    # A CMakeLists.txt alone (no conanfile) is not enough to claim cpp.
+    (tmp_path / "CMakeLists.txt").write_text("")
+    assert detect_language(tmp_path) == ""
 
 
 # -- default_image ------------------------------------------------------------
@@ -190,6 +217,56 @@ def test_default_image_no_language_falls_back_despite_declared_version() -> None
 
 def test_default_image_no_language_no_fallback_ignores_version() -> None:
     assert default_image("", version="latest") == ""
+
+
+# -- cpp compiler-family image resolution -------------------------------------
+
+
+def test_default_image_cpp_uses_builtin_clang_default() -> None:
+    # _DEFAULT_VERSIONS["cpp"] is the primary Clang tag (clang-20), so the
+    # family rides the image suffix and the numeric major is the tag.
+    assert default_image("cpp") == "ghcr.io/vergil-project/prod-cpp-clang:20"
+
+
+def test_default_image_cpp_clang_declared_version() -> None:
+    assert default_image("cpp", version="clang-20") == "ghcr.io/vergil-project/prod-cpp-clang:20"
+
+
+def test_default_image_cpp_gcc_declared_version() -> None:
+    # gcc-15 → prod-cpp-gcc:15, matching the image names T1/T2 produce.
+    assert default_image("cpp", version="gcc-15") == "ghcr.io/vergil-project/prod-cpp-gcc:15"
+
+
+def test_default_image_cpp_respects_prefix() -> None:
+    assert default_image("cpp", prefix="dev", version="clang-20") == (
+        "ghcr.io/vergil-project/dev-cpp-clang:20"
+    )
+
+
+def test_default_image_cpp_unparseable_version_no_fallback() -> None:
+    # A malformed cpp version tag (no clang-/gcc- prefix) must not build a
+    # malformed prod-cpp-:<ver> image — it returns empty without fallback.
+    assert default_image("cpp", version="latest") == ""
+
+
+def test_default_image_cpp_unparseable_version_with_fallback() -> None:
+    assert default_image("cpp", version="latest", fallback=True) == (
+        "ghcr.io/vergil-project/prod-base:latest"
+    )
+
+
+def test_cpp_default_version_is_primary_clang() -> None:
+    # The built-in default drives default_image("cpp") when no [ci].versions
+    # is declared — it must be the primary Clang tag.
+    assert _DEFAULT_VERSIONS["cpp"] == "clang-20"
+
+
+def test_cpp_default_test_command_is_conan_cmake_ctest() -> None:
+    # vrg-container-test runs this via `bash -c`, so `&&` chaining is valid.
+    cmd = _DEFAULT_TEST_COMMANDS["cpp"]
+    assert "conan install" in cmd
+    assert "cmake" in cmd
+    assert "ctest" in cmd
 
 
 # -- workspace_mount_args -----------------------------------------------------

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -17,6 +17,7 @@ from vergil_tooling.lib.languages import (
     check_cardinality,
     ecosystem_metadata,
     language_commands,
+    parse_cpp_version_tag,
     supported_languages,
 )
 
@@ -539,3 +540,24 @@ def test_language_may_declare_once_cardinality() -> None:
 def test_cardinality_enum_values() -> None:
     assert Cardinality.PER_VERSION.value == "per-version"
     assert Cardinality.ONCE.value == "once"
+
+
+# -- parse_cpp_version_tag ----------------------------------------------------
+
+
+def test_parse_cpp_version_tag_clang() -> None:
+    assert parse_cpp_version_tag("clang-20") == ("clang", "20")
+
+
+def test_parse_cpp_version_tag_gcc() -> None:
+    assert parse_cpp_version_tag("gcc-15") == ("gcc", "15")
+
+
+def test_parse_cpp_version_tag_unrecognized_prefix_returns_none() -> None:
+    # A tag with no clang-/gcc- prefix carries no compiler family.
+    assert parse_cpp_version_tag("latest") is None
+    assert parse_cpp_version_tag("20") is None
+
+
+def test_parse_cpp_version_tag_empty_returns_none() -> None:
+    assert parse_cpp_version_tag("") is None


### PR DESCRIPTION
# Pull Request

## Summary

- Add C++ language detection (CMakeLists.txt + a Conan manifest) and compiler-family image resolution (clang-20 to prod-cpp-clang:20, gcc-15 to prod-cpp-gcc:15) to container.py, sharing the tag parser with T7's scaffolding via languages.parse_cpp_version_tag.

## Issue Linkage

- Closes #2555

## Notes

- T6 of epic vergil-project/.github#207. Changes: (1) detect_language returns cpp only when BOTH a CMakeLists.txt and a conanfile.py/txt are present. (2) default_image parses the clang-/gcc- prefix and emits prod-cpp-<family>:<numeric>, matching the images T1/T2 build; a malformed tag falls back like an unknown language. (3) _DEFAULT_VERSIONS[cpp]=clang-20 and _DEFAULT_TEST_COMMANDS[cpp] is a conan install && cmake && ctest line. DRY: the clang-/gcc- parse was extracted to languages.parse_cpp_version_tag (single source of truth); repo_init._cpp_family_and_version from T7 now delegates to it. Validation green: 4550 tests, 100% coverage.