### PR TITLE
feat(vrg-vm): reconceive --fresh as supported retire-rename (never delete)

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2455,12 +2455,11 @@ def _cmd_session(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    if getattr(args, "label", None) is not None and (
-        args.resume is not None or args.fork or args.fresh
-    ):
+    if getattr(args, "label", None) is not None and (args.resume is not None or args.fork):
         print(
             "ERROR: --label creates a new named session and cannot be combined with "
-            "--resume (attach) or --fork/--fresh.",
+            "--resume (attach) or --fork. (Pair it with --fresh to retire a prior "
+            "same-named session and start clean.)",
             file=sys.stderr,
         )
         return 1
@@ -2818,8 +2817,8 @@ def main(argv: list[str] | None = None) -> int:
             "Create a new purpose-named session named '<label>:<workspace>' (e.g. "
             "--label epic-213-x). The label is a clean slug; an epic-/adhoc- prefix "
             "is the convention (off-convention warns, never blocks). Errors if a "
-            "session of that name already exists. Mutually exclusive with "
-            "--resume/--fork/--fresh."
+            "session of that name already exists (add --fresh to retire that prior "
+            "session and start clean). Mutually exclusive with --resume/--fork."
         ),
     )
     p_session.add_argument(
@@ -2830,7 +2829,10 @@ def main(argv: list[str] | None = None) -> int:
     p_session.add_argument(
         "--fresh",
         action="store_true",
-        help="Start a brand-new session in the workspace's next slot",
+        help=(
+            "With --label: retire any prior session of that name (rename to "
+            "'<name>~<datestamp>', never delete) and start a fresh one in its place."
+        ),
     )
     p_session.add_argument(
         "--model",

--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -18,6 +18,7 @@ import datetime
 import json
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from vergil_tooling.lib.session import (
@@ -464,6 +465,90 @@ def _resolve_label(path: str, label: str, extra: list[str]) -> int:
     return _execute(Create(name), extra)
 
 
+def retired_name(name: str, stamp: str) -> str:
+    """Compose the retired name for a session being replaced by ``--fresh``.
+
+    A retired session keeps its full history under a suffixed name
+    ``<name>~<stamp>``. The ``~`` separates the original name from the retire
+    stamp and never appears in a live ``label:workspace`` name, so a retired name
+    never collides with — nor resolves as — an active one. Nothing is deleted; the
+    transcript lives on under this name (the supported retire-rename, #2609).
+    """
+    return f"{name}~{stamp}"
+
+
+def _now_stamp() -> str:
+    """A compact UTC timestamp (``YYYYMMDDThhmmssZ``) for a retired-session suffix.
+
+    Supplied by the CLI layer so the pure planning (:func:`plan_fresh`,
+    :func:`retired_name`) never reaches for the wall clock itself.
+    """
+    return datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+@dataclass(frozen=True)
+class FreshPlan:
+    """The plan for a ``--fresh --label`` launch.
+
+    ``name`` is the clean ``label:workspace`` name to create. ``retire`` is
+    ``(old_session_id, retired_name)`` when a visible session already holds
+    ``name`` and must be renamed out of the way first, or ``None`` when the name
+    is free (nothing to retire — a plain create).
+    """
+
+    name: str
+    retire: tuple[str, str] | None
+
+
+def plan_fresh(store: SessionStore, name: str, stamp: str) -> FreshPlan:
+    """Plan a ``--fresh --label`` launch: retire-rename the prior session, then create.
+
+    Resolves the prior visible session named ``name`` through the seam. If one
+    exists, the plan retires it to :func:`retired_name` — carried out by the
+    caller via ``store.rename`` (a *supported* rename, never a deletion) — and
+    then a fresh session with the clean ``name`` is created. If no visible session
+    holds the name, the plan is a plain create. Ambiguity (two co-equal live
+    sessions) propagates as :class:`AmbiguousSessionError`: ``--fresh`` never
+    guesses which live session to retire (fail loud).
+    """
+    existing = store.resolve_name(name)
+    if existing is None:
+        return FreshPlan(name=name, retire=None)
+    return FreshPlan(name=name, retire=(existing.session_id, retired_name(name, stamp)))
+
+
+def _resolve_fresh(path: str, label: str, stamp: str, extra: list[str]) -> int:
+    """Create a fresh ``label:workspace`` session, retiring any prior one by name.
+
+    The ``--fresh --label`` path: validate the label (soft-warn an off-convention
+    prefix, fail loud on a structurally invalid slug), compose ``label:workspace``,
+    and plan a retire-rename via the seam. A prior visible session of that name is
+    renamed to ``<name>~<stamp>`` through ``store.rename`` — a supported rename,
+    so the transcript is never deleted — then a fresh session with the clean name
+    is created. Ambiguity fails loud (never renames when it cannot tell which
+    session to retire).
+    """
+    try:
+        warnings = validate_label(label)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    for warning in warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+    name = make_label_name(label, path)
+    store = _store(_project_slug(str(Path.cwd())))
+    try:
+        plan = plan_fresh(store, name, stamp)
+    except AmbiguousSessionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if plan.retire is not None:
+        old_session_id, retired = plan.retire
+        store.rename(old_session_id, retired)
+        _note(f"Retired prior session {name} -> {retired}")
+    return _execute(Create(plan.name), extra)
+
+
 def resolve(
     identity: str,
     path: str,
@@ -477,17 +562,22 @@ def resolve(
 
     ``label`` short-circuits into the named-creation path (``--label``): it
     composes and uniqueness-checks ``label:workspace`` and creates that session
-    (see :func:`_resolve_label`), bypassing the slot machinery entirely.
+    (see :func:`_resolve_label`), bypassing the slot machinery entirely. Combined
+    with ``fresh`` (``--fresh --label``) it instead *retires* any prior visible
+    session of that name via a supported rename and creates a fresh one in its
+    place (see :func:`_resolve_fresh`) — the transcript is never deleted (#2609).
 
     ``resume_name`` (``--resume``) resolves an exact session name to a session id
     through the ``SessionStore`` seam and attaches to it, deriving the bootstrap
     cwd from the resolved session (#2607). With no verb the recency list + the two
     verbs are printed and a nonzero code returned — there is no auto-resume-most-
-    recent / auto-create default and no ``--slot``. ``fork`` / ``fresh`` retain the
-    legacy slot machinery (reconceived by later tasks in the epic); auto-archive
-    and the staleness sweep are gone (#2608).
+    recent / auto-create default and no ``--slot``. ``fork`` (and ``fresh`` without
+    a ``label``) retain the legacy slot machinery; auto-archive and the staleness
+    sweep are gone (#2608).
     """
     if label is not None:
+        if fresh:
+            return _resolve_fresh(path, label, _now_stamp(), extra)
         return _resolve_label(path, label, extra)
     if resume_name is not None:
         return _resume_by_name(resume_name, extra)

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2385,12 +2385,36 @@ def test_session_inner_label() -> None:
     assert "--label epic-1" in inner
 
 
+def test_session_inner_fresh_with_label() -> None:
+    # --fresh --label (issue #2609): both flags reach the resolver, which retires
+    # the prior same-named session and creates a fresh one.
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _session_inner
+
+    ns = argparse.Namespace(cmd=[], fork=False, fresh=True, resume=None, label="epic-1")
+    inner = _session_inner(ns, "vergil", "p", "")
+    assert "--label epic-1" in inner
+    assert "--fresh" in inner
+
+
 def test_cmd_session_rejects_label_with_resume() -> None:
     import argparse
 
     from vergil_tooling.bin.vrg_vm import _cmd_session
 
     ns = argparse.Namespace(resume="epic-85", fork=False, fresh=False, label="epic-1")
+    assert _cmd_session(ns) == 1
+
+
+def test_cmd_session_rejects_label_with_fork() -> None:
+    # --label + --fork stays rejected (fork is a distinct verb); only --fresh now
+    # combines with --label (issue #2609).
+    import argparse
+
+    from vergil_tooling.bin.vrg_vm import _cmd_session
+
+    ns = argparse.Namespace(resume=None, fork=True, fresh=False, label="epic-1")
     assert _cmd_session(ns) == 1
 
 

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -521,6 +521,137 @@ def test_exec_claude_invokes_execvp(capture_exec: list[list[str]]) -> None:
     assert capture_exec == [["claude", "-n", "x"]]
 
 
+# --- --fresh retire-rename (issue #2609) ---
+
+
+class _RenameStore:
+    """A SessionStore fake that records rename calls for the --fresh path.
+
+    ``resolve_name`` delegates to the pure ``resolve_over`` so it reproduces the
+    seam's real fail-loud/None semantics; ``rename`` just records the call so a
+    test can assert the retire-rename happened (and never a deletion).
+    """
+
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+        self.renames: list[tuple[str, str]] = []
+
+    def list_sessions(self) -> list[Any]:
+        return list(self._rows)
+
+    def resolve_name(self, name: str) -> Any:
+        from vergil_tooling.lib.session_store import resolve_over
+
+        return resolve_over(self._rows, name)
+
+    def rename(self, session_id: str, new_name: str) -> None:
+        self.renames.append((session_id, new_name))
+
+
+def test_retired_name_suffixes_with_stamp() -> None:
+    assert r.retired_name("epic-1:w", "20260807T101500Z") == "epic-1:w~20260807T101500Z"
+
+
+def test_now_stamp_is_compact_utc() -> None:
+    import re
+
+    assert re.fullmatch(r"\d{8}T\d{6}Z", r._now_stamp())
+
+
+def test_plan_fresh_retires_existing_then_creates() -> None:
+    # A visible idle session holds the name: the plan retires it to <name>~<stamp>
+    # and then creates a fresh session with the clean name.
+    store = _RenameStore([_info("old", "epic-1:w", False, 10.0)])
+    plan = r.plan_fresh(store, "epic-1:w", "STAMP")
+    assert plan.name == "epic-1:w"
+    assert plan.retire == ("old", "epic-1:w~STAMP")
+
+
+def test_plan_fresh_no_retire_when_name_free() -> None:
+    # No visible session of that name: nothing to retire, just create.
+    store = _RenameStore([_info("other", "epic-2:w", True, 10.0)])
+    plan = r.plan_fresh(store, "epic-1:w", "STAMP")
+    assert plan.retire is None
+    assert plan.name == "epic-1:w"
+
+
+def test_plan_fresh_fails_loud_on_ambiguous() -> None:
+    # Two co-equal live sessions hold the name -> --fresh never guesses which to
+    # retire; the seam's fail-loud propagates.
+    store = _RenameStore([_info("a", "epic-1:w", True, 1.0), _info("b", "epic-1:w", True, 2.0)])
+    with pytest.raises(r.AmbiguousSessionError):
+        r.plan_fresh(store, "epic-1:w", "STAMP")
+
+
+def test_resolve_fresh_label_retires_and_creates(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # --fresh --label: retire the prior visible session via store.rename (never a
+    # deletion), then exec a fresh session with the clean composed name.
+    store = _RenameStore([_info("old", "epic-1:tooling", False, 10.0)])
+    monkeypatch.setattr(r, "_store", lambda *_a: store)
+    monkeypatch.setattr(r, "_now_stamp", lambda: "STAMP")
+    assert _resolve("id", "tooling", label="epic-1", fresh=True) == 0
+    assert store.renames == [("old", "epic-1:tooling~STAMP")]
+    assert capture_exec == [["claude", "-n", "epic-1:tooling"]]
+    err = capsys.readouterr().err
+    assert "Retired prior session epic-1:tooling -> epic-1:tooling~STAMP" in err
+
+
+def test_resolve_fresh_label_creates_when_name_free(
+    monkeypatch: pytest.MonkeyPatch, capture_exec: list[list[str]]
+) -> None:
+    store = _RenameStore([])
+    monkeypatch.setattr(r, "_store", lambda *_a: store)
+    monkeypatch.setattr(r, "_now_stamp", lambda: "STAMP")
+    assert _resolve("id", "tooling", label="epic-1", fresh=True) == 0
+    assert store.renames == []  # nothing to retire
+    assert capture_exec == [["claude", "-n", "epic-1:tooling"]]
+
+
+def test_resolve_fresh_label_warns_off_convention(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _RenameStore([])
+    monkeypatch.setattr(r, "_store", lambda *_a: store)
+    monkeypatch.setattr(r, "_now_stamp", lambda: "STAMP")
+    assert _resolve("id", "tooling", label="scratch", fresh=True) == 0
+    assert capture_exec == [["claude", "-n", "scratch:tooling"]]
+    assert "convention" in capsys.readouterr().err
+
+
+def test_resolve_fresh_label_rejects_invalid_slug(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _RenameStore([])
+    monkeypatch.setattr(r, "_store", lambda *_a: store)
+    assert _resolve("id", "tooling", label="bad:name", fresh=True) == 1
+    assert store.renames == []
+    assert capture_exec == []
+    assert "ERROR" in capsys.readouterr().err
+
+
+def test_resolve_fresh_label_fails_loud_on_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _RenameStore(
+        [_info("a", "epic-1:tooling", True, 1.0), _info("b", "epic-1:tooling", True, 2.0)]
+    )
+    monkeypatch.setattr(r, "_store", lambda *_a: store)
+    assert _resolve("id", "tooling", label="epic-1", fresh=True) == 1
+    assert store.renames == []  # never renames when it cannot tell which to retire
+    assert capture_exec == []
+    assert "live sessions" in capsys.readouterr().err
+
+
 # --- plan_resume (seam-based exact-name attach, issue #2607) ---
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Make vrg-vm session --fresh --label retire any prior visible same-named session via the SessionStore seam's supported rename (to <name>~<datestamp>) and create a fresh clean-named session, so a name is reclaimed without ever deleting a transcript.

## Issue Linkage

- Closes #2609

## Notes

- Adds retired_name(name, stamp), a pure FreshPlan/plan_fresh (timestamp injected by the CLI via _now_stamp, no wall-clock in pure logic), and the _resolve_fresh executor in vrg_vm_resolve.py; the rename is backend-agnostic (ScrapeStore does the isolated transcript write inside the seam). CLI now allows --label with --fresh (still rejects --label with --resume/--fork); ambiguity (2+ co-equal live sessions) fails loud and never renames. session.py is intentionally untouched (out of T5 scope); --fresh without --label keeps its legacy path. 100% coverage, vrg-validate green.