### PR TITLE
feat(vrg-release): mark confirm stages ⚠ when they defer a publish failure

### DIFF
--- a/src/vergil_tooling/lib/progress.py
+++ b/src/vergil_tooling/lib/progress.py
@@ -336,6 +336,10 @@ class _Session:
 
     renderer: Any
     log: RunLog
+    # Reason set by ``mark_warn`` during the current stage; ``run_pipeline``
+    # reads and clears it per stage to downgrade a normally-returning stage's
+    # status from ``ok`` to ``warn``.
+    pending_warn: str | None = None
 
     def __post_init__(self) -> None:
         self._lock = threading.Lock()
@@ -356,6 +360,25 @@ def emit(line: str) -> None:
         session.handle_line(line)
     else:
         print(line)
+
+
+def mark_warn(reason: str) -> None:
+    """Signal that the current stage completed but with a non-fatal warning.
+
+    A stage whose ``fn`` returns normally is recorded ``ok`` (✓). Calling this
+    while a stage runs downgrades that stage's recorded status to ``warn`` (⚠),
+    with *reason* shown on its status row and in the summary — **without
+    raising**, so control flow (including ``fail_fast``) is unaffected.
+
+    Used by vrg-release's confirm stages to surface a deferred publish failure
+    at the row where it was observed, not only in the terminal summary (a green
+    ✓ over a deferral reads as full success at a glance). Outside a running
+    pipeline (``_session is None``) it is a harmless no-op; the last call in a
+    stage wins.
+    """
+    session = _session
+    if session is not None:
+        session.pending_warn = reason
 
 
 class _EmitWriter(io.TextIOBase):
