### PR TITLE
refactor(vrg-vm): introduce SessionStore seam (scrape backend) for session enumeration/resolution

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -36,6 +36,7 @@ from vergil_tooling.lib.session import (
     plan_session,
     select_by_name,
 )
+from vergil_tooling.lib.session_store import ScrapeStore
 
 
 def _claude_dir() -> Path:
@@ -282,20 +283,19 @@ def roster_names(roster: list[dict[str, object]]) -> dict[str, str]:
 def _read_state(
     slug: str | None = None,
 ) -> tuple[dict[str, str], set[str], dict[str, float]]:
-    cdir = _claude_dir()
-    projects = cdir / "projects"
-    roster = read_roster(cdir / "sessions")
-    # Roster names are authoritative for live sessions and cover ones with no
-    # transcript yet; transcript names cover dead/archived sessions absent from
-    # the roster. Union them, letting the live roster name win on overlap.
-    names = {**name_by_session(projects, slug), **roster_names(roster)}
-    active = active_session_ids(roster)
-    last_active = _roster_updated_at(roster)
-    for sid in names:
-        if sid not in last_active:
-            ts = _last_activity(projects_glob(projects, sid))
-            if ts is not None:
-                last_active[sid] = ts
+    """Enumerate sessions through the ``SessionStore`` seam.
+
+    The transcript/roster scrape now lives behind :class:`ScrapeStore`; this
+    adapter collapses the seam's :class:`SessionInfo` rows back into the
+    ``(name_by_session, active_ids, last_active)`` tuple the slot machinery still
+    consumes. A ``name=None`` row (a live-but-unnamed session) contributes to the
+    active set and last-activity map but not to the name map — exactly as the
+    prior direct read did.
+    """
+    rows = ScrapeStore(_claude_dir(), slug).list_sessions()
+    names = {row.session_id: row.name for row in rows if row.name is not None}
+    active = {row.session_id for row in rows if row.active}
+    last_active = {row.session_id: row.last_active for row in rows if row.last_active is not None}
     return names, active, last_active
 
 

