### PR TITLE
feat(vrg-vm): add --label for named session creation (label:workspace)

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2381,6 +2381,8 @@ def _session_inner(
     ]
     if args.resume is not None:
         resolve_cmd += ["--resume-name", args.resume]
+    if getattr(args, "label", None) is not None:
+        resolve_cmd += ["--label", args.label]
     if args.slot is not None:
         resolve_cmd += ["--slot", str(args.slot)]
     if args.fork:
@@ -2460,6 +2462,15 @@ def _cmd_session(args: argparse.Namespace) -> int:
         print(
             "ERROR: --resume selects a session by name and cannot be combined with "
             "--slot/--fork/--fresh (which select by slot).",
+            file=sys.stderr,
+        )
+        return 1
+    if getattr(args, "label", None) is not None and (
+        args.resume is not None or args.slot is not None or args.fork or args.fresh
+    ):
+        print(
+            "ERROR: --label creates a new named session and cannot be combined with "
+            "--resume (attach) or --slot/--fork/--fresh (slot selection).",
             file=sys.stderr,
         )
         return 1
@@ -2809,6 +2820,18 @@ def main(argv: list[str] | None = None) -> int:
             "Resume the session with this exact display name (e.g. an epic "
             "session's renamed title, 'epic-85-centralize-epics-adhoc'), instead "
             "of selecting by slot. Mutually exclusive with --slot/--fork/--fresh."
