### PR TITLE
fix(platform-env): recognize Apple/vz Lima VMs so --platform stops fail-closing to cloud-vm

### DIFF
--- a/src/vergil_tooling/lib/platform_env.py
+++ b/src/vergil_tooling/lib/platform_env.py
@@ -16,7 +16,8 @@ no written marker file.** Candidate signals, in precedence order:
 1. macOS (``platform.system() == "Darwin"``) and no ``/vergil`` mount ⇒
    ``PHYSICAL_HOST``.
 2. ``/vergil`` mount present ⇒ in a VM. A reachable cloud metadata
-   endpoint ⇒ ``CLOUD_VM``; else Lima markers ⇒ ``LOCAL_VM``.
+   endpoint ⇒ ``CLOUD_VM``; else a Lima marker — a marker mount/device or
+   the ``lima-`` guest hostname, covering both Lima backends ⇒ ``LOCAL_VM``.
 3. **Fail closed:** any VM signal present (or a box that cannot be
    positively confirmed as the physical host) that is not positively
    confirmed ``LOCAL_VM`` ⇒ ``CLOUD_VM``. The resolver never falls
@@ -72,7 +73,13 @@ _METADATA_PORT = 80
 _METADATA_TIMEOUT_S = 0.25
 
 _VERGIL_MOUNT = "/vergil"
-_LIMA_MARKERS = ("/mnt/lima", "/dev/virtio-ports/lima")
+# Lima markers span both backends. The QEMU backend exposes
+# ``/dev/virtio-ports/lima``; the vz (Apple Virtualization) backend exposes
+# neither that device nor ``/mnt/lima`` but does mount cloud-init data at
+# ``/mnt/lima-cidata`` (issue #2656). The hostname prefix below is the
+# backend-independent signal — Lima names the guest ``lima-<instance>``.
+_LIMA_MARKERS = ("/mnt/lima", "/mnt/lima-cidata", "/dev/virtio-ports/lima")
+_LIMA_HOSTNAME_PREFIX = "lima-"
 
 
 @dataclass(frozen=True)
@@ -110,10 +117,21 @@ def _cloud_metadata_reachable() -> bool:
 
 
 def _lima_marker_present() -> bool:
-    """True when a Lima-specific marker is present (a local-VM signal)."""
+    """True when a Lima-specific marker is present (a local-VM signal).
+
+    Recognizes a Lima VM across both backends: a marker mount/device
+    (``_LIMA_MARKERS``) or the Lima-assigned guest hostname
+    (``lima-<instance>``). The vz (Apple Virtualization) backend exposes no
+    ``/dev/virtio-ports/lima`` device and no ``/mnt/lima``, so before this
+    fix both markers missed and a real local VM fail-closed to ``cloud-vm``
+    (issue #2656). This probe is only consulted after a cloud-metadata miss,
+    so it cannot mask a genuine cloud VM.
+    """
     from pathlib import Path
 
-    return any(Path(marker).exists() for marker in _LIMA_MARKERS)
+    if any(Path(marker).exists() for marker in _LIMA_MARKERS):
+        return True
+    return _platform_mod.node().startswith(_LIMA_HOSTNAME_PREFIX)
 
 
 def _identity_is_agent() -> bool:

--- a/tests/vergil_tooling/test_platform_env.py
+++ b/tests/vergil_tooling/test_platform_env.py
@@ -27,6 +27,10 @@ def _neutral_signals(monkeypatch: pytest.MonkeyPatch) -> None:
     on where it runs.
     """
     monkeypatch.setattr("platform.system", lambda: "Linux")
+    # Neutralize the hostname probe to a non-Lima value so the low-level
+    # marker tests stay hermetic even when the suite runs *on* a Lima VM
+    # (whose real hostname is lima-<instance>). See issue #2656.
+    monkeypatch.setattr("platform.node", lambda: "test-host")
     monkeypatch.setattr("vergil_tooling.lib.platform_env._vergil_mount_present", lambda: False)
     monkeypatch.setattr("vergil_tooling.lib.platform_env._cloud_metadata_reachable", lambda: False)
     monkeypatch.setattr("vergil_tooling.lib.platform_env._lima_marker_present", lambda: False)
@@ -176,4 +180,25 @@ def test_lima_marker_present_false_when_no_marker_exists(monkeypatch: pytest.Mon
         "vergil_tooling.lib.platform_env._LIMA_MARKERS",
         ("/nonexistent/vrg-lima-marker-should-not-exist",),
     )
+    # hostname is neutralized to a non-Lima value by the autouse fixture.
     assert _REAL_LIMA_MARKER_PRESENT() is False
+
+
+def test_lima_marker_present_true_when_hostname_has_lima_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # vz (Apple Virtualization) backend: no marker mount/device exists, but
+    # Lima sets the guest hostname to lima-<instance>. This is the signal that
+    # was missing, causing --platform to fail-close to cloud-vm (issue #2656).
+    monkeypatch.setattr(
+        "vergil_tooling.lib.platform_env._LIMA_MARKERS",
+        ("/nonexistent/vrg-lima-marker-should-not-exist",),
+    )
+    monkeypatch.setattr("platform.node", lambda: "lima-vergil-user")
+    assert _REAL_LIMA_MARKER_PRESENT() is True
+
+
+def test_lima_cidata_mount_is_a_recognized_marker() -> None:
+    # The vz backend mounts cloud-init data at /mnt/lima-cidata; dropping it
+    # from the marker set reintroduces the fail-closed-to-cloud bug (#2656).
+    assert "/mnt/lima-cidata" in platform_env._LIMA_MARKERS


### PR DESCRIPTION
# Pull Request

## Summary

- Broaden Lima detection to the vz (Apple Virtualization) backend via the /mnt/lima-cidata mount and the lima- guest-hostname signal, so a local Lima VM resolves to local-vm instead of fail-closing to cloud-vm.

## Issue Linkage

- Closes #2656

## Notes

- Fixes the mis-detection surfaced today (vrg-whoami --platform said cloud-vm on a local Lima VM). Root cause: the QEMU-backend markers /mnt/lima and /dev/virtio-ports/lima are both absent on vz. The new hostname signal is backend-independent; the marker probe still runs only after a cloud-metadata miss, so a genuine cloud VM cannot be masked and the fail-closed default is unchanged. Verified live: resolver now returns local-vm/resolved_from=lima-marker. Tests cover the hostname signal, the cidata marker, and hermeticity when the suite runs on a Lima VM. Promoted from triage vergil-project/.github#236.