### PR TITLE
feat(epics): add per-repo and org-wide ad-hoc drain engine

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -15,6 +15,7 @@ mock the ``github`` boundary; real GraphQL/REST correctness is exercised in use.
 from __future__ import annotations
 
 import re
+import sys
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -508,6 +509,96 @@ def list_open_adhoc_archives(home: str) -> list[tuple[IssueRef, str]]:
         if m:
             out.append((IssueRef(owner, home_repo, int(r["number"])), m.group("quarter")))
     return out
+
+
+@dataclass(frozen=True)
+class DrainPlan:
+    """A per-repo ad-hoc drain: what to re-parent and what to close.
+
+    ``live`` is the canonical (unstamped) ad-hoc epic. ``moves`` pairs each
+    closed child with its close-quarter (``YYYY-Qn``) archive bucket. ``close``
+    lists open archive epics whose quarter is now past and should be closed.
+    """
+
+    live: IssueRef
+    moves: list[tuple[IssueRef, str]]  # (closed child, its close-quarter)
+    close: list[IssueRef]  # open archives whose quarter is now past
+
+
+def plan_adhoc_drain(target_repo: str, *, now: datetime) -> DrainPlan | None:
+    """Plan *target_repo*'s ad-hoc drain, or None if it has no live ad-hoc epic.
+
+    Buckets each closed child of the live epic by its close-quarter and lists the
+    open archive epics whose quarter is strictly before the current quarter (so
+    they are eligible to close). Pure/read-only: no mutation happens here.
+    """
+    live = find_adhoc_epic(target_repo)
+    if live is None:
+        return None
+    moves = [
+        (c.ref, quarter_of(c.closed_at))
+        for c in child_states(live)
+        if c.state == "CLOSED" and c.closed_at
+    ]
+    owner, bare = target_repo.split("/", 1)
+    home = resolve_epic_home(owner, bare)
+    cur = current_quarter(now)
+    close = [ref for ref, q in list_open_adhoc_archives(home) if q < cur]
+    return DrainPlan(live=live, moves=moves, close=close)
+
+
+def apply_adhoc_drain(target_repo: str, plan: DrainPlan) -> None:
+    """Execute *plan*: ensure each archive, re-parent add-before-remove, close past.
+
+    Each closed child is added to its quarter's archive before being removed from
+    the live epic, so it is never orphaned under neither. Past archives are then
+    closed. ``YYYY-Qn`` is lexicographically chronological, so ``q < cur`` in the
+    plan is a correct "quarter is past" test.
+    """
+    for child, quarter in plan.moves:
+        archive = ensure_adhoc_archive(target_repo, quarter)
+        if archive == plan.live:
+            continue  # defensive: never re-parent into the live epic
+        add_child(archive, child)  # add before remove: never orphan-under-neither
+        remove_child(plan.live, child)
+    for archive in plan.close:
+        github.run(
+            "issue", "close", str(archive.number), "--repo", f"{archive.owner}/{archive.repo}"
+        )
+
+
+def drain_adhoc_repo(target_repo: str, *, apply: bool, now: datetime) -> DrainPlan | None:
+    """Plan *target_repo*'s ad-hoc drain, applying it when *apply* is True.
+
+    Returns the plan (None if *target_repo* has no live ad-hoc epic). With
+    ``apply=False`` this is a pure dry-run.
+    """
+    plan = plan_adhoc_drain(target_repo, now=now)
+    if plan is not None and apply:
+        apply_adhoc_drain(target_repo, plan)
+    return plan
+
+
+def drain_adhoc_org(org: str, *, apply: bool, now: datetime) -> list[DrainPlan]:
+    """Drain every repo in *org*, isolating per-repo failures (spec §7).
+
+    Each repo resolves its own epic home via :func:`drain_adhoc_repo` →
+    :func:`find_adhoc_epic` → :func:`resolve_epic_home`, so public
+    (``.github``-homed) and private (self-homed) ad-hoc epics are both covered. A
+    corrupted repo (e.g. two ad-hoc epics sharing a title) is reported and
+    skipped — never aborting the whole sweep. Returns one plan per repo that has
+    a live ad-hoc epic.
+    """
+    plans: list[DrainPlan] = []
+    for bare in github.list_org_repos(org):
+        try:
+            plan = drain_adhoc_repo(f"{org}/{bare}", apply=apply, now=now)
+        except (ValueError, RuntimeError) as exc:
+            print(f"skipped {org}/{bare}: {exc}", file=sys.stderr)
+            continue
+        if plan is not None:
+            plans.append(plan)
+    return plans
 
 
 def is_epic_linkage(ref: str, *, default_repo: str) -> bool:

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -919,6 +919,16 @@ def merge(pr: str, *, strategy: str) -> None:
     run("pr", "merge", f"--{strategy}", pr)
 
 