--- a/src/vergil_tooling/lib/session_store.py
+++ b/src/vergil_tooling/lib/session_store.py
@@ -1,0 +1,182 @@
+"""The ``SessionStore`` seam: one boundary for session enumeration/resolution.
+
+Everything the general code path needs about *which* Claude Code sessions exist
+and *how a name maps to a session id* goes through this seam. Today the only
+backend is :class:`ScrapeStore`, which reads the internal transcript JSONL and
+``~/.claude/sessions/<pid>.json`` roster — the formats Claude documents as
+unstable. That read is deliberately confined **here**: no other module parses a
+transcript or the roster, so when a verified Agent SDK backend arrives it drops
+in behind the same interface with no caller changes.
+
+The pure resolution rule (:func:`resolve_over`) lives here too so it is unit
+testable without any I/O: given the rows a store lists, resolve a name to at
+most one session — a live session wins, ties between two live sessions **fail
+loud**, and otherwise the most-recently-active idle session wins.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    """One Claude Code session as the seam sees it.
+
+    ``name`` is ``None`` for a live-but-unnamed session (a fresh session that has
+    not yet been named); such a row is enumerated but never matches a requested
+    name. ``last_active`` is epoch seconds, or ``None`` when the age is unknown.
+    """
+
+    session_id: str
+    name: str | None
+    cwd: str
+    active: bool
+    last_active: float | None
+
+
+class AmbiguousSessionError(Exception):
+    """A name resolved to two or more co-equal *live* sessions.
+
+    Resolution never silently picks one of several live sessions holding the same
+    name — that is the fail-loud rule of the seam.
+    """
+
+
+def resolve_over(rows: list[SessionInfo], name: str) -> SessionInfo | None:
+    """Resolve ``name`` against ``rows`` to at most one session.
+
+    The rule: consider only rows whose name matches exactly. **Zero matches →
+    ``None``.** **Two or more *active* matches → raise
+    :class:`AmbiguousSessionError`** (never guess between live sessions). A single
+    active match wins outright. Otherwise (all matches idle) the most recently
+    active wins, with an unknown age sorting oldest.
+    """
+    matches = [row for row in rows if row.name == name]
+    if not matches:
+        return None
+    active = [row for row in matches if row.active]
+    if len(active) >= 2:
+        raise AmbiguousSessionError(
+            f"name {name!r} resolves to {len(active)} live sessions: "
+            f"{', '.join(row.session_id for row in active)}"
+        )
+    if len(active) == 1:
+        return active[0]
+    return max(matches, key=lambda row: (row.last_active is not None, row.last_active or 0.0))
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    """The seam every session-enumeration/resolution caller depends on.
+
+    Backends: :class:`ScrapeStore` (today) and a future SDK-backed store. Callers
+    never branch on the backend; they call these three methods.
+    """
+
+    def list_sessions(self) -> list[SessionInfo]:
+        """Every session this store can see, as :class:`SessionInfo` rows."""
+        ...  # pragma: no cover
+
+    def resolve_name(self, name: str) -> SessionInfo | None:
+        """Resolve ``name`` to one session (or ``None``); fails loud on ambiguity."""
+        ...  # pragma: no cover
+
+    def rename(self, session_id: str, new_name: str) -> None:
+        """Rename a (possibly detached) session — the backend's supported path."""
+        ...  # pragma: no cover
+
+
+class ScrapeStore:
+    """``SessionStore`` backed by the transcript/roster scrape.
+
+    Shipped unconditionally: the seam always has a working backend, independent of
+    any Agent SDK. It wraps the existing scrape helpers in
+    :mod:`vergil_tooling.bin.vrg_vm_resolve` (``name_by_session`` / ``read_roster``
+    and friends) — the *only* place transcript/roster parsing is allowed — and
+    adapts their output into :class:`SessionInfo` rows.
+
+    ``rename`` appends a ``custom-title`` naming event to the session's transcript.
+    Hand-writing a naming event is the isolated hack that is legitimate **only**
+    here, inside the seam's scrape backend; every other code path renames via a
+    supported interface.
+
+    ``slug`` optionally scopes the transcript read to a single project slug (the
+    same scoping ``claude --resume`` uses); ``None`` scans every slug.
+    """
+
+    def __init__(self, claude_dir: Path, slug: str | None = None) -> None:
+        self._claude_dir = claude_dir
+        self._slug = slug
+
+    @property
+    def _projects_dir(self) -> Path:
+        return self._claude_dir / "projects"
+
+    @property
+    def _sessions_dir(self) -> Path:
+        return self._claude_dir / "sessions"
+
+    def list_sessions(self) -> list[SessionInfo]:
+        # Imported lazily to avoid an import cycle: ``vrg_vm_resolve`` imports this
+        # module at load time. The indirection keeps the transcript/roster scrape
+        # in one place while its low-level readers still live in the bin module
+        # (and stay monkeypatchable there).
+        from vergil_tooling.bin import vrg_vm_resolve as res
+
+        projects = self._projects_dir
+        roster = res.read_roster(self._sessions_dir)
+        # Roster names are authoritative for live sessions (and cover sessions with
+        # no transcript yet); transcript names cover idle sessions absent from the
+        # roster. Union them, letting the live roster name win on overlap.
+        names = {**res.name_by_session(projects, self._slug), **res.roster_names(roster)}
+        active = res.active_session_ids(roster)
+        last_active = res._roster_updated_at(roster)
+        for sid in names:
+            if sid not in last_active:
+                ts = res._last_activity(res.projects_glob(projects, sid))
+                if ts is not None:
+                    last_active[sid] = ts
+        cwds = _roster_cwds(roster)
+
+        # Named sessions first (preserving the union's order), then any other known
+        # session id — a live-but-unnamed session, or one carrying only a roster
+        # last-activity — as a name=None row so the seam surfaces every session.
+        extra = sorted(sid for sid in (active | set(last_active)) if sid not in names)
+        return [
+            SessionInfo(
+                session_id=sid,
+                name=names.get(sid),
+                cwd=cwds.get(sid, ""),
+                active=sid in active,
+                last_active=last_active.get(sid),
+            )
+            for sid in [*names, *extra]
+        ]
+
+    def resolve_name(self, name: str) -> SessionInfo | None:
+        return resolve_over(self.list_sessions(), name)
+
+    def rename(self, session_id: str, new_name: str) -> None:
+        from vergil_tooling.bin import vrg_vm_resolve as res
+
+        transcript = res.projects_glob(self._projects_dir, session_id)
+        entry = {"type": "custom-title", "customTitle": new_name, "sessionId": session_id}
+        with transcript.open("a") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _roster_cwds(roster: list[dict[str, object]]) -> dict[str, str]:
+    """Map session id to its roster ``cwd`` when the roster records one."""
+    out: dict[str, str] = {}
+    for entry in roster:
+        sid = entry.get("sessionId")
+        cwd = entry.get("cwd")
+        if isinstance(sid, str) and isinstance(cwd, str):
+            out[sid] = cwd
+    return out

