### PR TITLE
chore(vrg-vm): one-time cosmetic strip of legacy archived@ markers

### DIFF
--- a/scripts/dev/strip-archived-markers.py
+++ b/scripts/dev/strip-archived-markers.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""One-time cosmetic strip of legacy ``archived@`` session-name markers.
+
+Task 7 (Stage D) of epic vergil-project/.github#230. The old ``vrg-vm`` archive
+machinery renamed a stale session to ``archived@<timestamp>@<original-name>``;
+that behavior is gone (Task 4), but any such *name* left in a real transcript is
+now just an opaque string the seam still lists and resolves. It renders unevenly
+next to the clean ``label:workspace`` names.
+
+This script restores every such session's original name so the list renders
+uniformly. It is:
+
+- **idempotent** — a clean name never matches, so re-running is a no-op;
+- **dry-run by default** — it only prints what it *would* do; pass ``--apply``
+  to actually rename;
+- **rename-only** — it goes through the supported ``SessionStore.rename`` seam
+  and **never deletes** a session or a transcript.
+
+It touches nothing but ``archived@``-prefixed names; every other session is left
+exactly as it is.
+
+Usage::
+
+    # inside the dev container (see CLAUDE.md), or on a host/VM with real sessions
+    python scripts/dev/strip-archived-markers.py            # dry run (default)
+    python scripts/dev/strip-archived-markers.py --apply    # perform the renames
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, TextIO
+
+from vergil_tooling.lib.session_store import ScrapeStore
+
+if TYPE_CHECKING:
+    from vergil_tooling.lib.session_store import SessionInfo, SessionStore
+
+# The legacy archive label was ``archived@<timestamp>@<original-name>`` (see the
+# retired ``make_archived_name`` in ``lib/session.py`` history). ``parse_archived``
+# was deleted with the archive machinery in Task 4, so the minimal recovery of the
+# original name is reproduced here — this script is the only remaining reader of the
+# legacy form.
+_ARCHIVED_PREFIX = "archived@"
+
+
+def strip_archived_name(name: str) -> str | None:
+    """Recover the original name from a legacy ``archived@<ts>@<orig>`` label.
+
+    Splits on the **first two** ``@`` so an original name that itself contains
+    ``@`` (a workspace path can) is recovered intact. Returns ``None`` for any
+    name that is not a well-formed archive label — a clean name, a prefix with no
+    original segment — which is what makes the strip idempotent: the recovered
+    name no longer carries the prefix, so a second pass leaves it untouched.
+    """
+    if not name.startswith(_ARCHIVED_PREFIX):
+        return None
+    parts = name.split("@", 2)
+    if len(parts) != 3 or not parts[2]:
+        return None
+    return parts[2]
+
+
+@dataclass(frozen=True)
+class Strip:
+    """One planned rename: restore ``session_id`` from ``old_name`` to ``new_name``."""
+
+    session_id: str
+    old_name: str
+    new_name: str
+
+
+def plan_strips(rows: list[SessionInfo]) -> list[Strip]:
+    """Every archived-marked session row and the original name to restore it to.
+
+    Rows with no name, or with a name that is not an ``archived@`` label, are
+    skipped — only legacy markers are ever touched.
+    """
+    strips: list[Strip] = []
+    for row in rows:
+        if row.name is None:
+            continue
+        original = strip_archived_name(row.name)
+        if original is not None:
+            strips.append(Strip(row.session_id, row.name, original))
+    return strips
+
+
+def run(store: SessionStore, apply: bool, out: TextIO) -> int:
+    """List (and, when ``apply``, perform) every ``archived@`` marker strip.
+
+    Prints each planned/performed rename to ``out``. In dry-run mode nothing is
+    renamed; with ``apply`` set each rename goes through ``store.rename`` (the
+    supported seam). Returns ``0`` always — an empty plan is a clean success, not
+    an error.
+    """
+    strips = plan_strips(store.list_sessions())
+    if not strips:
+        print("No legacy archived@ session names found; nothing to strip.", file=out)
+        return 0
+
+    verb = "Renaming" if apply else "Would rename"
+    for item in strips:
+        print(f"{verb}: {item.old_name}  ->  {item.new_name}  ({item.session_id})", file=out)
+        if apply:
+            store.rename(item.session_id, item.new_name)
+
+    if apply:
+        print(f"\nRenamed {len(strips)} session(s).", file=out)
+    else:
+        print(
+            f"\nDry run: {len(strips)} session(s) would be renamed. "
+            f"Re-run with --apply to execute.",
+            file=out,
+        )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Cosmetically strip legacy archived@ markers from session names "
+        "(dry-run by default; never deletes).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the renames (default: dry run, print only).",
+    )
+    parser.add_argument(
+        "--claude-dir",
+        type=Path,
+        default=Path.home() / ".claude",
+        help="the ~/.claude directory to read/rewrite (default: ~/.claude).",
+    )
+    parser.add_argument(
+        "--slug",
+        default=None,
+        help="restrict to one project slug (default: every slug).",
+    )
+    args = parser.parse_args(argv)
+
+    store = ScrapeStore(args.claude_dir, args.slug)
+    return run(store, apply=args.apply, out=sys.stdout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vergil_tooling/test_strip_archived_markers.py
+++ b/tests/vergil_tooling/test_strip_archived_markers.py
@@ -1,0 +1,179 @@
+"""Tests for the one-time cosmetic ``archived@`` strip script (epic #230, Task 7).
+
+The script lives in ``scripts/dev/`` (a hyphenated filename, not an importable
+package module), so it is loaded here via :mod:`importlib.util` and its pure
+planning core plus the fake-store-driven ``run`` are exercised directly. No real
+transcript is touched — a fake :class:`SessionStore` records the renames.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from vergil_tooling.lib.session_store import SessionInfo
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "strip-archived-markers.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("strip_archived_markers", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the module's ``@dataclass`` can introspect its own
+    # (string, ``from __future__ import annotations``) field annotations.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+strip = _load_script()
+
+
+class FakeStore:
+    """A :class:`SessionStore` that records renames instead of touching a transcript."""
+
+    def __init__(self, rows: list[SessionInfo]) -> None:
+        self._rows = rows
+        self.renames: list[tuple[str, str]] = []
+
+    def list_sessions(self) -> list[SessionInfo]:
+        return list(self._rows)
+
+    def resolve_name(self, name: str) -> SessionInfo | None:  # pragma: no cover - unused here
+        raise NotImplementedError
+
+    def rename(self, session_id: str, new_name: str) -> None:
+        self.renames.append((session_id, new_name))
+
+
+def _row(sid: str, name: str | None) -> SessionInfo:
+    return SessionInfo(session_id=sid, name=name, cwd="/w", active=False, last_active=1.0)
+
+
+# --- strip_archived_name (pure) ---------------------------------------------
+
+
+def test_strip_recovers_original_name() -> None:
+    assert strip.strip_archived_name("archived@20260101T00@epic-1:w") == "epic-1:w"
+
+
+def test_strip_preserves_at_in_original() -> None:
+    # The original name may itself contain '@'; only the first two '@' delimit.
+    assert strip.strip_archived_name("archived@ts@user@host:w") == "user@host:w"
+
+
+def test_strip_returns_none_for_clean_name() -> None:
+    assert strip.strip_archived_name("epic-1:w") is None
+
+
+def test_strip_returns_none_for_malformed_marker() -> None:
+    # Prefix present but no original segment after the timestamp.
+    assert strip.strip_archived_name("archived@tsonly") is None
+    assert strip.strip_archived_name("archived@ts@") is None
+
+
+def test_strip_is_idempotent_on_recovered_name() -> None:
+    # Stripping an already-clean name a second time is a no-op.
+    recovered = strip.strip_archived_name("archived@ts@epic-1:w")
+    assert recovered is not None
+    assert strip.strip_archived_name(recovered) is None
+
+
+# --- plan_strips (pure) -----------------------------------------------------
+
+
+def test_plan_selects_only_archived_rows() -> None:
+    rows = [
+        _row("a", "archived@ts@epic-1:w"),
+        _row("b", "epic-2:w"),
+        _row("c", None),
+        _row("d", "archived@ts2@adhoc-x:w"),
+    ]
+    strips = strip.plan_strips(rows)
+    assert [(s.session_id, s.new_name) for s in strips] == [
+        ("a", "epic-1:w"),
+        ("d", "adhoc-x:w"),
+    ]
+
+
+# --- run (dry-run vs apply) -------------------------------------------------
+
+
+def test_run_dry_run_renames_nothing() -> None:
+    store = FakeStore([_row("a", "archived@ts@epic-1:w")])
+    out = io.StringIO()
+    rc = strip.run(store, apply=False, out=out)
+    assert rc == 0
+    assert store.renames == []
+    text = out.getvalue()
+    assert "epic-1:w" in text
+    assert "--apply" in text
+
+
+def test_run_apply_renames_each() -> None:
+    store = FakeStore([_row("a", "archived@ts@epic-1:w"), _row("d", "archived@ts2@adhoc-x:w")])
+    out = io.StringIO()
+    rc = strip.run(store, apply=True, out=out)
+    assert rc == 0
+    assert store.renames == [("a", "epic-1:w"), ("d", "adhoc-x:w")]
+
+
+def test_run_reports_nothing_when_clean() -> None:
+    store = FakeStore([_row("b", "epic-2:w"), _row("c", None)])
+    out = io.StringIO()
+    rc = strip.run(store, apply=True, out=out)
+    assert rc == 0
+    assert store.renames == []
+    assert "nothing" in out.getvalue().lower()
+
+
+# --- main (CLI glue) --------------------------------------------------------
+
+
+def test_main_dry_run_by_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    class _Store:
+        def __init__(self, claude_dir: Path, slug: str | None = None) -> None:
+            captured["claude_dir"] = claude_dir
+            captured["slug"] = slug
+
+        def list_sessions(self) -> list[SessionInfo]:
+            return [_row("a", "archived@ts@epic-1:w")]
+
+        def rename(self, session_id: str, new_name: str) -> None:  # pragma: no cover
+            captured["renamed"] = True
+
+    monkeypatch.setattr(strip, "ScrapeStore", _Store)
+    rc = strip.main(["--claude-dir", str(tmp_path)])
+    assert rc == 0
+    assert captured["claude_dir"] == tmp_path
+    assert "renamed" not in captured  # dry-run: no rename call
+
+
+def test_main_apply_passes_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    renamed: list[tuple[str, str]] = []
+
+    class _Store:
+        def __init__(self, claude_dir: Path, slug: str | None = None) -> None:
+            pass
+
+        def list_sessions(self) -> list[SessionInfo]:
+            return [_row("a", "archived@ts@epic-1:w")]
+
+        def rename(self, session_id: str, new_name: str) -> None:
+            renamed.append((session_id, new_name))
+
+    monkeypatch.setattr(strip, "ScrapeStore", _Store)
+    rc = strip.main(["--apply"])
+    assert rc == 0
+    assert renamed == [("a", "epic-1:w")]


### PR DESCRIPTION
# Pull Request

## Summary

- Add scripts/dev/strip-archived-markers.py, a one-time idempotent tool that renames any session whose name is a legacy archived@<ts>@<orig> marker back to <orig> via the supported SessionStore.rename seam so the session list renders uniformly.

## Issue Linkage

- Closes #2611

## Notes

- Task 7 of epic vergil-project/.github#230. Dry-run by default; --apply performs the renames; never deletes. Pure core (strip_archived_name/plan_strips) plus run/main are unit-tested with a fake store, and an end-to-end smoke against a seeded ~/.claude confirmed restore, clean-session pass-through, and idempotency. New file lives in scripts/dev/ (outside --cov=src, like the T0 probe); vrg-validate green at 100% src coverage.