### PR TITLE
docs(epic-224): document required-gate invariant and finalize orphaned-check handling

### DIFF
--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -271,6 +271,25 @@ Jobs that remain inline keep their names unchanged:
 - `test: unit (<version>)`
 - `test: integration (<version>)`
 
+The docs-build job is a universal reusable-CI job emitted on every
+managed repo with no `if:` guard, so it always runs and surfaces the
+`docs / docs` check.
+
+### Every gate is required — there are no optional PR gates
+
+Every check that can gate a PR is configured as a **required status
+check** on the target branch; there is no tier of checks that runs but
+does not block. `docs / docs` is required alongside the tests, audit,
+release gates, and the `security-and-standards /` checks — the desired
+required-check set is complete, and it is pinned by a test so it cannot
+silently drift.
+
+`vrg-github-repo-config audit` **hard-fails on required-set drift**: if a
+repo's configured required checks diverge from the desired set, the audit
+fails rather than reporting a warning. `vrg-release` gates on that audit,
+so a repo whose required-check set has drifted cannot release until the
+set is reconciled.
+
 ## Dev container images
 
 Published to `ghcr.io/vergil-project/dev-<language>:<version>` from the

--- a/docs/site/docs/reference/dev/finalize-pr.md
+++ b/docs/site/docs/reference/dev/finalize-pr.md
@@ -47,10 +47,24 @@ worktrees, which is unsafe when the calling shell's CWD is inside one.
 
 When the PR's checks are not finished, `vrg-finalize-pr` waits for
 them and merges automatically once everything is green and current.
-Doomed outcomes abort immediately rather than after the wait: a draft
-PR, merge conflicts, a failed check (named in the error), or a branch
-still behind after five update attempts. A branch that is merely
-behind the target is updated automatically and the wait restarts.
+The wait is **bounded** by a deadline — it never blocks forever — and
+it never merges past a non-terminal check. Doomed outcomes abort
+immediately rather than after the wait: a draft PR, merge conflicts, a
+failed check (named in the error), or a branch still behind after five
+update attempts. A branch that is merely behind the target is updated
+automatically and the wait restarts.
+
+**Orphaned check-runs.** GitHub occasionally leaves a check-run
+non-terminal (`queued`/`in_progress`) even though the workflow run that
+owns it has already completed — an *orphan* that would never go green on
+its own. When the deadline elapses with checks still pending, finalize
+cross-checks each one against its backing run (`gh run view`). A
+non-terminal check over a completed run is an orphan, so finalize
+**aborts with recovery guidance** — close and reopen the PR to re-run the
+gate, then re-run `vrg-finalize-pr` — rather than hanging. Genuinely
+still-running checks are waited on as normal; if the deadline elapses
+with nothing orphaned (for example an app-posted status that is legitimately
+slow), finalize fails with a plain timeout error instead.
 
 After the merge, the PR's own branch and worktree are cleaned up
 explicitly (a squash merge hides them from `git branch --merged`),
@@ -231,4 +245,4 @@ release — the batch runs those once at the end.
 | Code | Meaning |
 | ---- | ------- |
 | 0 | Finalization complete, or declined at a confirmation prompt |
-| 1 | Provenance violation, unmergeable PR (draft, conflicts, failed checks, stuck behind), not run from main worktree, non-TTY stdin or stdout in inference mode, dirty working tree, failed validation, failed CD run, or a batch item failed |
+| 1 | Provenance violation, unmergeable PR (draft, conflicts, failed checks, stuck behind, orphaned check-run, or wait timeout), not run from main worktree, non-TTY stdin or stdout in inference mode, dirty working tree, failed validation, failed CD run, or a batch item failed |


### PR DESCRIPTION
# Pull Request

## Summary

- Update user-facing docs to reflect epic #224: the no-optional-PR-gate invariant (docs / docs is a required check) and finalize's bounded, orphan-resilient check wait.

## Issue Linkage

- Closes #2596

## Notes

- ci-architecture.md CI gates section: added that docs / docs is a universal required gate and a new subsection stating every gate is required (no optional PR gates), that vrg-github-repo-config audit hard-fails on required-set drift, and that vrg-release gates on that audit. finalize-pr.md Waiting for green section: documented the bounded wait and the orphaned check-run case (aborts with close/reopen recovery guidance rather than hanging, never merges past a non-terminal check, genuinely-running checks still waited on, non-orphan timeout falls back to a plain error); updated the exit-code 1 row to include orphaned check-run and wait timeout.