### PR TITLE
fix(finalize): raise on GitHub-orphaned check-run instead of hanging

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -14,6 +14,7 @@ import functools
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -576,28 +577,94 @@ def _poll_and_watch_checks(
             return
 
 
+class OrphanedCheckError(Exception):
+    """A required check is stuck non-terminal after its backing run completed.
+
+    GitHub occasionally leaves a check-run in a non-terminal state
+    (``queued``/``in_progress``) even though the workflow run that owns it has
+    finished. ``gh pr checks --watch`` would block on such a check forever, so
+    the bounded watch surfaces it as this error instead of hanging (and never
+    merges past it). The message tells the operator how to recover.
+    """
+
+
+# A check ``link`` for an Actions job looks like
+# ``https://github.com/<owner>/<repo>/actions/runs/<run_id>/job/<job_id>``.
+# App-posted statuses (CodeQL/Semgrep/Trivy) use a different, non-Actions link
+# with no run id to probe, so they never match.
+_ACTIONS_RUN_LINK_RE = re.compile(r"/actions/runs/(\d+)/job/")
+
+
+def run_completed(run_id: str) -> bool:
+    """True if the workflow run has reached a terminal status."""
+    data = read_json("run", "view", run_id, "--json", "status")
+    return isinstance(data, dict) and data.get("status") == "completed"
+
+
+def all_checks_terminal(pr: str) -> bool:
+    """True when no check on *pr* is still ``pending`` (gh's non-terminal bucket)."""
+    return all(c.get("bucket") != "pending" for c in pr_checks(pr))
+
+
+def orphaned_check_names(pr: str) -> list[str]:
+    """Return names of non-terminal checks whose backing Actions run is completed.
+
+    A still-``pending`` check whose backing workflow run has already finished is
+    a GitHub orphan — it will never reach a terminal state on its own. Only
+    checks whose ``link`` is an Actions job link are probed; app-posted statuses
+    (no ``/actions/runs/.../job/`` link) have no run to query and are excluded.
+    """
+    orphans: list[str] = []
+    for check in pr_checks(pr):
+        if check.get("bucket") != "pending":
+            continue
+        match = _ACTIONS_RUN_LINK_RE.search(check.get("link") or "")
+        if match is None:
+            continue
+        if run_completed(match.group(1)):
+            orphans.append(str(check.get("name")))
+    return orphans
+
+
 def wait_for_checks(
     pr: str,
     *,
     poll_interval: int = _POLL_INTERVAL_SECS,
     poll_timeout: int = _POLL_TIMEOUT_SECS,
 ) -> None:
-    """Block until all checks on *pr* reach a terminal state.
+    """Block until all checks on *pr* reach a terminal state, bounded by a deadline.
 
-    Polls the GitHub REST API until at least one check run exists for
-    the PR's current head commit, then hands off to ``gh pr checks
-    --watch`` which blocks until every check completes.  Resilient to
-    the head moving mid-wait (see ``_poll_and_watch_checks``).
+    Polls ``gh pr checks`` until every check is terminal, then returns — leaving
+    ``pr_merge``'s ``failed_check_names`` gate to catch any failure. If the
+    deadline elapses with checks still pending, each still-pending check is
+    cross-checked against its backing workflow run via ``gh run view``: a
+    non-terminal check over a *completed* run is a GitHub orphan and raises
+    :class:`OrphanedCheckError` (never hang, never merge past it). If nothing is
+    orphaned (e.g. app-posted statuses genuinely still running), a plain timeout
+    :class:`GitHubAPIError` is raised instead.
 
     Transient GitHub API errors (401/502/503/504/429) are retried
     automatically via the library-level retry wrapper.
     """
-    _poll_and_watch_checks(
-        pr,
-        lambda: run("pr", "checks", pr, "--watch"),
-        poll_interval=poll_interval,
-        poll_timeout=poll_timeout,
-    )
+    deadline = time.monotonic() + poll_timeout
+    while True:
+        if all_checks_terminal(pr):
+            return  # let pr_merge.failed_check_names catch any failure
+        if time.monotonic() >= deadline:
+            orphans = orphaned_check_names(pr)
+            if orphans:
+                raise OrphanedCheckError(
+                    f"GitHub left {', '.join(orphans)} non-terminal after its "
+                    "backing workflow run completed (orphaned check-run). Close "
+                    "and reopen the PR to re-run the gate, then re-run "
+                    "vrg-finalize-pr."
+                )
+            raise GitHubAPIError(
+                1,
+                ("gh", "pr", "checks", pr),
+                stderr=f"checks still pending after {poll_timeout}s",
+            )
+        time.sleep(poll_interval)
 
 
 _FAILED_BUCKETS = frozenset({"fail", "cancel"})
@@ -630,7 +697,7 @@ def failed_check_names(pr: str) -> list[str]:
 
 
 def pr_checks(pr: str) -> list[dict[str, str]]:
-    """Return the PR's checks as ``{name, bucket, state}`` dicts.
+    """Return the PR's checks as ``{name, bucket, state, link}`` dicts.
 
     ``gh pr checks`` exits non-zero while checks are failing or pending but
     still emits the requested JSON, so the verdict is derived from the data,
@@ -638,8 +705,11 @@ def pr_checks(pr: str) -> list[dict[str, str]]:
     ``gh`` prints nothing and reports "no checks reported"; that is a valid
     empty result (checks may not have started), distinct from a transient API
     error, which is surfaced.
+
+    ``link`` is included so orphan detection can map a still-pending check
+    back to its backing Actions run (see :func:`orphaned_check_names`).
     """
-    cmd = ("gh", "pr", "checks", pr, "--json", "name,bucket,state")
+    cmd = ("gh", "pr", "checks", pr, "--json", "name,bucket,state,link")
     result = _run_with_retry(cmd, check=False, text=True, capture_output=True)  # noqa: S607
     out = result.stdout.strip()
     if out:

--- a/src/vergil_tooling/lib/pr_merge.py
+++ b/src/vergil_tooling/lib/pr_merge.py
@@ -24,7 +24,7 @@ from vergil_tooling.lib import github
 
 # Imported directly (not via the module) so the `except` clause holds the
 # real class even when tests replace the whole `github` module with a mock.
-from vergil_tooling.lib.github import GitHubAPIError
+from vergil_tooling.lib.github import GitHubAPIError, OrphanedCheckError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -87,7 +87,16 @@ def wait_and_merge(
             continue
 
         print(f"Waiting for checks on {pr}...")
-        wait(pr)
+        try:
+            wait(pr)
+        except OrphanedCheckError as exc:
+            msg = (
+                f"PR {pr} cannot be merged: GitHub left a check-run non-terminal "
+                "after its backing workflow run completed (orphaned check-run). "
+                "Close and reopen the PR to re-run the gate, then re-run "
+                "vrg-finalize-pr."
+            )
+            raise MergeAbortError(msg) from exc
 
         failed = github.failed_check_names(pr)
         if failed:

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -141,161 +141,156 @@ def test_edit_pr_body_cleans_up_temp_file() -> None:
     assert paths and not paths[0].exists()
 
 
-def test_wait_for_checks_resolves_sha_and_watches() -> None:
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123") as mock_sha,
-        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
-        patch("vergil_tooling.lib.github.run") as mock_run,
-    ):
-        github.wait_for_checks("https://github.com/pr/1")
-    mock_sha.assert_called_once_with("https://github.com/pr/1")
-    mock_run.assert_called_once_with("pr", "checks", "https://github.com/pr/1", "--watch")
-
-
-def test_wait_for_checks_polls_until_registered() -> None:
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
-        patch(
-            "vergil_tooling.lib.github._checks_registered",
-            side_effect=[False, False, True, True],
-        ),
-        patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
-        patch("vergil_tooling.lib.github.run") as mock_run,
-    ):
-        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
-    assert mock_sleep.call_count == 2
-    mock_sleep.assert_called_with(5)
-    mock_run.assert_called_once_with("pr", "checks", "https://github.com/pr/1", "--watch")
-
-
-def test_wait_for_checks_passes_repo_and_sha_to_checks_registered() -> None:
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
-        patch("vergil_tooling.lib.github._checks_registered", return_value=True) as mock_reg,
-        patch("vergil_tooling.lib.github.run"),
-    ):
-        github.wait_for_checks("https://github.com/pr/1")
-    mock_reg.assert_called_with("owner/repo", "abc123")
-
-
-def test_wait_for_checks_raises_after_timeout_with_sha() -> None:
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123def456"),
-        patch("vergil_tooling.lib.github._checks_registered", return_value=False),
-        patch(
-            "vergil_tooling.lib.github.time.monotonic",
-            side_effect=[0.0, 0.0, 61.0],
-        ),
-        patch("vergil_tooling.lib.github.time.sleep"),
-        patch("vergil_tooling.lib.github.run") as mock_run,
-        pytest.raises(github.GitHubAPIError, match="abc123de"),
-    ):
-        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
-    mock_run.assert_not_called()
-
-
-def test_wait_for_checks_uses_poll_interval_for_sleep() -> None:
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
-        patch(
-            "vergil_tooling.lib.github._checks_registered",
-            side_effect=[False, True, True],
-        ),
-        patch("vergil_tooling.lib.github.time.sleep") as mock_sleep,
-        patch("vergil_tooling.lib.github.run"),
-    ):
-        github.wait_for_checks("https://github.com/pr/1", poll_interval=10, poll_timeout=60)
-    mock_sleep.assert_called_once_with(10)
-
-
-def test_wait_for_checks_does_not_use_fail_fast() -> None:
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
-        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
-        patch("vergil_tooling.lib.github.run") as mock_run,
-    ):
-        github.wait_for_checks("https://github.com/pr/1")
-    call_args = mock_run.call_args[0]
-    assert "--fail-fast" not in call_args
-
-
-def test_wait_for_checks_reresolves_head_while_polling() -> None:
-    """The head SHA is re-resolved each poll — update-branch can move it (#1490)."""
-
-    def registered(_repo: str, sha: str) -> bool:
-        return sha == "new"
-
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", side_effect=["old", "new"]) as mock_sha,
-        patch("vergil_tooling.lib.github._checks_registered", side_effect=registered) as mock_reg,
-        patch("vergil_tooling.lib.github.time.sleep"),
-        patch("vergil_tooling.lib.github.run") as mock_run,
-    ):
-        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
-    assert mock_sha.call_count == 2
-    assert mock_reg.call_args[0] == ("owner/repo", "new")
-    mock_run.assert_called_once_with("pr", "checks", "https://github.com/pr/1", "--watch")
-
-
-def test_wait_for_checks_restarts_watch_on_no_checks_reported() -> None:
-    """A watch killed by "no checks reported" (head moved mid-watch) restarts (#1490)."""
-    no_checks = github.GitHubAPIError(
-        1,
-        ("gh", "pr", "checks", "1", "--watch"),
-        None,
-        "no checks reported on the 'feature/x' branch",
+def test_run_completed_true_when_status_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github, "read_json", lambda *a, **k: {"status": "completed", "conclusion": "success"}
     )
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", side_effect=["old", "new"]),
-        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
-        patch("vergil_tooling.lib.github.time.sleep"),
-        patch("vergil_tooling.lib.github.run", side_effect=[no_checks, None]) as mock_run,
-    ):
-        github.wait_for_checks("https://github.com/pr/1")
-    assert mock_run.call_count == 2
+    assert github.run_completed("31101639453") is True
 
 
-def test_wait_for_checks_propagates_other_watch_failures() -> None:
-    """Only the "no checks reported" watch failure is transient; the rest raise."""
-    boom = github.GitHubAPIError(1, ("gh",), None, "HTTP 401: Bad credentials")
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
-        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
-        patch("vergil_tooling.lib.github.run", side_effect=boom) as mock_run,
-        pytest.raises(github.GitHubAPIError, match="Bad credentials"),
-    ):
-        github.wait_for_checks("https://github.com/pr/1")
-    mock_run.assert_called_once()
+def test_run_completed_false_when_in_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github, "read_json", lambda *a, **k: {"status": "in_progress"})
+    assert github.run_completed("31101639453") is False
 
 
-def test_wait_for_checks_watch_restart_bounded_by_deadline() -> None:
-    """The no-checks restart shares the poll deadline — past it, the error raises (#1490)."""
-    no_checks = github.GitHubAPIError(
-        1,
-        ("gh", "pr", "checks", "1", "--watch"),
-        None,
-        "no checks reported on the 'feature/x' branch",
+def test_run_completed_queries_run_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_read_json(*args: str) -> dict[str, object]:
+        calls.append(args)
+        return {"status": "completed"}
+
+    monkeypatch.setattr(github, "read_json", fake_read_json)
+    github.run_completed("999")
+    assert calls == [("run", "view", "999", "--json", "status")]
+
+
+def test_orphaned_check_names_flags_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "pr_checks",
+        lambda pr: [
+            {
+                "name": "docs / docs",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "https://github.com/o/r/actions/runs/999/job/1",
+            },
+            {
+                "name": "quality / common",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://github.com/o/r/actions/runs/999/job/2",
+            },
+        ],
     )
