### PR TITLE
fix(worktree): thread one work-unit identifier across branch, dir, and summary

### DIFF
--- a/docs/specs/worktree-convention.md
+++ b/docs/specs/worktree-convention.md
@@ -330,6 +330,17 @@ tracked separately):
 - **`vrg-finalize-pr` worktree removal** (implemented). Removes the
   worktree when finalizing the branch for that worktree, covering the
   cleanup failure mode structurally.
+- **`vrg-git` creation-time naming guard** (implemented, issue #2550).
+  When an issue-family branch is created — `worktree add -b`,
+  `checkout -b`, `switch -c` — the branch must take the
+  `<type>/<N>-<slug>` form, and `worktree add` additionally requires the
+  directory to be the matching `issue-<N>-<slug>`. This enforces the
+  issue-number rule at branch creation rather than only later at
+  `vrg-commit`, and keeps the worktree directory, branch name, and issue
+  number in lockstep from the start (the divergence was the directory
+  being chosen at `worktree add` time and never re-checked). The shared
+  format lives in `lib/branch_names.py` so the creation guard and the
+  commit guard cannot drift.
 - **`vrg-worktree-prompt` helper.** Emits the canonical prompt
   template given an issue number and slug, so operators don't
   hand-author the prompt each time.

--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from vergil_tooling.lib import config, git
+from vergil_tooling.lib import branch_names, config, git
 from vergil_tooling.lib.commit_message import (
     ALLOWED_TYPES,
     build_commit_message,
@@ -39,9 +39,6 @@ _BRANCHING_MODELS: dict[str, tuple[str, str]] = {
     ),
 }
 
-_ISSUE_REQUIRED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
-_ISSUE_FORMAT_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/[0-9]+-[a-z0-9][a-z0-9.-]*$")
-_WORKTREE_SCOPED_RE = re.compile(r"^(feature|bugfix|hotfix|chore)/")
 _WORKTREES_DIRNAME = ".worktrees"
 
 
@@ -121,18 +118,21 @@ def _validate_commit_context(root: Path, branching_model: str) -> int:
             "Rename the branch before committing.",
         )
 
-    # Check 4: feature/bugfix/hotfix/chore branches must include an issue number
-    if _ISSUE_REQUIRED_RE.search(current_branch) and not _ISSUE_FORMAT_RE.match(current_branch):
+    # Check 4: feature/bugfix/hotfix/chore branches must include an issue number.
+    # Shared with the vrg-git creation-time guard via lib.branch_names so the
+    # format cannot drift between the two enforcement points (issue #2550).
+    if branch_names.requires_issue_number(current_branch) and not (
+        branch_names.is_valid_issue_branch(current_branch)
+    ):
         return _reject(
             f"ERROR: branch name must include a repo issue number ({current_branch}).",
-            "Expected format: {type}/{issue}-{description}",
-            "Example: feature/42-add-caching",
+            branch_names.FORMAT_HINT,
         )
 
     # Check 5: feature-branch commits from the main worktree are forbidden
     # when `.worktrees/` is present (worktree-convention rule 3).
     if (
-        _WORKTREE_SCOPED_RE.search(current_branch)
+        branch_names.requires_issue_number(current_branch)
         and (root / _WORKTREES_DIRNAME).is_dir()
         and git.is_main_worktree()
     ):

--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from vergil_tooling.lib import github
+from vergil_tooling.lib import branch_names, github
 from vergil_tooling.lib.git import _git_auth_env, main_worktree_root
 from vergil_tooling.lib.pr_workflow import freeze
 
@@ -329,16 +329,47 @@ def _parse_worktree_add_path(args: list[str]) -> str | None:
     return None
 
 
-def _check_worktree_add(args: list[str]) -> str | None:
-    """Reject a ``worktree add`` that would not land directly under .worktrees/.
+def _parse_new_branch(create_flags: tuple[str, ...], args: list[str]) -> str | None:
+    """Return the branch name a ``-b``/``-B``/``-c``/``-C`` flag creates, or None.
 
