### PR TITLE
fix(vrg-vm): detect --label collision before the name registers (#2654)

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -18,6 +18,7 @@ import datetime
 import json
 import os
 import sys
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -344,11 +345,22 @@ def _exec_claude(args: list[str]) -> int:
     return 0  # reached only when execvp is stubbed (tests)
 
 
+def _new_session_id() -> str:
+    """A fresh session id to pin a created session to via ``claude --session-id``.
+
+    Minting the id here — rather than letting claude choose it — is what lets the
+    ``--label`` create path reserve the name against this exact id *before* exec
+    (#2654), so the reservation and the session claude adopts are the same row. A
+    seam so tests can pin it deterministically (mirrors :func:`_now_stamp`).
+    """
+    return str(uuid.uuid4())
+
+
 def _note(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def _execute(action: Decision, extra: list[str]) -> int:
+def _execute(action: Decision, extra: list[str], session_id: str | None = None) -> int:
     """Carry out a ``--fresh`` plan action.
 
     With ``--slot`` and the auto-resume-most-recent default gone (#2607), the only
@@ -356,13 +368,19 @@ def _execute(action: Decision, extra: list[str]) -> int:
     session in the target slot) and ``Refuse`` (``--fresh`` over a live or
     exhausted slot). Exact-name attach (``--resume``) resolves through the seam in
     :func:`_resume_by_name`, not here.
+
+    ``session_id`` pins the created session to a specific id via ``--session-id``.
+    The ``--label`` create paths pass the id they reserved the name against (#2654)
+    so the reservation and the real session are one; the legacy slot ``Create`` path
+    passes ``None`` and keeps letting claude mint the id.
     """
     if isinstance(action, Refuse):
         print(f"ERROR: {action.message}", file=sys.stderr)
         return 1
     if isinstance(action, Create):
         _note(f"Creating session {action.name}")
-        return _exec_claude(["-n", action.name, *extra])
+        prefix = ["--session-id", session_id] if session_id is not None else []
+        return _exec_claude([*prefix, "-n", action.name, *extra])
     # Resume was the other slot-selection outcome; it is not reachable now that
     # selection is by exact name. Guard loudly rather than mis-exec.
     raise RuntimeError(f"unexpected session action {type(action).__name__}")  # pragma: no cover
@@ -464,7 +482,14 @@ def _resolve_label(path: str, label: str, extra: list[str]) -> int:
     ``label:workspace``, and refuse if a **visible** session already holds that
     name — creation must never silently shadow an existing session, so a collision
     (one match, or ambiguously many) is an error directing the user to ``--resume``
-    it or pick another label. Otherwise exec the existing ``Create`` path.
+    it or pick another label. Otherwise reserve the name and exec ``Create``.
+
+    The reservation (keyed by the ``--session-id`` the new session is pinned to) is
+    written *before* the exec so the name is resolvable the instant this create is
+    decided. That closes the registration-latency race (#2654): a rapid second
+    ``--label`` for the same name sees the reservation and refuses, rather than
+    racily creating a duplicate while claude has yet to write the first session's
+    transcript ``custom-title`` / roster ``name``.
     """
     try:
         warnings = validate_label(label)
@@ -487,7 +512,9 @@ def _resolve_label(path: str, label: str, extra: list[str]) -> int:
             file=sys.stderr,
         )
         return 1
-    return _execute(Create(name), extra)
+    session_id = _new_session_id()
+    store.reserve_name(session_id, name, str(Path.cwd()))
+    return _execute(Create(name), extra, session_id)
 
 
 def retired_name(name: str, stamp: str) -> str:
@@ -571,7 +598,9 @@ def _resolve_fresh(path: str, label: str, stamp: str, extra: list[str]) -> int:
         old_session_id, retired = plan.retire
         store.rename(old_session_id, retired)
         _note(f"Retired prior session {name} -> {retired}")
-    return _execute(Create(plan.name), extra)
+    session_id = _new_session_id()
+    store.reserve_name(session_id, plan.name, str(Path.cwd()))
+    return _execute(Create(plan.name), extra, session_id)
 
 
 def resolve(

--- a/src/vergil_tooling/lib/session_store.py
+++ b/src/vergil_tooling/lib/session_store.py
@@ -17,11 +17,21 @@ loud**, and otherwise the most-recently-active idle session wins.
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+# How long a name reservation (see ``ScrapeStore.reserve_name``) stays visible
+# before it is ignored/swept. A reservation only has to bridge the gap between a
+# ``--label`` create and claude writing that session's transcript/roster name —
+# a few seconds. The TTL just bounds a *stale* reservation whose session never
+# materialized (claude aborted before registering); it is generous because a
+# session that did start is superseded by its real transcript entry long before
+# it expires, so the TTL never truncates a live session's visibility.
+_RESERVATION_TTL_SECONDS = 600.0
 
 
 @dataclass(frozen=True)
@@ -91,6 +101,17 @@ class SessionStore(Protocol):
         """Rename a (possibly detached) session — the backend's supported path."""
         ...  # pragma: no cover
 
+    def reserve_name(self, session_id: str, name: str, cwd: str = "") -> None:
+        """Record a just-created session's name *synchronously*, before it registers.
+
+        Closes the ``--label`` uniqueness race (#2654): the name is visible to the
+        next resolver read immediately, without waiting for claude's asynchronous
+        transcript ``custom-title`` / roster ``name`` write. ``session_id`` must be
+        the id claude is pinned to (``--session-id``) so the reservation and the
+        real session resolve to a single row, never a duplicate.
+        """
+        ...  # pragma: no cover
+
 
 class ScrapeStore:
     """``SessionStore`` backed by the transcript/roster scrape.
@@ -106,8 +127,14 @@ class ScrapeStore:
     here, inside the seam's scrape backend; every other code path renames via a
     supported interface.
 
+    ``reserve_name`` adds a third, eager name source — a vrg-owned reservation file
+    written synchronously at ``--label`` create time — that the union in
+    ``list_sessions`` reads at lowest precedence to close the registration-latency
+    race (#2654); the authoritative transcript/roster names win on overlap.
+
     ``slug`` optionally scopes the transcript read to a single project slug (the
-    same scoping ``claude --resume`` uses); ``None`` scans every slug.
+    same scoping ``claude --resume`` uses); ``None`` scans every slug. The
+    reservation read is unscoped: a name is checked for global uniqueness.
     """
 
     def __init__(self, claude_dir: Path, slug: str | None = None) -> None:
@@ -122,6 +149,77 @@ class ScrapeStore:
     def _sessions_dir(self) -> Path:
         return self._claude_dir / "sessions"
 
+    @property
+    def _reservations_dir(self) -> Path:
+        # vrg-owned, VM-local, namespaced so claude never touches it. Holds the
+        # eager ``--label`` name reservations that bridge the registration-latency
+        # window (#2654). Distinct from claude's own ``sessions`` roster.
+        return self._claude_dir / "vrg-session-reservations"
+
+    def _read_reservations(self) -> dict[str, dict[str, object]]:
+        """Live name reservations by session id, expired ones filtered out.
+
+        A read-only view: it never deletes (that is the write-time sweep's job),
+        it only *ignores* a reservation past :data:`_RESERVATION_TTL_SECONDS` so a
+        stale one whose session never materialized cannot pin a name forever.
+        """
+        out: dict[str, dict[str, object]] = {}
+        reservations = self._reservations_dir
+        if not reservations.is_dir():
+            return out
+        now = time.time()
+        for path in sorted(reservations.glob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            sid = data.get("sessionId")
+            name = data.get("name")
+            created = data.get("createdAt")
+            if not isinstance(sid, str) or not isinstance(name, str):
+                continue
+            if (
+                isinstance(created, (int, float))
+                and now - float(created) > _RESERVATION_TTL_SECONDS
+            ):
+                continue
+            out[sid] = data
+        return out
+
+    def _sweep_reservations(self) -> None:
+        """Delete reservations that have done their job or gone stale.
+
+        A reservation is removed once (a) its session's transcript exists — the
+        authoritative name source has caught up, so the reservation is redundant —
+        or (b) it has passed the TTL without ever materializing. Runs at
+        reservation-write time so the read path stays side-effect free.
+        """
+        from vergil_tooling.bin import vrg_vm_resolve as res
+
+        reservations = self._reservations_dir
+        if not reservations.is_dir():
+            return
+        now = time.time()
+        for path in reservations.glob("*.json"):
+            try:
+                data = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                path.unlink(missing_ok=True)
+                continue
+            sid = data.get("sessionId") if isinstance(data, dict) else None
+            created = data.get("createdAt") if isinstance(data, dict) else None
+            expired = (
+                isinstance(created, (int, float))
+                and now - float(created) > _RESERVATION_TTL_SECONDS
+            )
+            superseded = (
+                isinstance(sid, str) and res.projects_glob(self._projects_dir, sid).exists()
+            )
+            if expired or superseded:
+                path.unlink(missing_ok=True)
+
     def list_sessions(self) -> list[SessionInfo]:
         # Imported lazily to avoid an import cycle: ``vrg_vm_resolve`` imports this
         # module at load time. The indirection keeps the transcript/roster scrape
@@ -131,10 +229,21 @@ class ScrapeStore:
 
         projects = self._projects_dir
         roster = res.read_roster(self._sessions_dir)
-        # Roster names are authoritative for live sessions (and cover sessions with
-        # no transcript yet); transcript names cover idle sessions absent from the
-        # roster. Union them, letting the live roster name win on overlap.
-        names = {**res.name_by_session(projects, self._slug), **res.roster_names(roster)}
+        reservations = self._read_reservations()
+        # Name sources, lowest precedence first. Reservations are the eager,
+        # synchronous source that closes the ``--label`` registration race (#2654):
+        # a just-created session's name is recorded here before claude has written
+        # its transcript ``custom-title`` or roster ``name``. Transcript names cover
+        # idle sessions absent from the roster; roster names are authoritative for
+        # live sessions and win on overlap. Because a reserved id is the one claude
+        # adopts (``--session-id``), a reservation that overlaps a real source is the
+        # *same* dict key — one row with the authoritative name, never a duplicate.
+        reserved_names = {sid: str(data["name"]) for sid, data in reservations.items()}
+        names = {
+            **reserved_names,
+            **res.name_by_session(projects, self._slug),
+            **res.roster_names(roster),
+        }
         active = res.active_session_ids(roster)
         last_active = res._roster_updated_at(roster)
         for sid in names:
@@ -143,6 +252,11 @@ class ScrapeStore:
                 if ts is not None:
                     last_active[sid] = ts
         cwds = _roster_cwds(roster)
+        reserved_cwds = {
+            sid: str(data["cwd"])
+            for sid, data in reservations.items()
+            if isinstance(data.get("cwd"), str) and data["cwd"]
+        }
 
         # Named sessions first (preserving the union's order), then any other known
         # session id — a live-but-unnamed session, or one carrying only a roster
@@ -152,10 +266,13 @@ class ScrapeStore:
         def _cwd(sid: str) -> str:
             # The live roster is authoritative; for an idle session absent from it
             # the transcript's recorded cwd stands in, so ``--resume`` can still
-            # derive that session's memory slug (#2607). Unknown ⇒ "".
+            # derive that session's memory slug (#2607). A reservation-only session
+            # (created but not yet registered) has neither, so its recorded cwd
+            # stands in last. Unknown ⇒ "".
             if sid in cwds:
                 return cwds[sid]
-            return res.transcript_cwd(res.projects_glob(projects, sid)) or ""
+            transcript_cwd = res.transcript_cwd(res.projects_glob(projects, sid))
+            return transcript_cwd or reserved_cwds.get(sid, "")
 
         return [
             SessionInfo(
@@ -178,6 +295,27 @@ class ScrapeStore:
         entry = {"type": "custom-title", "customTitle": new_name, "sessionId": session_id}
         with transcript.open("a") as fh:
             fh.write(json.dumps(entry) + "\n")
+
+    def reserve_name(self, session_id: str, name: str, cwd: str = "") -> None:
+        """Persist a name reservation keyed by the session id claude will adopt.
+
+        Written by the ``--label`` create path *before* it exec's ``claude
+        --session-id <session_id> -n <name>``, so the name is resolvable the instant
+        the create decision is made — closing the window in which a rapid second
+        ``--label`` would miss the collision (#2654). Sweeps done/stale reservations
+        first so the directory never accumulates. Pinning ``session_id`` to the id
+        claude adopts is what makes the reservation and the real session one row.
+        """
+        self._sweep_reservations()
+        reservations = self._reservations_dir
+        reservations.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "sessionId": session_id,
+            "name": name,
+            "cwd": cwd,
+            "createdAt": time.time(),
+        }
+        (reservations / f"{session_id}.json").write_text(json.dumps(entry) + "\n")
 
 
 def _roster_cwds(roster: list[dict[str, object]]) -> dict[str, str]:

--- a/tests/vergil_tooling/test_session_store.py
+++ b/tests/vergil_tooling/test_session_store.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
 
 from vergil_tooling.lib.session_store import (
+    _RESERVATION_TTL_SECONDS,
     AmbiguousSessionError,
     ScrapeStore,
     SessionInfo,
@@ -151,3 +153,136 @@ def test_scrape_store_resolve_name_uses_resolve_over(tmp_path: Path) -> None:
     assert resolved is not None
     assert resolved.session_id == "s1"
     assert store.resolve_name("nope:w") is None
+
+
+# --- reserve_name: the eager name source that closes the --label race (#2654) ---
+
+
+def _write_reservation(claude: Path, sid: str, name: str, created: float) -> None:
+    """Hand-write a reservation file with a chosen createdAt (for TTL tests)."""
+    reservations = claude / "vrg-session-reservations"
+    reservations.mkdir(parents=True, exist_ok=True)
+    (reservations / f"{sid}.json").write_text(
+        json.dumps({"sessionId": sid, "name": name, "cwd": "/work/repo", "createdAt": created})
+        + "\n"
+    )
+
+
+def test_reserved_name_resolves_before_transcript_or_roster(tmp_path: Path) -> None:
+    # The core regression: a session that exists only as a reservation (claude has
+    # not yet written its transcript custom-title or roster name) is still resolved,
+    # so a rapid second --label sees the collision.
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    store.reserve_name("s1", "epic-1:w", "/work/repo")
+
+    resolved = store.resolve_name("epic-1:w")
+    assert resolved is not None
+    assert resolved.session_id == "s1"
+    assert resolved.active is False  # a reservation is never counted as live
+    assert resolved.cwd == "/work/repo"  # recorded cwd stands in until registration
+
+
+def test_reservation_and_real_transcript_dedup_to_one_row(tmp_path: Path) -> None:
+    # Because the reservation is keyed by the id claude adopts (--session-id), once
+    # the real transcript appears the two are the SAME row — one session, the
+    # authoritative transcript name winning — never a phantom duplicate.
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-w"
+    slug.mkdir(parents=True)
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    store.reserve_name("s1", "epic-1:w", "/work/repo")
+    _write_title(slug / "s1.jsonl", "s1", "epic-1:w")  # claude has now registered
+
+    rows = [row for row in store.list_sessions() if row.session_id == "s1"]
+    assert len(rows) == 1
+    assert rows[0].name == "epic-1:w"
+
+
+def test_reservation_swept_once_transcript_exists(tmp_path: Path) -> None:
+    # A reservation is redundant once its transcript exists; the next reserve_name
+    # sweeps it, so the directory never accumulates superseded reservations.
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-w"
+    slug.mkdir(parents=True)
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    store.reserve_name("s1", "epic-1:w", "/work/repo")
+    _write_title(slug / "s1.jsonl", "s1", "epic-1:w")
+    store.reserve_name("s2", "epic-2:w", "/work/repo")  # triggers the sweep
+
+    reservations = claude / "vrg-session-reservations"
+    assert not (reservations / "s1.json").exists()  # superseded -> swept
+    assert (reservations / "s2.json").exists()  # still bridging -> kept
+
+
+def test_expired_reservation_is_ignored(tmp_path: Path) -> None:
+    # A stale reservation whose session never materialized cannot pin a name
+    # forever: past the TTL it is ignored by the read.
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    (claude / "sessions").mkdir()
+    _write_reservation(claude, "s1", "epic-1:w", created=0.0)  # epoch 0 -> long expired
+
+    store = ScrapeStore(claude)
+    assert store.resolve_name("epic-1:w") is None
+
+
+def test_fresh_reservation_within_ttl_is_honored(tmp_path: Path) -> None:
+    import time
+
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    (claude / "sessions").mkdir()
+    _write_reservation(claude, "s1", "epic-1:w", created=time.time() - _RESERVATION_TTL_SECONDS / 2)
+
+    store = ScrapeStore(claude)
+    resolved = store.resolve_name("epic-1:w")
+    assert resolved is not None
+    assert resolved.session_id == "s1"
+
+
+def test_two_reservations_same_name_do_not_falsely_conflict_as_live(tmp_path: Path) -> None:
+    # Reservations are idle rows, so two of them holding one name resolve to a
+    # single session (still a collision) rather than raising the fail-loud
+    # two-live-sessions error that is reserved for genuinely live duplicates.
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    store.reserve_name("s1", "epic-1:w", "/work/repo")
+    store.reserve_name("s2", "epic-1:w", "/work/repo")
+
+    resolved = store.resolve_name("epic-1:w")  # must not raise AmbiguousSessionError
+    assert resolved is not None
+    assert resolved.session_id in {"s1", "s2"}
+
+
+def test_malformed_reservations_are_ignored_and_unreadable_ones_swept(tmp_path: Path) -> None:
+    # The reservation reader must be robust to junk in its own directory: unreadable
+    # JSON, a valid-but-non-dict payload, and a dict missing the required fields all
+    # contribute no rows. A later reserve sweeps the unreadable file (pure cruft);
+    # the odd-but-parseable ones are harmless and left to age out.
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    (claude / "sessions").mkdir()
+    reservations = claude / "vrg-session-reservations"
+    reservations.mkdir()
+    (reservations / "bad.json").write_text("{ not json")
+    (reservations / "list.json").write_text("[1, 2, 3]")
+    (reservations / "nofields.json").write_text('{"sessionId": 5}')
+
+    store = ScrapeStore(claude)
+    assert store.list_sessions() == []  # nothing usable -> no rows
+    assert store.resolve_name("epic-1:w") is None
+
+    store.reserve_name("s1", "epic-1:w", "/w")  # triggers the sweep
+    assert not (reservations / "bad.json").exists()  # unreadable -> swept
+    assert (reservations / "s1.json").exists()

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -412,15 +412,19 @@ def _resolve(
 
 
 class _StubStore:
-    """Minimal SessionStore stub exposing only resolve_name for the label path."""
+    """Minimal SessionStore stub for the label path: resolve_name + reserve_name."""
 
     def __init__(self, result: object) -> None:
         self._result = result
+        self.reserved: list[tuple[str, str]] = []
 
     def resolve_name(self, name: str) -> object:  # noqa: ARG002
         if isinstance(self._result, Exception):
             raise self._result
         return self._result
+
+    def reserve_name(self, session_id: str, name: str, cwd: str = "") -> None:  # noqa: ARG002
+        self.reserved.append((session_id, name))
 
 
 def test_resolve_label_creates_when_name_free(
@@ -428,10 +432,16 @@ def test_resolve_label_creates_when_name_free(
     capture_exec: list[list[str]],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # No visible session holds the composed name -> create label:workspace.
-    monkeypatch.setattr(r, "_store", lambda *_a: _StubStore(None))
+    # No visible session holds the composed name -> reserve it, then create.
+    store = _StubStore(None)
+    monkeypatch.setattr(r, "_store", lambda *_a: store)
+    monkeypatch.setattr(r, "_new_session_id", lambda: "SID")
     assert _resolve("id", "vergil-project/tooling", label="epic-1") == 0
-    assert capture_exec == [["claude", "-n", "epic-1:vergil-project/tooling"]]
+    assert capture_exec == [
+        ["claude", "--session-id", "SID", "-n", "epic-1:vergil-project/tooling"]
+    ]
+    # The name was reserved against the same id claude is pinned to (#2654).
+    assert store.reserved == [("SID", "epic-1:vergil-project/tooling")]
     assert "Creating session epic-1:vergil-project/tooling" in capsys.readouterr().err
 
 
@@ -467,8 +477,9 @@ def test_resolve_label_warns_off_convention_but_creates(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(r, "_store", lambda *_a: _StubStore(None))
+    monkeypatch.setattr(r, "_new_session_id", lambda: "SID")
     assert _resolve("id", "p", label="scratch") == 0
-    assert capture_exec == [["claude", "-n", "scratch:p"]]
+    assert capture_exec == [["claude", "--session-id", "SID", "-n", "scratch:p"]]
     assert "convention" in capsys.readouterr().err
 
 
@@ -490,6 +501,40 @@ def test_resolve_label_rejects_invalid_slug(
     assert capture_exec == []
     assert called is False  # validation short-circuits before the uniqueness check
     assert "ERROR" in capsys.readouterr().err
+
+
+def test_resolve_label_detects_collision_before_name_registers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression (#2654): a rapid second --label detects the collision even though
+    the first session's name has not yet reached the transcript or roster.
+
+    Uses a *real* ScrapeStore over a temp claude dir so the reservation the first
+    create writes persists to the second invocation — the cross-process durability
+    the fix depends on. No transcript or roster is ever written, reproducing the
+    registration-latency window in which the old code missed the collision and
+    racily created a duplicate.
+    """
+    claude_dir = tmp_path / ".claude"
+    monkeypatch.setattr(r, "_claude_dir", lambda: claude_dir)
+    ids = iter(["SID-1", "SID-2"])
+    monkeypatch.setattr(r, "_new_session_id", lambda: next(ids))
+
+    # First --label: the name is free, so it reserves the name and execs a create
+    # pinned to SID-1. Nothing writes the transcript/roster (the race window).
+    assert _resolve("id", "vergil-project/tooling", label="epic-1") == 0
+    assert capture_exec == [
+        ["claude", "--session-id", "SID-1", "-n", "epic-1:vergil-project/tooling"]
+    ]
+
+    # Second --label for the same name, still inside the window: the reservation
+    # makes the collision visible, so it refuses and never execs a second session.
+    assert _resolve("id", "vergil-project/tooling", label="epic-1") == 1
+    assert len(capture_exec) == 1  # no duplicate create
+    assert "already exists" in capsys.readouterr().err
 
 
 def test_resolve_refuse(
@@ -525,6 +570,13 @@ def test_exec_claude_invokes_execvp(capture_exec: list[list[str]]) -> None:
     assert capture_exec == [["claude", "-n", "x"]]
 
 
+def test_new_session_id_is_a_canonical_uuid() -> None:
+    import uuid as _uuid
+
+    sid = r._new_session_id()
+    assert str(_uuid.UUID(sid)) == sid  # parses as, and round-trips to, a canonical UUID
+
+
 # --- --fresh retire-rename (issue #2609) ---
 
 
@@ -539,6 +591,7 @@ class _RenameStore:
     def __init__(self, rows: list[Any]) -> None:
         self._rows = rows
         self.renames: list[tuple[str, str]] = []
+        self.reserved: list[tuple[str, str]] = []
 
     def list_sessions(self) -> list[Any]:
         return list(self._rows)
@@ -550,6 +603,9 @@ class _RenameStore:
 
     def rename(self, session_id: str, new_name: str) -> None:
         self.renames.append((session_id, new_name))
+
+    def reserve_name(self, session_id: str, name: str, cwd: str = "") -> None:  # noqa: ARG002
+        self.reserved.append((session_id, name))
 
 
 def test_retired_name_suffixes_with_stamp() -> None:
@@ -597,9 +653,11 @@ def test_resolve_fresh_label_retires_and_creates(
     store = _RenameStore([_info("old", "epic-1:tooling", False, 10.0)])
     monkeypatch.setattr(r, "_store", lambda *_a: store)
     monkeypatch.setattr(r, "_now_stamp", lambda: "STAMP")
+    monkeypatch.setattr(r, "_new_session_id", lambda: "SID")
     assert _resolve("id", "tooling", label="epic-1", fresh=True) == 0
     assert store.renames == [("old", "epic-1:tooling~STAMP")]
-    assert capture_exec == [["claude", "-n", "epic-1:tooling"]]
+    assert store.reserved == [("SID", "epic-1:tooling")]
+    assert capture_exec == [["claude", "--session-id", "SID", "-n", "epic-1:tooling"]]
     err = capsys.readouterr().err
     assert "Retired prior session epic-1:tooling -> epic-1:tooling~STAMP" in err
 
@@ -610,9 +668,11 @@ def test_resolve_fresh_label_creates_when_name_free(
     store = _RenameStore([])
     monkeypatch.setattr(r, "_store", lambda *_a: store)
     monkeypatch.setattr(r, "_now_stamp", lambda: "STAMP")
+    monkeypatch.setattr(r, "_new_session_id", lambda: "SID")
     assert _resolve("id", "tooling", label="epic-1", fresh=True) == 0
     assert store.renames == []  # nothing to retire
-    assert capture_exec == [["claude", "-n", "epic-1:tooling"]]
+    assert store.reserved == [("SID", "epic-1:tooling")]
+    assert capture_exec == [["claude", "--session-id", "SID", "-n", "epic-1:tooling"]]
 
 
 def test_resolve_fresh_label_warns_off_convention(
@@ -623,8 +683,9 @@ def test_resolve_fresh_label_warns_off_convention(
     store = _RenameStore([])
     monkeypatch.setattr(r, "_store", lambda *_a: store)
     monkeypatch.setattr(r, "_now_stamp", lambda: "STAMP")
+    monkeypatch.setattr(r, "_new_session_id", lambda: "SID")
     assert _resolve("id", "tooling", label="scratch", fresh=True) == 0
-    assert capture_exec == [["claude", "-n", "scratch:tooling"]]
+    assert capture_exec == [["claude", "--session-id", "SID", "-n", "scratch:tooling"]]
     assert "convention" in capsys.readouterr().err
 
 
@@ -679,6 +740,9 @@ class _FakeStore:
         return resolve_over(self._rows, name)
 
     def rename(self, session_id: str, new_name: str) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def reserve_name(self, session_id: str, name: str, cwd: str = "") -> None:  # pragma: no cover
         raise NotImplementedError
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Root cause (confirmed by code reading + empirical probe): the --label uniqueness check `store.resolve_name(name)` reads only names that claude writes asynchronously after a session starts — the transcript `custom-title` event and the roster `name`. The create path exec'd claude and recorded nothing itself, so a rapid second --label for the same name ran inside the registration-latency window (resolve_name -> None), missed the collision, and created a duplicate; seconds later, once the name registered, the same command correctly errored. Same latency class as the finalize race (#2623).

Fix: close the window at the create decision. The --label / --fresh --label paths now mint the session id, reserve the name against it synchronously through the seam (new `ScrapeStore.reserve_name`), then exec `claude --session-id <id> -n <name>`. The reservation is a vrg-owned VM-local file that `list_sessions` unions in at lowest precedence, so the name is resolvable immediately. Pinning the reserved id to the one claude adopts makes the reservation and the real session dedup to one row (authoritative transcript/roster name wins on overlap); reservations self-clean — swept once the transcript exists, ignored/swept past a TTL if the session never materialized. Collision is now always detected and errors consistently ("a session named X already exists; --resume it or pick another label"); no duplicate, no racy reconnect.

Empirically ruled out pre-seeding the transcript: `claude --session-id` rejects a pre-existing transcript at that id ("Session ID ... is already in use"), so the reservation must live outside claude's own stores.

## Issue Linkage

- Closes #2654

## Notes

- Regression coverage added and vrg-validate is green in the dev container (authoritative gate), 4649 tests, 100% coverage.

Tests: a resolver-level regression drives two --label calls through a real ScrapeStore over a temp dir with no transcript/roster written (reproducing the missed-collision window) and asserts the second call errors and never execs a duplicate; seam-level tests cover reserve-then-resolve before registration, same-id dedup once the transcript appears, supersession sweep, TTL expiry, malformed-file robustness, and that reservations are idle (never falsely fail-loud as two live sessions).

Files: src/vergil_tooling/lib/session_store.py (reserve_name + reservation read/sweep + union), src/vergil_tooling/bin/vrg_vm_resolve.py (_new_session_id, --session-id threading, reserve in both label paths), plus the two test modules.