### PR TITLE
docs(cpp-standards): add C++ development standards docs

### DIFF
--- a/docs/site/docs/standards/development/cpp/naming-conventions.md
+++ b/docs/site/docs/standards/development/cpp/naming-conventions.md
@@ -1,0 +1,247 @@
+# C++ Naming Conventions
+
+## Purpose
+
+Provide naming rules that optimize for clarity, consistency, and accessibility.
+
+## C++ Conventions Baseline
+
+Follow the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/)
+naming and layout guidance as the default, with the house casing below:
+
+- Types (classes, structs, enums, type aliases, concepts): `PascalCase`
+- Functions and methods: `snake_case`
+- Local variables and parameters: `snake_case`
+- Data members: `snake_case`, with a trailing underscore for private members
+  (`buffer_`) to distinguish them from locals and parameters
+- Constants and `constexpr` values: `PascalCase` (`MaxRetries`) or the enum
+  scope they live in; avoid `UPPER_SNAKE_CASE` for these
+- Macros: `UPPER_SNAKE_CASE` — and reserved for cases a `constexpr`, `inline`,
+  or template cannot express, since macros ignore scope
+- Namespaces: `snake_case`, short, no underscores where a single word suffices
+- Template parameters: single uppercase letter (`T`, `U`) or short `PascalCase`
+  when more descriptive (`Element`, `Alloc`)
+- Enumerators in a scoped `enum class`: `PascalCase`
+- Acronyms in `PascalCase` contexts: capitalize only the first letter
+  (`HttpClient`, not `HTTPClient`; `JsonParser`, not `JSONParser`)
+
+Prefer the standard library's spelling for concepts it already names; do not
+invent a competing house term for something `std` already calls by a clear name.
+
+## Casing Convention Note
+
+The variable naming rules below are adapted from Damian Conway's "Perl Best
+Practices" (2005). Conway's original rules assume `snake_case` for all
+identifiers. C++ uses `snake_case` for variables and functions and `PascalCase`
+for types; where Conway specifies casing, the house casing above takes
+precedence. Conway's underlying principles (descriptive names, minimum length,
+complete words, grammatical consistency) are fully adopted.
+
+## Variable Naming Rules
+
+These rules are based on Damian Conway's "Perl Best Practices" (2005), adapted
+for C++ and validated over long-term use.
+
+### 1. Type-to-Variable Mapping
+
+Variables representing a class instance use the `snake_case` version of the type
+name.
+
+```cpp
+// Correct
+auto instrument = Instrument{};
+auto exercise_state = ExerciseState{};
+auto practice_block = PracticeBlock{};
+
+// Wrong
+auto inst = Instrument{};
+auto ex_state = ExerciseState{};
+auto block = PracticeBlock{};
+```
+
+### 2. Minimum Length: 3+ Characters
+
+One- and two-character variable names are prohibited because they reduce
+readability and accessibility.
+
+```cpp
+// Correct
+for (int index = 0; index < 10; ++index) {
+    const auto& instrument = instruments[index];
+    process(instrument);
+}
+
+const auto count = instruments.size();
+for (std::size_t instrument_index = 0; instrument_index < count; ++instrument_index) {
+    process(instruments[instrument_index]);
+}
+
+// Wrong
+for (int i = 0; i < 10; ++i) {
+    const auto& x = xs[i];
+    process(x);
+}
+```
+
+Exceptions:
+
+- C++-idiomatic short variables in tight scope (five lines or fewer): `i` in a
+  single-level index loop, `it` for an iterator in a short range, `os`/`is` for
+  a stream parameter in a one-line operator. These are entrenched idioms every
+  C++ developer reads fluently. Outside tight scope, use descriptive names
+  (`index`, `iterator`, `connection_error`).
+- Well-established mathematical variables in limited scope (`x`, `y` for a
+  five-line coordinate algorithm).
+- Common domain abbreviations used across a codebase may appear as tokens:
+  `id`, `db`, `api`, `env`, `app`. Use these only as clear tokens (for example,
+  `instrument_id`, `db_session`, `api_router`, `env_name`, `app_state`), not as
+  single-character variables.
+
+### 3. Complete English Words
+
+Use complete English words, not abbreviations.
+
+```cpp
+// Correct
+auto configuration = load_configuration();
+auto database_session = get_session();
+int instrument_index = 0;
+
+// Wrong
+auto cfg = load_configuration();    // Use configuration
+auto db = get_session();            // Use database_session
+int idx = 0;                        // Use index or instrument_index
+```
+
+Exception: allowed domain abbreviations (for example, `id`, `db`, `api`) may
+appear as tokens in identifiers. Other acronyms are acceptable only when they
+are official domain terms (for example, `UTC`) and should not be shortened
+further.
+
+### 4. Namespace Collision Handling
+
+When two namespaces export the same name, disambiguate with a namespace alias or
+a qualified name — never a blanket `using namespace` in a header.
+
+```cpp
+// Correct
+namespace fs = std::filesystem;
+namespace pt = boost::property_tree;
+
+auto path = fs::path{"/data"};
+auto tree = pt::ptree{};
+
+// Wrong
+using namespace std::filesystem;
+using namespace boost::property_tree;
+
+auto path = path{"/data"};   // Which path?
+```
+
+Alias prefixes are chosen contextually (for example, `fs`, `pt`, `net`).
+
+### 5. Boolean Variables
+
+Prefer `is_*`, `has_*`, or `can_*` prefixes when they make the name read more
+naturally as a true/false condition:
+
+- `is_*`: state or condition (`is_valid`, `is_empty`, `is_active`)
+- `has_*`: possession or presence (`has_permission`, `has_items`, `has_error`)
+- `can_*`: capability or permission (`can_delete`, `can_write`, `can_edit`)
+
+```cpp
+// Prefixes improve clarity — use them
+const bool is_valid = validate(instrument);
+const bool has_permission = check_access(user);
+const bool can_delete = user.is_admin() || resource.owner == user;
+
+if (is_valid && has_permission && can_delete) {
+    remove(resource);
+}
+```
+
+Omit the prefix when the name already reads unambiguously as a boolean without
+it. Names that are verbs, verb phrases, or adjective phrases often convey boolean
+intent on their own:
+
+```cpp
+// Already clear without a prefix
+const bool verify_tls = true;
+const bool map_attributes = true;
+const bool strict = true;
+```
+
+Avoid bare nouns or adjectives that could be mistaken for the thing itself rather
+than a condition about it:
+
+```cpp
+// Ambiguous without a prefix
+const bool valid = validate(instrument);       // Use is_valid
+const bool permission = check_access(user);    // Use has_permission
+const bool deletable = user.is_admin();        // Use can_delete
+```
+
+### 6. Collections: Plural vs. Singular
+
+Name collections based on how they are primarily used.
+
+Plural for collective processing (vectors, spans):
+
+```cpp
+auto instruments = query.all();
+for (const auto& instrument : instruments) {
+    process(instrument);
+}
+
+std::vector<std::int64_t> exercise_ids;
+exercise_ids.reserve(exercises.size());
+for (const auto& exercise : exercises) {
+    exercise_ids.push_back(exercise.id);
+}
+```
+
+Singular with `by_` suffix for individual access (maps):
+
+```cpp
+std::unordered_map<std::int64_t, Instrument> instrument_by_id;
+for (const auto& instrument : instruments) {
+    instrument_by_id.emplace(instrument.id, instrument);
+}
+const auto& instrument = instrument_by_id.at(42);
+
+std::unordered_map<std::string, Exercise> exercise_by_name;
+const auto& exercise = exercise_by_name.at("Chromatic Scale");
+```
+
+### 7. Consistency Rules
+
+- Syntactic consistency: if one variable uses `adjective_noun`, all similar
+  variables use `adjective_noun`.
+- Semantic consistency: names convey what data represents, not just its type.
+- Cross-codebase consistency: the same concept uses the same name everywhere.
+
+```cpp
+// Correct
+Instrument create_instrument(const std::string& name) {
+    auto instrument = Instrument{name};
+    db_session.create(instrument);
+    return instrument;
+}
+
+void update_instrument(Instrument& instrument, const std::string& name) {
+    instrument.name = name;
+    db_session.save(instrument);
+}
+
+// Wrong
+Instrument create_instrument(const std::string& name) {
+    auto inst = Instrument{name};
+    db_session.create(inst);
+    return inst;
+}
+
+void update_instrument(Instrument& instrument, const std::string& name) {
+    instrument.name = name;
+    db_session.save(instrument);
+}
+```

