### PR TITLE
fix(vrg-vm): --resume accepts bare label (validate workspace); remove --fork

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm.py
+++ b/src/vergil_tooling/bin/vrg_vm.py
@@ -2378,8 +2378,6 @@ def _session_inner(
         resolve_cmd += ["--resume-name", args.resume]
     if getattr(args, "label", None) is not None:
         resolve_cmd += ["--label", args.label]
-    if args.fork:
-        resolve_cmd += ["--fork"]
     if args.fresh:
         resolve_cmd += ["--fresh"]
     if extra:
@@ -2448,18 +2446,18 @@ def _cloud_session(target: Target, args: argparse.Namespace) -> int:
 
 
 def _cmd_session(args: argparse.Namespace) -> int:
-    if args.resume is not None and (args.fork or args.fresh):
+    if args.resume is not None and args.fresh:
         print(
             "ERROR: --resume attaches to a session by its exact name and cannot be "
-            "combined with --fork/--fresh.",
+            "combined with --fresh.",
             file=sys.stderr,
         )
         return 1
-    if getattr(args, "label", None) is not None and (args.resume is not None or args.fork):
+    if getattr(args, "label", None) is not None and args.resume is not None:
         print(
             "ERROR: --label creates a new named session and cannot be combined with "
-            "--resume (attach) or --fork. (Pair it with --fresh to retire a prior "
-            "same-named session and start clean.)",
+            "--resume (attach). (Pair it with --fresh to retire a prior same-named "
+            "session and start clean.)",
             file=sys.stderr,
         )
         return 1
@@ -2802,11 +2800,13 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         metavar="NAME",
         help=(
-            "Attach to the session with this exact name (e.g. "
-            "'epic-85-centralize-epics:vergil-project/tooling'). Resolves the name to "
-            "one session and derives its working directory from that session. With no "
-            "verb, the workspace's sessions are listed and --label/--resume are named. "
-            "Mutually exclusive with --fork/--fresh."
+            "Attach to a session by name. Accepts a bare label (e.g. "
+            "'epic-85-centralize-epics'), composed with the workspace positional into "
+            "'<label>:<workspace>' — symmetric with --label. A full 'label:workspace' is "
+            "also accepted, but its workspace segment must match the workspace positional. "
+            "Resolves the name to one session and derives its working directory from that "
+            "session. With no verb, the workspace's sessions are listed and --label/--resume "
+            "are named. Mutually exclusive with --fresh."
         ),
     )
     p_session.add_argument(
@@ -2818,13 +2818,8 @@ def main(argv: list[str] | None = None) -> int:
             "--label epic-213-x). The label is a clean slug; an epic-/adhoc- prefix "
             "is the convention (off-convention warns, never blocks). Errors if a "
             "session of that name already exists (add --fresh to retire that prior "
-            "session and start clean). Mutually exclusive with --resume/--fork."
+            "session and start clean). Mutually exclusive with --resume."
         ),