-    with (
-        patch("vergil_tooling.lib.github.current_repo", return_value="owner/repo"),
-        patch("vergil_tooling.lib.github.head_sha", return_value="abc123"),
-        patch("vergil_tooling.lib.github._checks_registered", return_value=True),
-        patch("vergil_tooling.lib.github.time.monotonic", side_effect=[0.0, 61.0]),
-        patch("vergil_tooling.lib.github.time.sleep"),
-        patch("vergil_tooling.lib.github.run", side_effect=no_checks) as mock_run,
-        pytest.raises(github.GitHubAPIError, match="no checks reported"),
-    ):
-        github.wait_for_checks("https://github.com/pr/1", poll_interval=5, poll_timeout=60)
-    mock_run.assert_called_once()
+    monkeypatch.setattr(github, "run_completed", lambda rid: True)
+    assert github.orphaned_check_names("934") == ["docs / docs"]
+
+
+def test_orphaned_check_names_ignores_running_and_app_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        github,
+        "pr_checks",
+        lambda pr: [
+            {
+                "name": "docs / docs",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "https://github.com/o/r/actions/runs/999/job/1",
+            },
+            {
+                "name": "CodeQL",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "https://github.com/o/r/runs/5",  # app-posted: no /actions/runs
+            },
+        ],
+    )
+    monkeypatch.setattr(github, "run_completed", lambda rid: False)
+    assert github.orphaned_check_names("934") == []
+
+
+def test_orphaned_check_names_parses_run_id_from_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(
+        github,
+        "pr_checks",
+        lambda pr: [
+            {
+                "name": "docs / docs",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "https://github.com/o/r/actions/runs/31101639453/job/77",
+            },
+        ],
+    )
+    monkeypatch.setattr(github, "run_completed", lambda rid: bool(seen.append(rid)) or True)
+    github.orphaned_check_names("934")
+    assert seen == ["31101639453"]
+
+
+def test_all_checks_terminal_true_when_no_pending(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "pr_checks",
+        lambda pr: [
+            {"name": "a", "bucket": "pass", "state": "SUCCESS", "link": ""},
+            {"name": "b", "bucket": "fail", "state": "FAILURE", "link": ""},
+        ],
+    )
+    assert github.all_checks_terminal("934") is True
+
+
+def test_all_checks_terminal_false_when_pending(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        github,
+        "pr_checks",
+        lambda pr: [
+            {"name": "a", "bucket": "pending", "state": "IN_PROGRESS", "link": ""},
+        ],
+    )
+    assert github.all_checks_terminal("934") is False
+
+
+def test_wait_for_checks_returns_when_all_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(github, "all_checks_terminal", lambda pr: True)
+    # must not consult orphan logic or raise when everything is terminal
+    monkeypatch.setattr(
+        github,
+        "orphaned_check_names",
+        lambda pr: pytest.fail("orphan check must not run when all terminal"),
+    )
+    assert github.wait_for_checks("934", poll_timeout=0, poll_interval=0) is None
+
+
+def test_wait_for_checks_raises_on_orphan(monkeypatch: pytest.MonkeyPatch) -> None:
+    # checks never all-terminal; timeout elapses; orphan detected
+    monkeypatch.setattr(github, "all_checks_terminal", lambda pr: False)
+    monkeypatch.setattr(github, "orphaned_check_names", lambda pr: ["docs / docs"])
+    with pytest.raises(github.OrphanedCheckError, match="docs / docs"):
+        github.wait_for_checks("934", poll_timeout=0, poll_interval=0)
+
+
+def test_wait_for_checks_timeout_without_orphan_raises_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # pending but nothing orphaned (e.g. app-posted status still running)
+    monkeypatch.setattr(github, "all_checks_terminal", lambda pr: False)
+    monkeypatch.setattr(github, "orphaned_check_names", lambda pr: [])
+    with pytest.raises(github.GitHubAPIError, match="still pending"):
+        github.wait_for_checks("934", poll_timeout=0, poll_interval=0)
+
+
+def test_wait_for_checks_polls_until_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    terminal_states = iter([False, False, True])
+    sleeps: list[int] = []
+    monkeypatch.setattr(github, "all_checks_terminal", lambda pr: next(terminal_states))
+    monkeypatch.setattr(github.time, "sleep", lambda s: sleeps.append(s))
+    github.wait_for_checks("934", poll_interval=7, poll_timeout=1000)
+    assert sleeps == [7, 7]
 
 
 def test_failed_check_names_returns_failing_checks() -> None:
