### PR TITLE
fix(vm-memory): reopen guest memory dir for writing before re-projection copy

### DIFF
--- a/src/vergil_tooling/lib/vm_memory.py
+++ b/src/vergil_tooling/lib/vm_memory.py
@@ -55,9 +55,12 @@ def project_memory(transport: Transport, *, claude_dir: Path, host_workdir: str)
     directory exists, then copies — file-by-file over ``transport.pipe`` — every
     file under the host ``memory/`` directory (including ``MEMORY.md``) to the
     matching guest path under ``~/.claude/projects/<slug>/memory/`` and the global
-    ``~/.claude/CLAUDE.md``. Each pipe clears any prior read-only lock
-    (``chmod u+w`` before ``cat >``) so a re-projection can overwrite a locked
-    cache. If the host has no memory directory for this repo yet, the guest memory
+    ``~/.claude/CLAUDE.md``. Before the copy the whole guest memory subtree is
+    reopened for writing (``chmod -R u+w``) so a re-projection can both overwrite
+    existing files *and* create new ones into a directory a prior
+    ``lock_projection`` froze read-only (issue #2591); each pipe additionally
+    clears the per-file lock (``chmod u+w`` before ``cat >``). If the host has no
+    memory directory for this repo yet, the guest memory
     directory is still created and the memory copy is skipped (not an error — a
     repo may have no memory yet); the global ``CLAUDE.md`` is projected regardless.
 
@@ -84,7 +87,20 @@ def project_memory(transport: Transport, *, claude_dir: Path, host_workdir: str)
         dest = f"{guest_memory_dir}/{rel}"
         guest_dirs.add(dest.rsplit("/", 1)[0])
         copies.append((dest, src))
-    transport.run("bash", "-c", f"mkdir -p {' '.join(sorted(guest_dirs))}")
+    # Reopen the whole memory subtree for writing *before* the copy so a *new*
+    # memory file can be created into a previously-locked projection (issue #2591).
+    # A prior ``lock_projection`` froze the directory itself read-only
+    # (``chmod -R a-w``), and that lock survives a VM rebuild on a persistent guest
+    # disk; the per-file ``chmod u+w`` below only reopens files that *already*
+    # exist, so without this the first host-added-since-last-projection file dies
+    # with EACCES (``cat >`` cannot create it in a ``dr-xr-xr-x`` dir). ``chmod``
+    # runs after ``mkdir`` so the target always exists; on a first projection the
+    # freshly-created dir is already writable and the ``chmod`` is a harmless no-op.
+    transport.run(
+        "bash",
+        "-c",
+        f"mkdir -p {' '.join(sorted(guest_dirs))} && chmod -R u+w {guest_memory_dir}",
+    )
 
     for dest, src in copies:
         transport.pipe(f"chmod u+w {dest} 2>/dev/null; cat > {dest}", src.read_text())

--- a/tests/vergil_tooling/test_vm_memory.py
+++ b/tests/vergil_tooling/test_vm_memory.py
@@ -73,6 +73,28 @@ def test_project_memory_mkdirs_guest_memory_dir(tmp_path: Path) -> None:
     assert f"mkdir -p ~/.claude/projects/{_SLUG}/memory" in script
 
 
+def test_project_memory_restores_dir_write_before_copy(tmp_path: Path) -> None:
+    # Regression (#2591): a prior projection locked the *directory* read-only
+    # (``lock_projection`` runs ``chmod -R a-w <memory_dir>``), and on a persistent
+    # guest disk that lock survives a VM rebuild. The re-projection restores write
+    # per *file* (``chmod u+w {dest}``) but that only reopens files that already
+    # exist — creating a *new* host-added memory file needs write on the *parent
+    # directory*, which is still ``dr-xr-xr-x``. So the setup step must reopen the
+    # whole memory subtree for writing *before* the copy loop, or the first new
+    # file aborts the cloud session with EACCES.
+    transport = MagicMock()
+    claude = tmp_path / ".claude"
+    _seed_memory(claude)
+
+    vm_memory.project_memory(transport, claude_dir=claude, host_workdir=_WORKDIR)
+
+    # The setup runs first (before any pipe) and reopens the guest memory subtree
+    # recursively so a new file can be created into a previously-locked dir.
+    setup = transport.run.call_args_list[0].args[-1]
+    assert transport.run.call_args_list[0].args[0] == "bash"
+    assert f"chmod -R u+w ~/.claude/projects/{_SLUG}/memory" in setup
+
+
 def test_project_memory_copies_nested_memory_file(tmp_path: Path) -> None:
     transport = MagicMock()
     claude = tmp_path / ".claude"


### PR DESCRIPTION
# Pull Request

## Summary

- Fold a chmod -R u+w of the guest memory subtree into project_memory's mkdir setup so a re-projection can create a NEW memory file into a directory a prior lock_projection froze read-only, instead of aborting the cloud session with EACCES.

## Issue Linkage

- Closes #2591

## Notes

- Root cause: lock_projection freezes the memory dir itself (chmod -R a-w); on a persistent guest disk that lock survives a VM rebuild. The re-projection only reopened existing files per-file (chmod u+w {dest}), never the directory, so creating the first host-added-since-last-projection memory file failed with permission denied. Test: project once, then assert the setup step reopens the whole subtree (chmod -R u+w) before the copy loop. Full vrg-validate green, 100% coverage. Live guest was manually unblocked (chmod -R u+w) so the affected VM is usable now; this fix makes re-projection self-healing.