### PR TITLE
feat(epics): ad-hoc archiving foundations — closedAt, quarter helpers, epic finders

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from vergil_tooling.lib import github
@@ -36,16 +37,36 @@ class IssueRef:
 
 @dataclass(frozen=True)
 class ChildState:
-    """A child task: its ref, open/closed state, and title.
+    """A child task: its ref, open/closed state, title, and close timestamp.
 
     ``title`` is descriptive metadata for machine-readable enumeration (issue
     #2538); it defaults to ``""`` so state-only consumers construct a
-    ``ChildState`` without supplying it.
+    ``ChildState`` without supplying it. ``closed_at`` is the ISO-8601
+    ``closedAt`` string (``""`` when open), so ad-hoc archiving can bucket a
+    closed child by its close-quarter (issue #2678).
     """
 
     ref: IssueRef
     state: str  # "OPEN" | "CLOSED"
     title: str = ""
+    closed_at: str = ""  # ISO-8601 closedAt; "" when open
+
+
+def _quarter_str(dt: datetime) -> str:
+    return f"{dt.year}-Q{(dt.month - 1) // 3 + 1}"
+
+
+def quarter_of(closed_at: str) -> str:
+    """Return the ``YYYY-Qn`` quarter of an ISO-8601 timestamp (UTC)."""
+    if not closed_at:
+        raise ValueError("quarter_of: empty timestamp")
+    dt = datetime.fromisoformat(closed_at.replace("Z", "+00:00"))
+    return _quarter_str(dt)
+
+
+def current_quarter(now: datetime) -> str:
+    """Return the ``YYYY-Qn`` quarter containing *now*."""
+    return _quarter_str(now)
 
 
 _PARENT_RE = re.compile(
@@ -101,7 +122,7 @@ query($id: ID!) {
   node(id: $id) {
     ... on Issue {
       subIssues(first: 100) {
-        nodes { number state title repository { name owner { login } } }
+        nodes { number state title closedAt repository { name owner { login } } }
       }
     }
   }
@@ -162,7 +183,10 @@ def _native_child_states(epic: IssueRef) -> list[ChildState]:
     nodes = (((data or {}).get("node") or {}).get("subIssues") or {}).get("nodes") or []
     return [
         ChildState(
-            ref=_ref_from_node(n), state=str(n["state"]).upper(), title=str(n.get("title") or "")
+            ref=_ref_from_node(n),
+            state=str(n["state"]).upper(),
+            title=str(n.get("title") or ""),
+            closed_at=str(n.get("closedAt") or ""),
         )
         for n in nodes
     ]
@@ -196,7 +220,7 @@ def _reflink_child_states(epic: IssueRef) -> list[ChildState]:
         "--owner",
         epic.owner,
         "--json",
-        "number,state,title,repository,body",
+        "number,state,title,closedAt,repository,body",
     )
     states: list[ChildState] = []
     for item in results if isinstance(results, list) else []:
@@ -211,6 +235,7 @@ def _reflink_child_states(epic: IssueRef) -> list[ChildState]:
                 ref=IssueRef(owner=owner, repo=name, number=int(item["number"])),
                 state=str(item["state"]).upper(),
                 title=str(item.get("title") or ""),
+                closed_at=str(item.get("closedAt") or ""),
             )
         )
     return states
@@ -345,26 +370,20 @@ _ADHOC_EPIC_BODY = (
     "Perpetual umbrella for ad-hoc work in {repo}. Created and reused "
     "idempotently; tasks routed to the ad-hoc epic are linked here.\n"
 )
+# A stamped per-quarter archive epic: "Epic (ad hoc): <bare> — <YYYY>-Qn". The
+# separator is a space, U+2014 em-dash, space. Matching this distinguishes a
+# terminal archive from the live canonical ad-hoc epic (which has no stamp).
+_ADHOC_ARCHIVE_RE = re.compile(r"^Epic \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$")
 
 
-def ensure_adhoc_epic(target_repo: str) -> IssueRef:
-    """Return *target_repo*'s ad-hoc epic in its resolved epic home, creating it if absent.
+def _find_epic_by_title(home: str, title: str) -> IssueRef | None:
+    """Return the open ``ad-hoc`` epic in *home* whose title is exactly *title*.
 
-    The home is derived from *target_repo*'s visibility by
-    :func:`resolve_epic_home`: a public repo homes its ad-hoc epic centrally in
-    ``<org>/.github``; a private repo homes it in itself. One per repo, each
-    disambiguated by the title ``Epic (ad hoc): <bare repo name>`` and labelled
-    ``epic`` + ``ad-hoc``. Idempotent: an existing epic with that title is
-    reused; none means create it; two sharing the title is ambiguous and an
-    error names an explicit ref instead of guessing. Applies to member repos and
-    ``.github`` itself alike.
+    Shared title search for the ad-hoc epic finders. Scoped to open ``epic`` +
+    ``ad-hoc`` issues in *home*; returns None when absent, raises when two share
+    the title (ambiguous — name an explicit ref rather than guess).
     """
-    if "/" not in target_repo:
-        raise ValueError(f"cannot resolve repo for ad-hoc epic (repo={target_repo!r})")
-    owner, bare = target_repo.split("/", 1)
-    home = resolve_epic_home(owner, bare)
-    home_repo = home.split("/", 1)[1]
-    title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}"
+    owner, home_repo = home.split("/", 1)
     raw: Any = github.read_json(
         "issue",
         "list",
@@ -391,6 +410,30 @@ def ensure_adhoc_epic(target_repo: str) -> IssueRef:
         )
     if rows:
         return IssueRef(owner=owner, repo=home_repo, number=int(rows[0]["number"]))
+    return None
+
+
+def ensure_adhoc_epic(target_repo: str) -> IssueRef:
+    """Return *target_repo*'s ad-hoc epic in its resolved epic home, creating it if absent.
+
+    The home is derived from *target_repo*'s visibility by
+    :func:`resolve_epic_home`: a public repo homes its ad-hoc epic centrally in
+    ``<org>/.github``; a private repo homes it in itself. One per repo, each
+    disambiguated by the title ``Epic (ad hoc): <bare repo name>`` and labelled
+    ``epic`` + ``ad-hoc``. Idempotent: an existing epic with that title is
+    reused; none means create it; two sharing the title is ambiguous and an
+    error names an explicit ref instead of guessing. Applies to member repos and
+    ``.github`` itself alike.
+    """
+    if "/" not in target_repo:
+        raise ValueError(f"cannot resolve repo for ad-hoc epic (repo={target_repo!r})")
+    owner, bare = target_repo.split("/", 1)
+    home = resolve_epic_home(owner, bare)
+    home_repo = home.split("/", 1)[1]
+    title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}"
+    found = _find_epic_by_title(home, title)
+    if found is not None:
+        return found
     url = github.create_issue(
         repo=home,
         title=title,
@@ -399,6 +442,72 @@ def ensure_adhoc_epic(target_repo: str) -> IssueRef:
     )
     number = int(url.rstrip("/").rsplit("/", 1)[-1])
     return IssueRef(owner=owner, repo=home_repo, number=number)
