### PR TITLE
fix(vrg-vm): resume a created-but-unused session by re-entering at its id

### DIFF
--- a/src/vergil_tooling/bin/vrg_vm_resolve.py
+++ b/src/vergil_tooling/bin/vrg_vm_resolve.py
@@ -440,12 +440,25 @@ def _resume_by_name(name: str, extra: list[str]) -> int:
     the caller passed, so Claude derives the same memory slug the session was created
     under (#2607). ``-n`` re-asserts the exact name so the prompt-box title is
     restored even when the last transcript naming event is a legacy ``agent-name``.
+
+    A **materialized** session (claude has written its transcript) is attached with
+    ``--resume <id>``. A **reservation-only** session — one that ``--label`` minted
+    and named but whose id claude never persisted a conversation to, because the
+    session was created and left unused (claude writes the transcript lazily) — has
+    no conversation for ``--resume`` to find, so it is re-entered *at* its id with
+    ``--session-id <id> -n <name>``, exactly as the create path launched it. That
+    materializes the conversation under the same id and name, keeping the
+    name→id binding stable, instead of failing with 'No conversation found with
+    session ID: <id>' (#2669).
     """
     info = plan_resume(ScrapeStore(_claude_dir()), name)
     if info.cwd:
         os.chdir(info.cwd)
-    _note(f"Resuming session {name}")
-    return _exec_claude(["--resume", info.session_id, "-n", name, *extra])
+    if info.materialized:
+        _note(f"Resuming session {name}")
+        return _exec_claude(["--resume", info.session_id, "-n", name, *extra])
+    _note(f"Entering created-but-unused session {name}")
+    return _exec_claude(["--session-id", info.session_id, "-n", name, *extra])
 
 
 def _list_and_guide(slug: str) -> int:

--- a/src/vergil_tooling/lib/session_store.py
+++ b/src/vergil_tooling/lib/session_store.py
@@ -41,6 +41,18 @@ class SessionInfo:
     ``name`` is ``None`` for a live-but-unnamed session (a fresh session that has
     not yet been named); such a row is enumerated but never matches a requested
     name. ``last_active`` is epoch seconds, or ``None`` when the age is unknown.
+
+    ``materialized`` is ``True`` when claude has actually written a transcript for
+    this session id — i.e. ``claude --resume <id>`` will find a conversation. It is
+    ``False`` for a **reservation-only** session: one that ``--label`` minted and
+    reserved a name for, but whose id claude has not yet persisted a conversation
+    to (a created-but-unused session, whose transcript claude writes lazily). The
+    resume path re-enters a reservation-only session *at* its id via
+    ``--session-id`` rather than ``--resume`` (#2669), so the name→id binding
+    stays stable and the resume does not fail with 'No conversation found'. It
+    defaults to ``True`` because only the scrape backend can distinguish the two,
+    and every other constructor (the host-side ``list`` view) neither knows nor
+    consults it; the authoritative value is set by :meth:`ScrapeStore.list_sessions`.
     """
 
     session_id: str
@@ -48,6 +60,7 @@ class SessionInfo:
     cwd: str
     active: bool
     last_active: float | None
+    materialized: bool = True
 
 
 class AmbiguousSessionError(Exception):
@@ -274,6 +287,16 @@ class ScrapeStore:
             transcript_cwd = res.transcript_cwd(res.projects_glob(projects, sid))
             return transcript_cwd or reserved_cwds.get(sid, "")
 
+        def _materialized(sid: str) -> bool:
+            # True iff claude has written a transcript for this id — the exact
+            # signal ``--resume`` needs (and the same one ``_sweep_reservations``
+            # calls "superseded"). A reservation-only session (``--label`` minted
+            # the id and reserved its name, but claude has not yet persisted a
+            # conversation there) has no transcript, so ``--resume`` would fail with
+            # 'No conversation found'; the resume path re-enters it at its id via
+            # ``--session-id`` instead (#2669).
+            return res.projects_glob(projects, sid).exists()
+
         return [
             SessionInfo(
                 session_id=sid,
@@ -281,6 +304,7 @@ class ScrapeStore:
                 cwd=_cwd(sid),
                 active=sid in active,
                 last_active=last_active.get(sid),
+                materialized=_materialized(sid),
             )
             for sid in [*names, *extra]
         ]

--- a/tests/vergil_tooling/test_session_store.py
+++ b/tests/vergil_tooling/test_session_store.py
@@ -186,6 +186,37 @@ def test_reserved_name_resolves_before_transcript_or_roster(tmp_path: Path) -> N
     assert resolved.cwd == "/work/repo"  # recorded cwd stands in until registration
 
 
+def test_reservation_only_session_is_not_materialized(tmp_path: Path) -> None:
+    # #2669: a reservation-only session (claude has written no transcript) resolves
+    # by name but is reported materialized=False, so the resume path re-enters it at
+    # its id instead of `claude --resume`ing an id with no conversation.
+    claude = tmp_path / ".claude"
+    (claude / "projects").mkdir(parents=True)
+    (claude / "sessions").mkdir()
+
+    store = ScrapeStore(claude)
+    store.reserve_name("s1", "adhoc-recheck:w", "/work/repo")
+
+    resolved = store.resolve_name("adhoc-recheck:w")
+    assert resolved is not None
+    assert resolved.session_id == "s1"
+    assert resolved.materialized is False
+
+
+def test_session_with_transcript_is_materialized(tmp_path: Path) -> None:
+    # The counterpart: a session claude has written a transcript for is reported
+    # materialized=True, so the resume path uses `claude --resume <id>` (#2669).
+    claude = tmp_path / ".claude"
+    slug = claude / "projects" / "-w"
+    slug.mkdir(parents=True)
+    (claude / "sessions").mkdir()
+    _write_title(slug / "s1.jsonl", "s1", "epic-1:w")
+
+    resolved = ScrapeStore(claude).resolve_name("epic-1:w")
+    assert resolved is not None
+    assert resolved.materialized is True
+
+
 def test_reservation_and_real_transcript_dedup_to_one_row(tmp_path: Path) -> None:
     # Because the reservation is keyed by the id claude adopts (--session-id), once
     # the real transcript appears the two are the SAME row — one session, the

--- a/tests/vergil_tooling/test_vrg_vm_resolve.py
+++ b/tests/vergil_tooling/test_vrg_vm_resolve.py
@@ -746,10 +746,17 @@ class _FakeStore:
         raise NotImplementedError
 
 
-def _info(sid: str, name: str | None, active: bool, last: float | None, cwd: str = "/w") -> Any:
+def _info(
+    sid: str,
+    name: str | None,
+    active: bool,
+    last: float | None,
+    cwd: str = "/w",
+    materialized: bool = True,
+) -> Any:
     from vergil_tooling.lib.session_store import SessionInfo
 
-    return SessionInfo(sid, name, cwd, active, last)
+    return SessionInfo(sid, name, cwd, active, last, materialized=materialized)
 
 
 def test_plan_resume_resolves_name_to_id() -> None:
@@ -789,6 +796,48 @@ def test_resume_by_name_execs_with_resolved_id_and_cwd(
     assert chdirs == ["/work/repo"]
     assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
     assert "Resuming session epic-1:w" in capsys.readouterr().err
+
+
+def test_resume_materialized_session_uses_resume(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A session whose transcript claude has written (materialized=True) is attached
+    # with `claude --resume <id>` — the normal path stays intact (#2669).
+    store = _FakeStore([_info("b", "epic-1:w", False, 5.0, cwd="/work/repo", materialized=True)])
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    monkeypatch.setattr(os, "chdir", lambda _p: None)
+    assert _resolve("id", "w", resume_name="epic-1:w") == 0
+    assert capture_exec == [["claude", "--resume", "b", "-n", "epic-1:w"]]
+    assert "Resuming session epic-1:w" in capsys.readouterr().err
+
+
+def test_resume_created_but_unused_session_reenters_at_id_2669(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_exec: list[list[str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression for #2669: `--label` mints an id and reserves the name, but the
+    # session is left unused so claude never materializes a transcript. On resume
+    # the name still resolves (via the reservation) to that id, but `claude
+    # --resume <id>` would fail with 'No conversation found'. A reservation-only
+    # (materialized=False) session must instead be re-entered AT its id with
+    # `claude --session-id <id> -n <name>`, exactly as it was created — keeping the
+    # name→id binding stable and materializing the conversation on entry.
+    store = _FakeStore(
+        [_info("uuid-1", "adhoc-recheck:w", False, None, cwd="/work/repo", materialized=False)]
+    )
+    monkeypatch.setattr(r, "ScrapeStore", lambda *_a, **_k: store)
+    chdirs: list[str] = []
+    monkeypatch.setattr(os, "chdir", lambda p: chdirs.append(p))
+    assert _resolve("id", "w", resume_name="adhoc-recheck:w") == 0
+    assert chdirs == ["/work/repo"]
+    # Re-entered at the reserved id, NOT `--resume` (which would 'No conversation found').
+    assert capture_exec == [["claude", "--session-id", "uuid-1", "-n", "adhoc-recheck:w"]]
+    err = capsys.readouterr().err
+    assert "--resume" not in err
+    assert "adhoc-recheck:w" in err
 
 
 def test_no_verb_lists_and_guides(


### PR DESCRIPTION
# Pull Request

## Summary

- On resume, a reservation-only (never-materialized) session is re-entered via 'claude --session-id <id> -n <name>' instead of 'claude --resume <id>', which failed with 'No conversation found' because claude persists a session's transcript lazily.

## Issue Linkage

- Closes #2669

## Notes

- Root cause (confirmed from code): the #2654 collision-race fix makes --label mint an id, reserve name->id in ~/.claude/vrg-session-reservations/<id>.json, and launch 'claude --session-id <id> -n <name>'. Claude writes the transcript lazily, so a created-but-unused session leaves the reservation (within its 600s TTL) resolving the name to an id claude never materialized; _resume_by_name then exec'd 'claude --resume <id>' -> 'No conversation found with session ID: <uuid>'.

Fix: surface transcript existence as a first-class SessionInfo.materialized, computed in ScrapeStore.list_sessions via projects_glob(...).exists() (the same signal _sweep_reservations already calls 'superseded'). _resume_by_name branches on it: materialized -> --resume <id> (unchanged); reservation-only -> re-enter at the id via 'claude --session-id <id> -n <name>', identical to how the create path launched it, so the name->id binding stays stable and the conversation materializes on entry. Idempotent if the re-entered session is again left unused.

Chose re-enter-at-id over force-materialize-on-create: it reuses the exact create-path mechanism and does not fight claude's lazy persistence. Assessment: the reservation approach is NOT fundamentally leaky -- this was the one resume-side hole; the create/collision path is working as intended.

Tests: regression 'create -> don't use -> resume' asserts re-entry via --session-id (not --resume); a materialized session still resumes via --resume; plus seam-level tests that list_sessions reports materialized False for a reservation-only session and True once a transcript exists. vrg-validate green (4705 passed, 100% coverage).