### PR TITLE
docs(vrg-vm): fix stale --fork help and error text referencing removed --slot

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2824,7 +2824,7 @@ def main(argv: list[str] | None = None) -> int:
     p_session.add_argument(
         "--fork",
         action="store_true",
-        help="Fork the targeted --slot into a new session instead of resuming it",
+        help="Fork the resolved session into a new session instead of resuming it",
     )
     p_session.add_argument(
         "--fresh",

--- a/src/vergil_tooling/lib/session.py
+++ b/src/vergil_tooling/lib/session.py
@@ -333,7 +333,10 @@ def _select_explicit(identity: str, path: str, slots: dict[int, Slot], slot: int
 def _select_fork(identity: str, path: str, slots: dict[int, Slot], slot: int | None) -> Decision:
     """``--fork``: copy the targeted slot's conversation into a new slot."""
     if slot is None:
-        return Refuse("--fork requires --slot N to identify the session to fork")
+        return Refuse(
+            "--fork has no session to fork; use --resume NAME to attach to a "
+            "session or --label to start a new one"
+        )
     if not SLOT_MIN <= slot <= SLOT_MAX:
         return _bad_range()
     info = slots.get(slot)

--- a/tests/vergil_tooling/test_session.py
+++ b/tests/vergil_tooling/test_session.py
@@ -170,10 +170,11 @@ def test_explicit_rejects_out_of_range_slot() -> None:
 # --- --fork ---
 
 
-def test_fork_requires_slot() -> None:
+def test_fork_without_target_refuses() -> None:
     result = select("vergil", "p", {}, fork=True)
     assert isinstance(result, Refuse)
-    assert "--slot" in result.message
+    assert "--slot" not in result.message
+    assert "--fork" in result.message
 
 
 def test_fork_rejects_out_of_range_slot() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Update the --fork argparse help in vrg_vm.py to describe the resolved-session model (the removed --slot flag from #2607 is gone) and reword the reachable Refuse message that a live 'vrg-vm session --fork' printed as '--fork requires --slot N ...' to point at the supported --resume/--label surface, with no behavior change.

## Issue Linkage

- Closes #2646

## Notes

- Scope was the two user-facing strings that still name the removed --slot flag. vrg_vm.py:2827 is the issue's named bug. lib/session.py's fork Refuse is also user-reachable: resolve() calls plan_session(..., slot=None), so 'session --fork' always hit '--fork requires --slot N ...' — a flag that no longer exists — reworded to the documented --resume/--label paths; --fork with no target still refuses (behavior unchanged). Updated the one test (test_session.py) that asserted the old --slot wording. Left as-is: internal docstrings in session.py / vrg_vm_resolve.py that still mention --slot or archived@ — they accurately describe the retained legacy slot machinery and the removals (#2607/#2608), and CHANGELOG/release notes per the issue. No session_stale_days/session_archive_days/identity:slot: strings remain in src. Validated green in-container (4637 passed, 100% coverage).