-    )
-    p_session.add_argument(
-        "--fork",
-        action="store_true",
-        help="Fork the resolved session into a new session instead of resuming it",
     )
     p_session.add_argument(
         "--fresh",

--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -349,12 +349,12 @@ def _note(message: str) -> None:
 
 
 def _execute(action: Decision, extra: list[str]) -> int:
-    """Carry out a ``--fork`` / ``--fresh`` plan action.
+    """Carry out a ``--fresh`` plan action.
 
     With ``--slot`` and the auto-resume-most-recent default gone (#2607), the only
     actions that still reach here are ``Create`` (``--fresh`` creating a fresh
-    session in the target slot) and ``Refuse`` (``--fork`` with no slot to
-    target). Exact-name attach (``--resume``) resolves through the seam in
+    session in the target slot) and ``Refuse`` (``--fresh`` over a live or
+    exhausted slot). Exact-name attach (``--resume``) resolves through the seam in
     :func:`_resume_by_name`, not here.
     """
     if isinstance(action, Refuse):
@@ -363,8 +363,8 @@ def _execute(action: Decision, extra: list[str]) -> int:
     if isinstance(action, Create):
         _note(f"Creating session {action.name}")
         return _exec_claude(["-n", action.name, *extra])
-    # Resume/Fork were the other slot-selection outcomes; neither is reachable
-    # now that selection is by exact name. Guard loudly rather than mis-exec.
+    # Resume was the other slot-selection outcome; it is not reachable now that
+    # selection is by exact name. Guard loudly rather than mis-exec.
     raise RuntimeError(f"unexpected session action {type(action).__name__}")  # pragma: no cover
 
 
@@ -387,6 +387,31 @@ def plan_resume(store: SessionStore, name: str) -> SessionInfo:
         print(f"ERROR: no session named {name!r} — create it with --label", file=sys.stderr)
         raise SystemExit(1)
     return info
+
+
+def _compose_resume_name(resume_name: str, path: str) -> str:
+    """Resolve a ``--resume`` argument to the exact session name to attach to.
+
+    ``--resume`` is symmetric with ``--label``: it accepts a **bare** ``<label>``
+    and composes ``<label>:<workspace>`` from the required workspace positional
+    (``path``). A **full** ``label:workspace`` name is still accepted for
+    back-compat, but its workspace segment (everything after the final ``:``, so
+    a legacy ``<identity>:<NN>:<path>`` name resolves correctly too) MUST equal
+    the command-line workspace positional. On a mismatch this fails loud rather
+    than silently preferring either the name's workspace or the positional.
+    """
+    if ":" not in resume_name:
+        return make_label_name(resume_name, path)
+    _label, workspace = resume_name.rsplit(":", 1)
+    if workspace != path:
+        print(
+            f"ERROR: --resume {resume_name!r} targets workspace {workspace!r}, but the "
+            f"command line names workspace {path!r}; they must match. Pass just the bare "
+            f"label to compose the name from the workspace positional.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return resume_name
 
 
 def _resume_by_name(name: str, extra: list[str]) -> int:
@@ -552,7 +577,6 @@ def _resolve_fresh(path: str, label: str, stamp: str, extra: list[str]) -> int:
 def resolve(
     identity: str,
     path: str,
-    fork: bool,
     fresh: bool,
     extra: list[str],
     resume_name: str | None = None,
@@ -567,26 +591,28 @@ def resolve(
     session of that name via a supported rename and creates a fresh one in its
     place (see :func:`_resolve_fresh`) — the transcript is never deleted (#2609).
 
-    ``resume_name`` (``--resume``) resolves an exact session name to a session id
-    through the ``SessionStore`` seam and attaches to it, deriving the bootstrap
-    cwd from the resolved session (#2607). With no verb the recency list + the two
-    verbs are printed and a nonzero code returned — there is no auto-resume-most-
-    recent / auto-create default and no ``--slot``. ``fork`` (and ``fresh`` without
-    a ``label``) retain the legacy slot machinery; auto-archive and the staleness
-    sweep are gone (#2608).
+    ``resume_name`` (``--resume``) accepts a bare ``<label>`` (composed with the
+    workspace positional, symmetric with ``--label``) or a full ``label:workspace``
+    whose workspace segment must match the positional (see
+    :func:`_compose_resume_name`); it then resolves that exact name to a session id
+    through the ``SessionStore`` seam and attaches, deriving the bootstrap cwd from
+    the resolved session (#2607). With no verb the recency list + the two verbs are
+    printed and a nonzero code returned — there is no auto-resume-most-recent /
+    auto-create default and no ``--slot``. ``fresh`` (without a ``label``) retains
+    the legacy slot machinery; auto-archive and the staleness sweep are gone (#2608).
     """
     if label is not None:
         if fresh:
             return _resolve_fresh(path, label, _now_stamp(), extra)
         return _resolve_label(path, label, extra)
     if resume_name is not None:
-        return _resume_by_name(resume_name, extra)
+        return _resume_by_name(_compose_resume_name(resume_name, path), extra)
     slug = _project_slug(str(Path.cwd()))
-    if not fork and not fresh:
+    if not fresh:
         return _list_and_guide(slug)
     names, active, last_active = _read_state(slug)
     slots = build_slots(identity, path, names, active, last_active)
-    action = plan_session(identity, path, slots, None, fork, fresh)
+    action = plan_session(identity, path, slots, None, fresh)
     return _execute(action, extra)
 
 
@@ -617,7 +643,6 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="vrg-vm-resolve-session")
     parser.add_argument("--identity")
     parser.add_argument("--path")
-    parser.add_argument("--fork", action="store_true")
     parser.add_argument("--fresh", action="store_true")
     parser.add_argument("--resume-name", dest="resume_name", default=None)
     parser.add_argument("--label", dest="label", default=None)