+def list_org_repos(org: str) -> list[str]:
+    """Return the bare names of all (non-archived) repositories in *org*."""
+    raw: Any = read_json("repo", "list", org, "--no-archived", "--limit", "1000", "--json", "name")
+    return (
+        [str(r["name"]) for r in raw if isinstance(r, dict) and "name" in r]
+        if isinstance(raw, list)
+        else []
+    )
+
+
 def list_project_repos(owner: str, project: str) -> list[str]:
     """Return sorted, unique repos linked to a GitHub Project."""
     jq_filter = (

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -835,3 +835,165 @@ def test_resolve_epic_home_fails_loud() -> None:
         pytest.raises(github.GitHubAPIError),
     ):
         epics.resolve_epic_home("org", "missing")
+
+
+# --- Task 4: per-repo drain (plan + apply) ---
+
+NOW = datetime(2026, 8, 8, tzinfo=UTC)  # 2026-Q3
+
+
+def _child(n: int, state: str, closed_at: str = "") -> ChildState:
+    return ChildState(IssueRef("org", ".github", n), state, "t", closed_at)
+
+
+def test_plan_drain_moves_closed_buckets_by_quarter_and_closes_past() -> None:
+    live = IssueRef("org", ".github", 40)
+    kids = [
+        _child(101, "CLOSED", "2026-05-10T00:00:00Z"),  # Q2
+        _child(102, "CLOSED", "2026-07-02T00:00:00Z"),  # Q3
+        _child(103, "OPEN"),  # stays
+    ]
+    with (
+        patch("vergil_tooling.lib.epics.find_adhoc_epic", return_value=live),
+        patch("vergil_tooling.lib.epics.child_states", return_value=kids),
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch(
+            "vergil_tooling.lib.epics.list_open_adhoc_archives",
+            return_value=[
+                (IssueRef("org", ".github", 88), "2026-Q2"),
+                (IssueRef("org", ".github", 91), "2026-Q3"),
+            ],
+        ),
+    ):
+        plan = epics.plan_adhoc_drain("org/tooling", now=NOW)
+    assert plan is not None
+    assert (IssueRef("org", ".github", 101), "2026-Q2") in plan.moves
+    assert (IssueRef("org", ".github", 102), "2026-Q3") in plan.moves
+    assert all(ref.number != 103 for ref, _ in plan.moves)  # open child not moved
+    assert plan.close == [IssueRef("org", ".github", 88)]  # Q2 < Q3 -> close; Q3 stays open
+
+
+def test_plan_drain_none_when_no_live_epic() -> None:
+    with patch("vergil_tooling.lib.epics.find_adhoc_epic", return_value=None):
+        assert epics.plan_adhoc_drain("org/tooling", now=NOW) is None
+
+
+def test_apply_drain_ensures_archive_moves_then_closes() -> None:
+    live = IssueRef("org", ".github", 40)
+    plan = epics.DrainPlan(
+        live=live,
+        moves=[(IssueRef("org", ".github", 101), "2026-Q2")],
+        close=[IssueRef("org", ".github", 88)],
+    )
+    arch = IssueRef("org", ".github", 88)
+    calls: list[tuple[str, IssueRef, IssueRef]] = []
+    with (
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
+        patch(
+            "vergil_tooling.lib.epics.add_child",
+            side_effect=lambda e, t: calls.append(("add", e, t)),
+        ),
+        patch(
+            "vergil_tooling.lib.epics.remove_child",
+            side_effect=lambda e, t: calls.append(("rm", e, t)),
+        ),
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.apply_adhoc_drain("org/tooling", plan)
+    mock_ens.assert_called_once_with("org/tooling", "2026-Q2")
+    # add_child before remove_child (never orphan-under-neither)
+    assert calls == [
+        ("add", arch, IssueRef("org", ".github", 101)),
+        ("rm", live, IssueRef("org", ".github", 101)),
+    ]
+    assert mock_run.call_args.args[:2] == ("issue", "close")
+    assert "88" in mock_run.call_args.args
+
+
+def test_apply_drain_skips_archive_equal_to_live() -> None:
+    live = IssueRef("org", ".github", 40)
+    plan = epics.DrainPlan(
+        live=live,
+        moves=[(IssueRef("org", ".github", 101), "2026-Q2")],
+        close=[],
+    )
+    with (
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=live),
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
+        epics.apply_adhoc_drain("org/tooling", plan)
+    mock_add.assert_not_called()  # defensive: never re-parent into the live epic
+    mock_rm.assert_not_called()
+    mock_run.assert_not_called()
+
+
+def test_drain_adhoc_repo_applies_when_apply_true() -> None:
+    plan = epics.DrainPlan(IssueRef("org", ".github", 40), moves=[], close=[])
+    with (
+        patch("vergil_tooling.lib.epics.plan_adhoc_drain", return_value=plan) as mock_plan,
+        patch("vergil_tooling.lib.epics.apply_adhoc_drain") as mock_apply,
+    ):
+        result = epics.drain_adhoc_repo("org/tooling", apply=True, now=NOW)
+    assert result is plan
+    mock_apply.assert_called_once_with("org/tooling", plan)
+    assert mock_plan.call_args.kwargs["now"] == NOW
+
+
+def test_drain_adhoc_repo_dry_run_does_not_apply() -> None:
+    plan = epics.DrainPlan(IssueRef("org", ".github", 40), moves=[], close=[])
+    with (
+        patch("vergil_tooling.lib.epics.plan_adhoc_drain", return_value=plan),
+        patch("vergil_tooling.lib.epics.apply_adhoc_drain") as mock_apply,
+    ):
+        result = epics.drain_adhoc_repo("org/tooling", apply=False, now=NOW)
+    assert result is plan
+    mock_apply.assert_not_called()
+
+
+def test_drain_adhoc_repo_none_plan_never_applies() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.plan_adhoc_drain", return_value=None),
+        patch("vergil_tooling.lib.epics.apply_adhoc_drain") as mock_apply,
+    ):
+        result = epics.drain_adhoc_repo("org/tooling", apply=True, now=NOW)
+    assert result is None
+    mock_apply.assert_not_called()
+
+
+# --- Task 5: org-wide drain (visibility-aware) ---
+
+
+def test_drain_adhoc_org_iterates_repos_visibility_aware() -> None:
+    seen: list[tuple[str, bool]] = []
+
+    def fake_repo(target_repo: str, *, apply: bool, now: datetime) -> None:
+        seen.append((target_repo, apply))
+        return None
+
+    with (
+        patch("vergil_tooling.lib.github.list_org_repos", return_value=["tooling", "priv"]),
+        patch("vergil_tooling.lib.epics.drain_adhoc_repo", side_effect=fake_repo),
+    ):
+        epics.drain_adhoc_org("org", apply=True, now=NOW)
+    assert ("org/tooling", True) in seen and ("org/priv", True) in seen
+
+
+def test_drain_adhoc_org_skips_repo_that_raises() -> None:
+    good = epics.DrainPlan(IssueRef("org", ".github", 40), moves=[], close=[])
+    seen: list[str] = []
+
+    def fake(target_repo: str, *, apply: bool, now: datetime) -> epics.DrainPlan:
+        seen.append(target_repo)
+        if target_repo == "org/bad":
+            raise ValueError("multiple ad-hoc epics — corruption")
+        return good
+
+    with (
+        patch("vergil_tooling.lib.github.list_org_repos", return_value=["bad", "good"]),
+        patch("vergil_tooling.lib.epics.drain_adhoc_repo", side_effect=fake),
+    ):
+        plans = epics.drain_adhoc_org("org", apply=True, now=NOW)  # must NOT raise
+    assert seen == ["org/bad", "org/good"]  # continued past the failure
+    assert plans == [good]  # the healthy repo still drained

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -572,6 +572,27 @@ def test_merge_squash_strategy() -> None:
     mock_run.assert_called_once_with("pr", "merge", "--squash", "https://github.com/pr/1")
 
 
