### PR TITLE
fix(pr-gates): require docs / docs check + pin universal reusable-CI set

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -279,6 +279,9 @@ def desired_ci_gates_ruleset(
     checks.append(_make_check("quality / common"))
     checks.append(_make_check("security / trivy"))
     checks.append(_make_check("security / semgrep"))
+    # docs / docs is emitted unconditionally by the reusable CI (no if: guard),
+    # so it must be a required PR gate — otherwise it can silently be optional.
+    checks.append(_make_check("docs / docs"))
 
     # GHAS check runs — created by GitHub Advanced Security (app 57789)
     # when workflows upload SARIF via codeql-action/upload-sarif.  These

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -272,6 +272,47 @@ def test_ci_gates_always_includes_common_and_security() -> None:
     assert "Semgrep OSS" in check_names
 
 
+def test_desired_ci_gates_requires_docs_check() -> None:
+    """`docs / docs` is emitted unconditionally by the reusable CI and must be a
+    required PR gate (present even without GHAS)."""
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=False)
+    contexts = {
+        str(c["context"])
+        for rule in ruleset.rules
+        for c in cast(
+            "dict[str, list[dict[str, object]]]",
+            rule["parameters"],
+        )["required_status_checks"]
+    }
+    assert "docs / docs" in contexts
+
+
+UNIVERSAL_REUSABLE_CI_CHECKS = frozenset(
+    {
+        "quality / common",
+        "security / trivy",
+        "security / semgrep",
+        "docs / docs",
+        "version / version-bump",
+    }
+)
+
+
+def test_universal_reusable_ci_checks_are_all_required() -> None:
+    """Pins the vergil-actions reusable-CI universal checks. Update this set
+    deliberately when the reusable CI adds/removes a universal PR job."""
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=False)
+    contexts = {
+        str(c["context"])
+        for rule in ruleset.rules
+        for c in cast(
+            "dict[str, list[dict[str, object]]]",
+            rule["parameters"],
+        )["required_status_checks"]
+    }
+    assert contexts >= UNIVERSAL_REUSABLE_CI_CHECKS
+
+
 def test_ci_gates_ghas_checks_use_ghas_integration_id() -> None:
     r = desired_ci_gates_ruleset(_project(), _ci(), ghas=True)
     checks = _checks(r)
@@ -436,6 +477,7 @@ _EXPECTED_GATES_TWO_VERSIONS = [
     "quality / common",
     "security / trivy",
     "security / semgrep",
+    "docs / docs",
     "Trivy",
     "Semgrep OSS",
     "security / codeql",


### PR DESCRIPTION
# Pull Request

## Summary

- Add the unconditionally-emitted docs / docs job to the desired required-status-check set so it becomes a required PR gate, and pin the universal reusable-CI check contract so no universal check can silently become optional.

## Issue Linkage

- Closes #2597

## Notes

- TDD: added test_desired_ci_gates_requires_docs_check (RED then GREEN) plus a completeness test pinning UNIVERSAL_REUSABLE_CI_CHECKS (quality/common, security/trivy, security/semgrep, docs/docs, version/version-bump); the existing byte-identical snapshot _EXPECTED_GATES_TWO_VERSIONS was updated to include docs / docs. Source change is one line: checks.append(_make_check('docs / docs')) in the Always-present block of desired_ci_gates_ruleset. Full vrg-validate green (4560 tests, 100% coverage). Task A1 of epic vergil-project/.github#224; unblocks the fleet-wide re-apply deployment task.