### PR TITLE
docs(standards): require hard gates only — eliminate soft gates

### DIFF
--- a/docs/site/docs/standards/source-control-guidelines.md
+++ b/docs/site/docs/standards/source-control-guidelines.md
@@ -82,20 +82,31 @@ references by tag or commit SHA.
 
 ### CI gates
 
-Every CI check must be classified as either a hard gate or a soft gate.
+Every CI gate is a hard gate. There are no soft gates. A check is either
+enforced as a required status check that blocks PR merge, or it is not a
+gate at all — there is no middle tier that runs but does not block. A check
+worth running is worth failing on; a non-blocking gate silently rots and
+gives false confidence.
 
 - Hard gate: blocking. A failing check prevents PR submission and merge.
-- Soft gate: warning-only. A failing check does not block merge, but must be
-  surfaced in the PR with rationale and any follow-up tracking.
+  This is the only kind of gate.
 
-Each repository must explicitly list its checks and their gate type. If a
-check is not classified, treat it as a hard gate until documented.
+Every gate that can block a PR must be enforced as a required status check
+on the target branches, so a failing GitHub Actions check blocks the merge.
+If a check is not worth enforcing as a required status check, it must not
+gate the PR — remove it rather than run it as a non-blocking warning. A
+report-only or "advisory-permanent" check is not an allowed category.
 
-Hard gates must be enforced as required status checks on the target branches
-so failing GitHub Actions block PR merges.
+Each repository must explicitly list its required checks, and the
+required-check set must be pinned (for example, by a test or a config audit)
+so it cannot silently drift. This mirrors the CI implementation, where the
+same configuration that computes a repo's required status checks drives
+branch protection. See the guide
+[CI Architecture](../guides/ci-architecture.md), section "Every gate is
+required — there are no optional PR gates".
 
-Each repository must also document which hard gates apply per branch. Some
-hard gates may be develop-only, while others must run on all eternal branches.
+Each repository must also document which gates apply per branch. Some gates
+may be develop-only, while others must run on all eternal branches.
 
 ## GitHub repository settings
 


### PR DESCRIPTION
# Pull Request

## Summary

- Rewrite the CI gates section of the source control guidelines to assert that every CI gate is a hard gate, eliminating the soft-gate concept.

## Issue Linkage

- Closes #2625

## Notes

- Deliverable 1 (doc): Rewrote the CI gates subsection of docs/site/docs/standards/source-control-guidelines.md. Removed the hard-gate/soft-gate classification and the warning-only definition; the page now states every gate is a hard gate, a check either blocks merge as a required status check or is not a gate, report-only/advisory-permanent is not an allowed category, and the required-check set must be pinned. Added a cross-reference to the ci-architecture guide's 'Every gate is required' subsection. Aligns with epic #224.

Deliverable 2 (verification): No IMPLEMENTED CI soft gates exist. desired_ci_gates_ruleset() in lib/github_config.py puts every computed check — including 'version / version-bump' — into required_status_checks (blocking); there is no continue-on-error, preview-<version>, or eol-<version> anywhere under .github/workflows/. The 'version /' check labelled 'non-blocking' in ci-evidence-convention.md is non-blocking only for RELEASE-EVIDENCE production, not for merge — it is still a required status check (red herring). ci-evidence-convention.md already rejects a permanent soft/report-only gate.

Exceptions to report (DOCUMENTED but NOT implemented — human decides converge-vs-exception, no code change made): (a) docs/site/docs/standards/development/runtime-version-support-policy.md still defines and prescribes soft gates (Tier 2 'preview-<version>') and advisory gates (Tier 4 'eol-<version>'); (b) python/version-management.md prescribes preview-/security- checks as advisory/non-blocking; (c) rust/overview.md lists soft gates. These contradict the new hard-gates-only standard on paper but no repo implements them today. (d) finalize-pr provenance advisories (pr_provenance.py _ADVISORY; 'Advisories are printed but do not block') are a real non-blocking behavior, but a human-run merge-time provenance NOTICE, not a CI status gate — out of scope of the CI-gate concept and advisory by design.

Follow-up (out of scope, not edited): five language overviews (go/python/shell/java/cpp) still say 'see source-control-guidelines for hard gate and soft gate definitions' — those cross-references are now stale and want a follow-up. Validation: vrg-container-run -- vrg-validate green (4584 passed, 100% coverage).