-    The new worktree's resolved path must be a direct child of
-    ``<main_worktree_root>/.worktrees/``. This one invariant rejects every way
-    the convention gets violated: a relative path resolved from inside another
-    worktree (the nesting bug, #1922), and any absolute or ``../`` path that
-    escapes the canonical container. When the main worktree root cannot be
-    resolved (not in a repo), the guard is skipped so git reports its own
-    error rather than this layer masking it.
+    *create_flags* is the set of new-branch flags for the subcommand (``-b``/
+    ``-B`` for ``worktree add`` and ``checkout``; ``-c``/``-C`` for ``switch``).
+    Returns the token immediately following the first such flag; None when no
+    new branch is being created (existing-branch checkout/adoption).
+    """
+    for index, arg in enumerate(args):
+        if arg in create_flags:
+            return args[index + 1] if index + 1 < len(args) else None
+    return None
+
+
+def _branch_format_error(branch: str) -> str:
+    """The shared refusal for an issue-family branch name missing ``<N>-<slug>``.
+
+    Same rule and wording as the vrg-commit Check-4 guard (both read from
+    lib.branch_names), so a branch rejected at creation and one rejected at
+    commit read identically (issue #2550).
+    """
+    return f"branch name must include a repo issue number ({branch}). {branch_names.FORMAT_HINT}"
+
+
+def _check_worktree_add(args: list[str]) -> str | None:
+    """Reject a ``worktree add`` that violates the work-unit conventions.
+
+    Two invariants, both required for the ``issue -> branch -> worktree`` chain
+    to thread one identifier (issue #2550):
+
+    1. **Anchoring (#1922).** The new worktree's resolved path must be a direct
+       child of ``<main_worktree_root>/.worktrees/``. This rejects a relative
+       path resolved from inside another worktree (the nesting bug) and any
+       absolute or ``../`` path that escapes the canonical container.
+    2. **Branch/directory lockstep (#2550).** When ``-b``/``-B`` creates an
+       issue-family branch, the branch must be a well-formed ``<type>/<N>-<slug>``
+       and the directory must be the ``issue-<N>-<slug>`` derived from it — so the
+       directory name, branch name, and issue number never diverge at the source.
+
+    When the main worktree root cannot be resolved (not in a repo), the guard is
+    skipped so git reports its own error rather than this layer masking it.
     """
     path = _parse_worktree_add_path(args)
     if path is None:
@@ -352,14 +383,50 @@ def _check_worktree_add(args: list[str]) -> str | None:
         target = Path.cwd() / target
     target = target.resolve()
     canonical = (root / ".worktrees").resolve()
-    if target.parent == canonical:
+    if target.parent != canonical:
+        return (
+            f"worktree add target must be a direct child of {canonical} "
+            f"(it resolved to {target}). Run the command from the project root "
+            f"with a relative path like .worktrees/issue-<N>-<slug>; never create "
+            f"a worktree from inside another worktree."
+        )
+
+    # Branch/directory lockstep: only when -b/-B creates an issue-family branch.
+    # A worktree adopting an existing branch (no -b), or creating a release/*
+    # branch, carries no issue number and is left untouched.
+    new_branch = _parse_new_branch(("-b", "-B"), args)
+    if new_branch is None or not branch_names.requires_issue_number(new_branch):
         return None
-    return (
-        f"worktree add target must be a direct child of {canonical} "
-        f"(it resolved to {target}). Run the command from the project root "
-        f"with a relative path like .worktrees/issue-<N>-<slug>; never create "
-        f"a worktree from inside another worktree."
-    )
+    if not branch_names.is_valid_issue_branch(new_branch):
+        return _branch_format_error(new_branch)
+    expected = branch_names.expected_worktree_dirname(new_branch)
+    if target.name != expected:
+        return (
+            f"worktree directory name '{target.name}' does not match branch "
+            f"'{new_branch}'. Use '.worktrees/{expected}' so the directory, "
+            f"branch, and issue number stay in lockstep (issue #2550)."
+        )
+    return None
+
+
+def _check_new_branch_name(subcmd: str, args: list[str]) -> str | None:
+    """Reject ``checkout -b``/``switch -c`` creating a malformed issue branch.
+
+    Extends the issue-number rule to the other creation paths the worktree
+    convention allows inside a secondary worktree, so a non-conforming branch is
+    caught at creation rather than only later at commit (issue #2550). A
+    non-issue branch (e.g. ``release/*``) and a plain checkout/switch of an
+    existing branch are left untouched.
+    """
+    create_flags = {"checkout": ("-b", "-B"), "switch": ("-c", "-C")}.get(subcmd)
+    if create_flags is None:
+        return None
+    new_branch = _parse_new_branch(create_flags, args)
+    if new_branch is None or not branch_names.requires_issue_number(new_branch):
+        return None
+    if not branch_names.is_valid_issue_branch(new_branch):
+        return _branch_format_error(new_branch)
+    return None
 
 
 _WORKFLOW_PERMISSION_RE = re.compile(
@@ -443,6 +510,10 @@ def _print_help() -> None:
         "    (develop, main, release/*).\n"
         "  - Worktree convention: branch switches in the main worktree and\n"
         "    'worktree add' targets outside .worktrees/ are refused.\n"
+        "  - Work-unit identifier: creating an issue-family branch (via\n"
+        "    'worktree add -b', 'checkout -b', 'switch -c') requires the\n"
+        "    <type>/<N>-<slug> form, and 'worktree add' requires the directory\n"
+        "    to be the matching issue-<N>-<slug> (dir/branch stay in lockstep).\n"
         "  - Freeze: a push is refused once the branch was reported ready\n"
         "    (vrg-pr-workflow report-ready); unfreeze deliberately to reopen it.\n"
         "  - Identity: remote ops run with the GitHub App installation token for\n"
@@ -522,6 +593,11 @@ def main(argv: list[str] | None = None) -> int:
     worktree_err = _check_worktree_convention(subcmd, argv[1:])
     if worktree_err:
         print(f"vrg-git: {worktree_err}", file=sys.stderr)
+        return 1
+
+    branch_name_err = _check_new_branch_name(subcmd, argv[1:])
+    if branch_name_err:
+        print(f"vrg-git: {branch_name_err}", file=sys.stderr)
         return 1
 
     if subcmd == "push":

--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -564,7 +564,12 @@ def _run_submit_batch(
     report = batch.run_batch(
         selected,
         _process,
-        label=lambda wt: wt.path.name,
+        # Label the batch summary by the full branch name, not the worktree
+        # directory name. The directory name can be a bare slug that hides the
+        # issue number (e.g. `authz-apply-tag`), making a correct merge look
+        # unattributable; the branch (`feature/<N>-<slug>`) is unambiguous and
+        # round-trippable back to the issue (issue #2550).
+        label=lambda wt: wt.branch,
         plan=plan,
         assume_yes=assume_yes,
         post_steps=post_steps,

--- a/src/vergil_tooling/lib/branch_names.py
+++ b/src/vergil_tooling/lib/branch_names.py
@@ -1,0 +1,94 @@
+"""Canonical work-unit identifier: branch name ⇄ worktree directory name.
+
+One unit of work threads a single identifier across the tooling —
+``feature/<N>-<slug>`` as the git branch and ``issue-<N>-<slug>`` as the
+canonical ``.worktrees/`` directory. This module is the single source of
+truth for parsing and validating that identifier, so the format cannot
+drift between the commit-time guard (``vrg-commit``) and the
+creation-time guard (``vrg-git worktree add``/``checkout -b``). Issue #2550.
+
+An "issue branch" is one whose prefix commits it to carrying a repo issue
+number: ``feature/``, ``bugfix/``, ``hotfix/``, ``chore/``. Integration and
+release branches (``develop``, ``main``, ``release/*``, ``promotion/*``) are
+deliberately *not* issue branches — they carry no issue number and are left
+untouched by every helper here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Branch prefixes that must carry a repo issue number. Kept as a tuple so the
+# two regexes below and the human-facing message all read from one list.
+ISSUE_BRANCH_TYPES: tuple[str, ...] = ("feature", "bugfix", "hotfix", "chore")
+
+_TYPES_ALT = "|".join(ISSUE_BRANCH_TYPES)
+
+# A branch *commits to* the issue-number rule as soon as it uses an issue-branch
+# prefix; whether it satisfies the rule is a separate check (_ISSUE_FORMAT_RE).
+_ISSUE_REQUIRED_RE = re.compile(rf"^({_TYPES_ALT})/")
+
+# The full canonical form: <type>/<N>-<slug>, where <N> is one or more digits and
+# <slug> starts with a lowercase alphanumeric then lowercase alphanumerics, dots
+# or hyphens. The capture groups back parse_issue_branch.
+_ISSUE_FORMAT_RE = re.compile(rf"^({_TYPES_ALT})/([0-9]+)-([a-z0-9][a-z0-9.-]*)$")
+
+# The canonical worktree-directory prefix. The directory is type-agnostic —
+# always ``issue-<N>-<slug>`` regardless of the branch's <type> — matching the
+# convention in lib/worktrees.py (_branch_from_worktree_name, match_worktrees).
+WORKTREE_DIR_PREFIX = "issue-"
+
+# Shown wherever a branch fails the format check, so the two guards give an
+# identical, actionable message.
+FORMAT_HINT = "Expected format: {type}/{issue}-{description}  (example: feature/42-add-caching)"
+
+
+@dataclass(frozen=True)
+class ParsedBranch:
+    """The three components of a canonical issue branch."""
+
+    type: str
+    number: str
+    slug: str
+
+
+def requires_issue_number(branch: str) -> bool:
+    """True when *branch*'s prefix commits it to carrying a repo issue number.
+
+    Only the issue-branch prefixes (``feature/`` etc.) qualify; ``develop``,
+    ``main``, ``release/*`` and the like return False and are never subject to
+    the format rule.
+    """
+    return bool(_ISSUE_REQUIRED_RE.match(branch))
+
+
+def is_valid_issue_branch(branch: str) -> bool:
+    """True when *branch* is a fully-formed ``<type>/<N>-<slug>`` issue branch."""
+    return bool(_ISSUE_FORMAT_RE.match(branch))
+
+
+def parse_issue_branch(branch: str) -> ParsedBranch | None:
+    """Split *branch* into ``ParsedBranch(type, number, slug)``, or None.
+
+    Returns None for anything that is not a fully-formed issue branch — a
+    non-issue prefix, or an issue prefix missing the ``<N>-<slug>`` body — so a
+    caller can distinguish "not our concern" from a positive parse.
+    """
+    match = _ISSUE_FORMAT_RE.match(branch)
+    if match is None:
+        return None
+    return ParsedBranch(type=match.group(1), number=match.group(2), slug=match.group(3))
+
+
+def expected_worktree_dirname(branch: str) -> str | None:
+    """Return the canonical ``issue-<N>-<slug>`` directory name for *branch*.
+
+    Derived from the same ``<N>`` and ``<slug>`` as the branch so the two stay
+    in lockstep (issue #2550). Returns None when *branch* is not a fully-formed
+    issue branch, since there is no canonical directory to derive.
+    """
+    parsed = parse_issue_branch(branch)
+    if parsed is None:
+        return None
+    return f"{WORKTREE_DIR_PREFIX}{parsed.number}-{parsed.slug}"

--- a/tests/vergil_tooling/test_branch_names.py
+++ b/tests/vergil_tooling/test_branch_names.py
@@ -1,0 +1,93 @@
+"""Tests for the canonical work-unit identifier helpers (issue #2550)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vergil_tooling.lib import branch_names
+
+
+class TestRequiresIssueNumber:
+    @pytest.mark.parametrize(
+        "branch",
+        ["feature/1-x", "bugfix/2-y", "hotfix/3-z", "chore/4-w", "feature/no-number"],
+    )
+    def test_issue_prefixes_require(self, branch: str) -> None:
+        assert branch_names.requires_issue_number(branch) is True
+
+    @pytest.mark.parametrize(
+        "branch",
+        ["develop", "main", "release/2.1.180", "promotion/main", "gh-pages", ""],
+    )
+    def test_non_issue_prefixes_exempt(self, branch: str) -> None:
+        assert branch_names.requires_issue_number(branch) is False
+
+
+class TestIsValidIssueBranch:
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "feature/42-add-caching",
+            "bugfix/99-fix-parsing",
+            "hotfix/7-patch",
+            "chore/5-update-deps",
+            "feature/1-a",
+            "feature/12-a.b-c",
+        ],
+    )
+    def test_valid(self, branch: str) -> None:
+        assert branch_names.is_valid_issue_branch(branch) is True
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "feature/no-number",
+            "feature/-leading-dash",
+            "feature/42",
+            "feature/42-",
+            "feature/42-Upper",
+            "feature/42-has space",
+            "release/2.1.180",
+            "develop",
+            "feature//double",
+        ],
+    )
+    def test_invalid(self, branch: str) -> None:
+        assert branch_names.is_valid_issue_branch(branch) is False
+
+
+class TestParseIssueBranch:
+    def test_parses_components(self) -> None:
+        parsed = branch_names.parse_issue_branch("feature/911-authz-apply-tag")
+        assert parsed == branch_names.ParsedBranch(
+            type="feature", number="911", slug="authz-apply-tag"
+        )
+
+    def test_parses_each_type(self) -> None:
+        parsed = branch_names.parse_issue_branch("chore/5-x")
+        assert parsed is not None
+        assert parsed.type == "chore"
+
+    def test_returns_none_for_non_issue_branch(self) -> None:
+        assert branch_names.parse_issue_branch("release/2.1.180") is None
+
+    def test_returns_none_for_malformed(self) -> None:
+        assert branch_names.parse_issue_branch("feature/no-number") is None
+
+
+class TestExpectedWorktreeDirname:
+    def test_derives_issue_dir(self) -> None:
+        assert (
+            branch_names.expected_worktree_dirname("feature/911-authz-apply-tag")
+            == "issue-911-authz-apply-tag"
+        )
+
+    def test_type_agnostic_prefix(self) -> None:
+        # The directory prefix is always ``issue-`` regardless of branch type.
+        assert branch_names.expected_worktree_dirname("bugfix/5-fix") == "issue-5-fix"
+
+    def test_none_for_non_issue_branch(self) -> None:
+        assert branch_names.expected_worktree_dirname("release/2.1.180") is None
+
+    def test_none_for_malformed(self) -> None:
+        assert branch_names.expected_worktree_dirname("feature/no-number") is None

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import subprocess
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_git import (
+    _check_new_branch_name,
     _noninteractive_rebase_env,
     _org_from_clone_url,
     _parse_branch_target,
+    _parse_new_branch,
     _parse_worktree_add_path,
     _worktree_convention_active,
     main,
@@ -1134,6 +1136,134 @@ class TestWorktreeAddAnchoring:
             rc = main(["worktree", "add", "anything", "origin/develop"])
         assert rc == 0
         mock_run.assert_called_once()
+
+
+# -- work-unit identifier: branch/dir lockstep at creation (#2550) ------------
+
+
+class TestParseNewBranch:
+    """Extract the branch a -b/-B/-c/-C flag creates."""
+
+    def test_worktree_add_b(self) -> None:
+        assert (
+            _parse_new_branch(("-b", "-B"), ["-b", "feature/1-x", ".worktrees/issue-1-x"])
+            == "feature/1-x"
+        )
+
+    def test_switch_c(self) -> None:
+        assert _parse_new_branch(("-c", "-C"), ["-c", "feature/2-y"]) == "feature/2-y"
+
+    def test_no_create_flag_returns_none(self) -> None:
+        assert _parse_new_branch(("-b", "-B"), [".worktrees/issue-1-x", "develop"]) is None
+
+    def test_flag_without_value_returns_none(self) -> None:
+        assert _parse_new_branch(("-b", "-B"), ["-b"]) is None
+
+
+class TestWorktreeAddBranchDirLockstep:
+    """`worktree add -b` enforces branch format and issue-<N>-<slug> directory."""
+
+    @staticmethod
+    def _make_root(tmp_path: Path) -> Path:
+        root = tmp_path / "repo"
+        (root / ".worktrees").mkdir(parents=True)
+        return root
+
+    def _run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, argv: list[str]
+    ) -> tuple[int, MagicMock]:
+        root = self._make_root(tmp_path)
+        monkeypatch.chdir(root)
+        with (
+            patch("vergil_tooling.bin.vrg_git.main_worktree_root", return_value=root),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            rc = main(argv)
+        return rc, mock_run
+
+    def test_matching_branch_and_dir_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        argv = ["worktree", "add", "-b", "feature/9-authz", ".worktrees/issue-9-authz"]
+        rc, mock_run = self._run(tmp_path, monkeypatch, argv)
+        assert rc == 0
+        mock_run.assert_called_once()
+
+    def test_branch_missing_issue_number_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        argv = ["worktree", "add", "-b", "feature/no-number", ".worktrees/issue-1-x"]
+        rc, mock_run = self._run(tmp_path, monkeypatch, argv)
+        assert rc == 1
+        mock_run.assert_not_called()
+        assert "repo issue number" in capsys.readouterr().err
+
+    def test_dir_not_matching_branch_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        argv = ["worktree", "add", "-b", "feature/9-authz", ".worktrees/authz"]
+        rc, mock_run = self._run(tmp_path, monkeypatch, argv)
+        assert rc == 1
+        mock_run.assert_not_called()
+        err = capsys.readouterr().err
+        assert "lockstep" in err
+        assert "issue-9-authz" in err
+
+    def test_release_branch_exempt(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A release branch carries no issue number; neither the format nor the
+        # directory rule applies.
+        argv = ["worktree", "add", "-b", "release/2.1.180", ".worktrees/rel"]
+        rc, mock_run = self._run(tmp_path, monkeypatch, argv)
+        assert rc == 0
+        mock_run.assert_called_once()
+
+    def test_adopt_existing_branch_exempt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No -b: adopting an existing branch into a worktree is not a creation,
+        # so the branch/dir lockstep rule does not apply (only anchoring does).
+        argv = ["worktree", "add", ".worktrees/whatever", "feature/9-authz"]
+        rc, mock_run = self._run(tmp_path, monkeypatch, argv)
+        assert rc == 0
+        mock_run.assert_called_once()
+
+
+class TestCheckNewBranchName:
+    """`checkout -b` / `switch -c` enforce the issue-number rule at creation."""
+
+    def test_checkout_b_malformed_rejected(self) -> None:
+        msg = _check_new_branch_name("checkout", ["-b", "feature/no-number"])
+        assert msg is not None
+        assert "repo issue number" in msg
+
+    def test_switch_c_malformed_rejected(self) -> None:
+        assert _check_new_branch_name("switch", ["-c", "bugfix/nope"]) is not None
+
+    def test_checkout_b_valid_allowed(self) -> None:
+        assert _check_new_branch_name("checkout", ["-b", "feature/12-ok"]) is None
+
+    def test_release_branch_allowed(self) -> None:
+        assert _check_new_branch_name("checkout", ["-b", "release/2.1.180"]) is None
+
+    def test_plain_checkout_allowed(self) -> None:
+        assert _check_new_branch_name("checkout", ["develop"]) is None
+
+    def test_other_subcommand_ignored(self) -> None:
+        # `branch` is not a creation path this guard handles.
+        assert _check_new_branch_name("branch", ["-b", "feature/no-number"]) is None
+
+    def test_checkout_b_malformed_denied_via_main(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Run outside a main worktree / convention dir so the convention guard
+        # is inert and this branch-name guard is what fires.
+        monkeypatch.chdir(tmp_path)
+        with patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run:
+            rc = main(["checkout", "-b", "feature/no-number"])
+        assert rc == 1
+        mock_run.assert_not_called()
+        assert "repo issue number" in capsys.readouterr().err
 
 
 # -- non-interactive rebase (#1742) -------------------------------------------

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -1469,6 +1469,32 @@ def test_submit_batch_rebases_submits_then_finalizes_each_and_releases_once() ->
     assert ("vrg-release",) in finalize_calls
 
 
+def test_submit_batch_summary_labels_by_branch_not_dir(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A worktree whose directory name is a bare slug that hides the issue number
+    # (the issue #2550 scenario). The batch summary must attribute the merge to
+    # the full branch, not the ambiguous directory name.
+    wt = Worktree(
+        path=Path("/repo/.worktrees/authz-apply-tag"), branch="feature/911-authz-apply-tag"
+    )
+    with (
+        patch(_MOD + ".worktrees.rebase_onto"),
+        patch(_MOD + ".os.chdir"),
+        patch(_MOD + ".git.main_worktree_root", return_value=Path("/repo")),
+        patch(_MOD + "._submit_one", return_value="https://x/pull/1"),
+        patch(_MOD + ".confirm", return_value=True),
+    ):
+        rc = _run_submit_batch(
+            [wt], base="develop", finalize=False, release=False, install=False, assume_yes=True
+        )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "feature/911-authz-apply-tag" in out
+    # The bare directory slug must never appear as a standalone summary label.
+    assert "\n    authz-apply-tag\n" not in out
+
+
 def test_submit_batch_rebase_conflict_stops_batch() -> None:
     a, b = _batch_wt("issue-1-a"), _batch_wt("issue-2-b")
     with (


### PR DESCRIPTION
# Pull Request

## Summary

- Enforce the <type>/<N>-<slug> branch rule (and the matching issue-<N>-<slug> worktree directory) at branch creation in vrg-git, and label the submit batch summary by the full branch name, so the issue -> branch -> worktree -> summary chain threads one identifier instead of three divergent ones.

## Issue Linkage

- Closes #2550

## Notes

- Root causes from #2550: (1) the issue-number rule only fired at vrg-commit, never at creation, so a worktree dir chosen at 'worktree add' time could drift from the branch; (2) the submit batch summary labelled by wt.path.name (dir), which could be a bare slug hiding the issue number. Fix adds creation-time enforcement in vrg-git for 'worktree add -b' (branch format + dir/branch lockstep), 'checkout -b', and 'switch -c', and switches the submit summary label to wt.branch. Shared format extracted to lib/branch_names.py so the creation and commit guards can't drift. Deliberate scope: bare 'git branch <name>' creation is left to the commit-time guard because its many read/query sub-modes make positional-creation detection ambiguous; managed_worktree.py is untouched (it uses raw git, not vrg-git, and its automated release/dep dirs are outside this convention). Validation green (4701 tests, 100% coverage).