### PR TITLE
feat(vrg-vm): inject Conan audit token into VM agent env

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2357,7 +2357,7 @@ def _session_inner(
     archive_days: int,
 ) -> str:
     """Build the in-VM command: a raw override, or the session resolver."""
-    source = ". ~/.config/vergil/claude.env 2>/dev/null;"
+    source = ". ~/.config/vergil/claude.env 2>/dev/null; . ~/.config/vergil/conan.env 2>/dev/null;"
 
     override = list(args.cmd)
     if override and override[0] == "--":

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -23,6 +23,7 @@ class Identity:
     app_id: str = ""
     private_key_path: str = ""
     claude_token_path: str = ""
+    conan_audit_token_path: str = ""
     projects_dir: str = ""
     vergil: str = ""
     vergil_vm: str = ""
@@ -150,6 +151,7 @@ def load_config(path: Path) -> IdentityConfig:
             app_id=str(data.get("app_id", "")),
             private_key_path=data.get("private_key_path", ""),
             claude_token_path=data.get("claude_token_path", ""),
+            conan_audit_token_path=data.get("conan_audit_token_path", ""),
             projects_dir=projects_dir,
             vergil=data.get("vergil", ""),
             vergil_vm=data.get("vergil-vm", ""),

--- a/src/vergil_tooling/lib/vm_guest.py
+++ b/src/vergil_tooling/lib/vm_guest.py
@@ -105,6 +105,9 @@ def inject_credentials(transport: Transport, identity: Identity) -> None:
     if identity.claude_token_path:
         _inject_claude_token(transport, identity.claude_token_path)
 
+    if identity.conan_audit_token_path:
+        _inject_conan_token(transport, identity.conan_audit_token_path)
+
 
 _BASHRC_MODE_LINE = (
     "[ -f ~/.config/vergil/identity-mode ]"
@@ -167,6 +170,38 @@ def _inject_claude_token(transport: Transport, token_path: str) -> None:
         "cat > ~/.claude.json",
         onboarding + "\n",
     )