@@ -350,19 +345,19 @@ def test_failed_check_names_raises_on_empty_output() -> None:
 def test_pr_checks_returns_parsed_checks() -> None:
     payload = json.dumps(
         [
-            {"name": "build", "bucket": "pass", "state": "SUCCESS"},
-            {"name": "deploy", "bucket": "pending", "state": "IN_PROGRESS"},
+            {"name": "build", "bucket": "pass", "state": "SUCCESS", "link": "https://x/1"},
+            {"name": "deploy", "bucket": "pending", "state": "IN_PROGRESS", "link": "https://x/2"},
         ]
     )
     with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
         mock_run.return_value = _completed(returncode=8, stdout=payload)
         result = github.pr_checks("https://github.com/pr/1")
     assert result == [
-        {"name": "build", "bucket": "pass", "state": "SUCCESS"},
-        {"name": "deploy", "bucket": "pending", "state": "IN_PROGRESS"},
+        {"name": "build", "bucket": "pass", "state": "SUCCESS", "link": "https://x/1"},
+        {"name": "deploy", "bucket": "pending", "state": "IN_PROGRESS", "link": "https://x/2"},
     ]
     mock_run.assert_called_once_with(
-        ("gh", "pr", "checks", "https://github.com/pr/1", "--json", "name,bucket,state"),
+        ("gh", "pr", "checks", "https://github.com/pr/1", "--json", "name,bucket,state,link"),
         check=False,
         text=True,
         capture_output=True,

--- a/tests/vergil_tooling/test_pr_merge.py
+++ b/tests/vergil_tooling/test_pr_merge.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vergil_tooling.lib.github import GitHubAPIError
+from vergil_tooling.lib.github import GitHubAPIError, OrphanedCheckError
 from vergil_tooling.lib.pr_merge import MergeAbortError, wait_and_merge
 
 _MOD = "vergil_tooling.lib.pr_merge"
@@ -85,6 +85,14 @@ def test_check_failure_aborts_with_names() -> None:
     gh = _gh(failed=["ci / test", "vergil-audit/approved"])
     with patch(_MOD + ".github", gh), pytest.raises(MergeAbortError, match="ci / test"):
         wait_and_merge("99", strategy="squash")
+    gh.merge.assert_not_called()
+
+
+def test_wait_and_merge_aborts_on_orphaned_check() -> None:
+    gh = _gh()
+    gh.wait_for_checks.side_effect = OrphanedCheckError("docs / docs")
+    with patch(_MOD + ".github", gh), pytest.raises(MergeAbortError, match="orphan"):
+        wait_and_merge("934", strategy="squash")
     gh.merge.assert_not_called()
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-finalize-pr now bounds its check watch and, on timeout, cross-checks each still-pending check against its backing workflow run so a non-terminal check over a completed run aborts with recovery guidance instead of hanging forever.

## Issue Linkage

- Closes #2598

## Notes

- wait_for_checks was rebuilt from the unbounded gh pr checks --watch into a bounded poll loop: it returns as soon as all checks are terminal (preserving pr_merge's failed_check_names gate for real failures), and on deadline it calls the new orphaned_check_names helper (run_completed + all_checks_terminal). An orphan raises OrphanedCheckError; app-posted statuses (CodeQL/Semgrep/Trivy), which have no Actions run link to probe, fall back to a plain timeout GitHubAPIError. pr_merge.wait_and_merge maps OrphanedCheckError to MergeAbortError and never merges. pr_checks now also requests the link field. The shared _poll_and_watch_checks helper is untouched (still used by the release path).