### PR TITLE
fix(github-config): gate `docs / docs` required check on [publish].docs

### DIFF
--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -535,7 +535,7 @@ def resolve_required_gates(repo: str, repo_root: Path) -> tuple[EvidenceGate, ..
     """
     config = read_config(repo_root)
     ghas = ghas_available(config, visibility=github.repo_visibility(repo))
-    return required_evidence_gates(config.project, config.ci, ghas=ghas)
+    return required_evidence_gates(config.project, config.ci, ghas=ghas, docs=config.publish.docs)
 
 
 def _gate_conclusion(checks: Sequence[str], conclusions: Mapping[str, str]) -> str:

--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -270,8 +270,17 @@ def desired_ci_gates_ruleset(
     ci: CiConfig,
     *,
     ghas: bool,
+    docs: bool = True,
 ) -> DesiredRuleset:
-    """Derive the CI gates ruleset from project identity and CI config."""
+    """Derive the CI gates ruleset from project identity and CI config.
+
+    ``docs`` mirrors ``[publish].docs``: the ``docs / docs`` gate is only
+    emitted by a repo whose ``ci.yml`` invokes ``ci-docs.yml``, which repos do
+    only when they publish docs. Requiring it on a non-docs repo (e.g. an org
+    ``.github`` repo with ``[publish].docs = false``) pins a status that never
+    reports, permanently blocking every merge with "the base branch policy
+    prohibits the merge" (vergil-project/vergil-tooling#2647).
+    """
     checks: list[dict[str, object]] = []
     lang = project.primary_language
 
@@ -279,9 +288,10 @@ def desired_ci_gates_ruleset(
     checks.append(_make_check("quality / common"))
     checks.append(_make_check("security / trivy"))
     checks.append(_make_check("security / semgrep"))
-    # docs / docs is emitted unconditionally by the reusable CI (no if: guard),
-    # so it must be a required PR gate — otherwise it can silently be optional.
-    checks.append(_make_check("docs / docs"))
+    # docs / docs is emitted only when the repo publishes docs; requiring it on
+    # a non-docs repo blocks every merge (its CI never reports the context).
+    if docs:
+        checks.append(_make_check("docs / docs"))
 
     # GHAS check runs — created by GitHub Advanced Security (app 57789)
     # when workflows upload SARIF via codeql-action/upload-sarif.  These
@@ -412,14 +422,16 @@ def required_evidence_gates(
     ci: CiConfig,
     *,
     ghas: bool,
+    docs: bool = True,
 ) -> tuple[EvidenceGate, ...]:
     """The evidence-producing gates this repo MUST emit.
 
     Derived from the same required-status-check computation that drives branch
     protection (:func:`desired_ci_gates_ruleset`), so the enforced gates and the
-    evidence-required gates cannot drift apart.
+    evidence-required gates cannot drift apart. ``docs`` is threaded through
+    identically for the same reason.
     """
-    ruleset = desired_ci_gates_ruleset(project, ci, ghas=ghas)
+    ruleset = desired_ci_gates_ruleset(project, ci, ghas=ghas, docs=docs)
     checks = _extract_status_checks(ruleset.rules) or []
 
     grouped: dict[str, list[str]] = {}
@@ -446,7 +458,9 @@ def compute_desired_state(
 
     rulesets.append(desired_branch_protection_ruleset())
     rulesets.append(desired_tag_protection_ruleset())
-    rulesets.append(desired_ci_gates_ruleset(config.project, config.ci, ghas=ghas))
+    rulesets.append(
+        desired_ci_gates_ruleset(config.project, config.ci, ghas=ghas, docs=config.publish.docs)
+    )
 
     if app_mode:
         for rs in rulesets:

--- a/tests/vergil_tooling/test_ci_evidence_harvest.py
+++ b/tests/vergil_tooling/test_ci_evidence_harvest.py
@@ -383,7 +383,7 @@ def test_resolve_required_gates_wires_config_ghas_and_derivation(
 
     from vergil_tooling.lib.github_config import EvidenceGate
 
-    cfg = SimpleNamespace(project="PROJECT", ci="CI")
+    cfg = SimpleNamespace(project="PROJECT", ci="CI", publish=SimpleNamespace(docs=False))
     monkeypatch.setattr(ci_evidence, "read_config", lambda _root: cfg)
     monkeypatch.setattr(github, "repo_visibility", lambda _repo: "public")
 
@@ -398,8 +398,8 @@ def test_resolve_required_gates_wires_config_ghas_and_derivation(
 
     sentinel = (EvidenceGate(name="test", checks=("test / unit",)),)
 
-    def fake_required(project: Any, ci: Any, *, ghas: bool) -> Any:
-        captured["derivation_args"] = (project, ci, ghas)
+    def fake_required(project: Any, ci: Any, *, ghas: bool, docs: bool) -> Any:
+        captured["derivation_args"] = (project, ci, ghas, docs)
         return sentinel
 
     monkeypatch.setattr(ci_evidence, "required_evidence_gates", fake_required)
@@ -409,7 +409,8 @@ def test_resolve_required_gates_wires_config_ghas_and_derivation(
     assert result is sentinel
     assert captured["ghas_config"] is cfg
     assert captured["visibility"] == "public"
-    assert captured["derivation_args"] == ("PROJECT", "CI", True)
+    # docs is wired from config.publish.docs (here False) alongside ghas.
+    assert captured["derivation_args"] == ("PROJECT", "CI", True, False)
 
 
 # --- _gate_conclusion ---------------------------------------------------

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -272,27 +272,30 @@ def test_ci_gates_always_includes_common_and_security() -> None:
     assert "Semgrep OSS" in check_names
 
 
-def test_desired_ci_gates_requires_docs_check() -> None:
-    """`docs / docs` is emitted unconditionally by the reusable CI and must be a
-    required PR gate (present even without GHAS)."""
-    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=False)
-    contexts = {
-        str(c["context"])
-        for rule in ruleset.rules
-        for c in cast(
-            "dict[str, list[dict[str, object]]]",
-            rule["parameters"],
-        )["required_status_checks"]
-    }
-    assert "docs / docs" in contexts
+def test_ci_gates_requires_docs_check_when_publishing_docs() -> None:
+    """A docs-publishing repo (`[publish].docs = true`) emits `docs / docs` from
+    the reusable CI, so it must be a required PR gate (present even without
+    GHAS)."""
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=False, docs=True)
+    assert "docs / docs" in _check_names(ruleset)
 
 
+def test_ci_gates_omits_docs_check_when_not_publishing_docs() -> None:
+    """A repo with `[publish].docs = false` (e.g. an org `.github` repo) has no
+    docs job in its CI, so `docs / docs` is never reported. Requiring it pins a
+    status that never resolves and blocks every merge with "the base branch
+    policy prohibits the merge" (vergil-project/vergil-tooling#2647)."""
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=False, docs=False)
+    assert "docs / docs" not in _check_names(ruleset)
+
+
+# `docs / docs` is deliberately absent here — it is conditional on
+# `[publish].docs` (see the two tests above), not universal.
 UNIVERSAL_REUSABLE_CI_CHECKS = frozenset(
     {
         "quality / common",
         "security / trivy",
         "security / semgrep",
-        "docs / docs",
         "version / version-bump",
     }
 )