--- a/tests/vergil_tooling/test_session_store.py
+++ b/tests/vergil_tooling/test_session_store.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vergil_tooling.lib.session_store import (
+    AmbiguousSessionError,
+    ScrapeStore,
+    SessionInfo,
+    resolve_over,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _s(sid: str, name: str | None, active: bool, last: float | None) -> SessionInfo:
+    return SessionInfo(sid, name, "/w", active, last)
+
+
+# --- pure resolve_over ---
+
+
+def test_resolve_picks_active_over_idle() -> None:
+    rows = [_s("a", "epic-1:w", False, 10.0), _s("b", "epic-1:w", True, 5.0)]
+    result = resolve_over(rows, "epic-1:w")
+    assert result is not None
+    assert result.session_id == "b"
+
+
+def test_resolve_idle_by_most_recent() -> None:
+    rows = [_s("a", "epic-1:w", False, 10.0), _s("b", "epic-1:w", False, 20.0)]
+    result = resolve_over(rows, "epic-1:w")
+    assert result is not None
+    assert result.session_id == "b"
+
+
+def test_resolve_none_when_absent() -> None:
+    assert resolve_over([_s("a", "other:w", True, 1.0)], "epic-1:w") is None
+
+
+def test_resolve_raises_on_two_active() -> None:
+    rows = [_s("a", "epic-1:w", True, 10.0), _s("b", "epic-1:w", True, 20.0)]
+    with pytest.raises(AmbiguousSessionError):
+        resolve_over(rows, "epic-1:w")
+
+
+def test_resolve_ignores_unnamed_rows() -> None:
+    # A live-but-unnamed session (name is None) never matches a requested name.
+    rows = [_s("a", None, True, 10.0), _s("b", "epic-1:w", False, 5.0)]
+    result = resolve_over(rows, "epic-1:w")
+    assert result is not None
+    assert result.session_id == "b"
+
+
+def test_resolve_idle_unknown_age_loses_to_known() -> None:
+    rows = [_s("a", "epic-1:w", False, None), _s("b", "epic-1:w", False, 1.0)]
+    result = resolve_over(rows, "epic-1:w")
+    assert result is not None
+    assert result.session_id == "b"
+
+
+# --- ScrapeStore over the transcript/roster scrape ---
+
+
+def _write_title(path: Path, sid: str, name: str) -> None:
+    path.write_text(f'{{"type":"custom-title","customTitle":"{name}","sessionId":"{sid}"}}\n')
+
+
+def test_scrape_store_lists_named_sessions(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-w"
+    slug.mkdir(parents=True)
+    _write_title(slug / "s1.jsonl", "s1", "epic-1:w")
+    (claude / "sessions").mkdir()
+
+    rows = ScrapeStore(claude).list_sessions()
+    by_id = {r.session_id: r for r in rows}
+    assert by_id["s1"].name == "epic-1:w"
+    assert by_id["s1"].active is False
+
+
+def test_scrape_store_rename_then_list_reflects_new_name(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-w"
+    slug.mkdir(parents=True)
+    _write_title(slug / "s1.jsonl", "s1", "epic-1:w")
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    store.rename("s1", "epic-1-renamed:w")
+
+    names = {r.session_id: r.name for r in store.list_sessions()}
+    assert names["s1"] == "epic-1-renamed:w"
+
+
+def test_scrape_store_surfaces_roster_cwd_and_active(tmp_path: Path) -> None:
+    # A live session named only in the roster (no transcript yet) is surfaced
+    # active, with the cwd the roster records.
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    sessions = claude / "sessions"
+    sessions.mkdir()
+    (sessions / "100.json").write_text(
+        '{"pid":100,"sessionId":"s1","name":"epic-9:w","cwd":"/work/repo",'
+        '"updatedAt":1748000000000}'
+    )
+
+    import vergil_tooling.bin.vrg_vm_resolve as res
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(res, "_is_live", lambda _pid, _ps: True)
+    try:
+        rows = {r.session_id: r for r in ScrapeStore(claude).list_sessions()}
+    finally:
+        monkey.undo()
+    assert rows["s1"].name == "epic-9:w"
+    assert rows["s1"].cwd == "/work/repo"
+    assert rows["s1"].active is True
+    assert rows["s1"].last_active == 1748000000.0
+
+
+def test_scrape_store_resolve_name_uses_resolve_over(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-w"
+    slug.mkdir(parents=True)
+    _write_title(slug / "s1.jsonl", "s1", "epic-1:w")
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    resolved = store.resolve_name("epic-1:w")
+    assert resolved is not None
+    assert resolved.session_id == "s1"
+    assert store.resolve_name("nope:w") is None


### PR DESCRIPTION
# Pull Request

## Summary

- Add the lib/session_store.py SessionStore seam with a ScrapeStore backend and the pure resolve_over rule, and route vrg_vm_resolve enumeration through it so all transcript/roster scraping is confined to one boundary.

## Issue Linkage

- Closes #2605

## Notes

- Task 1 of epic vergil-project/.github#230. New lib/session_store.py provides SessionInfo, AmbiguousSessionError, the pure resolve_over(rows, name) helper (0 matches to None, 2+ live matches raise, single-live wins, else most-recent idle), the SessionStore Protocol, and the unconditionally-shipped ScrapeStore over the existing name_by_session()/read_roster() scrape. ScrapeStore.rename appends a custom-title naming event to the transcript, the isolated hack confined to the seam. vrg_vm_resolve._read_state now derives its (names, active, last_active) tuple from ScrapeStore.list_sessions(), leaving _exec_claude and the supported-flag exec untouched; the slot machinery and existing behavior are unchanged (all 4581 tests green, 100% coverage). SDK backend is the separate conditional T8; the host aggregator in vrg_vm.py is left for T4.