+def test_list_org_repos() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_json",
+        return_value=[{"name": "tooling"}, {"name": ".github"}, {"name": "vm"}],
+    ):
+        assert github.list_org_repos("org") == ["tooling", ".github", "vm"]
+
+
+def test_list_org_repos_filters_non_dict_and_nameless() -> None:
+    with patch(
+        "vergil_tooling.lib.github.read_json",
+        return_value=["nope", {"id": 1}, {"name": "keep"}],
+    ):
+        assert github.list_org_repos("org") == ["keep"]
+
+
+def test_list_org_repos_non_list_is_empty() -> None:
+    with patch("vergil_tooling.lib.github.read_json", return_value={"unexpected": True}):
+        assert github.list_org_repos("org") == []
+
+
 def test_list_project_repos() -> None:
     with patch(
         "vergil_tooling.lib.github.read_output",


### PR DESCRIPTION
# Pull Request

## Summary

- Add DrainPlan plus plan/apply/drain_adhoc_repo and visibility-aware drain_adhoc_org (with github.list_org_repos) that bucket closed ad-hoc children into per-quarter archive epics and close past archives.

## Issue Linkage

- Closes #2679

## Notes

- Implements plan Tasks 4 and 5 for epic vergil-project/.github#238, building on the #2678 foundations. Pure plan_adhoc_drain buckets closed children by close-quarter and lists past archives; apply re-parents add-before-remove then closes past archives; drain_adhoc_org isolates per-repo ValueError/RuntimeError failures (report-and-skip). Full vrg-validate green: 4733 tests, 100% branch coverage.