### PR TITLE
fix(git): discard ref_exists subprocess streams so rev-parse's SHA doesn't leak to stdout

### DIFF
--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -135,12 +135,21 @@ def has_staged_changes() -> bool:
 
 
 def ref_exists(ref: str) -> bool:
-    """Return True if a git ref exists."""
+    """Return True if a git ref exists.
+
+    Only the return code is consulted, so both streams are discarded: on
+    success ``git rev-parse --verify`` prints the resolved SHA to stdout
+    (``--quiet`` suppresses only the failure diagnostic), which would
+    otherwise leak to the terminal — e.g. above the ``vrg-worktree-status``
+    table when the detached/rebase path probes a ref (issue #2658).
+    """
     args = ("rev-parse", "--verify", "--quiet", ref)
     result = subprocess.run(  # noqa: S603
         ("git", *args),  # noqa: S607
         check=False,
         env=_git_env(args),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
     return result.returncode == 0
 

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -200,6 +200,10 @@ def test_ref_exists_true() -> None:
     # Even this local op disables the prompt so it can never hang (#1830).
     _, kwargs = mock_run.call_args
     assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    # `git rev-parse --verify` prints the resolved SHA to stdout on success;
+    # both streams must be discarded so it never leaks to the terminal (#2658).
+    assert kwargs["stdout"] == subprocess.DEVNULL
+    assert kwargs["stderr"] == subprocess.DEVNULL
 
 
 def test_ref_exists_false() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Redirect ref_exists's git rev-parse stdout/stderr to DEVNULL so the resolved SHA it prints on success no longer leaks to the terminal above the vrg-worktree-status table.

## Issue Linkage

- Closes #2658

## Notes

- Root cause of the stray 40-char hash printed above the worktree-status table. git rev-parse --verify prints the SHA on success; --quiet only silences the failure diagnostic, and stdout was uncaptured. Surfaced via the new detached/rebase status path (#2634) which probes refs with ref_exists during gathering. Only the return code is used, so both streams are discarded. Verified against real git: no SHA emitted. Regression guard asserts the DEVNULL redirect at the call seam.