### PR TITLE
docs(standards): reframe preview/eol advisory gates as an unsupported-version carve-out

### DIFF
--- a/docs/site/docs/standards/development/cpp/overview.md
+++ b/docs/site/docs/standards/development/cpp/overview.md
@@ -135,7 +135,10 @@ framework, tests are registered with CTest so the runner contract holds.
 ## CI Gates
 
 See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
-for hard gate and soft gate definitions.
+for the hard-gates-only standard: every CI check is a hard gate, and the only
+sanctioned non-blocking category is the advisory-on-unsupported-versions
+carve-out (see the
+[Runtime Version Support Policy](../runtime-version-support-policy.md)).
 
 C++ hard gates run per compiler and per version:
 

--- a/docs/site/docs/standards/development/go/overview.md
+++ b/docs/site/docs/standards/development/go/overview.md
@@ -24,7 +24,10 @@ and long-term survivability across repositories.
 ## CI Gates
 
 See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
-for hard gate and soft gate definitions.
+for the hard-gates-only standard: every CI check is a hard gate, and the only
+sanctioned non-blocking category is the advisory-on-unsupported-versions
+carve-out (see the
+[Runtime Version Support Policy](../runtime-version-support-policy.md)).
 
 Required checks for Go repositories are maintained in the
 [standard-actions CI gates documentation](https://vergil-project.github.io/standard-actions/ci-gates/required-checks/).

--- a/docs/site/docs/standards/development/java/overview.md
+++ b/docs/site/docs/standards/development/java/overview.md
@@ -26,7 +26,10 @@ and long-term survivability across repositories.
 ## CI Gates
 
 See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
-for hard gate and soft gate definitions.
+for the hard-gates-only standard: every CI check is a hard gate, and the only
+sanctioned non-blocking category is the advisory-on-unsupported-versions
+carve-out (see the
+[Runtime Version Support Policy](../runtime-version-support-policy.md)).
 
 Required checks for Java repositories are maintained in the
 [standard-actions CI gates documentation](https://vergil-project.github.io/standard-actions/ci-gates/required-checks/).

--- a/docs/site/docs/standards/development/python/overview.md
+++ b/docs/site/docs/standards/development/python/overview.md
@@ -23,7 +23,10 @@ and long-term survivability across repositories.
 ## CI Gates
 
 See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
-for hard gate and soft gate definitions.
+for the hard-gates-only standard: every CI check is a hard gate, and the only
+sanctioned non-blocking category is the advisory-on-unsupported-versions
+carve-out (see the
+[Runtime Version Support Policy](../runtime-version-support-policy.md)).
 
 Required checks for Python repositories are maintained in the
 [standard-actions CI gates documentation](https://vergil-project.github.io/standard-actions/ci-gates/required-checks/).

--- a/docs/site/docs/standards/development/python/version-management.md
+++ b/docs/site/docs/standards/development/python/version-management.md
@@ -61,7 +61,14 @@ When the next Python minor series transitions from pre-release to bugfix
    `bugfix-<version>`, `preview-<version>`, and (when applicable)
    `security-<version>`.
 3. Keep `bugfix-<version>` jobs as the only hard gate. The
-   `preview-<version>` check is advisory and must not block merges.
+   `preview-<version>` check is non-blocking under the
+   advisory-on-unsupported-versions carve-out — advisory *because* the preview
+   minor is not yet in the supported set, not because it is a generic soft
+   gate. See the
+   [Runtime Version Support Policy](../runtime-version-support-policy.md) for
+   the carve-out and
+   [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
+   for the hard-gates-only standard.
 4. Record any failures in the preview check and track them as issues, but do
    not block PRs unless a bugfix-tier job fails.
 
@@ -77,9 +84,12 @@ threshold:
 2. Make the new minor the required (hard-gate) CI runtime and relabel it as
    `bugfix-<version>`.
 3. Relabel the prior bugfix minor as `security-<version>` and keep it
-   advisory to preserve rollback capability.
-4. Keep `security-<version>` advisory until humans explicitly decide to drop
-   it. Do not auto-remove based on elapsed cycles alone.
+   non-blocking under the advisory-on-unsupported-versions carve-out to
+   preserve rollback capability — advisory *because* the minor has left the
+   primary supported set, not as a generic soft gate.
+4. Keep `security-<version>` advisory under the same carve-out until humans
+   explicitly decide to drop it. Do not auto-remove based on elapsed cycles
+   alone.
 
 ### Stability tracking
 

--- a/docs/site/docs/standards/development/runtime-version-support-policy.md
+++ b/docs/site/docs/standards/development/runtime-version-support-policy.md
@@ -24,12 +24,20 @@ management standard; it does not replace them.
   patches, with no further bug fixes.
 - **EOL (end of life)**: A release series no longer receiving any patches from
   the upstream maintainer.
-- **Hard gate**: A CI check that blocks PR merge when it fails.
-- **Soft gate**: A CI check that surfaces warnings but does not block PR merge.
-  Failures must be documented in the PR with rationale and any follow-up
-  tracking.
-- **Advisory**: A CI check run for informational purposes only. Failures are
-  logged but carry no merge or follow-up obligations.
+- **Hard gate**: A CI check that blocks PR merge when it fails. Every CI gate
+  is a hard gate — a check either blocks as a required status check or it is
+  not a gate. See
+  [Source Control Guidelines](../source-control-guidelines.md#ci-gates) and the
+  [CI Architecture](../../guides/ci-architecture.md) guide for the
+  hard-gates-only standard.
+- **Advisory-on-unsupported-versions carve-out**: The single sanctioned
+  non-blocking category. A check is advisory *only because* the runtime version
+  it runs against is outside the supported set — a preview version not yet
+  promoted into the supported set, or an EOL version past upstream support. The
+  version, not the check, is what makes it non-blocking; the same check on a
+  supported version is a hard gate. This is deliberately distinct from a
+  generic soft gate on a supported check, which the hard-gates-only standard
+  does not permit.
 
 ## Support tiers
 
@@ -49,7 +57,9 @@ deployment, and release artifacts.
 The upcoming version that has entered GA but has not yet been promoted to the
 primary development version.
 
-- Gate type: soft gate (non-blocking).
+- Gate type: advisory under the advisory-on-unsupported-versions carve-out —
+  non-blocking *because* the version is not yet in the supported set, not
+  because the check itself is a soft gate.
 - Failures are tracked as issues but do not block PRs.
 - Purpose: early detection of incompatibilities before the next version becomes
   Tier 1.
@@ -67,7 +77,8 @@ Relevant primarily for libraries that must support consumers on older runtimes.
 
 A version that has reached end of life upstream.
 
-- Gate type: advisory (best-effort).
+- Gate type: advisory under the advisory-on-unsupported-versions carve-out —
+  non-blocking *because* the version has left the supported set.
 - Failures are logged but never block merges.
 - Do not invest effort maintaining compatibility with EOL versions.
 
@@ -76,9 +87,9 @@ A version that has reached end of life upstream.
 | Tier | CI job label | Gate type | Merge impact |
 | --- | --- | --- | --- |
 | 1 — active bugfix | `bugfix-<version>` | Hard gate | Blocks merge |
-| 2 — next development | `preview-<version>` | Soft gate | Warning only |
+| 2 — next development | `preview-<version>` | Advisory (unsupported-version carve-out) | Warning only |
 | 3 — security-fix-only | `security-<version>` | Hard gate | Blocks merge |
-| 4 — EOL | `eol-<version>` | Advisory | No impact |
+| 4 — EOL | `eol-<version>` | Advisory (unsupported-version carve-out) | No impact |
 
 Every label includes the version because each tier may contain more than one
 version simultaneously.
@@ -102,8 +113,9 @@ Libraries test against all Tier 1 versions and conditionally against Tier 3
 versions to support consumers on older runtimes.
 
 - CI matrix: Tier 1 (hard gate), Tier 3 if consumers require it (hard gate),
-  Tier 2 (soft gate).
-- Tier 4 is advisory and included only when the cost is negligible.
+  Tier 2 (advisory under the unsupported-version carve-out).
+- Tier 4 is advisory under the same carve-out and included only when the cost
+  is negligible.
 
 ## Drop criteria
 

--- a/docs/site/docs/standards/development/rust/overview.md
+++ b/docs/site/docs/standards/development/rust/overview.md
@@ -27,27 +27,31 @@ maintainability, and long-term survivability across repositories.
 
 ## CI Gates
 
-Every CI check is classified as a hard gate or soft gate.
+Every CI check is a hard gate. See
+[Source Control Guidelines](../../source-control-guidelines.md#ci-gates) for the
+hard-gates-only standard and the
+[CI Architecture](../../../guides/ci-architecture.md) guide for how required
+status checks are configured.
 
 Hard gate definition:
 
 - Merge-blocking. A required status check must be configured on the target
   branch. Any failure blocks merge until a new commit passes.
 
-Soft gate definition:
-
-- Warning-only. The check can fail without blocking merge, but failures must be
-  surfaced with rationale and follow-up tracking when applicable.
+The only sanctioned non-blocking category is the
+**advisory-on-unsupported-versions carve-out**: a check is advisory *because*
+the runtime version it runs against is outside the supported set (a preview
+version not yet promoted, or an EOL version past upstream support), not because
+the check itself is a generic soft gate. See the
+[Runtime Version Support Policy](../runtime-version-support-policy.md) for the
+carve-out. Rust runs no version-matrix advisory jobs today, so all of its gates
+are hard gates.
 
 Hard gates (all are required status checks):
 
 - `test: unit (current)`
 - `test: integration`
 - `ci: dependency-audit`
-
-Soft gates:
-
-- None (default to hard gate until documented).
 
 Branch applicability:
 

--- a/docs/site/docs/standards/development/shell/overview.md
+++ b/docs/site/docs/standards/development/shell/overview.md
@@ -28,7 +28,10 @@ readability, and long-term maintainability across repositories.
 ## CI Gates
 
 See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
-for hard gate and soft gate definitions.
+for the hard-gates-only standard: every CI check is a hard gate, and the only
+sanctioned non-blocking category is the advisory-on-unsupported-versions
+carve-out (see the
+[Runtime Version Support Policy](../runtime-version-support-policy.md)).
 
 Required checks for shell/infrastructure repositories are maintained in the
 [standard-actions CI gates documentation](https://vergil-project.github.io/standard-actions/ci-gates/required-checks/).


### PR DESCRIPTION
# Pull Request

## Summary

- Reconcile the runtime-version-support and language-overview docs with epic #224's hard-gates-only standard by reframing the preview/EOL non-blocking gates as the single named advisory-on-unsupported-versions carve-out.

## Issue Linkage

- Closes #2630

## Notes

- Files changed (docs only, no code/CI): runtime-version-support-policy.md (Definitions, Tier 2, Tier 4, CI matrix table, library scope), python/version-management.md (dual-CI preview- and cutover security- language), rust/overview.md (removed generic soft-gate section), and the go/python/shell/java/cpp overviews (updated the source-control-guidelines cross-reference). Every CI gate is a hard gate; the only sanctioned non-blocking category is the advisory-on-unsupported-versions carve-out (a check is advisory because its runtime version is outside the supported set), which is deliberately distinct from a generic soft gate. Cross-references source-control-guidelines.md and ci-architecture.md, which were left untouched (frozen on sibling branches).