@@ -495,7 +518,8 @@ def run_pipeline(
     log = RunLog(command, repo_root)
     fmt = args.output_format or detect_format()
     renderer = _make_renderer(fmt, out, args.output_window)
-    _session = _Session(renderer=renderer, log=log)
+    session = _Session(renderer=renderer, log=log)
+    _session = session
     results: list[StageResult] = []
     interrupted = False
     start_total = time.monotonic()
@@ -510,6 +534,7 @@ def run_pipeline(
                 continue
             renderer.start_stage(stage.name)
             log.write(f"=== {stage.name}: started ===")
+            session.pending_warn = None
             start = time.monotonic()
             try:
                 with (
@@ -548,8 +573,13 @@ def run_pipeline(
                     break
             else:
                 elapsed = time.monotonic() - start
-                result = StageResult(stage.name, "ok", elapsed)
-                log.write(f"=== {stage.name}: ok ({format_elapsed(elapsed)}) ===")
+                warn_reason = session.pending_warn
+                if warn_reason is not None:
+                    result = StageResult(stage.name, "warn", elapsed, warn_reason)
+                    log.write(f"=== {stage.name}: warn ({warn_reason}) ===")
+                else:
+                    result = StageResult(stage.name, "ok", elapsed)
+                    log.write(f"=== {stage.name}: ok ({format_elapsed(elapsed)}) ===")
                 renderer.end_stage(result)
                 results.append(result)
     finally:

--- a/src/vergil_tooling/lib/release/confirm.py
+++ b/src/vergil_tooling/lib/release/confirm.py
@@ -6,7 +6,7 @@ import json
 import time
 from typing import TYPE_CHECKING, Any
 
-from vergil_tooling.lib import git, github
+from vergil_tooling.lib import git, github, progress
 from vergil_tooling.lib.release.context import ReleaseError
 from vergil_tooling.lib.release.subprocess import watch_workflow
 
@@ -37,6 +37,7 @@ def confirm_main(ctx: ReleaseContext) -> None:
             d for d in deferred if d not in ctx.deferred_publish_failures
         )
         print(f"  Publish deferred (release is valid): {', '.join(deferred)}")
+        progress.mark_warn(f"publish deferred: {', '.join(deferred)}")
     else:
         print("  All CD jobs succeeded.")
 
@@ -57,6 +58,7 @@ def confirm_develop(ctx: ReleaseContext) -> None:
             d for d in deferred if d not in ctx.deferred_publish_failures
         )
         print(f"  Publish deferred on develop: {', '.join(deferred)}")
+        progress.mark_warn(f"publish deferred: {', '.join(deferred)}")
     else:
         print("Develop CD verified.")
 

--- a/tests/vergil_tooling/test_progress.py
+++ b/tests/vergil_tooling/test_progress.py
@@ -488,6 +488,56 @@ def test_pipeline_warn_does_not_affect_exit(
     assert "⚠  warnings (non-fatal):" in capsys.readouterr().out
 
 
+def test_mark_warn_downgrades_normal_stage_to_warn(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A stage that returns normally but calls mark_warn is recorded ⚠, not ✓,
+    with the reason on its status row — and the run still exits 0."""
+    stages = [
+        Stage(
+            "confirm",
+            lambda ctx: progress.mark_warn("publish deferred: docker-publish"),
+            mode="fail_defer",
+        ),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 0
+    out = capsys.readouterr().out
+    assert "⚠ confirm" in out
+    assert "publish deferred: docker-publish" in out
+    assert "✓ confirm" not in out
+
+
+def test_mark_warn_is_isolated_between_stages(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A warn marked in one stage does not leak into a later clean stage."""
+    stages = [
+        Stage("dirty", lambda ctx: progress.mark_warn("deferred"), mode="fail_defer"),
+        Stage("clean", lambda ctx: None, mode="fail_defer"),
+    ]
+    assert _pipeline(tmp_path, stages, _args()) == 0
+    out = capsys.readouterr().out
+    assert "⚠ dirty" in out
+    assert "✓ clean" in out
+
+
+def test_mark_warn_recorded_in_log(tmp_path: Path) -> None:
+    """The downgraded stage is logged as warn with its reason for the full log."""
+    stages = [
+        Stage(
+            "confirm", lambda ctx: progress.mark_warn("publish deferred: docs"), mode="fail_defer"
+        ),
+    ]
+    _pipeline(tmp_path, stages, _args())
+    log_text = next((tmp_path / ".vergil").glob("test-cmd-*.log")).read_text()
+    assert "confirm: warn (publish deferred: docs)" in log_text
+
+
+def test_mark_warn_without_session_is_noop() -> None:
+    """Calling mark_warn outside a running pipeline is a harmless no-op."""
+    progress.mark_warn("nothing is listening")  # must not raise
+
+
 def test_pipeline_skip_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
     stages = [

--- a/tests/vergil_tooling/test_release_confirm.py
+++ b/tests/vergil_tooling/test_release_confirm.py
@@ -484,6 +484,67 @@ def test_confirm_develop_clean_defers_nothing() -> None:
     assert ctx.deferred_publish_failures == []
 
 
+def test_confirm_main_marks_stage_warn_on_deferral() -> None:
+    """A deferred publish failure downgrades confirm-main's stage row to ⚠."""
+    ctx = _ctx()
+    jobs = [
+        _job("release / release"),
+        _job("docker-publish / publish: prod-base:latest", conclusion="failure"),
+    ]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + "._verify_artifacts"),
+        patch(_MOD + ".progress.mark_warn") as mark_warn,
+    ):
+        confirm_main(ctx)
+    mark_warn.assert_called_once()
+    assert "docker-publish" in mark_warn.call_args.args[0]
+
+
+def test_confirm_main_clean_run_does_not_mark_warn() -> None:
+    """A fully-clean confirm-main keeps its ✓ — mark_warn is never called."""
+    ctx = _ctx()
+    with (
+        patch(_MOD + "._watch_cd", return_value=("123", "https://run/123")),
+        patch(_MOD + "._settled_run_jobs", return_value=_MAIN_JOBS_OK),
+        patch(_MOD + "._verify_artifacts"),
+        patch(_MOD + ".progress.mark_warn") as mark_warn,
+    ):
+        confirm_main(ctx)
+    mark_warn.assert_not_called()
+
+
+def test_confirm_develop_marks_stage_warn_on_deferral() -> None:
+    """A deferred publish failure downgrades confirm-develop's stage row to ⚠,
+    even when the same family was already deferred on main (dedup keeps the
+    list from growing, but the stage still observed a break)."""
+    ctx = _ctx()
+    ctx.deferred_publish_failures = ["docker-publish"]
+    jobs = [_job("docker-publish / publish: dev-base:latest", conclusion="failure")]
+    with (
+        patch(_MOD + "._watch_cd", return_value=("9", "https://run/9")),
+        patch(_MOD + "._settled_run_jobs", return_value=jobs),
+        patch(_MOD + ".progress.mark_warn") as mark_warn,
+    ):
+        confirm_develop(ctx)
+    mark_warn.assert_called_once()
+    assert "docker-publish" in mark_warn.call_args.args[0]
+    # dedup: the shared family is not re-appended
+    assert ctx.deferred_publish_failures == ["docker-publish"]
+
+
+def test_confirm_develop_clean_run_does_not_mark_warn() -> None:
+    ctx = _ctx()
+    with (
+        patch(_MOD + "._watch_cd", return_value=("9", "https://run/9")),
+        patch(_MOD + "._settled_run_jobs", return_value=_DEVELOP_JOBS_OK),
+        patch(_MOD + ".progress.mark_warn") as mark_warn,
+    ):
+        confirm_develop(ctx)
+    mark_warn.assert_not_called()
+
+
 def test_settled_run_jobs_exhaust_returns_last_snapshot() -> None:
     """When no expected job ever settles, _settled_run_jobs exhausts all
     attempts and returns the final (unsettled) jobs snapshot."""


### PR DESCRIPTION
# Pull Request

## Summary

- confirm-main/confirm-develop now render ⚠ (not a green ✓) at their own status row when they defer a publish failure, via a new progress.mark_warn() that downgrades a normally-returning stage's status ok→warn without altering control flow or exit code.

## Issue Linkage

- Closes #2564

## Notes

- Root cause: the progress framework derives stage status from whether fn raised, so a deferring confirm stage returned normally and was recorded ok (✓); the break only showed in the terminal publish-status summary. Fix adds progress.mark_warn(reason) (session-scoped, reset per stage, no-op outside a pipeline) and wires both confirm stages to call it on an observed deferral. Chose the per-stage signal over the issue's _tracked length-snapshot sketch because dedup means confirm-develop would not grow deferred_publish_failures when the same family already failed on main, yet it must still show ⚠. Clean runs keep ✓; publish-status exit-1 and the failure summary are unchanged. 4613 tests pass, 100% coverage, validation green.