+
+
+def find_adhoc_epic(target_repo: str) -> IssueRef | None:
+    """Return the live canonical ad-hoc epic for *target_repo*, or None.
+
+    Unlike :func:`ensure_adhoc_epic`, this never creates: it is the read-only
+    lookup the drain uses to find the epic whose closed children it archives.
+    """
+    if "/" not in target_repo:
+        raise ValueError(f"cannot resolve repo for ad-hoc epic (repo={target_repo!r})")
+    owner, bare = target_repo.split("/", 1)
+    home = resolve_epic_home(owner, bare)
+    return _find_epic_by_title(home, f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}")
+
+
+def ensure_adhoc_archive(target_repo: str, quarter: str) -> IssueRef:
+    """Return *target_repo*'s ``— <quarter>`` archive epic, creating it if absent.
+
+    The archive is the stamped sibling of the live ad-hoc epic — same home, same
+    ``epic`` + ``ad-hoc`` labels — into which closed children of *quarter* are
+    re-parented. Idempotent: an existing stamped archive is reused.
+    """
+    owner, bare = target_repo.split("/", 1)
+    home = resolve_epic_home(owner, bare)
+    home_repo = home.split("/", 1)[1]
+    title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare} — {quarter}"
+    existing = _find_epic_by_title(home, title)
+    if existing is not None:
+        return existing
+    url = github.create_issue(
+        repo=home,
+        title=title,
+        body=f"Ad-hoc work in {target_repo} finished in {quarter}. Managed automatically.\n",
+        labels=list(_ADHOC_EPIC_LABELS),
+    )
+    return IssueRef(owner=owner, repo=home_repo, number=int(url.rstrip("/").rsplit("/", 1)[-1]))
+
+
+def list_open_adhoc_archives(home: str) -> list[tuple[IssueRef, str]]:
+    """Open ``ad-hoc`` archive epics in *home* with their ``YYYY-Qn`` quarter.
+
+    Only stamped archives (title carrying a ``— YYYY-Qn`` suffix) are returned;
+    the live canonical ad-hoc epic (no stamp) is skipped. Used to find archives
+    whose quarter is now past and should be closed.
+    """
+    owner, home_repo = home.split("/", 1)
+    raw: Any = github.read_json(
+        "issue",
+        "list",
+        "--repo",
+        home,
+        "--label",
+        "epic",
+        "--label",
+        "ad-hoc",
+        "--state",
+        "open",
+        "--json",
+        "number,title",
+    )
+    out: list[tuple[IssueRef, str]] = []
+    for r in raw if isinstance(raw, list) else []:
+        m = _ADHOC_ARCHIVE_RE.match(str(r.get("title", ""))) if isinstance(r, dict) else None
+        if m:
+            out.append((IssueRef(owner, home_repo, int(r["number"])), m.group("quarter")))
+    return out
 
 
 def is_epic_linkage(ref: str, *, default_repo: str) -> bool:

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -142,8 +143,93 @@ def test_child_states_reflink_carries_title() -> None:
     ):
         result = epics.child_states(EPIC)
     assert result == [ChildState(IssueRef("org", ".github", 41), "OPEN", "Fallback task")]