@@ -512,13 +515,14 @@ def _vergil_config(
     release_model: str = "tagged-release",
     versions: list[str] | None = None,
     integration_tests: bool = False,
+    docs: bool = True,
 ) -> VergilConfig:
     return VergilConfig(
         project=_project(language=language, release_model=release_model),
         dependencies={"vergil": "v1.4"},
         markdownlint=MarkdownlintConfig(ignore=[]),
         ci=_ci(versions=versions or ["3.14"], integration_tests=integration_tests),
-        publish=PublishConfig(release=False, docs=True, consumer_refresh=None),
+        publish=PublishConfig(release=False, docs=docs, consumer_refresh=None),
         container=ContainerConfig(env_prefixes=[]),
         validation=ValidationConfig(container_command=DEFAULT_VALIDATION_COMMAND),
     )
@@ -545,6 +549,21 @@ def test_compute_desired_state_has_three_rulesets() -> None:
     assert "Branch protection" in names
     assert "Tag protection" in names
     assert "CI gates" in names
+
+
+def test_compute_desired_state_omits_docs_gate_when_publish_docs_false() -> None:
+    """`[publish].docs = false` must flow through to the CI-gates ruleset, so a
+    non-docs repo's branch protection never requires the never-reported
+    `docs / docs` check (vergil-project/vergil-tooling#2647)."""
+    state = compute_desired_state(_vergil_config(docs=False), visibility="public", is_org=True)
+    gates = next(r for r in state.rulesets if r.name == "CI gates")
+    assert "docs / docs" not in _check_names(gates)
+
+
+def test_compute_desired_state_keeps_docs_gate_when_publish_docs_true() -> None:
+    state = compute_desired_state(_vergil_config(docs=True), visibility="public", is_org=True)
+    gates = next(r for r in state.rulesets if r.name == "CI gates")
+    assert "docs / docs" in _check_names(gates)
 
 
 def test_compute_desired_state_private_without_ghas_drops_alert_checks() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Gate the docs / docs required status check on [publish].docs so non-docs repos (whose CI never emits it) are no longer permanently blocked from merging.

## Issue Linkage

- Closes #2647

## Notes

- Root cause of the finalize-merge failure on logical-minds-foundry/.github#178. desired_ci_gates_ruleset required docs / docs unconditionally; a [publish].docs=false repo never reports that context, so GitHub kept the PR BLOCKED ('base branch policy prohibits the merge'). Fix gates it on the publish-docs flag and threads the flag through required_evidence_gates to keep enforced and evidence-required gates aligned. Tests: unit (docs true/false) + end-to-end through compute_desired_state; validation green, 100% cov. Fleet re-sync of already-synced repos is the paired deploy task #2648.