### PR TITLE
feat(vrg-vm): delete session archive + staleness; add recency display-filter

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from vergil_tooling.lib.vm_transport import Transport
 
 from vergil_tooling.bin.vrg_vm_resolve import (
-    _archived_rows,
     _last_activity,
     name_by_session,
     projects_glob,
@@ -39,8 +38,6 @@ from vergil_tooling.lib.identity import (
     load_config,
     resolve_identity_by_name,
     resolve_model,
-    resolve_session_archive_days,
-    resolve_session_stale_days,
     resolve_vergil_version,
     resolve_vm_tag,
     resolve_workspace,
@@ -60,7 +57,8 @@ from vergil_tooling.lib.lima import (
     write_instance_meta,
 )
 from vergil_tooling.lib.progress import Stage
-from vergil_tooling.lib.session import list_rows, make_name
+from vergil_tooling.lib.session import filter_recent
+from vergil_tooling.lib.session_store import SessionInfo
 from vergil_tooling.lib.vm_backend import select_backend
 from vergil_tooling.lib.vm_guest import (
     copy_claude_config,
@@ -2229,12 +2227,12 @@ def _vm_active_sessions(instance: str) -> dict[str, dict[str, object]]:
 
     A running VM owns its roster, so it is the only place a live session's name
     is known — including a freshly created session that has no host transcript
-    yet. The full row (identity, slot, path, lastActive) is returned so the host
+    yet. The full SessionInfo row (name, cwd, lastActive) is returned so the host
     can both name and age such sessions.
     """
     result = shell_run(instance, "vrg-vm-resolve-session", "--list-json")
     rows = json.loads(result.stdout)
-    return {row["sessionId"]: row for row in rows if row.get("state") == "active"}
+    return {row["sessionId"]: row for row in rows if row.get("active")}
 
 
 def _off_platform_active_sessions(vm: OffPlatformVm) -> dict[str, dict[str, object]]:
@@ -2248,7 +2246,7 @@ def _off_platform_active_sessions(vm: OffPlatformVm) -> dict[str, dict[str, obje
     transport = vm_cloud.off_platform_transport(vm.cloud_name, vm.state_dir, vm.provider)
     result = transport.run("vrg-vm-resolve-session", "--list-json")
     rows = json.loads(result.stdout)
-    return {row["sessionId"]: row for row in rows if row.get("state") == "active"}
+    return {row["sessionId"]: row for row in rows if row.get("active")}
 
 
 def _format_age(last_active: float | None, now: float) -> str:
@@ -2261,19 +2259,21 @@ def _format_age(last_active: float | None, now: float) -> str:
 
 
 def _selected_states(args: argparse.Namespace) -> set[str]:
-    if args.all:
-        return {"active", "idle", "archived"}
-    states = {s for s in ("active", "idle", "archived") if getattr(args, s)}
+    states = {s for s in ("active", "idle") if getattr(args, s)}
     return states or {"active", "idle"}
 
 
 def _list_sessions(config: IdentityConfig, args: argparse.Namespace) -> int:
-    """List named Claude sessions across all identity VMs.
+    """List Claude sessions across all identity VMs, by name and recency.
 
-    Transcripts are shared (host-backed), so idle ages and archived rows come
-    from the host store; active liveness, names, and updatedAt are queried per
-    running VM, since each VM owns its own roster. A live session is named from
-    that roster, so the VM is the only source for one with no host transcript.
+    Transcripts are shared (host-backed), so a session's name and idle age come
+    from the host store; active liveness, roster names, and updatedAt are queried
+    per running VM, since each VM owns its own roster. A live session is named
+    from that roster, so the VM is the only source for one with no host transcript
+    yet. By default the listing shows only sessions active within
+    ``session_recent_days``; ``--all`` shows every session regardless of age. A
+    legacy ``archived@…`` name renders as-is — an opaque string, its archive
+    behavior gone (#2608).
     """
     vm_map = {vm["name"]: vm["status"] for vm in list_vms()}
     active_rows: dict[str, dict[str, object]] = {}
@@ -2297,14 +2297,12 @@ def _list_sessions(config: IdentityConfig, args: argparse.Namespace) -> int:
             )
 
     projects = Path.home() / ".claude" / "projects"
-    names = name_by_session(projects)
-    # Adopt the VM-reported name for any active session the host has no
-    # transcript for (e.g. a brand-new session with zero turns); the host store
-    # alone would drop it entirely.
+    names: dict[str, str | None] = dict(name_by_session(projects))
+    # Adopt the VM-reported name for any live session the host has no transcript
+    # for (e.g. a brand-new session with zero turns); the host store alone would
+    # drop it entirely.
     for sid, row in active_rows.items():
-        names.setdefault(
-            sid, make_name(str(row["identity"]), cast("int", row["slot"]), str(row["path"]))
-        )
+        names.setdefault(sid, cast("str | None", row.get("name")))
     last_active: dict[str, float] = {
         sid: cast("float", row.get("lastActive") or 0.0) for sid, row in active_rows.items()
     }
@@ -2315,35 +2313,34 @@ def _list_sessions(config: IdentityConfig, args: argparse.Namespace) -> int:
                 last_active[sid] = ts
 
     active = set(active_rows)
-    rows: list[dict[str, object]] = [
-        {
-            "identity": row.identity,
-            "slot": row.slot,
-            "path": row.path,
-            "state": "active" if row.active else "idle",
-            "lastActive": row.last_active,
-        }
-        for row in list_rows(names, active, last_active)
+    infos = [
+        SessionInfo(
+            session_id=sid,
+            name=name,
+            cwd="",
+            active=sid in active,
+            last_active=last_active.get(sid),
+        )
+        for sid, name in names.items()
     ]
-    rows.extend(_archived_rows(names, last_active))
-
-    wanted = _selected_states(args)
-    rows = [r for r in rows if r["state"] in wanted]
-    # Group by workspace first, then slot within a workspace; identity is the
-    # final tiebreaker so same-workspace/same-slot rows stay stably ordered.
-    rows.sort(key=lambda r: (str(r["path"]), cast("int", r["slot"]), str(r["identity"])))
 
     now = datetime.datetime.now(tz=datetime.UTC).timestamp()
-    # Size the WORKSPACE column to the longest path present (36 floor), so a
-    # path wider than the historical fixed width keeps SLOT/STATE/LAST ACTIVE
-    # aligned.
-    ws = max([36, *(len(str(r["path"])) for r in rows)])
-    print(f"{'IDENTITY':<16} {'WORKSPACE':<{ws}} {'SLOT':<6} {'STATE':<9} {'LAST ACTIVE':<12}")
-    print(f"{'─' * 16} {'─' * ws} {'─' * 6} {'─' * 9} {'─' * 12}")
-    for r in rows:
-        slot = f"{cast('int', r['slot']):02d}"
-        age = _format_age(cast("float | None", r.get("lastActive")), now)
-        print(f"{r['identity']!s:<16} {r['path']!s:<{ws}} {slot:<6} {r['state']!s:<9} {age:<12}")
+    infos = filter_recent(infos, now, config.session_recent_days, all=args.all)
+    wanted = _selected_states(args)
+    infos = [i for i in infos if ("active" if i.active else "idle") in wanted]
+    # Sort by name (unnamed rows last), so same-workspace sessions group together.
+    infos.sort(key=lambda i: (i.name is None, i.name or "", i.session_id))
+
+    # Size the NAME column to the longest name present (36 floor), so a name wider
+    # than the historical fixed width keeps STATE / LAST ACTIVE aligned.
+    display_names = [i.name or "(unnamed)" for i in infos]
+    nw = max([36, *(len(n) for n in display_names)])
+    print(f"{'NAME':<{nw}} {'STATE':<9} {'LAST ACTIVE':<12}")
+    print(f"{'─' * nw} {'─' * 9} {'─' * 12}")
+    for info, display in zip(infos, display_names, strict=True):
+        state = "active" if info.active else "idle"
+        age = _format_age(info.last_active, now)
+        print(f"{display:<{nw}} {state:<9} {age:<12}")
 
     return 0
 
@@ -2353,8 +2350,6 @@ def _session_inner(
     identity_name: str,
     rel_path: str,
     model: str,
-    stale_days: int,
-    archive_days: int,
 ) -> str:
     """Build the in-VM command: a raw override, or the session resolver."""
     source = ". ~/.config/vergil/claude.env 2>/dev/null; . ~/.config/vergil/conan.env 2>/dev/null;"
@@ -2387,7 +2382,6 @@ def _session_inner(
         resolve_cmd += ["--fork"]
     if args.fresh:
         resolve_cmd += ["--fresh"]
-    resolve_cmd += ["--stale-days", str(stale_days), "--archive-days", str(archive_days)]
     if extra:
         resolve_cmd += ["--", *extra]
     return f"{source} exec {shlex.join(resolve_cmd)}"
@@ -2448,8 +2442,6 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
         name,
         rel_path,
         resolve_model(config, identity, args.model),
-        resolve_session_stale_days(config, identity),
-        resolve_session_archive_days(config, identity),
     )
     transport.exec_session(workdir=workdir, inner=inner)
     return 0  # unreachable, keeps the type checker happy
@@ -2514,8 +2506,6 @@ def _cmd_session(args: argparse.Namespace) -> int:
         name,
         rel_path,
         resolve_model(config, identity, args.model),
-        resolve_session_stale_days(config, identity),
-        resolve_session_archive_days(config, identity),
     )
     cmd = [
         "limactl",
@@ -2768,8 +2758,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_list.add_argument("--active", action="store_true", help="With --sessions: only active")
     p_list.add_argument("--idle", action="store_true", help="With --sessions: only idle")
-    p_list.add_argument("--archived", action="store_true", help="With --sessions: only archived")
-    p_list.add_argument("--all", action="store_true", help="With --sessions: include archived too")
+    p_list.add_argument(
+        "--all",
+        action="store_true",
+        help="With --sessions: include sessions older than the recency window",
+    )
 
     p_volumes = sub.add_parser(
         "volumes",
@@ -2837,7 +2830,7 @@ def main(argv: list[str] | None = None) -> int:
     p_session.add_argument(
         "--fresh",
         action="store_true",
-        help="Start a brand-new session, archiving the old one and reclaiming its name",
+        help="Start a brand-new session in the workspace's next slot",
     )
     p_session.add_argument(
         "--model",

--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -22,15 +22,10 @@ from pathlib import Path
 
 from vergil_tooling.lib.session import (
     Create,
-    PlanAction,
+    Decision,
     Refuse,
-    Slot,
     build_slots,
-    list_rows,
-    make_archived_name,
     make_label_name,
-    parse_archived,
-    parse_name,
     plan_session,
     validate_label,
 )
@@ -343,59 +338,23 @@ def _read_state(
     return names, active, last_active
 
 
-def _archive_session(session_id: str, timestamp: str) -> None:
-    """Relabel a cold session by appending an archived ``custom-title`` entry.
-
-    ``custom-title`` is the event type current Claude Code writes, so the
-    archived label also shows up in Claude's own resume picker.
-    """
-    transcript = projects_glob(_claude_dir() / "projects", session_id)
-    current = _last_session_name(transcript)
-    if current is None:
-        return
-    entry = {
-        "type": "custom-title",
-        "customTitle": make_archived_name(current, timestamp),
-        "sessionId": session_id,
-    }
-    try:
-        with transcript.open("a") as fh:
-            fh.write(json.dumps(entry) + "\n")
-    except OSError:
-        return
-
-
 def _exec_claude(args: list[str]) -> int:
     os.execvp("claude", ["claude", *args])  # noqa: S606, S607
     return 0  # reached only when execvp is stubbed (tests)
-
-
-def _now() -> float:
-    return datetime.datetime.now(tz=datetime.UTC).timestamp()
-
-
-def _now_iso() -> str:
-    return datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _run_sweep(slots: list[Slot]) -> None:
-    timestamp = _now_iso()
-    for slot in slots:
-        print(f"auto-archiving slot {slot.slot:02d} ({slot.session_id})…", file=sys.stderr)
-        _archive_session(slot.session_id, timestamp)
 
 
 def _note(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def _execute(action: PlanAction, extra: list[str]) -> int:
+def _execute(action: Decision, extra: list[str]) -> int:
     """Carry out a ``--fork`` / ``--fresh`` plan action.
 
     With ``--slot`` and the auto-resume-most-recent default gone (#2607), the only
-    actions that still reach here are ``Create`` (``--fresh`` reclaiming its name)
-    and ``Refuse`` (``--fork`` with no slot to target). Exact-name attach
-    (``--resume``) resolves through the seam in :func:`_resume_by_name`, not here.
+    actions that still reach here are ``Create`` (``--fresh`` creating a fresh
+    session in the target slot) and ``Refuse`` (``--fork`` with no slot to
+    target). Exact-name attach (``--resume``) resolves through the seam in
+    :func:`_resume_by_name`, not here.
     """
     if isinstance(action, Refuse):
         print(f"ERROR: {action.message}", file=sys.stderr)
@@ -403,7 +362,7 @@ def _execute(action: PlanAction, extra: list[str]) -> int:
     if isinstance(action, Create):
         _note(f"Creating session {action.name}")
         return _exec_claude(["-n", action.name, *extra])
-    # Resume/Fork/PromptStale were the slot-selection outcomes; none is reachable
+    # Resume/Fork were the other slot-selection outcomes; neither is reachable
     # now that selection is by exact name. Guard loudly rather than mis-exec.
     raise RuntimeError(f"unexpected session action {type(action).__name__}")  # pragma: no cover
 
@@ -511,8 +470,6 @@ def resolve(
     fork: bool,
     fresh: bool,
     extra: list[str],
-    stale_days: int,
-    archive_days: int,
     resume_name: str | None = None,
     label: str | None = None,
 ) -> int:
@@ -527,7 +484,8 @@ def resolve(
     cwd from the resolved session (#2607). With no verb the recency list + the two
     verbs are printed and a nonzero code returned — there is no auto-resume-most-
     recent / auto-create default and no ``--slot``. ``fork`` / ``fresh`` retain the
-    prior slot machinery (removed/reconceived by later tasks in the epic).
+    legacy slot machinery (reconceived by later tasks in the epic); auto-archive
+    and the staleness sweep are gone (#2608).
     """
     if label is not None:
         return _resolve_label(path, label, extra)
@@ -538,52 +496,29 @@ def resolve(
         return _list_and_guide(slug)
     names, active, last_active = _read_state(slug)
     slots = build_slots(identity, path, names, active, last_active)
-    plan = plan_session(identity, path, slots, _now(), stale_days, archive_days, None, fork, fresh)
-    _run_sweep(plan.auto_archive)
-    return _execute(plan.action, extra)
-
-
-def _archived_rows(names: dict[str, str], last_active: dict[str, float]) -> list[dict[str, object]]:
-    """Rows for archived sessions, parsed from ``archived@`` labels."""
-    out: list[dict[str, object]] = []
-    for session_id, name in names.items():
-        parsed = parse_archived(name)
-        if parsed is None:
-            continue
-        timestamp, original = parsed
-        slot = parse_name(original)
-        if slot is None:
-            continue
-        identity, num, path = slot
-        out.append(
-            {
-                "identity": identity,
-                "slot": num,
-                "path": path,
-                "sessionId": session_id,
-                "state": "archived",
-                "archivedAt": timestamp,
-                "lastActive": last_active.get(session_id),
-            }
-        )
-    return out
+    action = plan_session(identity, path, slots, None, fork, fresh)
+    return _execute(action, extra)
 
 
 def list_json() -> int:
-    """Print every named session's state as JSON (for ``list --sessions``)."""
-    names, active, last_active = _read_state()
-    rows: list[dict[str, object]] = [
+    """Print every session the seam sees as JSON (for ``list --sessions``).
+
+    Emits :class:`SessionInfo`-shaped rows straight from the store — session id,
+    name (``None`` for a live-but-unnamed session), cwd, liveness, and
+    last-activity. A legacy ``archived@…`` name rides through as an opaque string;
+    the archive *behavior* is gone (#2608), but the seam still lists and resolves
+    such a name. The host applies the recency display-filter; this only enumerates.
+    """
+    rows = [
         {
-            "identity": row.identity,
-            "slot": row.slot,
-            "path": row.path,
             "sessionId": row.session_id,
-            "state": "active" if row.active else "idle",
+            "name": row.name,
+            "cwd": row.cwd,
+            "active": row.active,
             "lastActive": row.last_active,
         }
-        for row in list_rows(names, active, last_active)
+        for row in _store().list_sessions()
     ]
-    rows.extend(_archived_rows(names, last_active))
     print(json.dumps(rows))
     return 0
 
@@ -596,8 +531,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fresh", action="store_true")
     parser.add_argument("--resume-name", dest="resume_name", default=None)
     parser.add_argument("--label", dest="label", default=None)
-    parser.add_argument("--stale-days", type=int, default=7, dest="stale_days")
-    parser.add_argument("--archive-days", type=int, default=14, dest="archive_days")
     parser.add_argument("--list-json", action="store_true", dest="list_json")
     parser.add_argument("extra", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
@@ -618,8 +551,6 @@ def main(argv: list[str] | None = None) -> int:
         args.fork,
         args.fresh,
         extra,
-        args.stale_days,
-        args.archive_days,
         args.resume_name,
         args.label,
     )

--- a/src/vergil_tooling/lib/identity.py
+++ b/src/vergil_tooling/lib/identity.py
@@ -11,8 +11,7 @@ from pathlib import Path
 
 _SIZE_PATTERN = re.compile(r"^\d+GiB$")
 
-_DEFAULT_SESSION_STALE_DAYS = 7
-_DEFAULT_SESSION_ARCHIVE_DAYS = 14
+_DEFAULT_SESSION_RECENT_DAYS = 7
 
 
 @dataclass
@@ -28,8 +27,7 @@ class Identity:
     vergil: str = ""
     vergil_vm: str = ""
     model: str = ""
-    session_stale_days: int | None = None
-    session_archive_days: int | None = None
+    session_recent_days: int | None = None
     cpus: int | None = None
     memory: str | None = None
     disk: str | None = None
@@ -43,21 +41,16 @@ class IdentityConfig:
     vergil: str = ""
     vergil_vm: str = ""
     model: str = ""
-    session_stale_days: int = 7
-    session_archive_days: int = 14
+    session_recent_days: int = 7
 
 
-def _validate_session_thresholds(
-    name: str, identity: Identity, cfg_stale: int, cfg_archive: int
-) -> None:
-    stale = identity.session_stale_days if identity.session_stale_days is not None else cfg_stale
-    archive = (
-        identity.session_archive_days if identity.session_archive_days is not None else cfg_archive
+def _validate_session_recent_days(name: str, identity: Identity, cfg_recent: int) -> None:
+    recent = (
+        identity.session_recent_days if identity.session_recent_days is not None else cfg_recent
     )
-    if archive != 0 and archive <= stale:
+    if recent < 1:
         print(
-            f"ERROR: identity '{name}': session_archive_days ({archive}) must be 0 "
-            f"or greater than session_stale_days ({stale})",
+            f"ERROR: identity '{name}': session_recent_days ({recent}) must be at least 1",
             file=sys.stderr,
         )
         raise SystemExit(1)
@@ -122,8 +115,7 @@ def load_config(path: Path) -> IdentityConfig:
     vergil = raw.get("vergil", "")
     vergil_vm = raw.get("vergil-vm", "")
     model = raw.get("model", "")
-    session_stale_days = raw.get("session_stale_days", _DEFAULT_SESSION_STALE_DAYS)
-    session_archive_days = raw.get("session_archive_days", _DEFAULT_SESSION_ARCHIVE_DAYS)
+    session_recent_days = raw.get("session_recent_days", _DEFAULT_SESSION_RECENT_DAYS)
 
     identities: dict[str, Identity] = {}
     for name, data in raw.get("identities", {}).items():
@@ -156,8 +148,7 @@ def load_config(path: Path) -> IdentityConfig:
             vergil=data.get("vergil", ""),
             vergil_vm=data.get("vergil-vm", ""),
             model=data.get("model", ""),
-            session_stale_days=data.get("session_stale_days"),
-            session_archive_days=data.get("session_archive_days"),
+            session_recent_days=data.get("session_recent_days"),
             cpus=data.get("cpus"),
             memory=data.get("memory"),
             disk=data.get("disk"),
@@ -165,17 +156,14 @@ def load_config(path: Path) -> IdentityConfig:
         )
         _validate_auth_type(name, identities[name])
         _validate_identity_resources(name, identities[name])
-        _validate_session_thresholds(
-            name, identities[name], session_stale_days, session_archive_days
-        )
+        _validate_session_recent_days(name, identities[name], session_recent_days)
     return IdentityConfig(
         identities=identities,
         default_identity=default_identity,
         vergil=vergil,
         vergil_vm=vergil_vm,
         model=model,
-        session_stale_days=session_stale_days,
-        session_archive_days=session_archive_days,
+        session_recent_days=session_recent_days,
     )
 
 
@@ -269,18 +257,11 @@ def resolve_model(config: IdentityConfig, identity: Identity, cli_model: str = "
     return config.model
 
 
-def resolve_session_stale_days(config: IdentityConfig, identity: Identity) -> int:
-    """Days idle before a session warns: identity, then config-level."""
-    if identity.session_stale_days is not None:
-        return identity.session_stale_days
-    return config.session_stale_days
-
-
-def resolve_session_archive_days(config: IdentityConfig, identity: Identity) -> int:
-    """Days idle before a session auto-archives (0 disables): identity, then config."""
-    if identity.session_archive_days is not None:
-        return identity.session_archive_days
-    return config.session_archive_days
+def resolve_session_recent_days(config: IdentityConfig, identity: Identity) -> int:
+    """Days a session stays in the default ``list`` recency band: identity, then config."""
+    if identity.session_recent_days is not None:
+        return identity.session_recent_days
+    return config.session_recent_days
 
 
 def resolve_workspace(path: str, projects_dir: str) -> str:

--- a/src/vergil_tooling/lib/session.py
+++ b/src/vergil_tooling/lib/session.py
@@ -14,13 +14,16 @@ workspace paths, even though dashes and slashes are common inside both fields.
 
 from __future__ import annotations
 
-import enum
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from vergil_tooling.lib.session_store import SessionInfo
 
 SLOT_MIN = 1
 SLOT_MAX = 99
-
-_ARCHIVED_PREFIX = "archived@"
 
 
 def make_name(identity: str, slot: int, path: str) -> str:
@@ -75,32 +78,17 @@ def validate_label(label: str) -> list[str]:
     return warnings
 
 
-def make_archived_name(name: str, timestamp: str) -> str:
-    """Archived label: ``archived@<timestamp>@<original-name>``."""
-    return f"{_ARCHIVED_PREFIX}{timestamp}@{name}"
-
-
-def parse_archived(name: str) -> tuple[str, str] | None:
-    """Parse an archived label into ``(timestamp, original_name)`` or ``None``.
-
-    Splits on the first two ``@`` so a workspace path containing ``@`` is safe.
-    """
-    if not name.startswith(_ARCHIVED_PREFIX):
-        return None
-    parts = name.split("@", 2)
-    if len(parts) != 3:
-        return None
-    return parts[1], parts[2]
-
-
 def parse_name(name: str) -> tuple[str, int, str] | None:
     """Parse ``<identity>:<NN>:<path>`` into its fields.
 
-    Returns ``None`` for any string that does not match the scheme (an archived
-    label, wrong field count, empty identity/path, or a slot that is not a
-    two-digit number in range).
+    Returns ``None`` for any string that does not match the scheme (wrong field
+    count, empty identity/path, or a slot that is not a two-digit number in
+    range). A legacy ``archived@…`` name is an **opaque** string — the archive
+    behavior is gone, but such a name must never misparse into a phantom slot
+    (its embedded timestamp colons would otherwise read as ``<id>:<NN>:<path>``),
+    so it is rejected here too.
     """
-    if name.startswith(_ARCHIVED_PREFIX):
+    if name.startswith("archived@"):
         return None
     parts = name.split(":", 2)
     if len(parts) != 3:
@@ -257,24 +245,31 @@ def list_rows(
     return sorted(best.values(), key=lambda r: (r.identity, r.slot, r.path))
 
 
-class AgeBand(enum.Enum):
-    FRESH = "fresh"
-    WARN = "warn"
-    STALE = "stale"
+def filter_recent(
+    rows: Iterable[SessionInfo],
+    now: float,
+    recent_days: int,
+    all: bool = False,  # noqa: A002 — the CLI flag this mirrors is literally ``--all``
+) -> list[SessionInfo]:
+    """Keep only sessions active within ``recent_days`` (the display recency band).
 
+    This is the replacement for the deleted staleness bands: it does not touch,
+    rename, or delete anything — it purely decides which rows a listing shows.
 
-def classify_age(
-    now: float, last_active: float | None, stale_days: int, archive_days: int
-) -> AgeBand:
-    """Classify a session's age. Unknown age is treated as FRESH (never swept)."""
-    if last_active is None:
-        return AgeBand.FRESH
-    age_days = (now - last_active) / 86400.0
-    if age_days < stale_days:
-        return AgeBand.FRESH
-    if archive_days != 0 and age_days >= archive_days:
-        return AgeBand.STALE
-    return AgeBand.WARN
+    - ``all=True`` returns every row unchanged (the ``--all`` escape hatch).
+    - A **live** session is always kept (a session in use is always relevant,
+      regardless of its last-activity timestamp).
+    - An **unknown** ``last_active`` is kept (age unknown ⇒ shown, never hidden —
+      the same "unknown is fresh" bias the old bands used).
+    - Otherwise the row is kept iff it was last active no more than
+      ``recent_days`` days before ``now``.
+    """
+    if all:
+        return list(rows)
+    cutoff = now - recent_days * 86400.0
+    return [
+        row for row in rows if row.active or row.last_active is None or row.last_active >= cutoff
+    ]
 
 
 def _lowest_free(slots: dict[int, Slot]) -> int | None:
@@ -383,26 +378,6 @@ def select_by_name(
     return Resume(best[0])
 
 
-@dataclass(frozen=True)
-class PromptStale:
-    """Warn-band: the resolver must prompt resume/fresh/cancel, then act."""
-
-    session_id: str  # resume this on [r]
-    name: str  # reclaim this name on [f] (archive session_id, then create name)
-    age_days: int
-
-
-PlanAction = Create | Resume | Fork | Refuse | PromptStale
-
-
-@dataclass(frozen=True)
-class SessionPlan:
-    """A full session decision: cold slots to auto-archive, then an action."""
-
-    auto_archive: list[Slot]
-    action: PlanAction
-
-
 def _idle_by_recency(slots: dict[int, Slot]) -> list[Slot]:
     """Idle slots, most-recently-active first (unknown age sorts oldest)."""
     idle = [s for s in slots.values() if not s.active]
@@ -417,62 +392,41 @@ def plan_session(
     identity: str,
     path: str,
     slots: dict[int, Slot],
-    now: float,
-    stale_days: int,
-    archive_days: int,
     requested_slot: int | None = None,
     fork: bool = False,
     fresh: bool = False,
-) -> SessionPlan:
-    """Plan a session launch: which cold slots to archive, then what to do."""
+) -> Decision:
+    """Plan a ``--fork`` / ``--fresh`` session launch (legacy slot machinery).
+
+    Auto-archive and the staleness bands are gone (issue #2608), so a plan is now
+    a single :class:`Decision` — there is no set of cold slots to sweep. The only
+    remaining callers are ``--fork`` and ``--fresh`` (create/resume-by-name is the
+    supported path via the seam); the no-verb default is handled by the resolver.
+    ``--fresh`` here simply creates a fresh session in the target slot — the
+    supported *retire-rename* of the prior session is a separate change (Task 5).
+    """
     if fork:
-        return SessionPlan([], _select_fork(identity, path, slots, requested_slot))
+        return _select_fork(identity, path, slots, requested_slot)
     if fresh:
         return _plan_fresh(identity, path, slots, requested_slot)
     if requested_slot is not None:
-        return SessionPlan([], _select_explicit(identity, path, slots, requested_slot))
-
-    sweep = [
-        s
-        for s in slots.values()
-        if not s.active
-        and classify_age(now, s.last_active, stale_days, archive_days) == AgeBand.STALE
-    ]
-    swept = {s.slot for s in sweep}
-    remaining = {n: s for n, s in slots.items() if n not in swept}
-    return SessionPlan(
-        sweep, _select_auto(identity, path, remaining, now, stale_days, archive_days)
-    )
-
-
-def _select_auto(
-    identity: str,
-    path: str,
-    slots: dict[int, Slot],
-    now: float,
-    stale_days: int,
-    archive_days: int,
-) -> PlanAction:
-    """Most-recent idle in FRESH resumes; in WARN prompts; else create free."""
-    for slot in _idle_by_recency(slots):
-        band = classify_age(now, slot.last_active, stale_days, archive_days)
-        if band == AgeBand.FRESH:
-            return Resume(slot.session_id)
-        age_days = int((now - (slot.last_active or now)) / 86400.0)
-        return PromptStale(slot.session_id, make_name(identity, slot.slot, path), age_days)
-    free = _lowest_free(slots)
-    if free is None:
-        return _all_in_use(identity, path)
-    return Create(make_name(identity, free, path))
+        return _select_explicit(identity, path, slots, requested_slot)
+    return _select_default(identity, path, slots)
 
 
 def _plan_fresh(
     identity: str, path: str, slots: dict[int, Slot], requested_slot: int | None
-) -> SessionPlan:
-    """``--fresh``: archive the (cold) target and create fresh in that slot."""
+) -> Decision:
+    """``--fresh``: create a fresh session in the (cold) target slot.
+
+    Picks the target slot (explicit, else the most-recent idle, else the lowest
+    free) and creates a new session there. The prior session is left untouched —
+    reclaiming its name via a supported rename is Task 5's retire-rename, not this
+    interim create.
+    """
     if requested_slot is not None:
         if not SLOT_MIN <= requested_slot <= SLOT_MAX:
-            return SessionPlan([], _bad_range())
+            return _bad_range()
         target = slots.get(requested_slot)
         slot_no = requested_slot
     else:
@@ -480,10 +434,7 @@ def _plan_fresh(
         target = idle[0] if idle else None
         slot_no = target.slot if target else (_lowest_free(slots) or 0)
     if slot_no == 0:
-        return SessionPlan([], _all_in_use(identity, path))
+        return _all_in_use(identity, path)
     if target is not None and target.active:
-        return SessionPlan(
-            [], Refuse(f"slot {slot_no:02d} is active; cannot start fresh over a live session")
-        )
-    archive = [target] if target is not None else []
-    return SessionPlan(archive, Create(make_name(identity, slot_no, path)))
+        return Refuse(f"slot {slot_no:02d} is active; cannot start fresh over a live session")
+    return Create(make_name(identity, slot_no, path))

--- a/tests/vergil_tooling/test_identity.py
+++ b/tests/vergil_tooling/test_identity.py
@@ -14,8 +14,7 @@ from vergil_tooling.lib.identity import (
     resolve_identity,
     resolve_identity_by_name,
     resolve_model,
-    resolve_session_archive_days,
-    resolve_session_stale_days,
+    resolve_session_recent_days,
     resolve_vergil_version,
     resolve_vm_tag,
     resolve_workspace,
@@ -674,61 +673,53 @@ def test_resolve_model_none_configured() -> None:
     assert resolve_model(cfg, Identity(vm_instance="x")) == ""
 
 
-def test_session_thresholds_parsed(tmp_path: Path) -> None:
+def test_session_recent_days_parsed(tmp_path: Path) -> None:
     p = tmp_path / "identities.toml"
     p.write_text(
         textwrap.dedent("""\
-        session_stale_days = 5
-        session_archive_days = 30
+        session_recent_days = 5
         [identities.vergil]
         vm_instance = "vergil-agent"
-        session_stale_days = 2
+        session_recent_days = 2
     """)
     )
     cfg = load_config(p)
-    assert cfg.session_stale_days == 5
-    assert cfg.session_archive_days == 30
-    assert cfg.identities["vergil"].session_stale_days == 2
-    assert cfg.identities["vergil"].session_archive_days is None
+    assert cfg.session_recent_days == 5
+    assert cfg.identities["vergil"].session_recent_days == 2
 
 
-def test_resolve_session_thresholds_cascade() -> None:
-    cfg = IdentityConfig(identities={}, session_stale_days=5, session_archive_days=30)
-    ident = Identity(vm_instance="x", session_stale_days=2)
-    assert resolve_session_stale_days(cfg, ident) == 2  # identity override
-    assert resolve_session_archive_days(cfg, ident) == 30  # falls back to config
-    # identity-level archive override
-    ident2 = Identity(vm_instance="x", session_archive_days=20)
-    assert resolve_session_archive_days(cfg, ident2) == 20
-
-
-def test_resolve_session_thresholds_builtin_defaults() -> None:
-    cfg = IdentityConfig(identities={})
-    ident = Identity(vm_instance="x")
-    assert resolve_session_stale_days(cfg, ident) == 7
-    assert resolve_session_archive_days(cfg, ident) == 14
-
-
-def test_session_archive_days_zero_disables(tmp_path: Path) -> None:
+def test_session_recent_days_defaults_none_per_identity(tmp_path: Path) -> None:
     p = tmp_path / "identities.toml"
     p.write_text(
         textwrap.dedent("""\
-        session_archive_days = 0
         [identities.vergil]
         vm_instance = "vergil-agent"
     """)
     )
-    assert load_config(p).session_archive_days == 0
+    cfg = load_config(p)
+    assert cfg.session_recent_days == 7  # built-in config default
+    assert cfg.identities["vergil"].session_recent_days is None
 
 
-def test_session_archive_days_must_exceed_stale(tmp_path: Path) -> None:
+def test_resolve_session_recent_days_cascade() -> None:
+    cfg = IdentityConfig(identities={}, session_recent_days=5)
+    ident = Identity(vm_instance="x", session_recent_days=2)
+    assert resolve_session_recent_days(cfg, ident) == 2  # identity override
+    assert resolve_session_recent_days(cfg, Identity(vm_instance="x")) == 5  # config fallback
+
+
+def test_resolve_session_recent_days_builtin_default() -> None:
+    cfg = IdentityConfig(identities={})
+    assert resolve_session_recent_days(cfg, Identity(vm_instance="x")) == 7
+
+
+def test_session_recent_days_must_be_positive(tmp_path: Path) -> None:
     p = tmp_path / "identities.toml"
     p.write_text(
         textwrap.dedent("""\
         [identities.vergil]
         vm_instance = "vergil-agent"
-        session_stale_days = 10
-        session_archive_days = 5
+        session_recent_days = 0
     """)
     )
     with pytest.raises(SystemExit):

--- a/tests/vergil_tooling/test_session.py
+++ b/tests/vergil_tooling/test_session.py
@@ -4,54 +4,30 @@ import pytest
 
 from vergil_tooling.lib.session import (
     SLOT_MAX,
-    AgeBand,
     Create,
     Fork,
-    PromptStale,
     Refuse,
     Resume,
-    SessionPlan,
     SessionRow,
     Slot,
     build_slots,
-    classify_age,
+    filter_recent,
     list_rows,
-    make_archived_name,
     make_label_name,
     make_name,
-    parse_archived,
     parse_name,
     plan_session,
     select,
     select_by_name,
     validate_label,
 )
-
-
-def test_make_archived_name() -> None:
-    assert (
-        make_archived_name("vergil:01:a/b", "2026-05-30T14:23:07Z")
-        == "archived@2026-05-30T14:23:07Z@vergil:01:a/b"
-    )
+from vergil_tooling.lib.session_store import SessionInfo
 
 
 def test_parse_name_rejects_archived_prefix() -> None:
+    # A legacy archived@ name is opaque — never a phantom slot (its timestamp
+    # colons would otherwise misparse as <id>:<NN>:<path>).
     assert parse_name("archived@2026-05-30T14:23:07Z@vergil:01:a/b") is None
-
-
-def test_parse_archived_roundtrip() -> None:
-    label = "archived@2026-05-30T14:23:07Z@vergil:01:a/b"
-    assert parse_archived(label) == ("2026-05-30T14:23:07Z", "vergil:01:a/b")
-
-
-def test_parse_archived_path_with_at_sign() -> None:
-    label = "archived@2026-05-30T14:23:07Z@vergil:01:clients/acme@2024"
-    assert parse_archived(label) == ("2026-05-30T14:23:07Z", "vergil:01:clients/acme@2024")
-
-
-def test_parse_archived_returns_none_for_non_archived() -> None:
-    assert parse_archived("vergil:01:a/b") is None
-    assert parse_archived("archived@only-two-parts") is None
 
 
 # --- make_label_name / validate_label (issue #2606) ---
@@ -387,40 +363,52 @@ def test_list_rows_recent_idle_wins_duplicate() -> None:
 
 
 DAY = 86400.0
-
-
-def test_classify_age_fresh() -> None:
-    assert classify_age(100 * DAY, 99 * DAY, 7, 14) == AgeBand.FRESH
-
-
-def test_classify_age_warn() -> None:
-    assert classify_age(100 * DAY, 90 * DAY, 7, 14) == AgeBand.WARN
-
-
-def test_classify_age_stale() -> None:
-    assert classify_age(100 * DAY, 80 * DAY, 7, 14) == AgeBand.STALE
-
-
-def test_classify_age_unknown_is_fresh() -> None:
-    assert classify_age(100 * DAY, None, 7, 14) == AgeBand.FRESH
-
-
-def test_classify_age_archive_zero_never_stale() -> None:
-    assert classify_age(100 * DAY, 0.0, 7, 0) == AgeBand.WARN
-
-
 NOW = 100 * DAY
+
+
+# --- filter_recent (display recency band, issue #2608) ---
+
+
+def _si(sid: str, active: bool, last: float | None) -> SessionInfo:
+    return SessionInfo(sid, f"name-{sid}", "/w", active, last)
+
+
+def test_filter_recent_keeps_recent_idle_drops_old() -> None:
+    rows = [_si("a", False, NOW - 2 * DAY), _si("b", False, NOW - 20 * DAY)]
+    out = filter_recent(rows, NOW, 7)
+    assert [r.session_id for r in out] == ["a"]
+
+
+def test_filter_recent_all_returns_everything() -> None:
+    rows = [_si("a", False, NOW - 20 * DAY), _si("b", False, NOW - 99 * DAY)]
+    assert filter_recent(rows, NOW, 7, all=True) == rows
+
+
+def test_filter_recent_keeps_active_regardless_of_age() -> None:
+    rows = [_si("a", True, NOW - 99 * DAY)]
+    assert filter_recent(rows, NOW, 7) == rows
+
+
+def test_filter_recent_keeps_unknown_age() -> None:
+    rows = [_si("a", False, None)]
+    assert filter_recent(rows, NOW, 7) == rows
+
+
+def test_filter_recent_boundary_is_inclusive() -> None:
+    # Exactly recent_days old is still within the window (>= cutoff).
+    rows = [_si("a", False, NOW - 7 * DAY)]
+    assert filter_recent(rows, NOW, 7) == rows
+
+
+# --- plan_session (legacy --fork / --fresh slot machinery; archive removed) ---
 
 
 def _slot(n: int, sid: str, active: bool = False, age_days: float = 0.0) -> Slot:
     return Slot(n, sid, active, NOW - age_days * DAY)
 
 
-def _plan(slots: dict[int, Slot], **kw: object) -> SessionPlan:
+def _plan(slots: dict[int, Slot], **kw: object) -> object:
     defaults: dict[str, object] = {
-        "now": NOW,
-        "stale_days": 7,
-        "archive_days": 14,
         "requested_slot": None,
         "fork": False,
         "fresh": False,
@@ -429,104 +417,62 @@ def _plan(slots: dict[int, Slot], **kw: object) -> SessionPlan:
     return plan_session("vergil", "p", slots, **defaults)  # type: ignore[arg-type]
 
 
-def test_plan_resume_most_recent_idle() -> None:
-    slots = {1: _slot(1, "old", age_days=3), 2: _slot(2, "new", age_days=0.1)}
-    plan = _plan(slots)
-    assert plan.auto_archive == []
-    assert plan.action == Resume("new")
+def test_plan_default_resumes_lowest_idle() -> None:
+    slots = {1: _slot(1, "s1", active=True), 2: _slot(2, "s2"), 3: _slot(3, "s3")}
+    assert _plan(slots) == Resume("s2")
 
 
-def test_plan_warn_band_prompts() -> None:
-    plan = _plan({1: _slot(1, "s1", age_days=9)})
-    assert plan.auto_archive == []
-    assert plan.action == PromptStale("s1", "vergil:01:p", 9)
+def test_plan_explicit_slot_resumes() -> None:
+    slots = {1: _slot(1, "s1"), 2: _slot(2, "s2")}
+    assert _plan(slots, requested_slot=1) == Resume("s1")
 
 
-def test_plan_stale_is_swept_then_fresh() -> None:
-    slots = {1: _slot(1, "s1", age_days=20)}
-    plan = _plan(slots)
-    assert plan.auto_archive == [slots[1]]
-    assert plan.action == Create("vergil:01:p")
-
-
-def test_plan_sweep_only_stale_keeps_fresh() -> None:
-    slots = {1: _slot(1, "s1", age_days=20), 2: _slot(2, "s2", age_days=0.1)}
-    plan = _plan(slots)
-    assert plan.auto_archive == [slots[1]]
-    assert plan.action == Resume("s2")
-
-
-def test_plan_never_sweeps_active() -> None:
-    plan = _plan({1: _slot(1, "s1", active=True, age_days=20)})
-    assert plan.auto_archive == []
-    assert plan.action == Create("vergil:02:p")
-
-
-def test_plan_explicit_slot_no_sweep_no_prompt() -> None:
-    slots = {1: _slot(1, "s1", age_days=20), 2: _slot(2, "s2", age_days=20)}
-    plan = _plan(slots, requested_slot=1)
-    assert plan.auto_archive == []
-    assert plan.action == Resume("s1")
-
-
-def test_plan_fresh_with_slot_archives_then_creates() -> None:
+def test_plan_fresh_with_slot_creates_no_archive() -> None:
+    # --fresh no longer archives (issue #2608): it just creates in the slot.
     slots = {1: _slot(1, "s1", age_days=1)}
-    plan = _plan(slots, requested_slot=1, fresh=True)
-    assert plan.auto_archive == [slots[1]]
-    assert plan.action == Create("vergil:01:p")
+    assert _plan(slots, requested_slot=1, fresh=True) == Create("vergil:01:p")
 
 
-def test_plan_fresh_no_slot_archives_most_recent_idle() -> None:
+def test_plan_fresh_no_slot_picks_most_recent_idle_slot() -> None:
     slots = {1: _slot(1, "s1", age_days=5), 2: _slot(2, "s2", age_days=1)}
-    plan = _plan(slots, fresh=True)
-    assert plan.auto_archive == [slots[2]]
-    assert plan.action == Create("vergil:02:p")
+    assert _plan(slots, fresh=True) == Create("vergil:02:p")
 
 
 def test_plan_fresh_no_idle_creates_lowest_free() -> None:
-    plan = _plan({}, fresh=True)
-    assert plan.auto_archive == []
-    assert plan.action == Create("vergil:01:p")
+    assert _plan({}, fresh=True) == Create("vergil:01:p")
 
 
 def test_plan_fresh_active_slot_refused() -> None:
     plan = _plan({1: _slot(1, "s1", active=True, age_days=1)}, requested_slot=1, fresh=True)
-    assert plan.auto_archive == []
-    assert isinstance(plan.action, Refuse)
+    assert isinstance(plan, Refuse)
 
 
 def test_plan_fresh_bad_range_refused() -> None:
-    plan = _plan({}, requested_slot=0, fresh=True)
-    assert isinstance(plan.action, Refuse)
+    assert isinstance(_plan({}, requested_slot=0, fresh=True), Refuse)
 
 
 def test_plan_fresh_all_slots_in_use() -> None:
     slots = {n: _slot(n, f"s{n}", active=True, age_days=1) for n in range(1, SLOT_MAX + 1)}
-    plan = _plan(slots, fresh=True)
-    assert isinstance(plan.action, Refuse)
+    assert isinstance(_plan(slots, fresh=True), Refuse)
 
 
 def test_plan_fork_unchanged() -> None:
     plan = _plan({1: _slot(1, "s1", active=True, age_days=1)}, requested_slot=1, fork=True)
-    assert plan.auto_archive == []
-    assert plan.action == Fork("s1", "vergil:02:p")
+    assert plan == Fork("s1", "vergil:02:p")
 
 
 def test_plan_no_slots_creates_first() -> None:
-    plan = _plan({})
-    assert plan.action == Create("vergil:01:p")
+    assert _plan({}) == Create("vergil:01:p")
 
 
 def test_plan_all_active_creates_next_free() -> None:
     slots = {1: _slot(1, "s1", active=True), 2: _slot(2, "s2", active=True)}
-    plan = _plan(slots)
-    assert plan.action == Create("vergil:03:p")
+    assert _plan(slots) == Create("vergil:03:p")
 
 
 def test_plan_all_slots_active_refused() -> None:
     slots = {n: _slot(n, f"s{n}", active=True) for n in range(1, SLOT_MAX + 1)}
-    plan = _plan(slots)
-    assert isinstance(plan.action, Refuse)
+    assert isinstance(_plan(slots), Refuse)
 
 
 # --- select_by_name (resume a session by its exact display name) ---

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import textwrap
+import time
 import types
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -969,24 +970,18 @@ class TestList:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
+        # The VM's --list-json now emits SessionInfo rows; only the live one is
+        # kept by _vm_active_sessions. The idle session comes from the host
+        # transcript scan (name_by_session). --all so the old idle row is shown.
         mock_shell.return_value = MagicMock(
             stdout=json.dumps(
                 [
                     {
-                        "identity": "vergil",
-                        "slot": 1,
-                        "path": "vergil-project/vm",
                         "sessionId": "s1",
-                        "state": "active",
+                        "name": "vergil:01:vergil-project/vm",
+                        "cwd": "",
+                        "active": True,
                         "lastActive": 1748000000.0,
-                    },
-                    {
-                        "identity": "vergil",
-                        "slot": 2,
-                        "path": "vergil-project/tooling",
-                        "sessionId": "s2",
-                        "state": "idle",
-                        "lastActive": 1700000000.0,
                     },
                 ]
             )
@@ -995,10 +990,10 @@ class TestList:
             "s1": "vergil:01:vergil-project/vm",
             "s2": "vergil:02:tooling",
         }
-        result = main(["list", "--sessions", "--config", str(config_file)])
+        result = main(["list", "--sessions", "--all", "--config", str(config_file)])
         assert result == 0
         out = capsys.readouterr().out
-        assert "WORKSPACE" in out
+        assert "NAME" in out
         assert "LAST ACTIVE" in out
         assert "vergil-project/vm" in out
         assert "active" in out
@@ -1025,11 +1020,10 @@ class TestList:
             stdout=json.dumps(
                 [
                     {
-                        "identity": "vergil",
-                        "slot": 2,
-                        "path": "vergil-project/tooling",
                         "sessionId": "s2",
-                        "state": "active",
+                        "name": "vergil:02:vergil-project/tooling",
+                        "cwd": "",
+                        "active": True,
                         "lastActive": 1748000000.0,
                     }
                 ]
@@ -1045,7 +1039,7 @@ class TestList:
     @patch("vergil_tooling.bin.vrg_vm.name_by_session")
     @patch("vergil_tooling.bin.vrg_vm.shell_run")
     @patch("vergil_tooling.bin.vrg_vm.list_vms")
-    def test_list_sessions_archived_filter(
+    def test_list_sessions_legacy_archived_name_is_opaque(
         self,
         mock_list: MagicMock,
         mock_shell: MagicMock,
@@ -1054,22 +1048,76 @@ class TestList:
         config_file: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        # The archive behavior is gone (#2608). A legacy archived@ name is no
+        # longer special-cased into an "archived" state — it renders verbatim as
+        # an opaque session name, listed like any other (unknown age ⇒ shown).
         mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
         mock_shell.return_value = MagicMock(stdout=json.dumps([]))
         mock_names.return_value = {
             "s1": "vergil:01:vergil-project/vm",
             "a1": "archived@2026-05-01T00:00:00Z@vergil:03:tooling",
         }
-        # default view hides archived
         assert main(["list", "--sessions", "--config", str(config_file)]) == 0
         out = capsys.readouterr().out
-        assert "vergil-project/vm" in out
-        assert "tooling" not in out
-        # --archived shows only archived
-        assert main(["list", "--sessions", "--archived", "--config", str(config_file)]) == 0
-        out = capsys.readouterr().out
-        assert "tooling" in out
-        assert "archived" in out
+        assert "vergil:01:vergil-project/vm" in out
+        assert "archived@2026-05-01T00:00:00Z@vergil:03:tooling" in out
+
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session", return_value={})
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_list_sessions_unnamed_live_session_renders(
+        self,
+        mock_list: MagicMock,
+        mock_shell: MagicMock,
+        _names: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # A live-but-unnamed session (name=None) is still listed, as "(unnamed)".
+        mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
+        mock_shell.return_value = MagicMock(
+            stdout=json.dumps(
+                [{"sessionId": "s1", "name": None, "cwd": "", "active": True, "lastActive": None}]
+            )
+        )
+        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        assert "(unnamed)" in capsys.readouterr().out
+
+    def test_list_sessions_archived_flag_removed(self, config_file: Path) -> None:
+        # --archived is gone; argparse rejects the unknown flag.
+        with pytest.raises(SystemExit):
+            main(["list", "--sessions", "--archived", "--config", str(config_file)])
+
+    @patch("vergil_tooling.bin.vrg_vm.name_by_session")
+    @patch("vergil_tooling.bin.vrg_vm.shell_run")
+    @patch("vergil_tooling.bin.vrg_vm.list_vms")
+    def test_list_sessions_recency_hides_old_idle(
+        self,
+        mock_list: MagicMock,
+        mock_shell: MagicMock,
+        mock_names: MagicMock,
+        config_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Idle sessions older than session_recent_days (default 7) are hidden by
+        # default and revealed by --all.
+        now = time.time()
+        mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
+        mock_shell.return_value = MagicMock(stdout=json.dumps([]))
+        mock_names.return_value = {"recent": "epic-recent:vm", "old": "epic-old:vm"}
+        ages = {"recent": now - 1 * 86400.0, "old": now - 30 * 86400.0}
+        with patch(
+            "vergil_tooling.bin.vrg_vm._last_activity",
+            side_effect=lambda path: ages[Path(path).stem],
+        ):
+            assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+            out = capsys.readouterr().out
+            assert "epic-recent:vm" in out
+            assert "epic-old:vm" not in out
+            assert main(["list", "--sessions", "--all", "--config", str(config_file)]) == 0
+            out = capsys.readouterr().out
+            assert "epic-recent:vm" in out
+            assert "epic-old:vm" in out
 
     @patch("vergil_tooling.bin.vrg_vm.name_by_session", return_value={})
     @patch("vergil_tooling.bin.vrg_vm.shell_run")
@@ -1090,7 +1138,7 @@ class TestList:
     @patch("vergil_tooling.bin.vrg_vm.name_by_session")
     @patch("vergil_tooling.bin.vrg_vm.shell_run")
     @patch("vergil_tooling.bin.vrg_vm.list_vms")
-    def test_list_sessions_workspace_column_fits_long_paths(
+    def test_list_sessions_name_column_fits_long_names(
         self,
         mock_list: MagicMock,
         mock_shell: MagicMock,
@@ -1099,44 +1147,39 @@ class TestList:
         config_file: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # A workspace longer than the historical 36-char column must render in
-        # full and must not shove STATE / LAST ACTIVE out of alignment.
-        long_path = "logical-minds-foundry/mq-cluster-tooling"  # 40 chars
-        assert len(long_path) > 36
+        # A name longer than the historical 36-char column must render in full and
+        # must not shove STATE / LAST ACTIVE out of alignment.
+        long_name = "epic-213-explicit-sessions:logical-minds-foundry/mq-cluster-tooling"
+        assert len(long_name) > 36
         mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
         mock_shell.return_value = MagicMock(
             stdout=json.dumps(
                 [
                     {
-                        "identity": "vergil",
-                        "slot": 1,
-                        "path": "vergil-project/vm",
                         "sessionId": "s1",
-                        "state": "active",
+                        "name": "epic-1:vergil-project/vm",
+                        "cwd": "",
+                        "active": True,
                         "lastActive": 1748000000.0,
                     },
                     {
-                        "identity": "vergil-user",
-                        "slot": 1,
-                        "path": long_path,
                         "sessionId": "s2",
-                        "state": "idle",
+                        "name": long_name,
+                        "cwd": "",
+                        "active": True,
                         "lastActive": 1748000000.0,
                     },
                 ]
             )
         )
-        mock_names.return_value = {
-            "s1": "vergil:01:vergil-project/vm",
-            "s2": "vergil-user:01:" + long_path,
-        }
+        mock_names.return_value = {}
         assert main(["list", "--sessions", "--config", str(config_file)]) == 0
         out = capsys.readouterr().out
         lines = [line for line in out.splitlines() if line.strip()]
         header = lines[0]
         state_col = header.index("STATE")
-        # The full long path is rendered, never truncated.
-        assert long_path in out
+        # The full long name is rendered, never truncated.
+        assert long_name in out
         # STATE begins at the same offset on every data row (header + divider
         # are lines[0] and lines[1]; data rows follow).
         for row in lines[2:]:
@@ -1155,61 +1198,25 @@ class TestList:
         config_file: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # Columns render IDENTITY -> WORKSPACE -> SLOT, and rows sort by
-        # workspace first then slot (identity is only the final tiebreaker).
+        # Columns render NAME -> STATE -> LAST ACTIVE, and rows sort by name.
         mock_list.return_value = [{"name": "vergil-agent", "status": "Running"}]
-        mock_shell.return_value = MagicMock(
-            stdout=json.dumps(
-                [
-                    {
-                        "identity": "vergil-user",
-                        "slot": 2,
-                        "path": "alpha/repo",
-                        "sessionId": "s1",
-                        "state": "idle",
-                        "lastActive": 1700000000.0,
-                    },
-                    {
-                        "identity": "vergil",
-                        "slot": 1,
-                        "path": "beta/repo",
-                        "sessionId": "s2",
-                        "state": "idle",
-                        "lastActive": 1700000000.0,
-                    },
-                    {
-                        "identity": "vergil-user",
-                        "slot": 1,
-                        "path": "alpha/repo",
-                        "sessionId": "s3",
-                        "state": "idle",
-                        "lastActive": 1700000000.0,
-                    },
-                ]
-            )
-        )
+        mock_shell.return_value = MagicMock(stdout=json.dumps([]))
         mock_names.return_value = {
-            "s1": "vergil-user:02:alpha/repo",
-            "s2": "vergil:01:beta/repo",
-            "s3": "vergil-user:01:alpha/repo",
+            "s1": "epic-b:alpha/repo",
+            "s2": "epic-c:beta/repo",
+            "s3": "epic-a:alpha/repo",
         }
-        assert main(["list", "--sessions", "--config", str(config_file)]) == 0
+        assert main(["list", "--sessions", "--all", "--config", str(config_file)]) == 0
         out = capsys.readouterr().out
         lines = [line for line in out.splitlines() if line.strip()]
         header = lines[0]
-        # Column order: IDENTITY, then WORKSPACE, then SLOT, then STATE.
-        assert (
-            header.index("IDENTITY")
-            < header.index("WORKSPACE")
-            < header.index("SLOT")
-            < header.index("STATE")
-        )
-        # Data rows (after header + divider) sort by workspace then slot:
-        # both alpha/repo rows precede beta/repo, slot 01 before slot 02.
+        # Column order: NAME, then STATE, then LAST ACTIVE.
+        assert header.index("NAME") < header.index("STATE") < header.index("LAST ACTIVE")
+        # Data rows (after header + divider) sort by name: epic-a, epic-b, epic-c.
         data = lines[2:]
-        assert "alpha/repo" in data[0] and "01" in data[0]
-        assert "alpha/repo" in data[1] and "02" in data[1]
-        assert "beta/repo" in data[2]
+        assert "epic-a:alpha/repo" in data[0]
+        assert "epic-b:alpha/repo" in data[1]
+        assert "epic-c:beta/repo" in data[2]
 
     @patch("vergil_tooling.bin.vrg_vm._last_activity", return_value=None)
     @patch("vergil_tooling.bin.vrg_vm.name_by_session", return_value={})
@@ -1244,11 +1251,10 @@ class TestList:
         ]
         mock_cloud_sessions.return_value = {
             "c1": {
-                "identity": "vergil",
-                "slot": 1,
-                "path": "lmf/cloud",
                 "sessionId": "c1",
-                "state": "active",
+                "name": "epic-1:lmf/cloud",
+                "cwd": "",
+                "active": True,
                 "lastActive": 1748000000.0,
             }
         }
@@ -2309,7 +2315,7 @@ def test_session_inner_strips_leading_double_dash() -> None:
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False, resume=None)
-    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    inner = _session_inner(ns, "vergil", "p", "")
     assert "exec bash" in inner
     assert "vrg-vm-resolve-session" not in inner
 
@@ -2320,20 +2326,22 @@ def test_session_inner_raw_override_ignores_model() -> None:
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False, resume=None)
-    inner = _session_inner(ns, "vergil", "p", "opus", 7, 14)
+    inner = _session_inner(ns, "vergil", "p", "opus")
     assert "exec bash" in inner
     assert "--model" not in inner
 
 
-def test_session_inner_includes_thresholds() -> None:
+def test_session_inner_omits_deleted_thresholds() -> None:
     import argparse
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None)
-    inner = _session_inner(ns, "vergil", "p", "", 5, 30)
-    assert "--stale-days 5" in inner
-    assert "--archive-days 30" in inner
+    inner = _session_inner(ns, "vergil", "p", "")
+    # session_stale_days / session_archive_days are deleted (#2608): the resolver
+    # is no longer handed any staleness thresholds.
+    assert "--stale-days" not in inner
+    assert "--archive-days" not in inner
 
 
 def test_session_inner_fresh_flag() -> None:
@@ -2342,7 +2350,7 @@ def test_session_inner_fresh_flag() -> None:
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=True, resume=None)
-    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    inner = _session_inner(ns, "vergil", "p", "")
     assert "--fresh" in inner
 
 
@@ -2352,7 +2360,7 @@ def test_session_inner_sources_conan_env() -> None:
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None)
-    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    inner = _session_inner(ns, "vergil", "p", "")
     assert "conan.env" in inner
     assert "claude.env" in inner
 
@@ -2363,7 +2371,7 @@ def test_session_inner_resume_name() -> None:
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume="epic-85-adhoc")
-    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    inner = _session_inner(ns, "vergil", "p", "")
     assert "--resume-name epic-85-adhoc" in inner
 
 
@@ -2373,7 +2381,7 @@ def test_session_inner_label() -> None:
     from vergil_tooling.bin.vrg_vm import _session_inner
 
     ns = argparse.Namespace(cmd=[], fork=False, fresh=False, resume=None, label="epic-1")
-    inner = _session_inner(ns, "vergil", "p", "", 7, 14)
+    inner = _session_inner(ns, "vergil", "p", "")
     assert "--label epic-1" in inner
 
 
@@ -2410,14 +2418,14 @@ def test_selected_states() -> None:
     from vergil_tooling.bin.vrg_vm import _selected_states
 
     def ns(**kw: bool) -> argparse.Namespace:
-        base = {"all": False, "active": False, "idle": False, "archived": False}
+        base = {"all": False, "active": False, "idle": False}
         base.update(kw)
         return argparse.Namespace(**base)
 
     assert _selected_states(ns()) == {"active", "idle"}  # default
-    assert _selected_states(ns(all=True)) == {"active", "idle", "archived"}
+    assert _selected_states(ns(all=True)) == {"active", "idle"}  # --all is recency, not state
     assert _selected_states(ns(active=True)) == {"active"}
-    assert _selected_states(ns(idle=True, archived=True)) == {"idle", "archived"}
+    assert _selected_states(ns(idle=True)) == {"idle"}
 
 
 # -- _resolve_target (issue #99) ----------------------------------------------
@@ -4656,8 +4664,8 @@ class TestCloudList:
         transport.run.return_value = MagicMock(
             stdout=json.dumps(
                 [
-                    {"sessionId": "c1", "state": "active", "path": "lmf/cloud"},
-                    {"sessionId": "c2", "state": "idle", "path": "lmf/cloud"},
+                    {"sessionId": "c1", "name": "epic-1:lmf/cloud", "active": True},
+                    {"sessionId": "c2", "name": "epic-2:lmf/cloud", "active": False},
                 ]
             )
         )

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -109,35 +109,11 @@ def test_last_activity_skips_bad_timestamp_lines(tmp_path: Path) -> None:
     assert r._last_activity(f) == datetime.datetime(2026, 5, 2, tzinfo=UTC).timestamp()
 
 
-def test_archive_session_append_oserror_is_swallowed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    projects = tmp_path / "projects" / "slug"
-    projects.mkdir(parents=True)
-    (projects / "adir.jsonl").mkdir()  # a directory -> open("a") raises OSError
-    monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
-    monkeypatch.setattr(r, "_last_session_name", lambda _t: "vergil:01:p")
-    r._archive_session("adir", "2026-05-30T14:23:07Z")  # must not raise
-
-
-def test_archive_session_appends_archived_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    projects = tmp_path / "projects" / "slug"
-    projects.mkdir(parents=True)
-    t = projects / "s1.jsonl"
-    t.write_text('{"type":"agent-name","agentName":"vergil:01:p","sessionId":"s1"}\n')
-    monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
-    r._archive_session("s1", "2026-05-30T14:23:07Z")
-    assert r._last_session_name(t) == "archived@2026-05-30T14:23:07Z@vergil:01:p"
-
-
-def test_archive_session_missing_transcript_is_noop(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    (tmp_path / "projects").mkdir()
-    monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
-    r._archive_session("ghost", "2026-05-30T14:23:07Z")  # must not raise
+def test_archive_machinery_is_removed() -> None:
+    # Auto-archive/staleness is deleted (issue #2608): no _archive_session,
+    # _run_sweep, _now_iso, or _archived_rows survive on the resolver module.
+    for gone in ("_archive_session", "_run_sweep", "_now_iso", "_archived_rows"):
+        assert not hasattr(r, gone), f"{gone} should be deleted"
 
 
 # --- _last_session_name ---
@@ -294,23 +270,6 @@ def test_name_by_session_reads_custom_title(tmp_path: Path) -> None:
     assert r.name_by_session(tmp_path) == {"s1": "id:01:a"}
 
 
-def test_archive_session_archives_custom_title_named_transcript(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Archiving must work on transcripts named only via custom-title events
-    # (previously a silent no-op) and must append a custom-title event so
-    # Claude's own resume picker shows the archived label too.
-    projects = tmp_path / "projects" / "slug"
-    projects.mkdir(parents=True)
-    t = projects / "s1.jsonl"
-    t.write_text('{"type":"custom-title","customTitle":"vergil:01:p","sessionId":"s1"}\n')
-    monkeypatch.setattr(r, "_claude_dir", lambda: tmp_path)
-    r._archive_session("s1", "2026-06-07T00:00:00Z")
-    assert r._last_session_name(t) == "archived@2026-06-07T00:00:00Z@vergil:01:p"
-    appended = json.loads(t.read_text().splitlines()[-1])
-    assert appended["type"] == "custom-title"
-
-
 def test_claude_dir_points_at_dot_claude() -> None:
     assert r._claude_dir().name == ".claude"
 
@@ -443,8 +402,6 @@ def _resolve(
         "fork": False,
         "fresh": False,
         "extra": [],
-        "stale_days": 7,
-        "archive_days": 14,
     }
     defaults.update(kw)
     return r.resolve(  # type: ignore[arg-type]
@@ -544,23 +501,18 @@ def test_resolve_refuse(
     assert "ERROR" in capsys.readouterr().err
 
 
-def test_resolve_fresh_creates_after_archiving(
+def test_resolve_fresh_creates_without_archiving(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     capture_exec: list[list[str]],
 ) -> None:
-    # --fresh retains the prior behavior (later reconceived by the epic): the most
-    # recent idle session is archived and a fresh one created in its place.
+    # Auto-archive is deleted (issue #2608): --fresh now just creates a fresh
+    # session in the target slot; nothing is archived (the retire-rename is Task 5).
     now = 100 * DAY
     monkeypatch.setattr(
         r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {"s1": now - 1 * DAY})
     )
-    monkeypatch.setattr(r, "_now", lambda: now)
-    monkeypatch.setattr(r, "_now_iso", lambda: "2026-05-30T00:00:00Z")
-    archived: list[str] = []
-    monkeypatch.setattr(r, "_archive_session", lambda sid, _ts: archived.append(sid))
     assert _resolve("vergil", "p", fresh=True) == 0
-    assert archived == ["s1"]
     assert capture_exec == [["claude", "-n", "vergil:01:p"]]
 
 
@@ -695,45 +647,50 @@ def test_transcript_cwd_stops_at_line_cap(tmp_path: Path) -> None:
 # --- list_json ---
 
 
-def test_list_json_includes_age_and_state(
+class _ListStore:
+    """Minimal SessionStore exposing only list_sessions for list_json tests."""
+
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def list_sessions(self) -> list[Any]:
+        return list(self._rows)
+
+
+def test_list_json_emits_session_info_rows(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(
-        r,
-        "_read_state",
-        lambda: (
-            {"s1": "vergil:01:p", "a1": "archived@2026-05-01T00:00:00Z@vergil:03:p"},
-            {"s1"},
-            {"s1": 1748000000.0, "a1": 1746000000.0},
-        ),
-    )
+    # list_json now emits raw SessionInfo rows (name/cwd/active/lastActive); the
+    # host applies the recency filter. A legacy archived@ name rides as an opaque
+    # string — no archived state, no archivedAt field.
+    rows = [
+        _info("s1", "epic-1:p", True, 1748000000.0, cwd="/w"),
+        _info("a1", "archived@2026-05-01T00:00:00Z@vergil:03:p", False, 1746000000.0),
+    ]
+    monkeypatch.setattr(r, "_store", lambda *_a, **_k: _ListStore(rows))
     assert r.list_json() == 0
-    rows = json.loads(capsys.readouterr().out)
-    by = {(x["identity"], x["slot"], x["state"]): x for x in rows}
-    assert ("vergil", 1, "active") in by
-    assert by[("vergil", 1, "active")]["lastActive"] == 1748000000.0
-    assert ("vergil", 3, "archived") in by
-    assert by[("vergil", 3, "archived")]["archivedAt"] == "2026-05-01T00:00:00Z"
+    out = json.loads(capsys.readouterr().out)
+    by = {x["sessionId"]: x for x in out}
+    assert by["s1"] == {
+        "sessionId": "s1",
+        "name": "epic-1:p",
+        "cwd": "/w",
+        "active": True,
+        "lastActive": 1748000000.0,
+    }
+    assert by["a1"]["name"] == "archived@2026-05-01T00:00:00Z@vergil:03:p"
+    assert by["a1"]["active"] is False
+    assert "archivedAt" not in by["a1"]
 
 
-def test_list_json_idle_state(
+def test_list_json_includes_unnamed_row(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda *_a: ({"s1": "vergil:01:p"}, set(), {}))
+    rows = [_info("s1", None, True, None, cwd="")]
+    monkeypatch.setattr(r, "_store", lambda *_a, **_k: _ListStore(rows))
     assert r.list_json() == 0
-    rows = json.loads(capsys.readouterr().out)
-    assert rows[0]["state"] == "idle"
-
-
-def test_archived_rows_skips_unparseable_original(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # archived label whose embedded "original" is not a valid slot name
-    monkeypatch.setattr(
-        r, "_read_state", lambda *_a: ({"a1": "archived@2026-05-01T00:00:00Z@garbage"}, set(), {})
-    )
-    assert r.list_json() == 0
-    assert json.loads(capsys.readouterr().out) == []
+    out = json.loads(capsys.readouterr().out)
+    assert out == [{"sessionId": "s1", "name": None, "cwd": "", "active": True, "lastActive": None}]
 
 
 # --- _read_state integration ---
@@ -800,7 +757,7 @@ def test_read_state_names_roster_session_without_transcript(
 def test_main_list_json(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
+    monkeypatch.setattr(r, "_store", lambda *_a, **_k: _ListStore([]))
     assert r.main(["--list-json"]) == 0
     assert json.loads(capsys.readouterr().out) == []
 
@@ -820,24 +777,10 @@ def test_main_dispatches_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
         return 0
 
     monkeypatch.setattr(r, "resolve", fake_resolve)
-    code = r.main(
-        [
-            "--identity",
-            "id",
-            "--path",
-            "p",
-            "--fresh",
-            "--stale-days",
-            "7",
-            "--archive-days",
-            "14",
-            "x",
-        ]
-    )
+    code = r.main(["--identity", "id", "--path", "p", "--fresh", "x"])
     assert code == 0
-    # args order: identity, path, fork, fresh, extra, stale_days,
-    # archive_days, resume_name, label
-    assert seen["args"] == ("id", "p", False, True, ["x"], 7, 14, None, None)
+    # args order: identity, path, fork, fresh, extra, resume_name, label
+    assert seen["args"] == ("id", "p", False, True, ["x"], None, None)
 
 
 def test_main_passes_resume_name(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Deletes the auto-archive/staleness machinery (archived@ markers, fresh/warn/stale bands, PromptStale, the sweep, and session_stale_days/session_archive_days config) and replaces it with a pure filter_recent over SessionInfo plus a cascading session_recent_days, wiring a name-based recency filter into vrg-vm list --sessions.

## Issue Linkage

- Closes #2608

## Notes

- Scope is Task 4 of epic vergil-project/.github#230. list --sessions is now built from the SessionStore seam and displayed by NAME/STATE/LAST ACTIVE, filtered to the recency window by default; --archived is removed and --all now means include-older-than-recent (list --list-json emits raw SessionInfo rows, host applies the filter). Legacy archived@ names stay opaque (parse_name keeps a defensive guard against phantom-slot misparse); only behavior is removed. --fork unchanged and --fresh still creates a fresh session (retire-rename is Task 5, #2602 selection is Task 6). vrg-validate green (4593 passed, 100% coverage). Note: test_help_coverage[vrg-update-deps] fails only in a direct user-agent run but passes in the container gate.