--- a/docs/site/docs/standards/development/cpp/overview.md
+++ b/docs/site/docs/standards/development/cpp/overview.md
@@ -1,0 +1,106 @@
+# C++ Development Standards Overview
+
+## Purpose
+
+Define consistent C++ standards that emphasize safety, portability,
+maintainability, and long-term survivability across repositories.
+
+## Core Principles
+
+- Two independent compilers are the baseline, not a luxury. Code must build
+  and pass warnings clean under both Clang and GCC.
+- Portability and correctness override cleverness or brevity.
+- Readability overrides micro-optimization.
+- Exceptions must be explicit, documented, and justified.
+
+## The Dual-Compiler Model
+
+C++ repositories are validated under **two co-equal, first-class open-source
+compilers**: **Clang/LLVM (primary)** and **GCC (secondary)**. Both are
+merge-blocking diagnostic engines, not a primary gate with a nightly
+afterthought.
+
+The payoff is two independent diagnostic engines. Clang and GCC disagree about
+which constructs are undefined, non-portable, or suspect; a warning one raises
+the other often misses. Holding code clean under both catches a class of
+portability and undefined-behavior defects that either compiler alone would let
+through.
+
+"Primary" and "secondary" describe defaults and ordering, not authority. LINT
+and AUDIT run **once** on the primary Clang image (there is nothing
+compiler-specific to gain from running a formatter or a dependency scan twice).
+The compiler-sensitive stages — TYPECHECK (the warnings build) and TEST
+(coverage and sanitizers) — run **per compiler and per version**, so both
+families gate every change equally.
+
+## Prebuilt Toolchains Only
+
+Compiler toolchains come **exclusively from prebuilt stable binary packages —
+never built from source**. Building a compiler from source in the validation
+path is slow, non-reproducible, and a supply-chain liability; the dev images
+pin prebuilt stable releases instead.
+
+The target is **two recent majors per family**, taken from whatever is cleanly
+available prebuilt. When the newest majors lack prebuilt binaries, the fallback
+steps back a release while keeping both families present (for example,
+gcc-13/14 and clang-18/19 rather than dropping a compiler). The matrix bends to
+availability; it never drops to one compiler.
+
+## Build System and Dependency Management
+
+The mandated build system is **CMake**, with **Conan 2** as the dependency
+manager.
+
+- **CMake** configures out-of-tree build directories and exports
+  `compile_commands.json` (via `CMAKE_EXPORT_COMPILE_COMMANDS=ON`). That
+  compilation database is what `clang-tidy` and other static-analysis tooling
+  read to see each translation unit's exact flags.
+- **Conan 2** resolves and builds dependencies (`conan install . --build=missing`).
+  Conan 2 is chosen in part for its built-in `conan audit` dependency-CVE scan,
+  which the AUDIT stage runs against the resolved dependency graph.
+
+vergil-tooling passes **intent** to the project's `CMakeLists.txt` as CMake
+cache variables rather than raw compiler flags, so every validation command
+stays portable across both compiler families. The project's `CMakeLists.txt`
+translates that intent per compiler (for example, libc++'s `-stdlib` is
+Clang-only and must never appear as a raw flag in a shared command):
+
+| Cache variable | Meaning |
+| --- | --- |
+| `VERGIL_CPP_STD` | the `[cpp].std` value (for example, `c++20`) |
+| `VERGIL_CPP_STDLIB` | the `[cpp].stdlib` value (for example, `libstdc++`) |
+| `VERGIL_CPP_COVERAGE` | `ON` selects coverage instrumentation |
+| `VERGIL_CPP_SANITIZE` | the sanitizer list (for example, `address,undefined`) |
+
+## Testing: CTest Runner, GoogleTest Default
+
+**CTest is the mandated test runner.** Every C++ repository exposes its tests
+through CTest, and the validation pipeline invokes them with
+`ctest --test-dir <build-dir> --output-on-failure`. CTest is the stable
+integration surface; the underlying test framework is a repository choice.
+
+**GoogleTest is the documented default framework.** A repository may instead use
+Catch2 or doctest, but GoogleTest is the recommended starting point and the one
+new repositories should reach for absent a specific reason. Whatever the
+framework, tests are registered with CTest so the runner contract holds.
+
+## CI Gates
+
+See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
+for hard gate and soft gate definitions.
+
+C++ hard gates run per compiler and per version:
+
+- **TYPECHECK** — the warnings build under each compiler×version (see
+  [Toolchain and Warnings](toolchain-and-warnings.md)).
+- **TEST** — the coverage-instrumented build and run, held to 100% line
+  coverage per compiler, plus a separate AddressSanitizer + UndefinedBehavior
+  Sanitizer build and run (see [Testing and Coverage](testing-and-coverage.md)).
+
+LINT and AUDIT run once on the primary Clang image.
+
+## Document Map
+
+- Toolchain and warnings: [toolchain-and-warnings.md](toolchain-and-warnings.md)
+- Testing and coverage: [testing-and-coverage.md](testing-and-coverage.md)
+- Naming conventions: [naming-conventions.md](naming-conventions.md)

