### PR TITLE
fix(vrg-validate): curate C++ cppcheck LINT enable set + exclude build tree

### DIFF
--- a/docs/site/docs/standards/development/cpp/toolchain-and-warnings.md
+++ b/docs/site/docs/standards/development/cpp/toolchain-and-warnings.md
@@ -104,3 +104,37 @@ The warning set is distinct from the LINT stage, which runs `clang-format`,
 and `cppcheck` once on the primary Clang image. TYPECHECK is the compiler's own
 judgment under both families; LINT is dedicated static analysis. Both gate a
 change; neither substitutes for the other.
+
+### cppcheck's curated enable set
+
+`cppcheck` runs with a **curated** enable set rather than `--enable=all`:
+
+```text
+--enable=warning,style,performance,portability
+```
+
+This deliberately drops three of `all`'s checks:
+
+- **`unusedFunction`** — an *unreliable* check for GoogleTest code. `cppcheck`
+  analyses one translation unit at a time and cannot see the
+  static-registration machinery behind the `TEST()` macro, so it reports every
+  test function as dead code. The finding is a systematic false positive, not a
+  real one.
+- **`information` / `missingInclude`** — diagnostics about `cppcheck`'s own
+  analysis coverage, not about the code. They add noise without gating quality.
+
+Dropping `unusedFunction` is **tool-tuning of a check that emits systematic
+false positives — not a suppression**. It honours the
+[No Standing Suppression List](#no-standing-suppression-list) rule exactly: no
+real finding is silenced, and no standing suppression-list entry is added. The
+distinction is deliberate. A suppression mutes a *true* warning about the code;
+here the check itself is wrong for this codebase's idioms, so the correct fix is
+to stop running the broken check, not to catalogue the findings it fabricates.
+The narrow, local suppression escape hatch (`--inline-suppr` plus the packaged
+`cppcheck-suppressions.txt`) still exists for a genuine, unavoidable finding.
+
+`cppcheck` also excludes the CMake build tree with `-i build -i build-sanitize`.
+Left to walk `.` unfiltered it descends into the compiler-probe file CMake
+generates under `build/` (`CMakeCXXCompilerId.cpp`) and trips `toomanyconfigs` —
+a build artifact, never source. This mirrors the build-dir prune the
+`clang-format` find driver already applies.

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -424,7 +424,16 @@ _REGISTRY: dict[str, Language] = {
                 ],
                 [
                     "cppcheck",
-                    "--enable=all",
+                    # Curated enable set, NOT ``--enable=all`` (#2585). This drops
+                    # the unreliable ``unusedFunction`` check — a systematic false
+                    # positive on GoogleTest's static-registered ``TEST()``
+                    # functions, which cppcheck reports as dead code because it
+                    # cannot see the cross-TU/static-registration usage — plus the
+                    # noisy ``information``/``missingInclude``. It is deliberate
+                    # tool-tuning of a check that emits systematic false positives,
+                    # not a standing suppression-list entry (§ No Standing
+                    # Suppression List): a real finding is never silenced here.
+                    "--enable=warning,style,performance,portability",
                     "--error-exitcode=1",
                     "--inline-suppr",
                     "--std={std}",
@@ -433,6 +442,14 @@ _REGISTRY: dict[str, Language] = {
                     # macro (T11 #2558). The images ship googletest.cfg. (#2579)
                     "--library=googletest",
                     "--suppressions-list={configs}/cpp/cppcheck-suppressions.txt",
+                    # Never walk CMake's ``build/``/``build-sanitize/`` output —
+                    # its compiler-probe file (``CMakeCXXCompilerId.cpp``) trips
+                    # ``toomanyconfigs`` (#2585). clang-format prunes the same dirs
+                    # via its find driver above; cppcheck excludes them with -i.
+                    "-i",
+                    _CPP_BUILD_DIR,
+                    "-i",
+                    _CPP_SANITIZE_BUILD_DIR,
                     ".",
                 ],
             ],

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -309,11 +309,21 @@ def test_cpp_lint_commands() -> None:
     # cppcheck runs with --library=googletest so it parses GoogleTest's TEST()
     # macro instead of throwing a syntaxError on it — GoogleTest is the
     # documented default framework and the images ship googletest.cfg. (#2579)
+    #
+    # The enable set is *curated*, not ``--enable=all`` (#2585): it drops the
+    # unreliable ``unusedFunction`` check (a systematic false positive on
+    # GoogleTest's static-registered ``TEST()`` functions — cppcheck cannot see
+    # cross-TU usage) plus the noisy ``information``/``missingInclude``. The
+    # build tree is excluded with ``-i build -i build-sanitize`` so cppcheck
+    # never walks CMake's compiler-probe file and trips ``toomanyconfigs``.
     assert any(
         "cppcheck" in c
-        and "--enable=all" in c
+        and "--enable=warning,style,performance,portability" in c
+        and "--enable=all" not in c
         and "--error-exitcode=1" in c
         and "--library=googletest" in c
+        and "-i build " in c
+        and "-i build-sanitize " in c
         for c in joined
     )
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fixes the C++ cppcheck LINT gate by excluding CMake's build tree (-i build -i build-sanitize) and replacing --enable=all with a curated warning,style,performance,portability set that drops the unreliable unusedFunction check.

## Issue Linkage

- Closes #2585

## Notes

- Two independent T11 (#2558) failures. (1) cppcheck walked build/ and tripped toomanyconfigs on CMakeCXXCompilerId.cpp; now excluded via -i, mirroring clang-format's build-dir prune. (2) --enable=all flagged unusedFunction on every GoogleTest TEST() function — a systematic false positive (single-TU analysis can't see TEST()'s static registration); the curated set drops it plus the noisy information/missingInclude. This is tool-tuning of a check that emits systematic false positives, NOT a standing suppression-list entry, so the no-standing-suppression rule stays intact (epic #207 decision (a)). Kept --error-exitcode=1, --inline-suppr, --std, --library=googletest, and the packaged cppcheck-suppressions.txt. Pinned argv test updated; C++ toolchain-and-warnings standard documents the enable set and the drop-vs-suppress rationale. Final argv: cppcheck --enable=warning,style,performance,portability --error-exitcode=1 --inline-suppr --std={std} --library=googletest --suppressions-list={configs}/cpp/cppcheck-suppressions.txt -i build -i build-sanitize .