### PR TITLE
fix(vrg-worktree-status): surface detached-HEAD / mid-rebase worktrees instead of hiding them

### DIFF
--- a/src/vergil_tooling/bin/vrg_worktree_status.py
+++ b/src/vergil_tooling/bin/vrg_worktree_status.py
@@ -20,13 +20,17 @@ from vergil_tooling.lib import git, worktrees
 from vergil_tooling.lib.worktrees import WorktreeState, WorktreeStatus
 
 # Live work first, cruft last, so the removable rows group at the bottom.
+# In-flight/mid-operation worktrees (rebasing, detached) sort near the top —
+# they are active work needing a human, never removable cruft (issue #2634).
 _SORT_RANK = {
     WorktreeState.OPEN_PR: 0,
-    WorktreeState.NO_PR: 1,
-    WorktreeState.DRAFT: 2,
-    WorktreeState.UNKNOWN: 3,
-    WorktreeState.MERGED: 4,
-    WorktreeState.CLOSED: 5,
+    WorktreeState.REBASING: 1,
+    WorktreeState.DETACHED: 2,
+    WorktreeState.NO_PR: 3,
+    WorktreeState.DRAFT: 4,
+    WorktreeState.UNKNOWN: 5,
+    WorktreeState.MERGED: 6,
+    WorktreeState.CLOSED: 7,
 }
 
 _COLUMNS = (
@@ -128,10 +132,26 @@ def _summary(statuses: list[WorktreeStatus]) -> str:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     root = git.repo_root()
-    statuses = [
-        worktrees.gather_worktree_status(wt, target=args.target_branch, with_freshness=True)
-        for wt in worktrees.list_worktrees(root)
-    ]
+    statuses: list[WorktreeStatus] = []
+    for raw in worktrees.discover_worktrees(root):
+        # A detached-HEAD worktree (the normal state during a paused rebase) has
+        # no branch to classify a lifecycle from — it gets its own REBASING /
+        # DETACHED status instead of being dropped, so an in-flight worktree is
+        # never hidden behind "no worktrees found" (issue #2634).
+        if raw.branch is None:
+            statuses.append(
+                worktrees.gather_detached_status(
+                    raw, target=args.target_branch, with_freshness=True
+                )
+            )
+        else:
+            statuses.append(
+                worktrees.gather_worktree_status(
+                    worktrees.Worktree(path=raw.path, branch=raw.branch),
+                    target=args.target_branch,
+                    with_freshness=True,
+                )
+            )
     if not statuses:
         print("No canonical .worktrees/ worktrees found.")
         return 0

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -150,6 +150,17 @@ def commit_sha(ref: str) -> str:
     return read_output("rev-parse", ref)
 
 
+def worktree_git_dir(path: str | Path) -> Path:
+    """Return the absolute git-dir for the worktree at *path*.
+
+    For a linked worktree this is ``.git/worktrees/<name>/`` — where the
+    per-worktree state of an in-progress operation lives, including a paused
+    rebase's ``rebase-merge/`` (or ``rebase-apply/``) directory. Used to detect
+    a mid-rebase worktree and recover the branch it is rebuilding (#2634).
+    """
+    return Path(read_output("-C", str(path), "rev-parse", "--absolute-git-dir"))
+
+
 def committer_timestamp(path: str | Path) -> int:
     """Return the committer date (epoch seconds) of *path*'s checked-out HEAD.
 

--- a/src/vergil_tooling/lib/worktrees.py
+++ b/src/vergil_tooling/lib/worktrees.py
@@ -29,10 +29,26 @@ class Worktree:
     branch: str
 
 
+@dataclass(frozen=True)
+class RawWorktree:
+    """A worktree under the canonical container exactly as git reports it.
+
+    Unlike ``Worktree``, this keeps **detached-HEAD** worktrees — ``branch`` is
+    ``None`` when no branch is checked out, the normal state during a paused
+    rebase. Discovery retains them so a status view can surface an in-flight
+    worktree rather than dropping it and reporting "none" (issue #2634).
+    """
+
+    path: Path
+    branch: str | None
+
+
 class WorktreeState(StrEnum):
     """Lifecycle state of a canonical worktree, derived from PR + local signals."""
 
     OPEN_PR = "open-pr"
+    REBASING = "rebasing"
+    DETACHED = "detached"
     NO_PR = "no-pr"
     DRAFT = "draft"
     MERGED = "merged"
@@ -329,30 +345,163 @@ def gather_worktree_status(
     )
 
 
-def list_worktrees(repo_root: Path) -> list[Worktree]:
-    """Return worktrees under ``repo_root/.worktrees/`` with their branches.
+def discover_worktrees(repo_root: Path) -> list[RawWorktree]:
+    """Return every worktree under ``repo_root/.worktrees/``, detached included.
 
-    Detached worktrees (no ``branch`` line in the porcelain output) and
-    worktrees outside the canonical container are excluded.
+    Parses ``git worktree list --porcelain`` and keeps one ``RawWorktree`` per
+    worktree inside the canonical container. ``branch`` is the checked-out
+    branch, or ``None`` when HEAD is detached (a worktree paused mid-rebase).
+    Worktrees outside the canonical container are ignored, as with
+    ``list_worktrees``.
+
+    This is the full-fidelity discovery a status view needs: a detached-HEAD
+    worktree still physically exists and must never be silently dropped
+    (issue #2634). ``list_worktrees`` layers the branch-only filter on top for
+    the callers (finalize/submit sweeps) that must not act on a mid-operation
+    worktree.
     """
     output = git.read_output("worktree", "list", "--porcelain")
     canonical_root = (repo_root / ".worktrees").resolve()
 
-    worktrees: list[Worktree] = []
+    records: list[RawWorktree] = []
     current_path: Path | None = None
-    for line in output.splitlines():
-        if line.startswith("worktree "):
-            current_path = Path(line.removeprefix("worktree ").strip())
-        elif line.startswith("branch ") and current_path is not None:
-            ref = line.removeprefix("branch ").strip()
+    current_branch: str | None = None
+
+    def flush() -> None:
+        nonlocal current_path, current_branch
+        if current_path is not None:
             resolved = current_path.resolve()
-            current_path = None
             try:
                 resolved.relative_to(canonical_root)
             except ValueError:
-                continue
-            worktrees.append(Worktree(path=resolved, branch=ref.removeprefix("refs/heads/")))
-    return worktrees
+                pass
+            else:
+                records.append(RawWorktree(path=resolved, branch=current_branch))
+        current_path = None
+        current_branch = None
+
+    # Porcelain output is one blank-line-separated block per worktree, each
+    # opening with a `worktree <path>` line; `branch` is present only when a
+    # branch is checked out (absent for detached HEAD). Flush the previous
+    # block when a new `worktree` line opens the next, and once more at the end.
+    for line in output.splitlines():
+        if line.startswith("worktree "):
+            flush()
+            current_path = Path(line.removeprefix("worktree ").strip())
+        elif line.startswith("branch ") and current_path is not None:
+            ref = line.removeprefix("branch ").strip()
+            current_branch = ref.removeprefix("refs/heads/")
+    flush()
+    return records
+
+
+def list_worktrees(repo_root: Path) -> list[Worktree]:
+    """Return worktrees under ``repo_root/.worktrees/`` with their branches.
+
+    Detached worktrees (no ``branch`` line in the porcelain output) and
+    worktrees outside the canonical container are excluded — a mid-operation
+    worktree is deliberately not a finalize/submit candidate. Use
+    ``discover_worktrees`` when detached worktrees must be surfaced too.
+    """
+    return [
+        Worktree(path=raw.path, branch=raw.branch)
+        for raw in discover_worktrees(repo_root)
+        if raw.branch is not None
+    ]
+
+
+def _branch_from_worktree_name(name: str) -> str | None:
+    """Map a canonical worktree directory name to its feature branch.
+
+    ``issue-<N>-<slug>`` -> ``feature/<N>-<slug>``. Returns ``None`` for a name
+    that does not follow the convention, so a caller can fall back rather than
+    inventing a branch. Used to recover the intended branch of a detached
+    worktree from its directory name (issue #2634).
+    """
+    remainder = name.removeprefix("issue-")
+    if remainder == name or not remainder:
+        return None
+    return f"feature/{remainder}"
+
+
+def _rebase_head_name(git_dir: Path) -> str | None:
+    """Return the branch a paused rebase is rebuilding, or ``None``.
+
+    Git records the original branch as ``refs/heads/<branch>`` in the
+    ``head-name`` file of the in-progress rebase state directory —
+    ``rebase-merge/`` (merge backend, the modern default) or ``rebase-apply/``
+    (apply backend). Returns the short branch name, or ``None`` when no rebase
+    is in progress or the file is absent/empty.
+    """
+    for backend in ("rebase-merge", "rebase-apply"):
+        try:
+            ref = (git_dir / backend / "head-name").read_text().strip()
+        except OSError:
+            continue
+        if ref:
+            return ref.removeprefix("refs/heads/")
+    return None
+
+
+def _rebase_in_progress(git_dir: Path) -> bool:
+    """Return True when *git_dir* holds an in-progress rebase's state directory."""
+    return (git_dir / "rebase-merge").is_dir() or (git_dir / "rebase-apply").is_dir()
+
+
+def gather_detached_status(
+    raw: RawWorktree, *, target: str, with_freshness: bool = False
+) -> WorktreeStatus:
+    """Classify a detached-HEAD worktree — the state a paused rebase leaves.
+
+    A detached worktree has no checked-out branch, so it never resolves to a
+    lifecycle state via ``gather_worktree_status``; without this it would be
+    dropped from discovery entirely and the worktree would look like it
+    vanished (issue #2634). The intended branch is recovered from the paused
+    rebase's ``head-name`` metadata, falling back to the ``issue-<N>-<slug>``
+    directory name, and the state is ``REBASING`` when a rebase is in progress
+    or ``DETACHED`` otherwise. A PR lookup is deliberately skipped: the point is
+    to *surface* the in-flight worktree with an actionable note, not to derive a
+    lifecycle it does not yet have.
+
+    Freshness timestamps mirror ``gather_worktree_status`` — gathered only when
+    ``with_freshness`` is set (``vrg-worktree-status``).
+    """
+    git_dir = git.worktree_git_dir(raw.path)
+    rebasing = _rebase_in_progress(git_dir)
+    branch = _rebase_head_name(git_dir) or _branch_from_worktree_name(raw.path.name)
+    worktree = Worktree(path=raw.path, branch=branch or "(detached)")
+
+    porcelain = git.read_output("-C", str(raw.path), "status", "--porcelain")
+    dirty = bool(porcelain)
+    # The branch ref still points at its pre-rebase tip during a rebase, so
+    # commits-ahead is meaningful — but only when the resolved branch actually
+    # exists; a name recovered solely from the directory may not.
+    ahead = git.commits_ahead(target, branch) if branch and git.ref_exists(branch) else 0
+    workflow_status, workflow_error, pr_prepared = _probe_pr_workflow(worktree)
+    last_commit_ts = git.committer_timestamp(raw.path) if with_freshness else None
+    last_modified_ts = _newest_mtime(raw.path) if with_freshness else None
+
+    if rebasing:
+        detail = (
+            "rebase in progress (detached HEAD) — resolve conflicts and run "
+            "'vrg-git rebase --continue', or 'vrg-git rebase --abort' to undo"
+        )
+    else:
+        detail = "detached HEAD — no branch checked out; check out a branch to resume work"
+
+    return WorktreeStatus(
+        worktree=worktree,
+        state=WorktreeState.REBASING if rebasing else WorktreeState.DETACHED,
+        pr_number=None,
+        ahead=ahead,
+        dirty=dirty,
+        detail=detail,
+        workflow_status=workflow_status,
+        workflow_error=workflow_error,
+        pr_prepared=pr_prepared,
+        last_commit_ts=last_commit_ts,
+        last_modified_ts=last_modified_ts,
+    )
 
 
 def worktree_for_branch(branch: str, repo_root: Path) -> Path | None:

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -128,6 +128,18 @@ def test_repo_root_returns_path() -> None:
     assert result == Path("/var/repo")
 
 
+def test_worktree_git_dir_returns_absolute_path() -> None:
+    with patch(
+        "vergil_tooling.lib.git.read_output",
+        return_value="/repo/.git/worktrees/issue-9-x",
+    ) as read_output:
+        result = git.worktree_git_dir("/repo/.worktrees/issue-9-x")
+    assert result == Path("/repo/.git/worktrees/issue-9-x")
+    read_output.assert_called_once_with(
+        "-C", "/repo/.worktrees/issue-9-x", "rev-parse", "--absolute-git-dir"
+    )
+
+
 def test_current_branch_returns_name() -> None:
     with patch("vergil_tooling.lib.git.read_output", return_value="feature/test"):
         result = git.current_branch()

--- a/tests/vergil_tooling/test_vrg_worktree_status.py
+++ b/tests/vergil_tooling/test_vrg_worktree_status.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from vergil_tooling.bin.vrg_worktree_status import _format_age, _row, main
-from vergil_tooling.lib.worktrees import Worktree, WorktreeState, WorktreeStatus
+from vergil_tooling.lib.worktrees import RawWorktree, Worktree, WorktreeState, WorktreeStatus
 
 if TYPE_CHECKING:
     import pytest
@@ -55,6 +55,12 @@ _LAST_MODIFIED_COL = 8
 _NOW = 1_700_000_000.0
 
 
+def _raws(statuses: list[WorktreeStatus]) -> list[RawWorktree]:
+    """Mirror a list of branched statuses as the RawWorktree records
+    discover_worktrees would return for them."""
+    return [RawWorktree(path=s.worktree.path, branch=s.worktree.branch) for s in statuses]
+
+
 def test_row_renders_loaded_workflow_status_verbatim() -> None:
     row = _row(
         _status("feature/1-x", WorktreeState.NO_PR, ahead=1, workflow_status="approved"), _NOW
@@ -87,7 +93,7 @@ def test_main_summary_reports_prepared_count(capsys: pytest.CaptureFixture[str])
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -103,7 +109,7 @@ def test_main_surfaces_workflow_read_error_note(capsys: pytest.CaptureFixture[st
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -123,7 +129,7 @@ def test_main_groups_cruft_last_and_summarizes(capsys: pytest.CaptureFixture[str
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -140,18 +146,43 @@ def test_main_groups_cruft_last_and_summarizes(capsys: pytest.CaptureFixture[str
 def test_main_empty_reports_none(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=[]),
     ):
         rc = main([])
     assert rc == 0
     assert "No canonical" in capsys.readouterr().out
 
 
+def test_main_surfaces_rebasing_worktree_not_none(capsys: pytest.CaptureFixture[str]) -> None:
+    """Issue #2634: a detached-HEAD / mid-rebase worktree must be listed with a
+    REBASING state and its resolved branch — never hidden behind "none"."""
+    rebasing = _status(
+        "feature/2607-resume-attach",
+        WorktreeState.REBASING,
+        ahead=3,
+        detail="rebase in progress (detached HEAD) — resolve conflicts and continue",
+    )
+    raw = RawWorktree(path=rebasing.worktree.path, branch=None)
+    with (
+        patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=[raw]),
+        patch(_MOD + ".worktrees.gather_detached_status", return_value=rebasing),
+    ):
+        rc = main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "No canonical" not in out
+    assert "rebasing" in out
+    assert "feature/2607-resume-attach" in out
+    assert "note: feature/2607-resume-attach:" in out
+    assert "rebase in progress" in out
+
+
 def test_main_surfaces_unknown_detail(capsys: pytest.CaptureFixture[str]) -> None:
     statuses = [_status("feature/9-x", WorktreeState.UNKNOWN, detail="gh boom")]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -176,7 +207,7 @@ def test_main_surfaces_reused_branch_detail(capsys: pytest.CaptureFixture[str]) 
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -208,7 +239,7 @@ def test_main_merged_dirty_is_needs_attention_not_active(
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -242,7 +273,7 @@ def test_main_four_merged_dirty_never_reported_all_active(
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -268,7 +299,7 @@ def test_main_reused_branch_is_needs_attention_not_stalled(
     ]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])
@@ -304,7 +335,7 @@ def test_main_includes_timestamp_headers(capsys: pytest.CaptureFixture[str]) -> 
     statuses = [_status("feature/1-a", WorktreeState.NO_PR, ahead=1)]
     with (
         patch(_MOD + ".git.repo_root", return_value=Path("/repo")),
-        patch(_MOD + ".worktrees.list_worktrees", return_value=[s.worktree for s in statuses]),
+        patch(_MOD + ".worktrees.discover_worktrees", return_value=_raws(statuses)),
         patch(_MOD + ".worktrees.gather_worktree_status", side_effect=statuses),
     ):
         rc = main([])

--- a/tests/vergil_tooling/test_worktrees.py
+++ b/tests/vergil_tooling/test_worktrees.py
@@ -11,12 +11,17 @@ import pytest
 
 from vergil_tooling.lib.pr_workflow.state import WorkflowState
 from vergil_tooling.lib.worktrees import (
+    RawWorktree,
     Worktree,
     WorktreeState,
     WorktreeStatus,
+    _branch_from_worktree_name,
     _newest_mtime,
     _probe_pr_workflow,
+    _rebase_head_name,
     classify_worktree,
+    discover_worktrees,
+    gather_detached_status,
     gather_worktree_status,
     list_worktrees,
     match_worktrees,
@@ -94,6 +99,106 @@ def test_list_worktrees_ignores_detached_worktrees() -> None:
     porcelain = "worktree /repo/.worktrees/issue-5-x\nHEAD 5555\ndetached\n"
     with patch(_MOD + ".git.read_output", return_value=porcelain):
         assert list_worktrees(Path("/repo")) == []
+
+
+_PORCELAIN_WITH_DETACHED = """\
+worktree /repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/develop
+
+worktree /repo/.worktrees/issue-7-foo
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/feature/7-foo
+
+worktree /repo/.worktrees/issue-9-mid-rebase
+HEAD 3333333333333333333333333333333333333333
+detached
+"""
+
+
+def test_discover_worktrees_keeps_detached() -> None:
+    """Issue #2634: a detached-HEAD canonical worktree (paused mid-rebase) must
+    survive discovery with branch=None, not be dropped like list_worktrees drops
+    it."""
+    with patch(_MOD + ".git.read_output", return_value=_PORCELAIN_WITH_DETACHED):
+        result = discover_worktrees(Path("/repo"))
+    assert result == [
+        RawWorktree(path=Path("/repo/.worktrees/issue-7-foo"), branch="feature/7-foo"),
+        RawWorktree(path=Path("/repo/.worktrees/issue-9-mid-rebase"), branch=None),
+    ]
+
+
+def test_list_worktrees_filters_detached_out_of_discovery() -> None:
+    """list_worktrees still excludes the detached worktree discovery keeps, so
+    the finalize/submit sweeps never act on a mid-operation worktree."""
+    with patch(_MOD + ".git.read_output", return_value=_PORCELAIN_WITH_DETACHED):
+        assert list_worktrees(Path("/repo")) == [
+            Worktree(path=Path("/repo/.worktrees/issue-7-foo"), branch="feature/7-foo"),
+        ]
+
+
+def test_branch_from_worktree_name_maps_canonical() -> None:
+    assert _branch_from_worktree_name("issue-2607-resume-attach") == "feature/2607-resume-attach"
+
+
+def test_branch_from_worktree_name_none_for_non_canonical() -> None:
+    assert _branch_from_worktree_name("scratch") is None
+    assert _branch_from_worktree_name("issue-") is None
+
+
+def test_rebase_head_name_empty_file_falls_through(tmp_path: Path) -> None:
+    """An empty head-name is treated as absent — skipped, never returned as an
+    empty branch name."""
+    (tmp_path / "rebase-merge").mkdir()
+    (tmp_path / "rebase-merge" / "head-name").write_text("\n")
+    assert _rebase_head_name(tmp_path) is None
+
+
+def test_gather_detached_status_rebasing_resolves_branch(tmp_path: Path) -> None:
+    """A mid-rebase worktree resolves REBASING and recovers its branch from the
+    paused rebase's head-name metadata (issue #2634)."""
+    git_dir = tmp_path / "gitdir"
+    (git_dir / "rebase-merge").mkdir(parents=True)
+    (git_dir / "rebase-merge" / "head-name").write_text("refs/heads/feature/2607-resume-attach\n")
+    raw = RawWorktree(path=Path("/repo/.worktrees/issue-2607-resume-attach"), branch=None)
+    with (
+        patch(_MOD + ".git.worktree_git_dir", return_value=git_dir),
+        patch(_MOD + ".git.read_output", return_value=""),
+        patch(_MOD + ".git.ref_exists", return_value=True),
+        patch(_MOD + ".git.commits_ahead", return_value=3),
+        patch(_MOD + "._probe_pr_workflow", return_value=(None, None, False)),
+    ):
+        status = gather_detached_status(raw, target="develop")
+    assert status.state is WorktreeState.REBASING
+    assert status.worktree.branch == "feature/2607-resume-attach"
+    assert status.ahead == 3
+    assert status.dirty is False
+    assert status.detail is not None
+    assert "rebase in progress" in status.detail
+
+
+def test_gather_detached_status_falls_back_to_dir_name(tmp_path: Path) -> None:
+    """A detached worktree with no rebase in progress classifies DETACHED and
+    recovers its branch from the issue-<N>-<slug> directory name."""
+    git_dir = tmp_path / "gitdir"
+    git_dir.mkdir()
+    raw = RawWorktree(path=Path("/repo/.worktrees/issue-42-widget"), branch=None)
+    with (
+        patch(_MOD + ".git.worktree_git_dir", return_value=git_dir),
+        patch(_MOD + ".git.read_output", return_value=" M src/x.py"),
+        patch(_MOD + ".git.ref_exists", return_value=False),
+        patch(_MOD + ".git.commits_ahead") as ahead,
+        patch(_MOD + "._probe_pr_workflow", return_value=(None, None, False)),
+    ):
+        status = gather_detached_status(raw, target="develop")
+    assert status.state is WorktreeState.DETACHED
+    assert status.worktree.branch == "feature/42-widget"
+    # Branch ref does not exist, so commits-ahead is skipped, not guessed.
+    ahead.assert_not_called()
+    assert status.ahead == 0
+    assert status.dirty is True
+    assert status.detail is not None
+    assert "detached HEAD" in status.detail
 
 
 def test_worktree_for_branch_found() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-worktree-status now discovers detached-HEAD worktrees and lists a mid-rebase worktree with a REBASING/DETACHED state and its resolved branch, instead of filtering it out and printing 'No canonical worktrees found'.

## Issue Linkage

- Closes #2634

## Notes

- Root cause: the command built its list from list_worktrees(), which keeps only worktrees with a checked-out branch; a mid-rebase worktree is detached-HEAD and was dropped. Fix adds discover_worktrees() (retains detached, branch=None) and reimplements list_worktrees() on top so the finalize/submit sweeps keep their branch-only filter unchanged and never act on a mid-operation worktree. Detached worktrees are classified REBASING (rebase in progress) or DETACHED, with the intended branch recovered from the paused rebase's rebase-merge/head-name metadata, falling back to the issue-<N>-<slug> directory name. Tests: discover_worktrees keeps/filters detached, gather_detached_status for both rebasing and dir-name fallback, empty head-name fall-through, worktree_git_dir, and a bin-level test asserting the 'none' message no longer appears when a rebasing worktree exists. Validation green (100% coverage).