### PR TITLE
fix(cpp): switch AUDIT to OSV-Scanner, fix Conan build_type + gcovr paths

### DIFF
--- a/docs/site/docs/standards/development/cpp/overview.md
+++ b/docs/site/docs/standards/development/cpp/overview.md
@@ -55,9 +55,15 @@ manager.
   `compile_commands.json` (via `CMAKE_EXPORT_COMPILE_COMMANDS=ON`). That
   compilation database is what `clang-tidy` and other static-analysis tooling
   read to see each translation unit's exact flags.
-- **Conan 2** resolves and builds dependencies (`conan install . --build=missing`).
-  Conan 2 is chosen in part for its built-in `conan audit` dependency-CVE scan,
-  which the AUDIT stage runs against the resolved dependency graph.
+- **Conan 2** resolves and builds dependencies
+  (`conan install . -s build_type=Debug --build=missing`, matching the CMake
+  Debug build so dependency binaries share the same configuration). INSTALL also
+  writes a `conan.lock` (`conan lock create`), which the AUDIT stage scans.
+- The AUDIT stage runs **OSV-Scanner** over that `conan.lock`
+  (`osv-scanner scan source --lockfile=conan.lock`) for dependency CVEs.
+  OSV-Scanner is tokenless, offline-capable, and scales with per-PR volume;
+  `conan audit` was reconsidered because its hosted provider needs a token and
+  is rate-limited (decision: vergil-project/.github#209).
 
 vergil-tooling passes **intent** to the project's `CMakeLists.txt` as CMake
 cache variables rather than raw compiler flags, so every validation command

--- a/docs/site/docs/standards/development/cpp/testing-and-coverage.md
+++ b/docs/site/docs/standards/development/cpp/testing-and-coverage.md
@@ -25,8 +25,14 @@ Coverage is measured with **gcovr** and enforced at **100% line coverage, bound
 per compiler (per image) — never on a single merged report**:
 
 ```bash
-gcovr --config <configs>/cpp/gcovr.cfg --fail-under-line 100
+gcovr --config <configs>/cpp/gcovr.cfg --root . --filter src/ --fail-under-line 100
 ```
+
+`--root`/`--filter` are passed on the command line, not in the packaged config
+file: gcovr resolves relative paths inside a config file against the config
+file's own directory, so anchoring them there pointed gcovr at the packaged
+config directory and filtered all coverage out. On the command line they resolve
+against the repo root (the working directory) as intended.
 
 The image supplies the correct `gcov` executable for the compiler under test —
 plain `gcov` on GCC, `llvm-cov gcov` on Clang — so each family's coverage is

--- a/src/vergil_tooling/configs/cpp/gcovr.cfg
+++ b/src/vergil_tooling/configs/cpp/gcovr.cfg
@@ -1,14 +1,20 @@
 # Packaged gcovr config for Vergil C++ repos
 # (epic vergil-project/.github#207, T5). Consumed via
-# `gcovr --config {configs}/cpp/gcovr.cfg --fail-under-line 100`.
+# `gcovr --config {configs}/cpp/gcovr.cfg --root . --filter src/ --fail-under-line 100`.
 #
-# The 100%-per-compiler line gate itself is passed on the command line
-# (--fail-under-line 100) so it stays visible in the registry command; this
-# file carries the non-compiler-specific search/filter settings. The gcov
-# executable is compiler-specific (gcov on GCC, `llvm-cov gcov` on Clang) and
-# is supplied by the container image's environment, not pinned here.
-root = .
-filter = src/
+# This file carries only path-INDEPENDENT settings. `root`/`filter` are passed
+# on the command line, NOT here: gcovr resolves relative paths in a config file
+# against the config file's own directory, so a config-relative `root = .` /
+# `filter = src/` pointed at the packaged config dir ({configs}/cpp/) and
+# filtered all coverage out (T11 #2558). On the command line they resolve
+# against the repo root (cwd) as intended (#2572). The 100%-per-compiler line
+# gate (--fail-under-line 100) is likewise on the command line so it stays
+# visible in the registry command. The gcov executable is compiler-specific
+# (gcov on GCC, `llvm-cov gcov` on Clang) and is supplied by the container
+# image's environment, not pinned here.
+#
+# The `exclude` patterns below are anchored regexes (not path-relative), so they
+# are unaffected by the root/filter move and stay here.
 exclude = .*/build.*/.*
 exclude = .*/tests?/.*
 exclude-unreachable-branches = yes

--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -36,7 +36,9 @@ _DEFAULT_TEST_COMMANDS: dict[str, str] = {
     "rust": "cargo test",
     "java": "./mvnw verify",
     "cpp": (
-        "conan install . --build=missing "
+        # -s build_type=Debug keeps Conan's dep binaries in the same config as
+        # the CMake Debug build below (else: fmt/format.h not found). (#2572)
+        "conan install . -s build_type=Debug --build=missing "
         "&& cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug "
         "&& cmake --build build --parallel "
         "&& ctest --test-dir build --output-on-failure"

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -376,8 +376,17 @@ _REGISTRY: dict[str, Language] = {
     "cpp": Language(
         name="cpp",
         checks={
+            # ``conan lock create`` resolves the dependency graph and writes the
+            # ``conan.lock`` that AUDIT (OSV-Scanner) scans; ``conan install``
+            # then materializes the binaries. Both pin ``build_type=Debug`` so
+            # Conan builds deps in the *same* configuration as the CMake
+            # coverage/sanitizer builds — the container image only bakes a
+            # default profile (build_type=Release), and that mismatch broke the
+            # T11 cold rebuild (#2558): ``fmt/format.h`` not found because the
+            # Debug config had no matching Conan binary. (#2572, image side #487)
             CheckKind.INSTALL: [
-                ["conan", "install", ".", "--build=missing"],
+                ["conan", "lock", "create", ".", "-s", "build_type=Debug"],
+                ["conan", "install", ".", "-s", "build_type=Debug", "--build=missing"],
                 [
                     "cmake",
                     "-S",
@@ -460,7 +469,23 @@ _REGISTRY: dict[str, Language] = {
                 ],
                 ["cmake", "--build", _CPP_BUILD_DIR, "--parallel"],
                 ["ctest", "--test-dir", _CPP_BUILD_DIR, "--output-on-failure"],
-                ["gcovr", "--config", "{configs}/cpp/gcovr.cfg", "--fail-under-line", "100"],
+                # ``--root``/``--filter`` are on the command line so they resolve
+                # against the repo root (cwd), not the packaged config file's own
+                # directory. A config-relative ``root``/``filter`` pointed gcovr
+                # at ``{configs}/cpp/`` and filtered *all* coverage out in T11
+                # (#2558); the config file now carries only path-independent
+                # settings. (#2572)
+                [
+                    "gcovr",
+                    "--config",
+                    "{configs}/cpp/gcovr.cfg",
+                    "--root",
+                    ".",
+                    "--filter",
+                    "src/",
+                    "--fail-under-line",
+                    "100",
+                ],
                 [
                     "cmake",
                     "-S",
@@ -475,15 +500,18 @@ _REGISTRY: dict[str, Language] = {
                 ["cmake", "--build", _CPP_SANITIZE_BUILD_DIR, "--parallel"],
                 ["ctest", "--test-dir", _CPP_SANITIZE_BUILD_DIR, "--output-on-failure"],
             ],
-            # AUDIT runs *once* (§3.6). ``conan audit`` scans the dependency
-            # graph for CVEs; its provider/token setup is verified live in T11
-            # (spec §4 acceptance), and if it cannot be shown to *detect* a
-            # known-vulnerable pin the objective trigger is to switch to the
-            # OSV-Scanner-over-``conan.lock`` contingency. License checking is
-            # best-effort surfacing in v1 (no turnkey Conan allowlist gate);
-            # hardened gating against ``_CPP_LICENSES_ALLOWLIST`` is ledger #7.
+            # AUDIT runs *once* (§3.6). OSV-Scanner scans the ``conan.lock``
+            # produced in INSTALL for CVEs. This replaces ``conan audit``, whose
+            # SaaS provider (audit.conan.io) needs a JFrog token and is
+            # rate-limited — a throughput bottleneck under AI-speed per-PR
+            # scanning. OSV-Scanner is tokenless, offline-capable, and natively
+            # parses ``conan.lock``, so it scales with PR velocity (decision:
+            # vergil-project/.github#209; T11 finding #2558; tool added to the
+            # images image-side in #487). License checking stays best-effort
+            # surfacing in v1 (no turnkey Conan allowlist gate); hardened gating
+            # against ``_CPP_LICENSES_ALLOWLIST`` is ledger #7.
             CheckKind.AUDIT: [
-                ["conan", "audit", "scan", "."],
+                ["osv-scanner", "scan", "source", "--lockfile=conan.lock"],
                 ["conan", "graph", "info", ".", "--format=json"],
             ],
         },

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -267,6 +267,10 @@ def test_cpp_default_test_command_is_conan_cmake_ctest() -> None:
     assert "conan install" in cmd
     assert "cmake" in cmd
     assert "ctest" in cmd
+    # Conan must resolve deps in the same build_type as the CMake Debug build,
+    # or the Debug config finds no matching binary (fmt/format.h not found). (#2572)
+    assert "conan install . -s build_type=Debug --build=missing" in cmd
+    assert "-DCMAKE_BUILD_TYPE=Debug" in cmd
 
 
 # -- workspace_mount_args -----------------------------------------------------

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -371,10 +371,7 @@ def test_cpp_test_commands_coverage_ctest_and_sanitizers() -> None:
     # (cwd), not the packaged config's own dir — a config-relative root/filter
     # filtered all coverage out in T11 (#2558). (#2572)
     assert any(
-        "gcovr" in c
-        and "--fail-under-line 100" in c
-        and "--root ." in c
-        and "--filter src/" in c
+        "gcovr" in c and "--fail-under-line 100" in c and "--root ." in c and "--filter src/" in c
         for c in joined
     )
     # A separate ASan+UBSan build+run in its own build dir.

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -282,7 +282,16 @@ def test_cpp_is_supported() -> None:
 
 def test_cpp_install_commands() -> None:
     joined = _joined(language_commands("cpp", CheckKind.INSTALL))
-    assert "conan install . --build=missing" in joined
+    # A conan.lock is produced so AUDIT (OSV-Scanner) has a lockfile to scan.
+    assert any("conan lock create" in c for c in joined)
+    # Conan resolves deps in the same build_type (Debug) as the CMake
+    # coverage/sanitizer builds — a Release/Debug mismatch broke the cold
+    # rebuild in T11 (#2558): fmt/format.h not found. (#2572)
+    assert "conan install . -s build_type=Debug --build=missing" in joined
+    # Both conan steps pin build_type=Debug to stay consistent with the build.
+    for cmd in language_commands("cpp", CheckKind.INSTALL):
+        if cmd and cmd[0] == "conan":
+            assert "build_type=Debug" in cmd
     # cmake configure exports the compile DB that feeds clang-tidy and threads
     # the [cpp] std/stdlib in as cache vars.
     cmake_cmd = [c for c in language_commands("cpp", CheckKind.INSTALL) if c[0] == "cmake"]
@@ -357,8 +366,17 @@ def test_cpp_test_commands_coverage_ctest_and_sanitizers() -> None:
     joined = _joined(cmds)
     # CTest as the framework-agnostic runner.
     assert any(c.startswith("ctest") and "--output-on-failure" in c for c in joined)
-    # Coverage held to 100% line via gcovr.
-    assert any("gcovr" in c and "--fail-under-line 100" in c for c in joined)
+    # Coverage held to 100% line via gcovr. The root/filter that anchor the
+    # search live on the command line so they resolve against the repo root
+    # (cwd), not the packaged config's own dir — a config-relative root/filter
+    # filtered all coverage out in T11 (#2558). (#2572)
+    assert any(
+        "gcovr" in c
+        and "--fail-under-line 100" in c
+        and "--root ." in c
+        and "--filter src/" in c
+        for c in joined
+    )
     # A separate ASan+UBSan build+run in its own build dir.
     assert any("-DVERGIL_CPP_SANITIZE=address,undefined" in c for c in joined)
     assert any("cmake --build build-sanitize" in c for c in joined)
@@ -367,8 +385,11 @@ def test_cpp_test_commands_coverage_ctest_and_sanitizers() -> None:
 
 def test_cpp_audit_commands() -> None:
     joined = _joined(language_commands("cpp", CheckKind.AUDIT))
-    # conan audit is the CVE scan (provider verified live in T11, spec §4).
-    assert any("conan audit" in c for c in joined)
+    # OSV-Scanner over conan.lock is the CVE scan — tokenless and scalable,
+    # replacing conan audit (SaaS token, rate-limited). Decision: #209. (#2572)
+    assert "osv-scanner scan source --lockfile=conan.lock" in joined
+    # conan audit is retired here.
+    assert not any("conan audit" in c for c in joined)
     # Best-effort license-metadata surfacing (hardened gating deferred, §9 #7).
     assert any("conan graph info" in c for c in joined)
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fixes the three C++ registry/config gaps from T11 (#2558): AUDIT now runs OSV-Scanner over a conan.lock instead of the token-gated conan audit, Conan resolves deps as build_type=Debug to match the CMake coverage/sanitizer builds, and gcovr's root/filter move to the command line so they resolve against the repo root.

## Issue Linkage

- Closes #2572

## Notes

- AUDIT argv is 'osv-scanner scan source --lockfile=conan.lock' (v2 form, per #209 decision; osv-scanner is added image-side in vergil-containers#487). INSTALL now writes conan.lock via 'conan lock create . -s build_type=Debug' and installs with '-s build_type=Debug --build=missing'; the same build_type fix is applied to the container-test default cpp command. gcovr.cfg keeps only path-independent settings; '--root . --filter src/' are on the command line. Docs (cpp overview + testing-and-coverage) and unit tests updated. Local vrg-validate is green; full cold end-to-end proof lands when T11 #2558 re-runs against rebuilt images. Needs a vergil-tooling re-release afterward.