-    # The search requests the title field so the fallback listing is complete.
-    assert "number,state,title,repository,body" in mock_search.call_args.args
+    # The search requests the title and closedAt fields so the listing is complete.
+    assert "number,state,title,closedAt,repository,body" in mock_search.call_args.args
+
+
+def test_child_states_native_includes_closed_at() -> None:
+    # The native traversal propagates each child's closedAt (issue #2678); an open
+    # child (closedAt null) yields "".
+    data = {
+        "node": {
+            "subIssues": {
+                "nodes": [
+                    {
+                        "number": 101,
+                        "state": "CLOSED",
+                        "title": "t",
+                        "closedAt": "2026-08-01T10:00:00Z",
+                        "repository": _repo_node("org", "repo-a"),
+                    },
+                    {
+                        "number": 102,
+                        "state": "OPEN",
+                        "title": "u",
+                        "closedAt": None,
+                        "repository": _repo_node("org", "repo-b"),
+                    },
+                ]
+            }
+        }
+    }
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=data),
+    ):
+        result = epics.child_states(EPIC)
+    assert result[0].closed_at == "2026-08-01T10:00:00Z"
+    assert result[1].closed_at == ""
+    # The GraphQL query asks GitHub for the closedAt field.
+    assert "closedAt" in _SUBISSUES_QUERY
+
+
+def test_child_states_reflink_includes_closed_at() -> None:
+    # The portable Parent: reflink fallback also propagates closedAt.
+    empty = {"node": {"subIssues": {"nodes": []}}}
+    search = [
+        {
+            "number": 41,
+            "state": "CLOSED",
+            "title": "t",
+            "closedAt": "2026-05-10T00:00:00Z",
+            "repository": {"nameWithOwner": "org/.github"},
+            "body": "Parent: org/.github#40",
+        }
+    ]
+    with (
+        patch("vergil_tooling.lib.epics._node_id", return_value="NODE"),
+        patch("vergil_tooling.lib.github.graphql", return_value=empty),
+        patch("vergil_tooling.lib.github.read_json", return_value=search),
+    ):
+        result = epics.child_states(EPIC)
+    assert result[0].closed_at == "2026-05-10T00:00:00Z"
+
+
+# -- quarter helpers (issue #2678) -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "iso,expected",
+    [
+        ("2026-01-31T00:00:00Z", "2026-Q1"),
+        ("2026-03-31T23:59:59Z", "2026-Q1"),
+        ("2026-04-01T00:00:00Z", "2026-Q2"),
+        ("2026-07-15T12:00:00Z", "2026-Q3"),
+        ("2026-12-31T23:59:59Z", "2026-Q4"),
+        ("2026-08-01T10:00:00+00:00", "2026-Q3"),
+    ],
+)
+def test_quarter_of(iso: str, expected: str) -> None:
+    assert epics.quarter_of(iso) == expected
+
+
+def test_quarter_of_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="empty timestamp"):
+        epics.quarter_of("")
+
+
+def test_current_quarter() -> None:
+    assert epics.current_quarter(datetime(2026, 8, 8, tzinfo=UTC)) == "2026-Q3"
 
 
 # -- parent_of ---------------------------------------------------------------
