### PR TITLE
docs(config): correct stale port_forwards relay comment

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -212,10 +212,11 @@ class VmStanza:
 # Recognized keys in a [vm] / [vm.<role>] table. apt_repos is a list of tables
 # (key + apt source line); vagrant_plugins is a list of plugin names. The
 # vergil-vm template owns *how* these install — repos never supply a script.
-# port_forwards is a list of "<port>|<host:port>" records the template relays
-# via systemd-socket-proxyd (vergil-vm #170). nested enables Lima nested
-# virtualization for the profile (issue #1447); default off, requires macOS 15+
-# on M3-or-later Apple silicon at create time.
+# port_forwards is a list of "<port>|<host:port>" records the vergil-vm
+# template relays via a per-forward socat service (vergil-vm #170; the relay
+# proxy was switched from systemd-socket-proxyd to socat in vergil-vm #298).
+# nested enables Lima nested virtualization for the profile (issue #1447);
+# default off, requires macOS 15+ on M3-or-later Apple silicon at create time.
 _VM_KEYS = frozenset(
     {
         "cpus",


### PR DESCRIPTION
# Pull Request

## Summary

- Update the config.py comment so port_forwards is described as relayed via socat rather than the now-retired systemd-socket-proxyd (per vergil-vm #298).

## Issue Linkage

- Closes #2674

## Notes

- Comment-only change in src/vergil_tooling/lib/config.py; no behavior change (vergil-tooling only passes the PORT_FORWARDS param through). Follow-up to the relay fix in vergil-project/vergil-vm#298. vrg-validate green.