@@ -638,7 +663,6 @@ def main(argv: list[str] | None = None) -> int:
     return resolve(
         args.identity,
         args.path,
-        args.fork,
         args.fresh,
         extra,
         args.resume_name,

--- a/src/vergil_tooling/lib/session.py
+++ b/src/vergil_tooling/lib/session.py
@@ -1,8 +1,8 @@
 """Deterministic Claude Code session naming and slot selection.
 
-Pure logic: given the existing slots for an identity + workspace path and the
-caller's ``--slot`` / ``--fork`` choices, decide whether to create, resume, or
-fork a session — or refuse. No I/O lives here, so every rule is unit-testable.
+Pure logic: given the existing slots for an identity + workspace path, decide
+whether to create or resume a session — or refuse. No I/O lives here, so every
+rule is unit-testable.
 
 Naming scheme::
 
@@ -129,21 +129,13 @@ class Resume:
 
 
 @dataclass(frozen=True)
-class Fork:
-    """Fork an existing session into a new named session."""
-
-    session_id: str
-    name: str
-
-
-@dataclass(frozen=True)
 class Refuse:
     """Refuse to act, with a user-facing reason."""
 
     message: str
 
 
-Decision = Create | Resume | Fork | Refuse
+Decision = Create | Resume | Refuse
 
 
 @dataclass(frozen=True)
@@ -293,15 +285,12 @@ def select(
     path: str,
     slots: dict[int, Slot],
     requested_slot: int | None = None,
-    fork: bool = False,
 ) -> Decision:
     """Decide what to do for ``identity`` + ``path`` given existing ``slots``.
 
     ``slots`` maps slot number to :class:`Slot`. ``requested_slot`` is the
-    explicit ``--slot N`` (or ``None``). ``fork`` is the ``--fork`` flag.
+    explicit ``--slot N`` (or ``None``).
     """
-    if fork:
-        return _select_fork(identity, path, slots, requested_slot)
     if requested_slot is not None:
         return _select_explicit(identity, path, slots, requested_slot)
     return _select_default(identity, path, slots)
@@ -326,26 +315,8 @@ def _select_explicit(identity: str, path: str, slots: dict[int, Slot], slot: int
     if info is None:
         return Create(make_name(identity, slot, path))
     if info.active:
-        return Refuse(f"slot {slot:02d} is active; use --fork to branch it into a new session")
+        return Refuse(f"slot {slot:02d} is active")
     return Resume(info.session_id)
-
-
-def _select_fork(identity: str, path: str, slots: dict[int, Slot], slot: int | None) -> Decision:
-    """``--fork``: copy the targeted slot's conversation into a new slot."""
-    if slot is None:
-        return Refuse(
-            "--fork has no session to fork; use --resume NAME to attach to a "
-            "session or --label to start a new one"
-        )
-    if not SLOT_MIN <= slot <= SLOT_MAX:
-        return _bad_range()
-    info = slots.get(slot)
-    if info is None:
-        return Refuse(f"slot {slot:02d} does not exist; nothing to fork")
-    free = _lowest_free(slots)
-    if free is None:
-        return _all_in_use(identity, path)
-    return Fork(info.session_id, make_name(identity, free, path))
 
 
 def select_by_name(
@@ -396,20 +367,17 @@ def plan_session(
     path: str,
     slots: dict[int, Slot],
     requested_slot: int | None = None,
-    fork: bool = False,
     fresh: bool = False,
 ) -> Decision:
-    """Plan a ``--fork`` / ``--fresh`` session launch (legacy slot machinery).
+    """Plan a ``--fresh`` session launch (legacy slot machinery).
 
     Auto-archive and the staleness bands are gone (issue #2608), so a plan is now
     a single :class:`Decision` — there is no set of cold slots to sweep. The only
-    remaining callers are ``--fork`` and ``--fresh`` (create/resume-by-name is the
-    supported path via the seam); the no-verb default is handled by the resolver.
-    ``--fresh`` here simply creates a fresh session in the target slot — the
-    supported *retire-rename* of the prior session is a separate change (Task 5).
+    remaining caller is ``--fresh`` (create/resume-by-name is the supported path
+    via the seam); the no-verb default is handled by the resolver. ``--fresh``
+    here simply creates a fresh session in the target slot — the supported
+    *retire-rename* of the prior session is a separate change (Task 5).
     """
-    if fork:
-        return _select_fork(identity, path, slots, requested_slot)
     if fresh:
         return _plan_fresh(identity, path, slots, requested_slot)
     if requested_slot is not None:

--- a/tests/vergil_tooling/test_session.py
+++ b/tests/vergil_tooling/test_session.py
@@ -5,7 +5,6 @@ import pytest
 from vergil_tooling.lib.session import (
     SLOT_MAX,
     Create,
-    Fork,
     Refuse,
     Resume,
     SessionRow,
@@ -115,7 +114,7 @@ def test_parse_name_rejects_out_of_range_slot() -> None:
     assert parse_name("id:00:path") is None
 
 
-# --- default selection (no --slot, no --fork) ---
+# --- default selection (no --slot) ---
 
 
 def test_default_creates_first_slot_when_none_exist() -> None:
@@ -155,48 +154,16 @@ def test_explicit_resumes_idle_slot() -> None:
     assert select("vergil", "p", slots, requested_slot=3) == Resume("sid-3")
 
 
-def test_explicit_refuses_active_slot_with_fork_hint() -> None:
+def test_explicit_refuses_active_slot() -> None:
     slots = {3: Slot(3, "sid-3", active=True)}
     result = select("vergil", "p", slots, requested_slot=3)
     assert isinstance(result, Refuse)
-    assert "--fork" in result.message
+    assert "active" in result.message
 
 
 def test_explicit_rejects_out_of_range_slot() -> None:
     assert isinstance(select("vergil", "p", {}, requested_slot=0), Refuse)
     assert isinstance(select("vergil", "p", {}, requested_slot=100), Refuse)
-
-
-# --- --fork ---
-
-
-def test_fork_without_target_refuses() -> None:
-    result = select("vergil", "p", {}, fork=True)
-    assert isinstance(result, Refuse)
-    assert "--slot" not in result.message
-    assert "--fork" in result.message
-
-
-def test_fork_rejects_out_of_range_slot() -> None:
-    assert isinstance(select("vergil", "p", {}, requested_slot=0, fork=True), Refuse)
-
-
-def test_fork_refuses_nonexistent_slot() -> None:
-    result = select("vergil", "p", {}, requested_slot=2, fork=True)
-    assert isinstance(result, Refuse)
-    assert "does not exist" in result.message
-
-
-def test_fork_branches_active_slot_into_next_free() -> None:
-    slots = {1: Slot(1, "sid-1", active=True)}
-    assert select("vergil", "p", slots, requested_slot=1, fork=True) == Fork("sid-1", "vergil:02:p")
-
-
-def test_fork_refuses_when_all_slots_in_use() -> None:
-    slots = {n: Slot(n, f"sid-{n}", active=True) for n in range(1, SLOT_MAX + 1)}
-    result = select("vergil", "p", slots, requested_slot=1, fork=True)
-    assert isinstance(result, Refuse)
-    assert "all 99 slots" in result.message
 
 
 # --- build_slots ---
@@ -401,7 +368,7 @@ def test_filter_recent_boundary_is_inclusive() -> None:
     assert filter_recent(rows, NOW, 7) == rows
 
 
-# --- plan_session (legacy --fork / --fresh slot machinery; archive removed) ---
+# --- plan_session (legacy --fresh slot machinery; archive removed) ---
 
 
 def _slot(n: int, sid: str, active: bool = False, age_days: float = 0.0) -> Slot:
@@ -411,7 +378,6 @@ def _slot(n: int, sid: str, active: bool = False, age_days: float = 0.0) -> Slot
 def _plan(slots: dict[int, Slot], **kw: object) -> object:
     defaults: dict[str, object] = {
         "requested_slot": None,
-        "fork": False,
         "fresh": False,
     }
     defaults.update(kw)
@@ -455,11 +421,6 @@ def test_plan_fresh_bad_range_refused() -> None:
 def test_plan_fresh_all_slots_in_use() -> None:
     slots = {n: _slot(n, f"s{n}", active=True, age_days=1) for n in range(1, SLOT_MAX + 1)}
     assert isinstance(_plan(slots, fresh=True), Refuse)
-
-
-def test_plan_fork_unchanged() -> None:
-    plan = _plan({1: _slot(1, "s1", active=True, age_days=1)}, requested_slot=1, fork=True)
-    assert plan == Fork("s1", "vergil:02:p")
 
 
 def test_plan_no_slots_creates_first() -> None:

--- a/tests/vergil_tooling/test_vrg_vm.py
+++ b/tests/vergil_tooling/test_vrg_vm.py
@@ -2224,7 +2224,7 @@ class TestSession:
         with pytest.raises(SystemExit):
             main(["session", "--config", str(config_file), "--slot", "3", "vergil-tooling"])
 
-    def test_session_fork_passed_to_resolver(
+    def test_session_fork_flag_removed(
         self,
         _age: MagicMock,
         _copy: MagicMock,
@@ -2232,10 +2232,9 @@ class TestSession:
         mock_exec: MagicMock,
         config_file: Path,
     ) -> None:
-        main(["session", "--config", str(config_file), "--fork", "vergil-tooling"])
-        inner = self._inner(mock_exec)
-        assert "--fork" in inner
-        assert "--slot" not in inner
+        # --fork is removed (#2653): argparse rejects it as an unrecognized flag.
+        with pytest.raises(SystemExit):
+            main(["session", "--config", str(config_file), "--fork", "vergil-tooling"])
 
     def test_session_resume_passed_to_resolver(
         self,
@@ -2314,7 +2313,7 @@ def test_session_inner_strips_leading_double_dash() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False, resume=None)
+    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "")
     assert "exec bash" in inner
     assert "vrg-vm-resolve-session" not in inner
@@ -2325,7 +2324,7 @@ def test_session_inner_raw_override_ignores_model() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fork=False, fresh=False, resume=None)
+    ns = argparse.Namespace(cmd=["--", "bash"], slot=None, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "opus")
     assert "exec bash" in inner
     assert "--model" not in inner
@@ -2336,7 +2335,7 @@ def test_session_inner_omits_deleted_thresholds() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None)
+    ns = argparse.Namespace(cmd=[], slot=None, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "")
     # session_stale_days / session_archive_days are deleted (#2608): the resolver
     # is no longer handed any staleness thresholds.
@@ -2349,7 +2348,7 @@ def test_session_inner_fresh_flag() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=True, resume=None)
+    ns = argparse.Namespace(cmd=[], slot=None, fresh=True, resume=None)
     inner = _session_inner(ns, "vergil", "p", "")
     assert "--fresh" in inner
 
@@ -2359,7 +2358,7 @@ def test_session_inner_sources_conan_env() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume=None)
+    ns = argparse.Namespace(cmd=[], slot=None, fresh=False, resume=None)
     inner = _session_inner(ns, "vergil", "p", "")
     assert "conan.env" in inner
     assert "claude.env" in inner
@@ -2370,7 +2369,7 @@ def test_session_inner_resume_name() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], slot=None, fork=False, fresh=False, resume="epic-85-adhoc")
+    ns = argparse.Namespace(cmd=[], slot=None, fresh=False, resume="epic-85-adhoc")
     inner = _session_inner(ns, "vergil", "p", "")
     assert "--resume-name epic-85-adhoc" in inner
 
@@ -2380,7 +2379,7 @@ def test_session_inner_label() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], fork=False, fresh=False, resume=None, label="epic-1")
+    ns = argparse.Namespace(cmd=[], fresh=False, resume=None, label="epic-1")
     inner = _session_inner(ns, "vergil", "p", "")
     assert "--label epic-1" in inner
 
@@ -2392,7 +2391,7 @@ def test_session_inner_fresh_with_label() -> None:
 
     from vergil_tooling.bin.vrg_vm import _session_inner
 
-    ns = argparse.Namespace(cmd=[], fork=False, fresh=True, resume=None, label="epic-1")
+    ns = argparse.Namespace(cmd=[], fresh=True, resume=None, label="epic-1")
     inner = _session_inner(ns, "vergil", "p", "")
     assert "--label epic-1" in inner
     assert "--fresh" in inner
@@ -2403,27 +2402,16 @@ def test_cmd_session_rejects_label_with_resume() -> None:
 
     from vergil_tooling.bin.vrg_vm import _cmd_session
 
-    ns = argparse.Namespace(resume="epic-85", fork=False, fresh=False, label="epic-1")
+    ns = argparse.Namespace(resume="epic-85", fresh=False, label="epic-1")
     assert _cmd_session(ns) == 1
 
 
-def test_cmd_session_rejects_label_with_fork() -> None:
-    # --label + --fork stays rejected (fork is a distinct verb); only --fresh now
-    # combines with --label (issue #2609).
+def test_cmd_session_rejects_resume_with_fresh() -> None:
     import argparse
 
     from vergil_tooling.bin.vrg_vm import _cmd_session
 
-    ns = argparse.Namespace(resume=None, fork=True, fresh=False, label="epic-1")
-    assert _cmd_session(ns) == 1
-
-
-def test_cmd_session_rejects_resume_with_fork() -> None:
-    import argparse
-
-    from vergil_tooling.bin.vrg_vm import _cmd_session
-
-    ns = argparse.Namespace(resume="epic-85", fork=True, fresh=False)
+    ns = argparse.Namespace(resume="epic-85", fresh=True, label=None)
     assert _cmd_session(ns) == 1
 
 

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -399,7 +399,6 @@ def _resolve(
     **kw: object,
 ) -> int:
     defaults: dict[str, object] = {
-        "fork": False,
         "fresh": False,
         "extra": [],
     }
@@ -496,8 +495,13 @@ def test_resolve_label_rejects_invalid_slug(
 def test_resolve_refuse(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # A Refuse from the plan (e.g. --fresh with every slot in use) prints ERROR and
+    # exits 1 without ever exec'ing claude.
+    from vergil_tooling.lib.session import Refuse
+
     monkeypatch.setattr(r, "_read_state", lambda *_a: ({}, set(), {}))
-    assert _resolve("id", "p", fork=True) == 1  # fork without slot refuses (no --slot)
+    monkeypatch.setattr(r, "plan_session", lambda *_a, **_k: Refuse("all 99 slots are in use"))
+    assert _resolve("vergil", "p", fresh=True) == 1
     assert "ERROR" in capsys.readouterr().err
 
 
@@ -717,7 +721,7 @@ def test_resume_by_name_execs_with_resolved_id_and_cwd(
     monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
     chdirs: list[str] = []
     monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
-    assert _resolve("id", "p", resume_name="epic-1:w") == 0
+    assert _resolve("id", "w", resume_name="epic-1:w") == 0
     assert chdirs == ["/work/repo"]
     assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
     assert "Resuming session epic-1:w" in capsys.readouterr().err
@@ -750,9 +754,78 @@ def test_resume_by_name_skips_chdir_when_cwd_unknown(
     monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
     chdirs: list[str] = []
     monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
-    assert _resolve("id", "p", resume_name="epic-1:w") == 0
+    assert _resolve("id", "w", resume_name="epic-1:w") == 0
     assert chdirs == []
     assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
+
+
+# --- --resume argument composition (issue #2653: bare label + workspace match) ---
+
+
+def test_compose_resume_name_composes_bare_label() -> None:
+    # A bare label (no ':') is composed with the workspace positional, symmetric
+    # with --label.
+    assert r._compose_resume_name("epic-1", "vergil-project/tooling") == (
+        "epic-1:vergil-project/tooling"
+    )
+
+
+def test_compose_resume_name_accepts_full_name_matching_workspace() -> None:
+    # A full 'label:workspace' whose workspace segment equals the positional is
+    # accepted unchanged (back-compat).
+    assert r._compose_resume_name("epic-1:w", "w") == "epic-1:w"
+
+
+def test_compose_resume_name_accepts_legacy_multicolon_matching_workspace() -> None:
+    # A legacy '<identity>:<NN>:<path>' name has two colons; the workspace segment
+    # is the part after the FINAL ':', so it still matches its positional.
+    name = "vergil-user:02:vergil-project/vergil-tooling"
+    assert r._compose_resume_name(name, "vergil-project/vergil-tooling") == name
+
+
+def test_compose_resume_name_rejects_mismatched_workspace(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A full name whose workspace segment disagrees with the positional fails loud
+    # rather than silently preferring either side.
+    with pytest.raises(SystemExit):
+        r._compose_resume_name("epic-1:other", "w")
+    err = capsys.readouterr().err
+    assert "must match" in err
+    assert "'other'" in err
+    assert "'w'" in err
+
+
+def test_resume_bare_label_composes_and_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # End to end: --resume with a bare label composes '<label>:<workspace>' from the
+    # workspace positional, resolves it through the seam, and execs the resume.
+    store = _FakeStore([_info("b", "epic-1:w", False, 5.0, cwd="/work/repo")])
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    monkeypatch.setattr(os, "chdir", lambda _p: None)
+    assert _resolve("id", "w", resume_name="epic-1") == 0
+    assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
+    assert "Resuming session epic-1:w" in capsys.readouterr().err
+
+
+def test_resume_full_name_mismatched_workspace_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A full name whose workspace disagrees with the positional aborts before any
+    # store read or exec.
+    def _boom(*_a: object, **_k: object) -> object:
+        raise AssertionError("store must not be consulted on a workspace mismatch")
+
+    monkeypatch.setattr(r, "ScrapeStore", _boom)
+    with pytest.raises(SystemExit):
+        _resolve("id", "w", resume_name="epic-1:other")
+    assert capture_exec == []
+    assert "must match" in capsys.readouterr().err
 
 
 def test_no_verb_guide_when_no_sessions(
@@ -835,7 +908,7 @@ def test_resume_by_name_reasserts_requested_title_over_archived_2602(
     monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
     chdirs: list[str] = []
     monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
-    assert _resolve("id", "p", resume_name=_REQUESTED) == 0
+    assert _resolve("id", "vergil-project/vergil-tooling", resume_name=_REQUESTED) == 0
     assert chdirs == ["/work/repo"]  # requested session's cwd, not the archived /stale
     assert capture_exec == [["claude", "--resume", "want", "-n", _REQUESTED]]
     assert _ARCHIVED not in capsys.readouterr().err
@@ -995,8 +1068,8 @@ def test_main_dispatches_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(r, "resolve", fake_resolve)
     code = r.main(["--identity", "id", "--path", "p", "--fresh", "x"])
     assert code == 0
-    # args order: identity, path, fork, fresh, extra, resume_name, label
-    assert seen["args"] == ("id", "p", False, True, ["x"], None, None)
+    # args order: identity, path, fresh, extra, resume_name, label
+    assert seen["args"] == ("id", "p", True, ["x"], None, None)
 
 
 def test_main_passes_resume_name(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1024,7 +1097,7 @@ def test_main_strips_leading_double_dash(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(
         r,
         "resolve",
-        lambda *args: captured.update(extra=args[4]) or 0,  # noqa: ARG005
+        lambda *args: captured.update(extra=args[3]) or 0,  # noqa: ARG005
     )
     r.main(["--identity", "id", "--path", "p", "--", "claude", "--model", "opus"])
     assert captured["extra"] == ["claude", "--model", "opus"]
@@ -1072,7 +1145,10 @@ def test_resume_by_name_scans_all_slugs_and_derives_cwd(
     monkeypatch.setattr(r, "_claude_dir", lambda: claude)
     chdirs: list[str] = []
     monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
-    assert _resolve("id", "somewhere-else", resume_name="epic-7:tool") == 0
+    # The workspace positional matches the name's workspace segment ("tool"), but the
+    # session's transcript-recorded cwd ("/work/tool") is a different path and is what
+    # the resolver chdirs to — the memory slug follows the session, not the positional.
+    assert _resolve("id", "tool", resume_name="epic-7:tool") == 0
     assert chdirs == ["/work/tool"]
     assert capture_exec == [["claude", "--resume", "good", "-n", "epic-7:tool"]]
 


### PR DESCRIPTION
# Pull Request

## Summary

- Make vrg-vm session --resume symmetric with --label (accept a bare label composed with the workspace positional, reject a full name whose workspace segment mismatches) and remove the orphaned --fork flag and its dead plumbing.

## Issue Linkage

- Closes #2653

## Notes

- A: --resume composition/validation lives in the resolver's new _compose_resume_name; the workspace segment is taken after the final colon so legacy identity:NN:path names still resolve. B: removed the --fork CLI flag, resolver exec path, the fork branch in plan_session, and the Fork decision + _select_fork in session.lib; the no-double-attach guardrail (AmbiguousSessionError fail-loud) is separate and retained. Tests: added bare-label resume, full-name match, and mismatch-rejection cases; removed fork-only tests. vrg-validate green (4639 passed, 100% coverage). Docs note: vergil-vm doc-review #291 must be updated for both changes (session docs live there, out of this repo).