### PR TITLE
fix(languages): revert C++ AUDIT to conan audit + cppcheck googletest lib

### DIFF
--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -376,8 +376,8 @@ _REGISTRY: dict[str, Language] = {
     "cpp": Language(
         name="cpp",
         checks={
-            # ``conan lock create`` resolves the dependency graph and writes the
-            # ``conan.lock`` that AUDIT (OSV-Scanner) scans; ``conan install``
+            # ``conan lock create`` resolves the dependency graph and writes a
+            # ``conan.lock`` that pins it for the Debug builds; ``conan install``
             # then materializes the binaries. Both pin ``build_type=Debug`` so
             # Conan builds deps in the *same* configuration as the CMake
             # coverage/sanitizer builds — the container image only bakes a
@@ -428,6 +428,10 @@ _REGISTRY: dict[str, Language] = {
                     "--error-exitcode=1",
                     "--inline-suppr",
                     "--std={std}",
+                    # GoogleTest is the documented default framework; without its
+                    # library config cppcheck throws a syntaxError on the TEST()
+                    # macro (T11 #2558). The images ship googletest.cfg. (#2579)
+                    "--library=googletest",
                     "--suppressions-list={configs}/cpp/cppcheck-suppressions.txt",
                     ".",
                 ],
@@ -500,18 +504,18 @@ _REGISTRY: dict[str, Language] = {
                 ["cmake", "--build", _CPP_SANITIZE_BUILD_DIR, "--parallel"],
                 ["ctest", "--test-dir", _CPP_SANITIZE_BUILD_DIR, "--output-on-failure"],
             ],
-            # AUDIT runs *once* (§3.6). OSV-Scanner scans the ``conan.lock``
-            # produced in INSTALL for CVEs. This replaces ``conan audit``, whose
-            # SaaS provider (audit.conan.io) needs a JFrog token and is
-            # rate-limited — a throughput bottleneck under AI-speed per-PR
-            # scanning. OSV-Scanner is tokenless, offline-capable, and natively
-            # parses ``conan.lock``, so it scales with PR velocity (decision:
-            # vergil-project/.github#209; T11 finding #2558; tool added to the
-            # images image-side in #487). License checking stays best-effort
-            # surfacing in v1 (no turnkey Conan allowlist gate); hardened gating
-            # against ``_CPP_LICENSES_ALLOWLIST`` is ledger #7.
+            # AUDIT runs *once* (§3.6). ``conan audit`` scans the dependency
+            # graph against ConanCenter's advisory database, reading its provider
+            # token from ``CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER`` in the env.
+            # This *reverts* the #2572 switch to OSV-Scanner: T11 (#2558) proved
+            # OSV.dev carries no ConanCenter package data, so ``osv-scanner`` over
+            # ``conan.lock`` reported a false all-clear — it never had the CVE
+            # data to find anything. The decision was reversed on
+            # vergil-project/.github#209 (#2579). License checking stays
+            # best-effort surfacing in v1 (no turnkey Conan allowlist gate);
+            # hardened gating against ``_CPP_LICENSES_ALLOWLIST`` is ledger #7.
             CheckKind.AUDIT: [
-                ["osv-scanner", "scan", "source", "--lockfile=conan.lock"],
+                ["conan", "audit", "scan", "."],
                 ["conan", "graph", "info", ".", "--format=json"],
             ],
         },

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -282,7 +282,7 @@ def test_cpp_is_supported() -> None:
 
 def test_cpp_install_commands() -> None:
     joined = _joined(language_commands("cpp", CheckKind.INSTALL))
-    # A conan.lock is produced so AUDIT (OSV-Scanner) has a lockfile to scan.
+    # A conan.lock is produced to pin the dependency graph for the Debug builds.
     assert any("conan lock create" in c for c in joined)
     # Conan resolves deps in the same build_type (Debug) as the CMake
     # coverage/sanitizer builds — a Release/Debug mismatch broke the cold
@@ -306,8 +306,15 @@ def test_cpp_lint_commands() -> None:
     joined = _joined(cmds)
     assert any("clang-format" in c and "--dry-run --Werror" in c for c in joined)
     assert any("run-clang-tidy" in c for c in joined)
+    # cppcheck runs with --library=googletest so it parses GoogleTest's TEST()
+    # macro instead of throwing a syntaxError on it — GoogleTest is the
+    # documented default framework and the images ship googletest.cfg. (#2579)
     assert any(
-        "cppcheck" in c and "--enable=all" in c and "--error-exitcode=1" in c for c in joined
+        "cppcheck" in c
+        and "--enable=all" in c
+        and "--error-exitcode=1" in c
+        and "--library=googletest" in c
+        for c in joined
     )
 
 
@@ -382,11 +389,13 @@ def test_cpp_test_commands_coverage_ctest_and_sanitizers() -> None:
 
 def test_cpp_audit_commands() -> None:
     joined = _joined(language_commands("cpp", CheckKind.AUDIT))
-    # OSV-Scanner over conan.lock is the CVE scan — tokenless and scalable,
-    # replacing conan audit (SaaS token, rate-limited). Decision: #209. (#2572)
-    assert "osv-scanner scan source --lockfile=conan.lock" in joined
-    # conan audit is retired here.
-    assert not any("conan audit" in c for c in joined)
+    # conan audit is the CVE scan — it reads ConanCenter advisories using the
+    # CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER env token. OSV-Scanner was reverted
+    # because OSV.dev carries no ConanCenter data, so it produced a false
+    # all-clear (T11 #2558; decision reversal #209). (#2579)
+    assert "conan audit scan ." in joined
+    # OSV-Scanner is retired here.
+    assert not any("osv-scanner" in c for c in joined)
     # Best-effort license-metadata surfacing (hardened gating deferred, §9 #7).
     assert any("conan graph info" in c for c in joined)
 


### PR DESCRIPTION
# Pull Request

## Summary

- Revert the C++ AUDIT command from OSV-Scanner back to conan audit (which had no ConanCenter CVE data, per T11 #2558) and add --library=googletest to the cppcheck LINT argv so it parses GoogleTest's TEST() macro.

## Issue Linkage

- Closes #2579

## Notes

- Reverts the #2572 AUDIT tool switch only: AUDIT is now [conan, audit, scan, .] (reads CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER from the env) plus the retained best-effort conan graph info license surface, cardinality ONCE. Rationale: T11 (#2558) showed OSV.dev carries no ConanCenter data, so osv-scanner over conan.lock was a false all-clear; decision reversal on vergil-project/.github#209. cppcheck gains --library=googletest (images ship googletest.cfg; GoogleTest is the default framework). All other #2572 fixes are kept unchanged: conan.lock production, -s build_type=Debug --build=missing on conan install, and repo-relative gcovr --root/--filter paths. Unit tests in test_languages.py updated to pin the new AUDIT and cppcheck argv. Validation green: 4550 passed, 100% coverage.