+        ),
+    )
+    p_session.add_argument(
+        "--label",
+        default=None,
+        metavar="LABEL",
+        help=(
+            "Create a new purpose-named session named '<label>:<workspace>' (e.g. "
+            "--label epic-213-x). The label is a clean slug; an epic-/adhoc- prefix "
+            "is the convention (off-convention warns, never blocks). Errors if a "
+            "session of that name already exists. Mutually exclusive with "
+            "--resume/--slot/--fork/--fresh."
         ),
     )
     p_session.add_argument(

--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -31,12 +31,14 @@ from vergil_tooling.lib.session import (
     build_slots,
     list_rows,
     make_archived_name,
+    make_label_name,
     parse_archived,
     parse_name,
     plan_session,
     select_by_name,
+    validate_label,
 )
-from vergil_tooling.lib.session_store import ScrapeStore
+from vergil_tooling.lib.session_store import AmbiguousSessionError, ScrapeStore
 
 
 def _claude_dir() -> Path:
@@ -280,6 +282,16 @@ def roster_names(roster: list[dict[str, object]]) -> dict[str, str]:
     return out
 
 
+def _store(slug: str | None = None) -> ScrapeStore:
+    """Build the ``SessionStore`` backend the resolver enumerates/resolves through.
+
+    A single seam constructor so every resolver path (state read, label
+    uniqueness check) goes through the same backend — and tests can substitute a
+    fake store by patching this one function.
+    """
+    return ScrapeStore(_claude_dir(), slug)
+
+
 def _read_state(
     slug: str | None = None,
 ) -> tuple[dict[str, str], set[str], dict[str, float]]:
@@ -292,7 +304,7 @@ def _read_state(
     active set and last-activity map but not to the name map — exactly as the
     prior direct read did.
     """
-    rows = ScrapeStore(_claude_dir(), slug).list_sessions()
+    rows = _store(slug).list_sessions()
     names = {row.session_id: row.name for row in rows if row.name is not None}
     active = {row.session_id for row in rows if row.active}
     last_active = {row.session_id: row.last_active for row in rows if row.last_active is not None}
@@ -399,6 +411,40 @@ def _execute(path: str, action: PlanAction, extra: list[str], names: dict[str, s
     return _exec_claude(["--resume", prompt.session_id, "-n", prompt.name, *extra])
 
 
+def _resolve_label(path: str, label: str, extra: list[str]) -> int:
+    """Create a purpose-named ``label:workspace`` session, enforcing uniqueness.
+
+    The named-creation path (``--label``): validate the label slug (soft-warning
+    an off-convention prefix, failing loud on a structurally invalid one), compose
+    ``label:workspace``, and refuse if a **visible** session already holds that
+    name — creation must never silently shadow an existing session, so a collision
+    (one match, or ambiguously many) is an error directing the user to ``--resume``
+    it or pick another label. Otherwise exec the existing ``Create`` path.
+    """
+    try:
+        warnings = validate_label(label)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    for warning in warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+    name = make_label_name(label, path)
+    store = _store(_project_slug(str(Path.cwd())))
+    try:
+        # A single match, or ambiguously many (the seam fails loud), both mean the
+        # name is taken — creation must never silently shadow an existing session.
+        collision = store.resolve_name(name) is not None
+    except AmbiguousSessionError:
+        collision = True
+    if collision:
+        print(
+            f"ERROR: a session named {name!r} already exists; --resume it or pick another label",
+            file=sys.stderr,
+        )
+        return 1
+    return _execute(path, Create(name), extra, {})
+
+
 def resolve(
     identity: str,
     path: str,
@@ -409,14 +455,21 @@ def resolve(
     stale_days: int,
     archive_days: int,
     resume_name: str | None = None,
+    label: str | None = None,
 ) -> int:
     """Plan, auto-archive stale cold slots, then exec Claude for one identity + path.
+
+    ``label`` short-circuits into the named-creation path (``--label``): it
+    composes and uniqueness-checks ``label:workspace`` and creates that session
+    (see :func:`_resolve_label`), bypassing the slot machinery entirely.
 
     ``resume_name`` short-circuits the slot machinery: it resumes the session with
     that exact display name (an epic-renamed title that does not fit the slot
     scheme), with no staleness sweep or prompt — the caller named the session
     explicitly, so it is resumed as-is.
     """
+    if label is not None:
+        return _resolve_label(path, label, extra)
     names, active, last_active = _read_state(_project_slug(str(Path.cwd())))
     if resume_name is not None:
         return _execute(path, select_by_name(resume_name, names, active, last_active), extra, names)
@@ -481,6 +534,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fork", action="store_true")
     parser.add_argument("--fresh", action="store_true")
     parser.add_argument("--resume-name", dest="resume_name", default=None)
+    parser.add_argument("--label", dest="label", default=None)
     parser.add_argument("--stale-days", type=int, default=7, dest="stale_days")
     parser.add_argument("--archive-days", type=int, default=14, dest="archive_days")
     parser.add_argument("--list-json", action="store_true", dest="list_json")
@@ -507,6 +561,7 @@ def main(argv: list[str] | None = None) -> int:
         args.stale_days,
         args.archive_days,
         args.resume_name,
+        args.label,
     )
 
 

--- a/src/vergil_tooling/lib/session.py
+++ b/src/vergil_tooling/lib/session.py
@@ -28,6 +28,53 @@ def make_name(identity: str, slot: int, path: str) -> str:
     return f"{identity}:{slot:02d}:{path}"
 
 
+_LABEL_CONVENTION_PREFIXES = ("epic-", "adhoc-")
+
+
+def make_label_name(label: str, workspace: str) -> str:
+    """Compose a purpose-named session name ``<label>:<workspace>``.
+
+    The name drops identity entirely — a session is named by *what it is for*
+    (its ``label``) scoped to *where it runs* (its ``workspace`` path), joined by
+    the same unambiguous colon delimiter the slot scheme used. ``label`` is a
+    clean slug (validated by :func:`validate_label`); ``workspace`` is the
+    workspace-relative path, e.g. ``vergil-project/vergil-tooling``.
+    """
+    return f"{label}:{workspace}"
+
+
+def validate_label(label: str) -> list[str]:
+    """Validate a session ``label`` slug, returning non-fatal warnings.
+
+    Two tiers, mirroring the spec's "clean slug required, convention soft":
+
+    - **Hard (raises :class:`ValueError`).** The label must be a clean slug: a
+      ``:`` would break the ``label:workspace`` delimiter, and whitespace or an
+      empty/blank label is never a valid name. These are structural — the name
+      cannot be formed — so they fail loud.
+    - **Soft (returned as a warning, never rejected).** A label that is not
+      prefixed ``epic-``/``adhoc-`` is off-convention but still usable; it yields
+      one warning string so the caller can surface it without blocking creation.
+
+    Returns an empty list for a clean, on-convention label.
+    """
+    if not label or not label.strip():
+        msg = "label must not be empty"
+        raise ValueError(msg)
+    if ":" in label:
+        msg = "label must not contain ':' (the label:workspace delimiter)"
+        raise ValueError(msg)
+    if any(ch.isspace() for ch in label):
+        msg = "label must not contain whitespace"
+        raise ValueError(msg)
+    warnings: list[str] = []
+    if not label.startswith(_LABEL_CONVENTION_PREFIXES):
+        warnings.append(
+            f"label {label!r} does not follow the epic-/adhoc- naming convention (using it anyway)"
+        )
+    return warnings
+
+
 def make_archived_name(name: str, timestamp: str) -> str:
     """Archived label: ``archived@<timestamp>@<original-name>``."""
     return f"{_ARCHIVED_PREFIX}{timestamp}@{name}"

--- a/tests/vergil_tooling/test_session.py
+++ b/tests/vergil_tooling/test_session.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from vergil_tooling.lib.session import (
     SLOT_MAX,
     AgeBand,
@@ -15,12 +17,14 @@ from vergil_tooling.lib.session import (
     classify_age,
     list_rows,
     make_archived_name,
+    make_label_name,
     make_name,
     parse_archived,
     parse_name,
     plan_session,
     select,
     select_by_name,
+    validate_label,
 )
 
 
@@ -48,6 +52,53 @@ def test_parse_archived_path_with_at_sign() -> None:
 def test_parse_archived_returns_none_for_non_archived() -> None:
     assert parse_archived("vergil:01:a/b") is None
     assert parse_archived("archived@only-two-parts") is None
+
+
+# --- make_label_name / validate_label (issue #2606) ---
+
+
+def test_make_label_name_composes() -> None:
+    assert (
+        make_label_name("epic-213-x", "vergil-project/vergil-tooling")
+        == "epic-213-x:vergil-project/vergil-tooling"
+    )
+
+
+def test_make_label_name_drops_identity() -> None:
+    # The name is purpose:workspace only — no identity segment.
+    assert make_label_name("adhoc-spike", ".") == "adhoc-spike:."
+
+
+def test_validate_label_clean_epic() -> None:
+    assert validate_label("epic-213-x") == []
+
+
+def test_validate_label_clean_adhoc() -> None:
+    assert validate_label("adhoc-spike") == []
+
+
+def test_validate_label_warns_non_convention() -> None:
+    warnings = validate_label("scratch")
+    # Non-empty, and every warning names the epic-/adhoc- convention.
+    assert warnings
+    assert all("epic-" in w or "adhoc-" in w for w in warnings)
+
+
+def test_validate_label_rejects_colon() -> None:
+    with pytest.raises(ValueError, match="':'"):
+        validate_label("bad:name")
+
+
+def test_validate_label_rejects_whitespace() -> None:
+    with pytest.raises(ValueError, match="whitespace"):
+        validate_label("bad name")
+
+
+def test_validate_label_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        validate_label("")
+    with pytest.raises(ValueError, match="empty"):
+        validate_label("   ")
 
 
 def test_make_name_zero_pads_slot() -> None:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2377,6 +2377,34 @@ def test_session_inner_resume_name() -> None:
     assert "--resume-name epic-85-adhoc" in inner
 
 
+def test_session_inner_label() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _session_inner
+
+    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None, label="epic-1")
+    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    assert "--label epic-1" in inner
+
+
+def test_cmd_session_rejects_label_with_slot() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _cmd_session
+
+    ns = argparse.Namespace(resume=None, slot=3, fork=False, fresh=False, label="epic-1")
+    assert _cmd_session(ns) == 1
+
+
+def test_cmd_session_rejects_label_with_resume() -> None:
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _cmd_session
+
+    ns = argparse.Namespace(resume="epic-85", slot=None, fork=False, fresh=False, label="epic-1")
+    assert _cmd_session(ns) == 1
+
+
 def test_cmd_session_rejects_resume_with_slot() -> None:
     import argparse
 

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -396,7 +396,13 @@ def capture_exec(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 DAY = 86400.0
 
 
-def _resolve(identity: str, path: str, resume_name: str | None = None, **kw: object) -> int:
+def _resolve(
+    identity: str,
+    path: str,
+    resume_name: str | None = None,
+    label: str | None = None,
+    **kw: object,
+) -> int:
     defaults: dict[str, object] = {
         "requested_slot": None,
         "fork": False,
@@ -406,7 +412,9 @@ def _resolve(identity: str, path: str, resume_name: str | None = None, **kw: obj
         "archive_days": 14,
     }
     defaults.update(kw)
-    return r.resolve(identity, path, resume_name=resume_name, **defaults)  # type: ignore[arg-type]
+    return r.resolve(  # type: ignore[arg-type]
+        identity, path, resume_name=resume_name, label=label, **defaults
+    )
 
 
 def test_resolve_create(
@@ -452,6 +460,90 @@ def test_resolve_by_name_refuses_unknown_name(
     monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, set(), {}))
     assert _resolve("id", "p", resume_name="ghost") == 1
     assert "no session named 'ghost'" in capsys.readouterr().err
+
+
+# --- --label (named creation, issue #2606) ---
+
+
+class _FakeStore:
+    """Minimal SessionStore stub exposing only resolve_name for the label path."""
+
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    def resolve_name(self, name: str) -> object:  # noqa: ARG002
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def test_resolve_label_creates_when_name_free(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # No visible session holds the composed name -> create label:workspace.
+    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(None))
+    assert _resolve("id", "vergil-project/tooling", label="epic-1") == 0
+    assert capture_exec == [["claude", "-n", "epic-1:vergil-project/tooling"]]
+    assert "Creating session epic-1:vergil-project/tooling" in capsys.readouterr().err
+
+
+def test_resolve_label_rejects_existing_name(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from vergil_tooling.lib.session_store import SessionInfo
+
+    hit = SessionInfo("s1", "epic-1:p", "/w", active=True, last_active=None)
+    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(hit))
+    assert _resolve("id", "p", label="epic-1") == 1
+    assert capture_exec == []  # uniqueness collision -> never execs
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_resolve_label_rejects_ambiguous_name(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Two live sessions hold the name -> the seam fails loud; still a collision.
+    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(r.AmbiguousSessionError("boom")))
+    assert _resolve("id", "p", label="epic-1") == 1
+    assert capture_exec == []
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_resolve_label_warns_off_convention_but_creates(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(None))
+    assert _resolve("id", "p", label="scratch") == 0
+    assert capture_exec == [["claude", "-n", "scratch:p"]]
+    assert "convention" in capsys.readouterr().err
+
+
+def test_resolve_label_rejects_invalid_slug(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A ':' in the label is structurally invalid -> fail loud before any store read.
+    called = False
+
+    def _boom(*_a: object) -> object:
+        nonlocal called
+        called = True
+        return _FakeStore(None)
+
+    monkeypatch.setattr(r, "_store", _boom)
+    assert _resolve("id", "p", label="bad:name") == 1
+    assert capture_exec == []
+    assert called is False  # validation short-circuits before the uniqueness check
+    assert "ERROR" in capsys.readouterr().err
 
 
 def test_resolve_fork(
@@ -709,18 +801,28 @@ def test_main_dispatches_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert code == 0
     # args order: identity, path, slot, fork, fresh, extra, stale_days,
-    # archive_days, resume_name
-    assert seen["args"] == ("id", "p", 2, False, True, ["x"], 7, 14, None)
+    # archive_days, resume_name, label
+    assert seen["args"] == ("id", "p", 2, False, True, ["x"], 7, 14, None, None)
 
 
 def test_main_passes_resume_name(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
     monkeypatch.setattr(r, "resolve", lambda *args: seen.update(args=args) or 0)
     r.main(["--identity", "id", "--path", "p", "--resume-name", "epic-85-adhoc"])
-    # resume_name is the final positional arg.
+    # resume_name is the penultimate positional arg (label is last).
     passed = seen["args"]
     assert isinstance(passed, tuple)
-    assert passed[-1] == "epic-85-adhoc"
+    assert passed[-2] == "epic-85-adhoc"
+    assert passed[-1] is None  # label unset
+
+
+def test_main_passes_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(r, "resolve", lambda *args: seen.update(args=args) or 0)
+    r.main(["--identity", "id", "--path", "p", "--label", "epic-1"])
+    passed = seen["args"]
+    assert isinstance(passed, tuple)
+    assert passed[-1] == "epic-1"  # label is the final positional arg
 
 
 def test_main_strips_leading_double_dash(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add a --label flag to vrg-vm session that creates a purpose-named 'label:workspace' Claude session (identity dropped), refusing to shadow a session that already holds the name.

## Issue Linkage

- Closes #2606

## Notes

- Task 2 of epic vergil-project/.github#230, building on the merged SessionStore seam (T1). New pure helpers in lib/session.py: make_label_name(label, workspace) composes 'label:workspace'; validate_label(label) raises ValueError on a structurally invalid slug (':'/whitespace/empty) and soft-warns (never rejects) a non-epic-/adhoc- prefix. The in-VM resolver (vrg_vm_resolve.py) gains a --label create path that validates, composes the name, checks uniqueness via the seam's ScrapeStore.resolve_name (a single match or an AmbiguousSessionError both count as a collision -> error), then execs the existing Create path (claude -n <name>). Host vrg_vm.py adds the --label arg, threads it through _session_inner, and rejects combining --label with --resume/--slot/--fork/--fresh. Note: the plan's T2 file list named only vrg_vm.py + session.py, but the uniqueness-check-and-create logic must live in the in-VM resolver (where the seam has access to the real ~/.claude roster), so vrg_vm_resolve.py + test_vrg_vm_resolve.py were also touched. vrg-validate green (4601 tests, 100% coverage).