+
+
+_BASHRC_CONAN_SOURCE_LINE = "[ -f ~/.config/vergil/conan.env ] && . ~/.config/vergil/conan.env"
+
+
+def _inject_conan_token(transport: Transport, token_path: str) -> None:
+    """Inject the Conan audit provider token as an env file sourced from bashrc.
+
+    Mirrors ``_inject_claude_token``: read the bare token from the host file,
+    write ``export CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER=<token>`` into
+    ``~/.config/vergil/conan.env`` (peer to ``claude.env``), and add an
+    idempotent ``~/.bashrc`` source line so interactive shells pick it up. The
+    token value is shell-quoted so any special characters survive the export.
+    """
+    path = Path(token_path).expanduser()
+    if not path.exists():
+        print(f"ERROR: Conan audit token not found: {path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    token = path.read_text().strip()
+
+    print("  Injecting Conan audit token...")
+    transport.pipe(
+        "cat > ~/.config/vergil/conan.env && chmod 600 ~/.config/vergil/conan.env",
+        f"export CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER={shlex.quote(token)}\n",
+    )
+
+    source_cmd = (
+        f'grep -qF "conan.env" ~/.bashrc 2>/dev/null'
+        f" || echo '{_BASHRC_CONAN_SOURCE_LINE}' >> ~/.bashrc"
+    )
+    transport.run("bash", "-c", source_cmd)
 
 
 def get_tooling_version(transport: Transport) -> str | None:

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -501,6 +501,25 @@ def test_claude_token_path_defaults_empty(config_file: Path) -> None:
     assert cfg.identities["vergil"].claude_token_path == ""
 
 
+def test_conan_audit_token_path_parsed(tmp_path: Path) -> None:
+    p = tmp_path / "identities.toml"
+    p.write_text(
+        textwrap.dedent("""\
+        [identities.vergil]
+        vm_instance = "vergil-agent"
+        conan_audit_token_path = "~/.config/vergil/keys/conan-audit-token"
+    """)
+    )
+    cfg = load_config(p)
+    expected = "~/.config/vergil/keys/conan-audit-token"
+    assert cfg.identities["vergil"].conan_audit_token_path == expected
+
+
+def test_conan_audit_token_path_defaults_empty(config_file: Path) -> None:
+    cfg = load_config(config_file)
+    assert cfg.identities["vergil"].conan_audit_token_path == ""
+
+
 def test_resource_fields_parsed(tmp_path: Path) -> None:
     p = tmp_path / "identities.toml"
     p.write_text(

--- a/tests/vergil_tooling/test_vm_guest.py
+++ b/tests/vergil_tooling/test_vm_guest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -150,6 +151,96 @@ class TestInjectCredentials:
             app_id="12345",
             private_key_path=str(key_file),
             claude_token_path=bad_path,
+        )
+        with pytest.raises(SystemExit):
+            inject_credentials(_transport(), identity)
+
+    @patch("vergil_tooling.lib.vm_guest._inject_host_git_identity")
+    def test_injects_conan_token(self, _mock_id: MagicMock, tmp_path: Path) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        token_file = tmp_path / "conan-audit-token"
+        token_file.write_text("conan-token-xyz789\n")
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            mode="user",
+            app_id="12345",
+            private_key_path=str(key_file),
+            conan_audit_token_path=str(token_file),
+        )
+
+        transport = _transport()
+        inject_credentials(transport, identity)
+
+        # base 3 runs + 1 bashrc source line for conan.env
+        assert transport.run.call_count == 4
+        bashrc_call = transport.run.call_args_list[3]
+        assert "conan.env" in " ".join(str(a) for a in bashrc_call[0])
+
+        # base 3 pipes + 1 conan.env write
+        assert transport.pipe.call_count == 4
+        conan_call = transport.pipe.call_args_list[3]
+        assert "conan.env" in conan_call[0][0]
+        assert "chmod 600" in conan_call[0][0]
+        assert "CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER=conan-token-xyz789" in conan_call[0][1]
+
+    @patch("vergil_tooling.lib.vm_guest._inject_host_git_identity")
+    def test_conan_token_value_is_shell_quoted(self, _mock_id: MagicMock, tmp_path: Path) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        token_file = tmp_path / "conan-audit-token"
+        token_file.write_text("tok en$with;special\n")
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            mode="user",
+            app_id="12345",
+            private_key_path=str(key_file),
+            conan_audit_token_path=str(token_file),
+        )
+
+        transport = _transport()
+        inject_credentials(transport, identity)
+
+        conan_call = transport.pipe.call_args_list[3]
+        quoted = shlex.quote("tok en$with;special")
+        assert conan_call[0][1] == f"export CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER={quoted}\n"
+
+    @patch("vergil_tooling.lib.vm_guest._inject_host_git_identity")
+    def test_skips_conan_token_when_not_configured(
+        self, _mock_id: MagicMock, tmp_path: Path
+    ) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            mode="user",
+            app_id="12345",
+            private_key_path=str(key_file),
+        )
+
+        transport = _transport()
+        inject_credentials(transport, identity)
+
+        assert transport.run.call_count == 3
+        assert transport.pipe.call_count == 3
+        for call in transport.pipe.call_args_list:
+            assert "conan.env" not in call[0][0]
+
+    @patch("vergil_tooling.lib.vm_guest._inject_host_git_identity")
+    def test_exits_if_conan_token_missing(self, _mock_id: MagicMock, tmp_path: Path) -> None:
+        key_file = tmp_path / "app.pem"
+        key_file.write_text("-----BEGIN RSA PRIVATE KEY-----\nfakekey\n")
+        bad_path = "/nonexistent/conan-audit-token"  # noqa: S105
+
+        identity = Identity(
+            vm_instance="vergil-agent",
+            mode="user",
+            app_id="12345",
+            private_key_path=str(key_file),
+            conan_audit_token_path=bad_path,
         )
         with pytest.raises(SystemExit):
             inject_credentials(_transport(), identity)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2356,6 +2356,17 @@ def test_session_inner_fresh_flag() -> None:
     assert "--fresh" in inner
 
 
+def test_session_inner_sources_conan_env() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _session_inner
+
+    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None)
+    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    assert "conan.env" in inner
+    assert "claude.env" in inner
+
+
 def test_session_inner_resume_name() -> None:
     import argparse
 


### PR DESCRIPTION
# Pull Request

## Summary

- Deliver CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER into the VM agent environment via a new identities.toml conan_audit_token_path field and a _inject_conan_token injector, mirroring the Anthropic-token pattern.

## Issue Linkage

- Closes #2578

## Notes

- Mirrors the claude-token injection exactly. identity.py gains a conan_audit_token_path field parsed from the conan_audit_token_path TOML key. vm_guest._inject_conan_token (gated on the field, transport-agnostic for Lima and cloud) reads the bare token from the host file and writes a shell-quoted export CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER line into ~/.config/vergil/conan.env (chmod 600) plus an idempotent .bashrc source line. vrg_vm._session_inner also sources conan.env as a peer to claude.env for non-interactive sessions. The token value never lives in the repo; it stays in a host file the code only reads by path. Tests cover identity parsing, the injector including shell-quoting, and session sourcing. Full vrg-validate green (4557 tests, 100% coverage).