@@ -644,6 +730,71 @@ def test_resolve_epic_ref_explicit_non_epic_raises() -> None:
 def test_ensure_adhoc_epic_repo_without_owner_raises() -> None:
     with pytest.raises(ValueError, match="cannot resolve repo for ad-hoc epic"):
         epics.ensure_adhoc_epic("tooling")
+
+
+# -- ad-hoc archive finders (issue #2678) ------------------------------------
+
+
+def test_find_adhoc_epic_returns_none_when_absent() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+    ):
+        assert epics.find_adhoc_epic("org/tooling") is None
+
+
+def test_find_adhoc_epic_reuses_existing_by_title() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[_adhoc_row(1972)]),
+        patch("vergil_tooling.lib.github.create_issue") as mock_create,
+    ):
+        assert epics.find_adhoc_epic("org/tooling") == IssueRef("org", ".github", 1972)
+    mock_create.assert_not_called()  # find never creates
+
+
+def test_find_adhoc_epic_repo_without_owner_raises() -> None:
+    with pytest.raises(ValueError, match="cannot resolve repo for ad-hoc epic"):
+        epics.find_adhoc_epic("tooling")
+
+
+def test_ensure_adhoc_archive_creates_stamped_title() -> None:
+    created = "https://github.com/org/.github/issues/88"
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
+    ):
+        ref = epics.ensure_adhoc_archive("org/tooling", "2026-Q3")
+    assert ref == IssueRef("org", ".github", 88)
+    assert mock_create.call_args.kwargs["title"] == "Epic (ad hoc): tooling — 2026-Q3"
+    assert mock_create.call_args.kwargs["labels"] == ["epic", "ad-hoc"]
+
+
+def test_ensure_adhoc_archive_reuses_existing_stamped() -> None:
+    rows = [{"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q3"}]
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=rows),
+        patch("vergil_tooling.lib.github.create_issue") as mock_create,
+    ):
+        assert epics.ensure_adhoc_archive("org/tooling", "2026-Q3") == IssueRef(
+            "org", ".github", 88
+        )
+    mock_create.assert_not_called()
+
+
+def test_list_open_adhoc_archives_parses_quarter() -> None:
+    rows = [
+        {"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q2"},
+        {"number": 90, "title": "Epic (ad hoc): tooling"},  # live, not an archive
+        {"number": 91, "title": "Epic (ad hoc): tooling — 2026-Q3"},
+    ]
+    with patch("vergil_tooling.lib.github.read_json", return_value=rows):
+        got = epics.list_open_adhoc_archives("org/.github")
+    assert (IssueRef("org", ".github", 88), "2026-Q2") in got
+    assert (IssueRef("org", ".github", 91), "2026-Q3") in got
+    assert all(q for _, q in got) and len(got) == 2
 
 
 # -- resolve_epic_home (epic #130) -------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Adds the shared building blocks for continuous ad-hoc epic archiving (ChildState.closed_at, quarter_of/current_quarter, and the live/archive ad-hoc epic finders) with no behavior change yet, so the drain engine and its call sites can build on them.

## Issue Linkage

- Closes #2678

## Notes

- Plan Tasks 1-3 of epic vergil-project/.github#238. Foundations only — no drain logic wired yet. ensure_adhoc_epic is refactored onto the new shared _find_epic_by_title (its ambiguity error keeps the 'multiple ad-hoc epics' wording so the existing test stays green). Full vrg-validate green: lint, mypy, 4721 tests, 100% branch coverage, audit.