### PR TITLE
fix(github): don't crash finalize merge gate on a fresh PR with zero registered checks

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -602,8 +602,19 @@ def run_completed(run_id: str) -> bool:
 
 
 def all_checks_terminal(pr: str) -> bool:
-    """True when no check on *pr* is still ``pending`` (gh's non-terminal bucket)."""
-    return all(c.get("bucket") != "pending" for c in pr_checks(pr))
+    """True when *pr* has at least one check and none is still ``pending``.
+
+    An empty check set is deliberately **not** terminal. Zero registered checks
+    means CI has not registered yet — transient right after PR creation or a head
+    move — so the waiter must keep waiting rather than conclude "all done" from a
+    vacuous ``all([])`` and hand a check-less PR straight to the merge gate. That
+    vacuous-true short-circuit was the primary defect behind the finalize
+    registration-race crash (#2623): GitHub's post-outage timing widened the
+    window where a freshly-created PR briefly has no checks, and the old
+    ``all([]) is True`` made ``wait_for_checks`` return immediately.
+    """
+    checks = pr_checks(pr)
+    return bool(checks) and all(c.get("bucket") != "pending" for c in checks)
 
 
 def orphaned_check_names(pr: str) -> list[str]:
@@ -691,6 +702,13 @@ def failed_check_names(pr: str) -> list[str]:
     result = _run_with_retry(cmd, check=False, text=True, capture_output=True)  # noqa: S607
     out = result.stdout.strip()
     if not out:
+        if _NO_CHECKS_MARKER in (result.stderr or "").lower():
+            # Zero checks registered for the head — transient (right after PR
+            # creation or a head move), not a real API error. No checks means no
+            # *known* failures, mirroring pr_checks' handling of the same marker.
+            # Raising here (instead of tolerating) was the defect that crashed the
+            # finalize merge gate during the registration race (#2623).
+            return []
         raise GitHubAPIError(result.returncode or 1, cmd, stderr=result.stderr)
     checks = json.loads(out)
     return [str(c["name"]) for c in checks if c.get("bucket") in _FAILED_BUCKETS]

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -255,6 +255,29 @@ def test_all_checks_terminal_false_when_pending(monkeypatch: pytest.MonkeyPatch)
     assert github.all_checks_terminal("934") is False
 
 
+def test_all_checks_terminal_false_when_no_checks_registered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Zero registered checks (freshly-created PR) must NOT read as terminal — the
+    # vacuous all([]) short-circuit was the finalize registration-race bug (#2623).
+    monkeypatch.setattr(github, "pr_checks", lambda pr: [])
+    assert github.all_checks_terminal("934") is False
+
+
+def test_wait_for_checks_does_not_return_early_on_zero_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression (#2623): with no checks registered yet, the waiter must keep
+    # polling until checks appear, then return once they are terminal — not
+    # return immediately on the empty set.
+    check_batches = iter([[], [], [{"name": "a", "bucket": "pass", "state": "S", "link": ""}]])
+    monkeypatch.setattr(github, "pr_checks", lambda pr: next(check_batches))
+    sleeps: list[int] = []
+    monkeypatch.setattr(github.time, "sleep", lambda s: sleeps.append(s))
+    github.wait_for_checks("934", poll_interval=5, poll_timeout=1000)
+    assert sleeps == [5, 5]  # waited through the two zero-check polls
+
+
 def test_wait_for_checks_returns_when_all_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(github, "all_checks_terminal", lambda pr: True)
     # must not consult orphan logic or raise when everything is terminal
@@ -340,6 +363,19 @@ def test_failed_check_names_raises_on_empty_output() -> None:
     ):
         mock_run.return_value = _completed(returncode=1, stdout="", stderr="boom")
         github.failed_check_names("https://github.com/pr/1")
+
+
+def test_failed_check_names_tolerates_no_checks_reported() -> None:
+    # Regression (#2623): empty output with gh's "no checks reported" stderr is a
+    # freshly-created-PR / head-moved race, not a failure. It must yield no failing
+    # checks rather than raising and crashing the finalize merge gate.
+    with patch("vergil_tooling.lib.retry.subprocess.run") as mock_run:
+        mock_run.return_value = _completed(
+            returncode=1,
+            stdout="",
+            stderr="no checks reported on the 'feature/x' branch",
+        )
+        assert github.failed_check_names("https://github.com/pr/1") == []
 
 
 def test_pr_checks_returns_parsed_checks() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Fixes the fleet-blocking vrg-finalize-pr regression exposed by GitHub's post-outage timing changes: when a freshly-created PR briefly has zero registered checks, the merge gate crashed with 'no checks reported'. Two root-cause fixes in lib/github.py — all_checks_terminal([]) is no longer vacuously True (so wait_for_checks actually waits for checks to register instead of returning early), and failed_check_names now tolerates the 'no checks reported' marker like its sibling pr_checks (defense in depth).

## Issue Linkage

- Closes #2623

## Notes

- Root cause: all_checks_terminal([]) returned True via vacuous all([]), so wait_for_checks returned immediately on a check-less fresh PR and handed straight to failed_check_names, which raised on empty output. GitHub's increased check-registration latency widened the race window. Fix mirrors patterns already in the file (the --watch path already tolerated this). Adds 3 regression tests; vrg-validate green (4584 passed, 100% coverage). Must be released + installed to take effect (human-gated). Recommend fast-tracking a release since this blocks automated PR finalize fleet-wide.