### PR TITLE
feat(vrg-vm): promote --resume to exact-name attach; remove --slot and auto-resume

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2383,8 +2383,6 @@ def _session_inner(
         resolve_cmd += ["--resume-name", args.resume]
     if getattr(args, "label", None) is not None:
         resolve_cmd += ["--label", args.label]
-    if args.slot is not None:
-        resolve_cmd += ["--slot", str(args.slot)]
     if args.fork:
         resolve_cmd += ["--fork"]
     if args.fresh:
@@ -2458,19 +2456,19 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
 
 
 def _cmd_session(args: argparse.Namespace) -> int:
-    if args.resume is not None and (args.slot is not None or args.fork or args.fresh):
+    if args.resume is not None and (args.fork or args.fresh):
         print(
-            "ERROR: --resume selects a session by name and cannot be combined with "
-            "--slot/--fork/--fresh (which select by slot).",
+            "ERROR: --resume attaches to a session by its exact name and cannot be "
+            "combined with --fork/--fresh.",
             file=sys.stderr,
         )
         return 1
     if getattr(args, "label", None) is not None and (
-        args.resume is not None or args.slot is not None or args.fork or args.fresh
+        args.resume is not None or args.fork or args.fresh
     ):
         print(
             "ERROR: --label creates a new named session and cannot be combined with "
-            "--resume (attach) or --slot/--fork/--fresh (slot selection).",
+            "--resume (attach) or --fork/--fresh.",
             file=sys.stderr,
         )
         return 1
@@ -2808,18 +2806,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Connect even if the VM exceeds the staleness threshold",
     )
     p_session.add_argument(
-        "--slot",
-        type=int,
-        help="Session slot number (1-99); default picks the lowest idle/free slot",
-    )
-    p_session.add_argument(
         "--resume",
         default=None,
         metavar="NAME",
         help=(
-            "Resume the session with this exact display name (e.g. an epic "
-            "session's renamed title, 'epic-85-centralize-epics-adhoc'), instead "
-            "of selecting by slot. Mutually exclusive with --slot/--fork/--fresh."
+            "Attach to the session with this exact name (e.g. "
+            "'epic-85-centralize-epics:vergil-project/tooling'). Resolves the name to "
+            "one session and derives its working directory from that session. With no "
+            "verb, the workspace's sessions are listed and --label/--resume are named. "
+            "Mutually exclusive with --fork/--fresh."
         ),
     )
     p_session.add_argument(
@@ -2831,7 +2826,7 @@ def main(argv: list[str] | None = None) -> int:
             "--label epic-213-x). The label is a clean slug; an epic-/adhoc- prefix "
             "is the convention (off-convention warns, never blocks). Errors if a "
             "session of that name already exists. Mutually exclusive with "
-            "--resume/--slot/--fork/--fresh."
+            "--resume/--fork/--fresh."
         ),
     )
     p_session.add_argument(

--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -22,11 +22,8 @@ from pathlib import Path
 
 from vergil_tooling.lib.session import (
     Create,
-    Fork,
     PlanAction,
-    PromptStale,
     Refuse,
-    Resume,
     Slot,
     build_slots,
     list_rows,
@@ -35,10 +32,14 @@ from vergil_tooling.lib.session import (
     parse_archived,
     parse_name,
     plan_session,
-    select_by_name,
     validate_label,
 )
-from vergil_tooling.lib.session_store import AmbiguousSessionError, ScrapeStore
+from vergil_tooling.lib.session_store import (
+    AmbiguousSessionError,
+    ScrapeStore,
+    SessionInfo,
+    SessionStore,
+)
 
 
 def _claude_dir() -> Path:
@@ -180,6 +181,37 @@ def _last_activity(transcript: Path) -> float | None:
                     ts = _parse_ts(entry.get("timestamp"))
                     if ts is not None:
                         return ts
+    except OSError:
+        return None
+    return None
+
+
+def transcript_cwd(transcript: Path) -> str | None:
+    """The working directory a session ran in, from its transcript, or ``None``.
+
+    Every substantive transcript entry records the ``cwd`` it executed in. The
+    first one found (read forward and bounded — a leading ``summary`` entry
+    carries none, but the first real turn does) is authoritative and stable for
+    the session, so a large transcript need not be read in full. This is what
+    lets the seam report a cwd for an *idle* session absent from the live roster,
+    so ``--resume`` can derive its memory slug from the resolved session (#2607).
+    """
+    try:
+        with transcript.open("rb") as fh:
+            for _ in range(200):
+                raw = fh.readline()
+                if not raw:
+                    break
+                line = raw.strip()
+                if not line or b'"cwd"' not in line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                cwd = entry.get("cwd")
+                if isinstance(cwd, str) and cwd:
+                    return cwd
     except OSError:
         return None
     return None
@@ -346,18 +378,6 @@ def _now_iso() -> str:
     return datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _prompt_stale(path: str, slot: int, age_days: int) -> str:
-    """Return ``'r'`` (resume), ``'f'`` (fresh), or ``'c'`` (cancel). Non-TTY -> ``'r'``."""
-    if not sys.stdin.isatty():
-        return "r"
-    print(
-        f"Slot {slot:02d} for {path} was last active {age_days} days ago.",
-        file=sys.stderr,
-    )
-    answer = input("[r]esume / [f]resh / [c]ancel? ").strip().lower()
-    return {"r": "r", "f": "f", "c": "c"}.get(answer[:1], "c")
-
-
 def _run_sweep(slots: list[Slot]) -> None:
     timestamp = _now_iso()
     for slot in slots:
@@ -365,50 +385,90 @@ def _run_sweep(slots: list[Slot]) -> None:
         _archive_session(slot.session_id, timestamp)
 
 
-def _slot_num(name: str) -> int:
-    parsed = parse_name(name)
-    return parsed[1] if parsed else 0
-
-
 def _note(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def _execute(path: str, action: PlanAction, extra: list[str], names: dict[str, str]) -> int:
+def _execute(action: PlanAction, extra: list[str]) -> int:
+    """Carry out a ``--fork`` / ``--fresh`` plan action.
+
+    With ``--slot`` and the auto-resume-most-recent default gone (#2607), the only
+    actions that still reach here are ``Create`` (``--fresh`` reclaiming its name)
+    and ``Refuse`` (``--fork`` with no slot to target). Exact-name attach
+    (``--resume``) resolves through the seam in :func:`_resume_by_name`, not here.
+    """
     if isinstance(action, Refuse):
         print(f"ERROR: {action.message}", file=sys.stderr)
         return 1
     if isinstance(action, Create):
         _note(f"Creating session {action.name}")
         return _exec_claude(["-n", action.name, *extra])
-    if isinstance(action, Resume):
-        name = names.get(action.session_id)
-        _note(f"Resuming session {name or action.session_id}")
-        # Re-assert -n on every resume so Claude restores the prompt-box
-        # title. Claude derives the displayed title from the last naming
-        # event in the transcript; sessions last named by a transitional
-        # Claude version end on a legacy ``agent-name`` event that current
-        # Claude no longer recognizes, leaving the label blank. Passing -n
-        # sets the live title directly, independent of transcript history.
-        rename = ["-n", name] if name else []
-        return _exec_claude(["--resume", action.session_id, *rename, *extra])
-    if isinstance(action, Fork):
-        _note(f"Forking session {names.get(action.session_id, action.session_id)} -> {action.name}")
-        return _exec_claude(
-            ["--resume", action.session_id, "--fork-session", "-n", action.name, *extra]
-        )
-    prompt: PromptStale = action
-    choice = _prompt_stale(path, _slot_num(prompt.name), prompt.age_days)
-    if choice == "c":
-        return 0
-    if choice == "f":
-        _note(f"Archiving session {prompt.name}")
-        _archive_session(prompt.session_id, _now_iso())
-        _note(f"Creating session {prompt.name}")
-        return _exec_claude(["-n", prompt.name, *extra])
-    _note(f"Resuming session {prompt.name}")
-    # Re-assert -n on resume (see the Resume branch above).
-    return _exec_claude(["--resume", prompt.session_id, "-n", prompt.name, *extra])
+    # Resume/Fork/PromptStale were the slot-selection outcomes; none is reachable
+    # now that selection is by exact name. Guard loudly rather than mis-exec.
+    raise RuntimeError(f"unexpected session action {type(action).__name__}")  # pragma: no cover
+
+
+def plan_resume(store: SessionStore, name: str) -> SessionInfo:
+    """Resolve an exact session name to the session to resume, via the seam.
+
+    Delegates to ``store.resolve_name`` and applies the fail-loud contract of
+    exact-name attach (#2607): a name that resolves to **no** visible session and
+    a name that resolves to **two or more co-equal live** sessions both abort with
+    a nonzero exit and an actionable message — the resolver never guesses which
+    session the caller meant. On success the resolved :class:`SessionInfo` carries
+    both the session id (for ``--resume``) and the cwd (for memory-slug parity).
+    """
+    try:
+        info = store.resolve_name(name)
+    except AmbiguousSessionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    if info is None:
+        print(f"ERROR: no session named {name!r} — create it with --label", file=sys.stderr)
+        raise SystemExit(1)
+    return info
+
+
+def _resume_by_name(name: str, extra: list[str]) -> int:
+    """Attach to the session named ``name`` exactly, deriving cwd from it.
+
+    The store is unscoped (every slug) so the name resolves globally; the bootstrap
+    cwd is then taken from the resolved session's own cwd rather than any positional
+    the caller passed, so Claude derives the same memory slug the session was created
+    under (#2607). ``-n`` re-asserts the exact name so the prompt-box title is
+    restored even when the last transcript naming event is a legacy ``agent-name``.
+    """
+    info = plan_resume(ScrapeStore(_claude_dir()), name)
+    if info.cwd:
+        os.chdir(info.cwd)
+    _note(f"Resuming session {name}")
+    return _exec_claude(["--resume", info.session_id, "-n", name, *extra])
+
+
+def _list_and_guide(slug: str) -> int:
+    """No verb given: show this workspace's sessions by recency, name the two verbs.
+
+    The old no-arg behavior — auto-resume the most-recent idle session, else create
+    one — is gone (#2607). A session is now addressed explicitly: ``--label`` to
+    create ``label:workspace`` (Task 2) or ``--resume`` to attach by exact name.
+    Returns nonzero: no session was launched.
+    """
+    rows = [row for row in ScrapeStore(_claude_dir(), slug).list_sessions() if row.name is not None]
+    rows.sort(key=lambda row: (row.last_active is not None, row.last_active or 0.0), reverse=True)
+    if rows:
+        print("Sessions for this workspace (most recent first):", file=sys.stderr)
+        for row in rows:
+            marker = "* " if row.active else "  "
+            print(f"  {marker}{row.name}", file=sys.stderr)
+    else:
+        print("No sessions yet for this workspace.", file=sys.stderr)
+    print(
+        "\nName the session you want — choose one verb:\n"
+        "  --label <label>   start a new session named <label>:<workspace>\n"
+        "  --resume <name>   attach to an existing session by its exact name",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def _resolve_label(path: str, label: str, extra: list[str]) -> int:
@@ -442,13 +502,12 @@ def _resolve_label(path: str, label: str, extra: list[str]) -> int:
             file=sys.stderr,
         )
         return 1
-    return _execute(path, Create(name), extra, {})
+    return _execute(Create(name), extra)
 
 
 def resolve(
     identity: str,
     path: str,
-    requested_slot: int | None,
     fork: bool,
     fresh: bool,
     extra: list[str],
@@ -457,28 +516,31 @@ def resolve(
     resume_name: str | None = None,
     label: str | None = None,
 ) -> int:
-    """Plan, auto-archive stale cold slots, then exec Claude for one identity + path.
+    """Attach a named session, or (no verb) list this workspace and guide.
 
     ``label`` short-circuits into the named-creation path (``--label``): it
     composes and uniqueness-checks ``label:workspace`` and creates that session
     (see :func:`_resolve_label`), bypassing the slot machinery entirely.
 
-    ``resume_name`` short-circuits the slot machinery: it resumes the session with
-    that exact display name (an epic-renamed title that does not fit the slot
-    scheme), with no staleness sweep or prompt — the caller named the session
-    explicitly, so it is resumed as-is.
+    ``resume_name`` (``--resume``) resolves an exact session name to a session id
+    through the ``SessionStore`` seam and attaches to it, deriving the bootstrap
+    cwd from the resolved session (#2607). With no verb the recency list + the two
+    verbs are printed and a nonzero code returned — there is no auto-resume-most-
+    recent / auto-create default and no ``--slot``. ``fork`` / ``fresh`` retain the
+    prior slot machinery (removed/reconceived by later tasks in the epic).
     """
     if label is not None:
         return _resolve_label(path, label, extra)
-    names, active, last_active = _read_state(_project_slug(str(Path.cwd())))
     if resume_name is not None:
-        return _execute(path, select_by_name(resume_name, names, active, last_active), extra, names)
+        return _resume_by_name(resume_name, extra)
+    slug = _project_slug(str(Path.cwd()))
+    if not fork and not fresh:
+        return _list_and_guide(slug)
+    names, active, last_active = _read_state(slug)
     slots = build_slots(identity, path, names, active, last_active)
-    plan = plan_session(
-        identity, path, slots, _now(), stale_days, archive_days, requested_slot, fork, fresh
-    )
+    plan = plan_session(identity, path, slots, _now(), stale_days, archive_days, None, fork, fresh)
     _run_sweep(plan.auto_archive)
-    return _execute(path, plan.action, extra, names)
+    return _execute(plan.action, extra)
 
 
 def _archived_rows(names: dict[str, str], last_active: dict[str, float]) -> list[dict[str, object]]:
@@ -530,7 +592,6 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="vrg-vm-resolve-session")
     parser.add_argument("--identity")
     parser.add_argument("--path")
-    parser.add_argument("--slot", type=int)
     parser.add_argument("--fork", action="store_true")
     parser.add_argument("--fresh", action="store_true")
     parser.add_argument("--resume-name", dest="resume_name", default=None)
@@ -554,7 +615,6 @@ def main(argv: list[str] | None = None) -> int:
     return resolve(
         args.identity,
         args.path,
-        args.slot,
         args.fork,
         args.fresh,
         extra,

--- a/src/vergil_tooling/lib/session_store.py
+++ b/src/vergil_tooling/lib/session_store.py
@@ -148,11 +148,20 @@ class ScrapeStore:
         # session id — a live-but-unnamed session, or one carrying only a roster
         # last-activity — as a name=None row so the seam surfaces every session.
         extra = sorted(sid for sid in (active | set(last_active)) if sid not in names)
+
+        def _cwd(sid: str) -> str:
+            # The live roster is authoritative; for an idle session absent from it
+            # the transcript's recorded cwd stands in, so ``--resume`` can still
+            # derive that session's memory slug (#2607). Unknown ⇒ "".
+            if sid in cwds:
+                return cwds[sid]
+            return res.transcript_cwd(res.projects_glob(projects, sid)) or ""
+
         return [
             SessionInfo(
                 session_id=sid,
                 name=names.get(sid),
-                cwd=cwds.get(sid, ""),
+                cwd=_cwd(sid),
                 active=sid in active,
                 last_active=last_active.get(sid),
             )

--- a/tests/vergil_tooling/test_session_store.py
+++ b/tests/vergil_tooling/test_session_store.py
@@ -121,6 +121,24 @@ def test_scrape_store_surfaces_roster_cwd_and_active(tmp_path: Path) -> None:
     assert rows["s1"].last_active == 1748000000.0
 
 
+def test_scrape_store_derives_idle_cwd_from_transcript(tmp_path: Path) -> None:
+    # An idle session (no live roster entry) still reports its cwd, read from the
+    # transcript, so --resume can derive that session's memory slug (#2607).
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-work-repo"
+    slug.mkdir(parents=True)
+    (slug / "s1.jsonl").write_text(
+        '{"type":"user","cwd":"/work/repo","timestamp":"2026-05-02T00:00:00.000Z"}\n'
+        '{"type":"custom-title","customTitle":"epic-1:w","sessionId":"s1"}\n'
+    )
+    (claude / "sessions").mkdir()
+
+    rows = {r.session_id: r for r in ScrapeStore(claude).list_sessions()}
+    assert rows["s1"].name == "epic-1:w"
+    assert rows["s1"].active is False
+    assert rows["s1"].cwd == "/work/repo"
+
+
 def test_scrape_store_resolve_name_uses_resolve_over(tmp_path: Path) -> None:
     claude = tmp_path / ".claude"
     slug = claude / "projects" / "-w"

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2206,17 +2206,17 @@ class TestSession:
                 ]
             )
 
-    def test_session_slot_passed_to_resolver(
+    def test_session_no_slot_flag(
         self,
         _age: MagicMock,
         _copy: MagicMock,
         _link: MagicMock,
-        mock_exec: MagicMock,
+        _exec: MagicMock,
         config_file: Path,
     ) -> None:
-        main(["session", "--config", str(config_file), "--slot", "3", "vergil-tooling"])
-        inner = self._inner(mock_exec)
-        assert "--slot 3" in inner
+        # --slot is removed (#2607): sessions are addressed by name, not slot.
+        with pytest.raises(SystemExit):
+            main(["session", "--config", str(config_file), "--slot", "3", "vergil-tooling"])
 
     def test_session_fork_passed_to_resolver(
         self,
@@ -2226,20 +2226,10 @@ class TestSession:
         mock_exec: MagicMock,
         config_file: Path,
     ) -> None:
-        main(
-            [
-                "session",
-                "--config",
-                str(config_file),
-                "--slot",
-                "2",
-                "--fork",
-                "vergil-tooling",
-            ]
-        )
+        main(["session", "--config", str(config_file), "--fork", "vergil-tooling"])
         inner = self._inner(mock_exec)
         assert "--fork" in inner
-        assert "--slot 2" in inner
+        assert "--slot" not in inner
 
     def test_session_resume_passed_to_resolver(
         self,
@@ -2382,18 +2372,9 @@ def test_session_inner_label() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None, label="epic-1")
+    ns = argparse.Namespace(cmd=[], fork=False, fresh=False, resume=None, label="epic-1")
     inner = _session_inner(ns, "vergil", "p", "", 7, 14)
     assert "--label epic-1" in inner
-
-
-def test_cmd_session_rejects_label_with_slot() -> None:
-    import argparse
-
-    from vergil_tooling.bin.vrg_vm import _cmd_session
-
-    ns = argparse.Namespace(resume=None, slot=3, fork=False, fresh=False, label="epic-1")
-    assert _cmd_session(ns) == 1
 
 
 def test_cmd_session_rejects_label_with_resume() -> None:
@@ -2401,16 +2382,7 @@ def test_cmd_session_rejects_label_with_resume() -> None:
 
     from vergil_tooling.bin.vrg_vm import _cmd_session
 
-    ns = argparse.Namespace(resume="epic-85", slot=None, fork=False, fresh=False, label="epic-1")
-    assert _cmd_session(ns) == 1
-
-
-def test_cmd_session_rejects_resume_with_slot() -> None:
-    import argparse
-
-    from vergil_tooling.bin.vrg_vm import _cmd_session
-
-    ns = argparse.Namespace(resume="epic-85", slot=3, fork=False, fresh=False)
+    ns = argparse.Namespace(resume="epic-85", fork=False, fresh=False, label="epic-1")
     assert _cmd_session(ns) == 1
 
 
@@ -2419,7 +2391,7 @@ def test_cmd_session_rejects_resume_with_fork() -> None:
 
     from vergil_tooling.bin.vrg_vm import _cmd_session
 
-    ns = argparse.Namespace(resume="epic-85", slot=None, fork=True, fresh=False)
+    ns = argparse.Namespace(resume="epic-85", fork=True, fresh=False)
     assert _cmd_session(ns) == 1
 
 

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -57,6 +57,42 @@ def test_last_activity_handles_large_file_via_tail(tmp_path: Path) -> None:
     assert r._last_activity(f) == datetime.datetime(2026, 5, 30, 12, tzinfo=UTC).timestamp()
 
 
+# --- transcript_cwd (issue #2607) ---
+
+
+def test_transcript_cwd_returns_first_recorded(tmp_path: Path) -> None:
+    # A leading entry without cwd is skipped; the first entry carrying a cwd wins.
+    f = tmp_path / "s.jsonl"
+    f.write_text(
+        '{"type":"summary","leafUuid":"x"}\n'
+        '{"type":"user","cwd":"/work/repo","timestamp":"2026-05-02T00:00:00.000Z"}\n'
+        '{"type":"user","cwd":"/other","timestamp":"2026-05-03T00:00:00.000Z"}\n'
+    )
+    assert r.transcript_cwd(f) == "/work/repo"
+
+
+def test_transcript_cwd_skips_malformed_then_matches(tmp_path: Path) -> None:
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":"x","cwd": BROKEN}\n{"type":"user","cwd":"/good"}\n')
+    assert r.transcript_cwd(f) == "/good"
+
+
+def test_transcript_cwd_ignores_non_string_or_empty(tmp_path: Path) -> None:
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":"a","cwd":123}\n{"type":"b","cwd":""}\n{"type":"c","cwd":"/w"}\n')
+    assert r.transcript_cwd(f) == "/w"
+
+
+def test_transcript_cwd_none_when_absent(tmp_path: Path) -> None:
+    f = tmp_path / "s.jsonl"
+    f.write_text('{"type":"user","message":"hi"}\n')
+    assert r.transcript_cwd(f) is None
+
+
+def test_transcript_cwd_missing_file(tmp_path: Path) -> None:
+    assert r.transcript_cwd(tmp_path / "nope.jsonl") is None
+
+
 def test_parse_ts_invalid_returns_none() -> None:
     assert r._parse_ts("not a date") is None
     assert r._parse_ts(12345) is None
@@ -404,7 +440,6 @@ def _resolve(
     **kw: object,
 ) -> int:
     defaults: dict[str, object] = {
-        "requested_slot": None,
         "fork": False,
         "fresh": False,
         "extra": [],
@@ -415,51 +450,6 @@ def _resolve(
     return r.resolve(  # type: ignore[arg-type]
         identity, path, resume_name=resume_name, label=label, **defaults
     )
-
-
-def test_resolve_create(
-    monkeypatch: pytest.MonkeyPatch,
-    capture_exec: list[list[str]],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
-    assert _resolve("id", "p", extra=["--model", "opus"]) == 0
-    assert capture_exec == [["claude", "-n", "id:01:p", "--model", "opus"]]
-    assert "Creating session id:01:p" in capsys.readouterr().err
-
-
-def test_resolve_resume(
-    monkeypatch: pytest.MonkeyPatch,
-    capture_exec: list[list[str]],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, set(), {}))
-    assert _resolve("id", "p") == 0
-    # -n is re-asserted on resume so Claude restores the prompt-box title.
-    assert capture_exec == [["claude", "--resume", "s1", "-n", "id:01:p"]]
-    assert "Resuming session id:01:p" in capsys.readouterr().err
-
-
-def test_resolve_by_name_resumes_named_session(
-    monkeypatch: pytest.MonkeyPatch,
-    capture_exec: list[list[str]],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(
-        r, "_read_state", lambda *_a: ({"s1": "epic-85-adhoc", "s2": "id:01:p"}, set(), {})
-    )
-    assert _resolve("id", "p", resume_name="epic-85-adhoc") == 0
-    # Resume-by-name bypasses the slot machinery; -n restores the title.
-    assert capture_exec == [["claude", "--resume", "s1", "-n", "epic-85-adhoc"]]
-    assert "Resuming session epic-85-adhoc" in capsys.readouterr().err
-
-
-def test_resolve_by_name_refuses_unknown_name(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, set(), {}))
-    assert _resolve("id", "p", resume_name="ghost") == 1
-    assert "no session named 'ghost'" in capsys.readouterr().err
 
 
 # --- --label (named creation, issue #2606) ---
@@ -546,113 +536,160 @@ def test_resolve_label_rejects_invalid_slug(
     assert "ERROR" in capsys.readouterr().err
 
 
-def test_resolve_fork(
-    monkeypatch: pytest.MonkeyPatch,
-    capture_exec: list[list[str]],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "id:01:p"}, {"s1"}, {}))
-    assert _resolve("id", "p", requested_slot=1, fork=True) == 0
-    assert capture_exec == [["claude", "--resume", "s1", "--fork-session", "-n", "id:02:p"]]
-    assert "Forking session id:01:p -> id:02:p" in capsys.readouterr().err
-
-
 def test_resolve_refuse(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
-    assert _resolve("id", "p", fork=True) == 1  # fork without slot
+    assert _resolve("id", "p", fork=True) == 1  # fork without slot refuses (no --slot)
     assert "ERROR" in capsys.readouterr().err
 
 
-def test_resolve_sweeps_stale_and_creates(
+def test_resolve_fresh_creates_after_archiving(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     capture_exec: list[list[str]],
 ) -> None:
+    # --fresh retains the prior behavior (later reconceived by the epic): the most
+    # recent idle session is archived and a fresh one created in its place.
     now = 100 * DAY
     monkeypatch.setattr(
-        r, "_read_state", lambda *_a: ({"old": "vergil:01:p"}, set(), {"old": now - 20 * DAY})
+        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 1 * DAY})
     )
     monkeypatch.setattr(r, "_now", lambda: now)
     monkeypatch.setattr(r, "_now_iso", lambda: "2026-05-30T00:00:00Z")
     archived: list[str] = []
     monkeypatch.setattr(r, "_archive_session", lambda sid, _ts: archived.append(sid))
-    assert _resolve("vergil", "p") == 0
-    assert archived == ["old"]
-    assert capture_exec == [["claude", "-n", "vergil:01:p"]]
-    err = capsys.readouterr().err
-    assert "auto-archiving" in err
-    assert "Creating session vergil:01:p" in err
-
-
-def test_resolve_warn_prompt_resume(
-    monkeypatch: pytest.MonkeyPatch,
-    capture_exec: list[list[str]],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    now = 100 * DAY
-    monkeypatch.setattr(
-        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
-    )
-    monkeypatch.setattr(r, "_now", lambda: now)
-    monkeypatch.setattr(r, "_prompt_stale", lambda *_a: "r")
-    assert _resolve("vergil", "p") == 0
-    assert capture_exec == [["claude", "--resume", "s1", "-n", "vergil:01:p"]]
-    assert "Resuming session vergil:01:p" in capsys.readouterr().err
-
-
-def test_resolve_warn_prompt_fresh(
-    monkeypatch: pytest.MonkeyPatch,
-    capture_exec: list[list[str]],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    now = 100 * DAY
-    monkeypatch.setattr(
-        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
-    )
-    monkeypatch.setattr(r, "_now", lambda: now)
-    monkeypatch.setattr(r, "_now_iso", lambda: "2026-05-30T00:00:00Z")
-    monkeypatch.setattr(r, "_prompt_stale", lambda *_a: "f")
-    archived: list[str] = []
-    monkeypatch.setattr(r, "_archive_session", lambda sid, _ts: archived.append(sid))
-    assert _resolve("vergil", "p") == 0
+    assert _resolve("vergil", "p", fresh=True) == 0
     assert archived == ["s1"]
     assert capture_exec == [["claude", "-n", "vergil:01:p"]]
-    err = capsys.readouterr().err
-    assert "Archiving session vergil:01:p" in err
-    assert "Creating session vergil:01:p" in err
-
-
-def test_resolve_warn_prompt_cancel(
-    monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
-) -> None:
-    now = 100 * DAY
-    monkeypatch.setattr(
-        r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 9 * DAY})
-    )
-    monkeypatch.setattr(r, "_now", lambda: now)
-    monkeypatch.setattr(r, "_prompt_stale", lambda *_a: "c")
-    assert _resolve("vergil", "p") == 0
-    assert capture_exec == []
-
-
-def test_prompt_stale_non_tty_returns_resume(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(r.sys.stdin, "isatty", lambda: False)
-    assert r._prompt_stale("vergil-project/p", 1, 9) == "r"
-
-
-def test_prompt_stale_tty_reads_choice(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(r.sys.stdin, "isatty", lambda: True)
-    monkeypatch.setattr("builtins.input", lambda _p: "f")
-    assert r._prompt_stale("vergil-project/p", 1, 9) == "f"
-    monkeypatch.setattr("builtins.input", lambda _p: "")  # unrecognized -> cancel
-    assert r._prompt_stale("vergil-project/p", 1, 9) == "c"
 
 
 def test_exec_claude_invokes_execvp(capture_exec: list[list[str]]) -> None:
     assert r._exec_claude(["-n", "x"]) == 0
     assert capture_exec == [["claude", "-n", "x"]]
+
+
+# --- plan_resume (seam-based exact-name attach, issue #2607) ---
+
+
+class _FakeStore:
+    """A minimal SessionStore for plan_resume tests.
+
+    ``resolve_name`` delegates to the pure ``resolve_over`` over the supplied
+    rows, so it reproduces the seam's real fail-loud/None semantics without any
+    transcript I/O.
+    """
+
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def list_sessions(self) -> list[Any]:
+        return list(self._rows)
+
+    def resolve_name(self, name: str) -> Any:
+        from vergil_tooling.lib.session_store import resolve_over
+
+        return resolve_over(self._rows, name)
+
+    def rename(self, session_id: str, new_name: str) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _info(sid: str, name: str | None, active: bool, last: float | None, cwd: str = "/w") -> Any:
+    from vergil_tooling.lib.session_store import SessionInfo
+
+    return SessionInfo(sid, name, cwd, active, last)
+
+
+def test_plan_resume_resolves_name_to_id() -> None:
+    store = _FakeStore([_info("a", "epic-1:w", False, 10.0), _info("b", "epic-1:w", True, 5.0)])
+    action = r.plan_resume(store, "epic-1:w")
+    assert action.session_id == "b"  # the active one wins
+    assert action.cwd == "/w"
+
+
+def test_plan_resume_errors_when_absent(capsys: pytest.CaptureFixture[str]) -> None:
+    store = _FakeStore([_info("a", "other:w", True, 1.0)])
+    with pytest.raises(SystemExit):
+        r.plan_resume(store, "nope:w")
+    assert "no session named 'nope:w'" in capsys.readouterr().err
+
+
+def test_plan_resume_fails_loud_on_ambiguous(capsys: pytest.CaptureFixture[str]) -> None:
+    store = _FakeStore([_info("a", "epic-1:w", True, 10.0), _info("b", "epic-1:w", True, 20.0)])
+    with pytest.raises(SystemExit):
+        r.plan_resume(store, "epic-1:w")
+    assert "live sessions" in capsys.readouterr().err
+
+
+def test_resume_by_name_execs_with_resolved_id_and_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # --resume resolves the name to a session via the seam, chdirs to the
+    # resolved session's cwd (memory-slug parity), then execs claude --resume
+    # with -n re-asserting the exact name.
+    store = _FakeStore([_info("b", "epic-1:w", False, 5.0, cwd="/work/repo")])
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    chdirs: list[str] = []
+    monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
+    assert _resolve("id", "p", resume_name="epic-1:w") == 0
+    assert chdirs == ["/work/repo"]
+    assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
+    assert "Resuming session epic-1:w" in capsys.readouterr().err
+
+
+def test_no_verb_lists_and_guides(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # No --resume (and no fork/fresh): the old auto-resume-most-recent/create
+    # default is gone. Print the recency list + the two verbs and exit non-zero;
+    # never exec claude.
+    store = _FakeStore([_info("b", "epic-1:w", False, 5.0), _info("a", "epic-2:w", True, 50.0)])
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    assert _resolve("id", "p") == 1
+    err = capsys.readouterr().err
+    assert "--label" in err
+    assert "--resume" in err
+    assert "epic-2:w" in err  # most-recent first
+    assert capture_exec == []
+
+
+def test_resume_by_name_skips_chdir_when_cwd_unknown(
+    monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
+) -> None:
+    # An idle session whose cwd could not be recovered (empty) is still resumed;
+    # the resolver simply does not chdir (the launch cwd stands in).
+    store = _FakeStore([_info("b", "epic-1:w", False, 5.0, cwd="")])
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    chdirs: list[str] = []
+    monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
+    assert _resolve("id", "p", resume_name="epic-1:w") == 0
+    assert chdirs == []
+    assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
+
+
+def test_no_verb_guide_when_no_sessions(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # With nothing to list, the guide still names the two verbs and exits nonzero.
+    store = _FakeStore([_info("a", None, True, 1.0)])  # unnamed rows are filtered out
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    assert _resolve("id", "p") == 1
+    err = capsys.readouterr().err
+    assert "No sessions yet" in err
+    assert "--label" in err
+
+
+def test_transcript_cwd_stops_at_line_cap(tmp_path: Path) -> None:
+    # No cwd within the bounded line budget ⇒ None (a huge cwd-less transcript is
+    # not read in full).
+    f = tmp_path / "s.jsonl"
+    f.write_text("".join('{"type":"user","message":"x"}\n' for _ in range(250)))
+    assert r.transcript_cwd(f) is None
 
 
 # --- list_json ---
@@ -789,8 +826,6 @@ def test_main_dispatches_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
             "id",
             "--path",
             "p",
-            "--slot",
-            "2",
             "--fresh",
             "--stale-days",
             "7",
@@ -800,9 +835,9 @@ def test_main_dispatches_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
         ]
     )
     assert code == 0
-    # args order: identity, path, slot, fork, fresh, extra, stale_days,
+    # args order: identity, path, fork, fresh, extra, stale_days,
     # archive_days, resume_name, label
-    assert seen["args"] == ("id", "p", 2, False, True, ["x"], 7, 14, None, None)
+    assert seen["args"] == ("id", "p", False, True, ["x"], 7, 14, None, None)
 
 
 def test_main_passes_resume_name(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -830,7 +865,7 @@ def test_main_strips_leading_double_dash(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(
         r,
         "resolve",
-        lambda *args: captured.update(extra=args[5]) or 0,  # noqa: ARG005
+        lambda *args: captured.update(extra=args[4]) or 0,  # noqa: ARG005
     )
     r.main(["--identity", "id", "--path", "p", "--", "claude", "--model", "opus"])
     assert captured["extra"] == ["claude", "--model", "opus"]
@@ -861,43 +896,26 @@ def test_name_by_session_scoped_to_one_slug(tmp_path: Path) -> None:
     assert r.name_by_session(tmp_path) == {"s1": "id:01:a", "s2": "id:01:b"}
 
 
-def test_resolve_ignores_session_under_other_slug(
+def test_resume_by_name_scans_all_slugs_and_derives_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
 ) -> None:
-    # A session whose NAME claims path "tool" but whose transcript physically
-    # lives under a different workspace's slug must be ignored: claude --resume
-    # is scoped to the current cwd's slug, so resuming it would hard-fail.
-    claude = tmp_path / ".claude"
-    projects = claude / "projects"
-    (projects / "-work-tool").mkdir(parents=True)
-    (projects / "-work-vm").mkdir(parents=True)
-    (projects / "-work-vm" / "mis.jsonl").write_text(
-        '{"type":"agent-name","agentName":"id:01:tool","sessionId":"mis"}\n'
-    )
-    (claude / "sessions").mkdir()
-    monkeypatch.setattr(r, "_claude_dir", lambda: claude)
-    monkeypatch.setattr(os, "getcwd", lambda: "/work/tool")
-    assert _resolve("id", "tool") == 0
-    assert capture_exec == [["claude", "-n", "id:01:tool"]]
-
-
-def test_resolve_resumes_session_under_current_slug(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
-) -> None:
-    # Regression guard: a session whose transcript lives under the current cwd's
-    # slug is still resumable after scoping. Its name lives in a legacy
-    # ``agent-name`` event, so resume must re-assert -n to restore the title.
+    # --resume resolves the exact name across every slug (not just the launch
+    # cwd's) and chdirs to the resolved session's transcript-recorded cwd, so the
+    # memory slug follows the session rather than any positional (#2607).
     claude = tmp_path / ".claude"
     projects = claude / "projects"
     (projects / "-work-tool").mkdir(parents=True)
     (projects / "-work-tool" / "good.jsonl").write_text(
-        '{"type":"agent-name","agentName":"id:01:tool","sessionId":"good"}\n'
+        '{"type":"user","cwd":"/work/tool","timestamp":"2026-05-02T00:00:00.000Z"}\n'
+        '{"type":"custom-title","customTitle":"epic-7:tool","sessionId":"good"}\n'
     )
     (claude / "sessions").mkdir()
     monkeypatch.setattr(r, "_claude_dir", lambda: claude)
-    monkeypatch.setattr(os, "getcwd", lambda: "/work/tool")
-    assert _resolve("id", "tool") == 0
-    assert capture_exec == [["claude", "--resume", "good", "-n", "id:01:tool"]]
+    chdirs: list[str] = []
+    monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
+    assert _resolve("id", "somewhere-else", resume_name="epic-7:tool") == 0
+    assert chdirs == ["/work/tool"]
+    assert capture_exec == [["claude", "--resume", "good", "-n", "epic-7:tool"]]
 
 
 # --- _resolve_target / _resolve_instance named-instance tests (issue #1831) ---

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -455,7 +455,7 @@ def _resolve(
 # --- --label (named creation, issue #2606) ---
 
 
-class _FakeStore:
+class _StubStore:
     """Minimal SessionStore stub exposing only resolve_name for the label path."""
 
     def __init__(self, result: object) -> None:
@@ -473,7 +473,7 @@ def test_resolve_label_creates_when_name_free(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # No visible session holds the composed name -> create label:workspace.
-    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(None))
+    monkeypatch.setattr(r, "_store", lambda *_a: _StubStore(None))
     assert _resolve("id", "vergil-project/tooling", label="epic-1") == 0
     assert capture_exec == [["claude", "-n", "epic-1:vergil-project/tooling"]]
     assert "Creating session epic-1:vergil-project/tooling" in capsys.readouterr().err
@@ -487,7 +487,7 @@ def test_resolve_label_rejects_existing_name(
     from vergil_tooling.lib.session_store import SessionInfo
 
     hit = SessionInfo("s1", "epic-1:p", "/w", active=True, last_active=None)
-    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(hit))
+    monkeypatch.setattr(r, "_store", lambda *_a: _StubStore(hit))
     assert _resolve("id", "p", label="epic-1") == 1
     assert capture_exec == []  # uniqueness collision -> never execs
     assert "already exists" in capsys.readouterr().err
@@ -499,7 +499,7 @@ def test_resolve_label_rejects_ambiguous_name(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # Two live sessions hold the name -> the seam fails loud; still a collision.
-    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(r.AmbiguousSessionError("boom")))
+    monkeypatch.setattr(r, "_store", lambda *_a: _StubStore(r.AmbiguousSessionError("boom")))
     assert _resolve("id", "p", label="epic-1") == 1
     assert capture_exec == []
     assert "already exists" in capsys.readouterr().err
@@ -510,7 +510,7 @@ def test_resolve_label_warns_off_convention_but_creates(
     capture_exec: list[list[str]],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    monkeypatch.setattr(r, "_store", lambda *_a: _FakeStore(None))
+    monkeypatch.setattr(r, "_store", lambda *_a: _StubStore(None))
     assert _resolve("id", "p", label="scratch") == 0
     assert capture_exec == [["claude", "-n", "scratch:p"]]
     assert "convention" in capsys.readouterr().err
@@ -527,7 +527,7 @@ def test_resolve_label_rejects_invalid_slug(
     def _boom(*_a: object) -> object:
         nonlocal called
         called = True
-        return _FakeStore(None)
+        return _StubStore(None)
 
     monkeypatch.setattr(r, "_store", _boom)
     assert _resolve("id", "p", label="bad:name") == 1


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-vm session --resume now resolves an exact session name to one session through the SessionStore seam (fail-loud on absent/ambiguous) and derives the bootstrap cwd from the resolved session for memory-slug parity, while --slot and the auto-resume-most-recent/auto-create default are removed in favor of a no-verb list-and-guide.

## Issue Linkage

- Closes #2607

## Notes

- Task 3 of epic vergil-project/.github#230, built on the merged Task 1 seam. Resolver: new plan_resume(store, name) via store.resolve_name; _resume_by_name chdirs to the resolved SessionInfo.cwd then execs 'claude --resume <id> -n <name>'; no-verb path prints the workspace recency list plus the --label/--resume verbs and exits non-zero. Seam: ScrapeStore now fills an idle session's cwd from its transcript (new transcript_cwd reader) so resume of a detached session derives the right slug. Host vrg-vm: --slot removed from the session command and _session_inner; --resume/--fork guard and help updated. The now-unreachable slot-selection branches inside the resolver's _execute were dropped; --fork/--fresh and the archive/staleness machinery are intentionally left for Tasks 4/5 (they depend on this task). Overlaps Task 2 (#2606, --label create) in bin/vrg_vm.py and the guide text references --label, which lands there; conflicts resolve at rebase. vrg-validate green (100% coverage). Pre-existing, unrelated: test_help_coverage[vrg-update-deps] fails only when the suite runs as a user-agent (human-only tool refusal), on develop too; it passes inside the validation container.