--- a/docs/site/docs/standards/development/cpp/testing-and-coverage.md
+++ b/docs/site/docs/standards/development/cpp/testing-and-coverage.md
@@ -40,9 +40,10 @@ the whole point of the dual-compiler model — the two engines only both protect
 line if the tests actually run that line under both.
 
 The coverage build is instrumented separately from the sanitizer build. TEST
-does a coverage-instrumented build and run, then a **separate** AddressSanitizer
-+ UndefinedBehaviorSanitizer build and run in a distinct build directory, so the
-sanitizer instrumentation never shares object files with the coverage build.
+does a coverage-instrumented build and run, then a **separate** build and run
+under AddressSanitizer plus UndefinedBehaviorSanitizer in a distinct build
+directory, so the sanitizer instrumentation never shares object files with the
+coverage build.
 
 ## Exclusion Discipline
 

--- a/docs/site/docs/standards/development/cpp/testing-and-coverage.md
+++ b/docs/site/docs/standards/development/cpp/testing-and-coverage.md
@@ -1,0 +1,111 @@
+# C++ Testing and Coverage
+
+## Core Principle
+
+Maintain 100% line coverage **per compiler**, where 100% means: you tested
+everything you could, and positively acknowledged the things you could not.
+
+## Test Runner and Framework
+
+Tests run through **CTest**, the mandated runner:
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+**GoogleTest** is the documented default framework; Catch2 and doctest are
+permitted alternatives. Whatever the framework, tests are registered with CTest
+so the runner contract holds regardless of the choice. See the
+[overview](overview.md#testing-ctest-runner-googletest-default) for the runner
+rationale.
+
+## The 100%-Per-Compiler Gate
+
+Coverage is measured with **gcovr** and enforced at **100% line coverage, bound
+per compiler (per image) — never on a single merged report**:
+
+```bash
+gcovr --config <configs>/cpp/gcovr.cfg --fail-under-line 100
+```
+
+The image supplies the correct `gcov` executable for the compiler under test —
+plain `gcov` on GCC, `llvm-cov gcov` on Clang — so each family's coverage is
+computed with its own instrumentation.
+
+**Why per-compiler, not merged.** A merged report hides gaps. If a line is
+exercised under Clang but not under GCC, a single combined report still shows it
+as covered, and the GCC-only gap disappears. Binding the gate to each compiler's
+own report forces every line to be reached under **both** toolchains, which is
+the whole point of the dual-compiler model — the two engines only both protect a
+line if the tests actually run that line under both.
+
+The coverage build is instrumented separately from the sanitizer build. TEST
+does a coverage-instrumented build and run, then a **separate** AddressSanitizer
++ UndefinedBehaviorSanitizer build and run in a distinct build directory, so the
+sanitizer instrumentation never shares object files with the coverage build.
+
+## Exclusion Discipline
+
+A legitimate coverage gap is acknowledged narrowly and visibly with a `gcovr`
+exclusion marker: `// GCOVR_EXCL_LINE` for a single line, or a matched
+`// GCOVR_EXCL_START` / `// GCOVR_EXCL_STOP` pair for a small contiguous region.
+
+An exclusion is a **positive acknowledgment of a specific untestable branch**,
+not a way to make the number go up. What separates a legitimate exclusion from
+abuse:
+
+**Legitimate** — narrow, adjacent to the untestable code, and self-explaining:
+
+```cpp
+switch (state) {
+  case State::Ready:   return handleReady();
+  case State::Closed:  return handleClosed();
+}
+// Unreachable: the enum is exhaustively handled above, but the compiler
+// still emits an implicit-default path.
+GCOVR_EXCL_LINE
+throw std::logic_error("unreachable state");
+```
+
+A legitimate exclusion covers the smallest possible region, sits right on the
+branch it excuses, and reads clearly as "this specific path cannot be exercised,
+and here is why."
+
+**Abuse** — anything that exempts more than the untestable branch itself:
+
+- **Whole-file exemptions.** Excluding an entire file (or wrapping a whole file
+  in a `START`/`STOP` pair) removes real, testable code from the denominator.
+  This is the primary abuse pattern to reject in review — it converts a coverage
+  gate into a coverage suggestion.
+- **Unexplained markers.** An exclusion with no comment, or a vague one
+  ("hard to test"), is not an acknowledgment — it is a mute. State the concrete
+  reason the branch cannot be reached.
+- **Exclusions standing in for missing tests.** If a branch *can* be tested,
+  test it. An exclusion is for the genuinely unreachable or the genuinely
+  untestable, not for code the author did not get around to covering.
+
+The discipline is the same shape as the no-standing-suppression rule for
+[compiler warnings](toolchain-and-warnings.md#no-standing-suppression-list):
+gaps are acknowledged one at a time, in place, with a reason — never blanketed.
+
+## Compiler-Specific `#ifdef` Blocks Are a Smell
+
+Compiler-specific `#ifdef` blocks are a **code smell to minimize**. They
+fragment behavior across toolchains and, in a per-compiler coverage world, they
+split the code each compiler actually sees.
+
+The good news is that clean preprocessor splits **mostly self-handle** under
+per-compiler coverage. A branch that is compiled out for a given compiler is not
+instrumented on that compiler's build, so it simply does not appear as a gap in
+that compiler's report — no exclusion marker is needed. This is a reason to keep
+such splits clean and minimal rather than to reach for exclusions:
+
+- Prefer a portable formulation that both compilers compile the same way.
+- When a split is genuinely unavoidable, keep each arm small so the compiled-in
+  arm is fully testable on the compiler that sees it.
+- Reserve `GCOVR_EXCL_*` for the truly unreachable, not for papering over a
+  conditional block you could have written portably.
+
+Minimizing these blocks keeps the two diagnostic engines looking at as nearly
+the same code as possible, which is exactly what makes the dual-compiler gate
+worth running.

--- a/docs/site/docs/standards/development/cpp/toolchain-and-warnings.md
+++ b/docs/site/docs/standards/development/cpp/toolchain-and-warnings.md
@@ -1,0 +1,106 @@
+# C++ Toolchain and Warnings
+
+## Purpose
+
+Document the concrete compiler warning set enforced in the TYPECHECK stage and
+the no-standing-suppression rule that governs it. This page **describes** the
+set; it does not choose it. The set is decided and tested in the language
+registry (`src/vergil_tooling/lib/languages.py`), and this page mirrors that
+single source of truth.
+
+## TYPECHECK Is "The Compiler"
+
+For C++, the TYPECHECK stage is the **warnings build**: a full compile under
+each compiler and version with the curated warning set promoted to errors. There
+is no separate type checker the way Python has mypy or Rust has `cargo check` —
+the compiler itself, run strict, is the type-and-soundness gate.
+
+The warning flags are threaded into the build as a single `CMAKE_CXX_FLAGS`
+cache value, so the whole set lands on every translation unit's compile line.
+
+## The Curated Warning Set
+
+The floor is `-Wall -Wextra -Werror -Wpedantic`, tuned upward with a curated set
+of extras. The complete set enforced today:
+
+```text
+# Floor
+-Wall
+-Wextra
+-Werror
+-Wpedantic
+
+# Curated extras
+-Wshadow
+-Wconversion
+-Wsign-conversion
+-Wcast-qual
+-Wold-style-cast
+-Wnon-virtual-dtor
+-Woverloaded-virtual
+-Wdouble-promotion
+-Wformat=2
+-Wimplicit-fallthrough
+-Wnull-dereference
+```
+
+What each extra buys:
+
+| Flag | Catches |
+| --- | --- |
+| `-Wshadow` | a local name silently shadowing an outer one |
+| `-Wconversion` | implicit conversions that may change a value |
+| `-Wsign-conversion` | implicit signed/unsigned conversions |
+| `-Wcast-qual` | a cast that drops a `const`/`volatile` qualifier |
+| `-Wold-style-cast` | C-style casts in C++ code (use named casts) |
+| `-Wnon-virtual-dtor` | a base class with virtuals but a non-virtual destructor |
+| `-Woverloaded-virtual` | a derived member hiding, not overriding, a virtual |
+| `-Wdouble-promotion` | an implicit `float`-to-`double` promotion |
+| `-Wformat=2` | format-string and security issues (`printf`-family) |
+| `-Wimplicit-fallthrough` | a `switch` case falling through without annotation |
+| `-Wnull-dereference` | a path that dereferences a known-null pointer |
+
+## One Portable Set, On Purpose
+
+This is a **single portable set that both current GCC and Clang accept** — it is
+not a per-compiler list. The reasoning is a direct consequence of how the
+warnings build runs:
+
+- TYPECHECK is a per-compiler×version stage, but the registry command is
+  version-agnostic — the *same* argument list runs inside every `clang-*` and
+  `gcc-*` image. The two-diagnostics win comes from the two **compilers**
+  interpreting these flags, not from two different flag lists.
+- Under `-Werror`, a flag that only one compiler recognizes is itself a hard
+  error. GCC rejects an unknown `-W` outright, and Clang's `-Werror` promotes
+  `-Wunknown-warning-option`. So every flag in the set must be one that **both**
+  current GCC (>= 13) and Clang (>= 18) accept.
+
+**Per-compiler warning sets are deferred.** Compiler-exclusive warnings — GCC's
+`-Wlogical-op` and `-Wduplicated-cond`, for example — are deliberately out of
+the current set. Adding them requires a compiler-branched TYPECHECK command,
+which means teaching the registry a compiler dimension; that is a separate,
+tracked change, not something smuggled into the portable set. When it lands,
+this page is updated to describe it.
+
+## No Standing Suppression List
+
+There is **no project-wide standing suppression list** for compiler warnings. A
+warning is fixed, not muted. The set is promoted to errors precisely so a
+warning cannot accumulate as ignored noise — under `-Werror` it stops the build
+until the code is corrected.
+
+If a specific, unavoidable warning genuinely must be silenced, the suppression
+is **local and narrow**: a targeted pragma around the smallest possible region,
+carrying a comment that states the reason. A broad, file-level, or repository-
+level suppression that hides a whole warning category is not permitted — it
+defeats the reason the flag is in the set. The discipline mirrors the coverage
+exclusion rule in [Testing and Coverage](testing-and-coverage.md): gaps are
+acknowledged narrowly and visibly, never blanketed away.
+
+## Relationship to the Static-Analysis Stage
+
+The warning set is distinct from the LINT stage, which runs `clang-format`,
+`clang-tidy` (via `run-clang-tidy` over the `compile_commands.json` database),
+and `cppcheck` once on the primary Clang image. TYPECHECK is the compiler's own
+judgment under both families; LINT is dedicated static analysis. Both gate a
+change; neither substitutes for the other.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -106,6 +106,11 @@ nav:
               - Local Validation: standards/development/python/local-validation-scripts.md
               - Version Management: standards/development/python/version-management.md
               - ty Migration Plan: standards/development/python/ty-migration-plan.md
+          - C++:
+              - Overview: standards/development/cpp/overview.md
+              - Toolchain and Warnings: standards/development/cpp/toolchain-and-warnings.md
+              - Testing and Coverage: standards/development/cpp/testing-and-coverage.md
+              - Naming Conventions: standards/development/cpp/naming-conventions.md
           - Go:
               - Overview: standards/development/go/overview.md
               - Naming Conventions: standards/development/go/naming-conventions.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add the four C++ standards pages (overview, toolchain-and-warnings, testing-and-coverage, naming-conventions) under docs/site/docs/standards/development/cpp/ and register them in the MkDocs nav, documenting the CMake+Conan 2 / dual-compiler / prebuilt-toolchain model and the exact warning set and coverage discipline the merged T5 registry established.

## Issue Linkage

- Closes #2557

## Notes

- Task T9 of epic vergil-project/.github#207; documents decisions already made and tested in T5 (it does not re-choose them). toolchain-and-warnings.md mirrors the concrete portable warning set from the cpp registry entry in src/vergil_tooling/lib/languages.py verbatim (floor -Wall -Wextra -Werror -Wpedantic plus 11 curated extras) and explains it is one portable GCC/Clang set with per-compiler sets deferred. testing-and-coverage.md covers the 100%-per-compiler gcovr gate, legitimate GCOVR_EXCL usage vs whole-file abuse, and compiler-specific #ifdef as a smell that self-handles under per-compiler coverage. naming-conventions.md matches the sibling languages' Conway-based depth. Nav registration required (mkdocs.yml uses explicit nav). Docs-only change; vrg-validate green (markdownlint + all common checks pass). Two commits on the branch (initial + a markdownlint reword fix).