### PR TITLE
fix(finalize): sweep orphaned cached dev images for abandoned branches

### DIFF
--- a/src/vergil_tooling/bin/vrg_finalize_pr.py
+++ b/src/vergil_tooling/bin/vrg_finalize_pr.py
@@ -55,7 +55,11 @@ from vergil_tooling.lib import (
 )
 from vergil_tooling.lib.confirm import add_yes_argument, confirm
 from vergil_tooling.lib.container import detect_language
-from vergil_tooling.lib.container_cache import clean_branch_images, provision_dev_image
+from vergil_tooling.lib.container_cache import (
+    clean_branch_images,
+    provision_dev_image,
+    prune_orphan_branch_images,
+)
 from vergil_tooling.lib.pr_workflow import batch, github_transport
 from vergil_tooling.lib.progress import Stage
 from vergil_tooling.lib.repo_init import prompt_choice
@@ -307,6 +311,24 @@ def _prune_orphan_relay_refs(*, dry_run: bool) -> None:
             continue
         print(f"  Deleting orphaned relay ref for {branch} (branch no longer exists)")
         github_transport.GitHubTransport(branch).delete()
+
+
+def _prune_orphan_branch_images(*, dry_run: bool) -> None:
+    """Prune cached dev images whose branch no longer exists locally (issue #2600).
+
+    The per-branch cleanup already prunes the finalized branch's cached image
+    (``clean_branch_images``). This is the swept safety net for the branch that
+    was never finalized — abandoned, or its PR closed out of band — whose
+    ~1.3–2G cached image would otherwise linger and fill the VM disk. Mirrors
+    ``_prune_orphan_relay_refs``: keep images for still-live local branches,
+    remove the rest.
+    """
+    if dry_run:
+        print("  [dry-run] prune orphaned cached dev images")
+        return
+    removed = prune_orphan_branch_images(git.local_branches())
+    if removed:
+        print(f"  Pruned {removed} orphaned cached container image(s)")
 
 
 def _delete_branch_and_worktree(
@@ -778,6 +800,9 @@ def _stage_cleanup(ctx: FinalizeContext) -> None:
 
     print("Checking for orphaned pr-workflow relay refs...")
     _prune_orphan_relay_refs(dry_run=args.dry_run)
+
+    print("Checking for orphaned cached dev images...")
+    _prune_orphan_branch_images(dry_run=args.dry_run)
 
     print("Pruning stale remote-tracking references...")
     if args.dry_run:

--- a/src/vergil_tooling/lib/container_cache.py
+++ b/src/vergil_tooling/lib/container_cache.py
@@ -19,6 +19,7 @@ from vergil_tooling.lib.container import (
 from vergil_tooling.lib.languages import CheckKind, language_commands
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 _SELF_PROJECT_NAME = "vergil-tooling"
@@ -403,4 +404,46 @@ def clean_branch_images(branch: str, *, runtime: str = "") -> int:
                 capture_output=True,
             )
             removed += 1
+    return removed
+
+
+def prune_orphan_branch_images(live_branches: Iterable[str], *, runtime: str = "") -> int:
+    """Remove cached per-branch images whose branch is no longer live.
+
+    ``clean_branch_images`` prunes only the branch handed to it — the one being
+    finalized. A branch that is never finalized (abandoned, or its PR closed out
+    of band) leaves its ~1.3–2G cached image behind to accumulate and fill the
+    disk (issue #2600). This is the swept safety net, the image analogue of
+    ``vrg_finalize_pr._prune_orphan_relay_refs``: any cached image whose branch
+    segment matches no entry in *live_branches* is orphaned and removed.
+
+    A cached tag is ``<base_tag>--<sanitized_branch>--<cache_hash>``; a plain base
+    tag (``3.14``, ``latest``, ``clang-20``) never contains ``--``, so ``--`` in
+    the tag distinguishes our cached images without needing to know the base repo.
+    Cached images are local artifacts of local branches, so passing the live
+    *local* branches is the correct keep signal — an orphaned image simply
+    rebuilds on demand if its branch is resumed. Returns the count removed.
+    """
+    rt = runtime or detect_runtime()
+    keep = {f"--{_sanitize_branch(b)}--" for b in live_branches}
+    result = subprocess.run(  # noqa: S603
+        [rt, "images", "--format", "{{.Repository}}:{{.Tag}}"],  # noqa: S607
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return 0
+
+    removed = 0
+    for line in result.stdout.splitlines():
+        tag = line.rsplit(":", 1)[-1]
+        if "--" not in tag:
+            continue
+        if any(marker in tag for marker in keep):
+            continue
+        subprocess.run(  # noqa: S603
+            [rt, "rmi", line],  # noqa: S607
+            capture_output=True,
+        )
+        removed += 1
     return removed

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -172,6 +172,19 @@ def commits_ahead(base: str, branch: str) -> int:
     return int(read_output("rev-list", "--count", f"{base}..{branch}"))
 
 
+def local_branches() -> set[str]:
+    """Return the short names of all local branches.
+
+    Used to tell whether a cached per-branch dev image is orphaned: an image is a
+    local artifact of a local branch, so a branch absent here has no live work
+    referencing its image (#2600).
+    """
+    output = read_output("branch", "--format=%(refname:short)")
+    if not output:
+        return set()
+    return set(output.splitlines())
+
+
 def remote_branches(remote: str = "origin") -> set[str]:
     """Return the branch names present on *remote* (via ``ls-remote --heads``).
 

--- a/tests/vergil_tooling/test_container_cache.py
+++ b/tests/vergil_tooling/test_container_cache.py
@@ -19,6 +19,7 @@ from vergil_tooling.lib.container_cache import (
     ensure_cached_image,
     find_cached_image,
     provision_dev_image,
+    prune_orphan_branch_images,
     resolve_base_digest,
 )
 
@@ -377,6 +378,65 @@ def test_clean_branch_images_docker_error() -> None:
     mock_result = MagicMock(returncode=1, stdout="")
     with patch("vergil_tooling.lib.container_cache.subprocess.run", return_value=mock_result):
         assert clean_branch_images("feature/42", runtime="docker") == 0
+
+
+# -- prune_orphan_branch_images -----------------------------------------------
+
+
+def test_prune_orphan_branch_images_removes_only_orphans() -> None:
+    images = (
+        "ghcr.io/r/dev-python:3.14--develop--aaaa1111\n"  # live
+        "ghcr.io/r/dev-python:3.14--feature-300-live--bbbb2222\n"  # live
+        "ghcr.io/r/dev-python:3.14--feature-42-gone--cccc3333\n"  # orphan
+        "ghcr.io/r/dev-go:1.26--feature-9-abandoned--dddd4444\n"  # orphan
+        "ghcr.io/r/dev-python:3.14\n"  # plain base image — never touched
+    )
+    removed_lines: list[str] = []
+
+    def capture_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        if len(cmd) >= 2 and cmd[1] == "rmi":
+            removed_lines.append(cmd[2])
+            return MagicMock(returncode=0, stdout="")
+        return MagicMock(returncode=0, stdout=images)
+
+    with patch("vergil_tooling.lib.container_cache.subprocess.run", side_effect=capture_run):
+        removed = prune_orphan_branch_images(["develop", "feature/300-live"], runtime="docker")
+
+    assert removed == 2
+    assert removed_lines == [
+        "ghcr.io/r/dev-python:3.14--feature-42-gone--cccc3333",
+        "ghcr.io/r/dev-go:1.26--feature-9-abandoned--dddd4444",
+    ]
+
+
+def test_prune_orphan_branch_images_keeps_all_when_all_live() -> None:
+    images = "ghcr.io/r/dev-python:3.14--develop--aaaa1111\n"
+
+    def capture_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        assert not (len(cmd) >= 2 and cmd[1] == "rmi"), "no image should be removed"
+        return MagicMock(returncode=0, stdout=images)
+
+    with patch("vergil_tooling.lib.container_cache.subprocess.run", side_effect=capture_run):
+        assert prune_orphan_branch_images(["develop"], runtime="docker") == 0
+
+
+def test_prune_orphan_branch_images_no_live_branches_removes_all_cached() -> None:
+    images = (
+        "ghcr.io/r/dev-python:3.14--feature-1-x--aaaa1111\n"
+        "ghcr.io/r/dev-python:3.14\n"  # base — no `--`, untouched
+    )
+
+    def capture_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        return MagicMock(returncode=0, stdout=images)
+
+    with patch("vergil_tooling.lib.container_cache.subprocess.run", side_effect=capture_run):
+        assert prune_orphan_branch_images([], runtime="docker") == 1
+
+
+def test_prune_orphan_branch_images_docker_error() -> None:
+    mock_result = MagicMock(returncode=1, stdout="")
+    with patch("vergil_tooling.lib.container_cache.subprocess.run", return_value=mock_result):
+        assert prune_orphan_branch_images(["develop"], runtime="docker") == 0
 
 
 # -- _build_cached_image ------------------------------------------------------

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -231,6 +231,21 @@ def test_remote_branches_empty() -> None:
         assert git.remote_branches() == set()
 
 
+def test_local_branches_returns_set() -> None:
+    with patch(
+        "vergil_tooling.lib.git.read_output",
+        return_value="develop\nfeature/12-x\nfeature/13-y",
+    ) as mock:
+        result = git.local_branches()
+    assert result == {"develop", "feature/12-x", "feature/13-y"}
+    mock.assert_called_once_with("branch", "--format=%(refname:short)")
+
+
+def test_local_branches_empty() -> None:
+    with patch("vergil_tooling.lib.git.read_output", return_value=""):
+        assert git.local_branches() == set()
+
+
 def test_working_tree_status_returns_porcelain_output() -> None:
     with patch("vergil_tooling.lib.git.read_output", return_value="?? orphan.md") as mock:
         result = git.working_tree_status()

--- a/tests/vergil_tooling/test_vrg_finalize_pr.py
+++ b/tests/vergil_tooling/test_vrg_finalize_pr.py
@@ -19,6 +19,7 @@ from vergil_tooling.bin.vrg_finalize_pr import (
     _delete_branch_and_worktree,
     _dirt_is_untracked_only,
     _parse_pr_list,
+    _prune_orphan_branch_images,
     _prune_orphan_relay_refs,
     _resolve_open_prs,
     _resolve_strategy,
@@ -94,6 +95,22 @@ def _relay_refs_inert() -> Iterator[None]:
         patch(_MOD + ".github_transport.GitHubTransport"),
         patch(_MOD + ".github_transport.list_relay_branches", return_value=[]),
         patch(_MOD + ".git.remote_branches", return_value=set()),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _branch_images_inert() -> Iterator[None]:
+    """Default: the cached-image sweep touches nothing (issue #2600).
+
+    Cleanup sweeps orphaned per-branch dev images, which lists local branches and
+    shells out to the container runtime. Stub both seams so the many cleanup
+    tests neither hit docker/nerdctl nor need to know about image pruning. Tests
+    that assert sweep behavior re-patch these directly — the innermost patch wins.
+    """
+    with (
+        patch(_MOD + ".prune_orphan_branch_images", return_value=0),
+        patch(_MOD + ".git.local_branches", return_value=set()),
     ):
         yield
 
@@ -2403,6 +2420,33 @@ def test_prune_orphan_relay_refs_skipped_on_dry_run(
     mock_list.assert_not_called()
     mock_transport.assert_not_called()
     assert "[dry-run] prune orphaned" in capsys.readouterr().out
+
+
+def test_prune_orphan_branch_images_sweeps_dead_branches(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Cached images for branches absent locally are swept; live ones kept."""
+    with (
+        patch(_MOD + ".git.local_branches", return_value={"develop", "feature/live"}),
+        patch(_MOD + ".prune_orphan_branch_images", return_value=3) as mock_prune,
+    ):
+        _prune_orphan_branch_images(dry_run=False)
+    mock_prune.assert_called_once_with({"develop", "feature/live"})
+    assert "Pruned 3 orphaned cached container image(s)" in capsys.readouterr().out
+
+
+def test_prune_orphan_branch_images_skipped_on_dry_run(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--dry-run neither lists local branches nor removes any image."""
+    with (
+        patch(_MOD + ".git.local_branches") as mock_local,
+        patch(_MOD + ".prune_orphan_branch_images") as mock_prune,
+    ):
+        _prune_orphan_branch_images(dry_run=True)
+    mock_local.assert_not_called()
+    mock_prune.assert_not_called()
+    assert "[dry-run] prune orphaned cached dev images" in capsys.readouterr().out
 
 
 def test_main_sweeps_orphan_relay_ref(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-finalize-pr now sweeps cached per-branch dev images whose branch no longer exists locally, reclaiming the ~1.3-2G images that abandoned/never-finalized branches leave behind and fill the VM disk.

## Issue Linkage

- Closes #2600

## Notes

- Triaged from vergil-project/.github#228. The issue's primary ask (prune at finalize) was already implemented (clean_branch_images, wired at vrg_finalize_pr.py:353); the real gap was abandoned branches whose finalize never runs. New _prune_orphan_branch_images mirrors the existing _prune_orphan_relay_refs sweep — keep images for live LOCAL branches, remove the rest; honours --dry-run. Cached images are identified by their --<branch>--<hash> tag shape (base tags never contain --). ensure_cached_image is the only per-branch image builder, so finalize prune + this sweep cover all callers. Runtime-agnostic (nerdctl/docker).