### PR TITLE
feat(epics): drain closed child on close via rollup hook

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -171,6 +171,16 @@ def _issue_state(ref: IssueRef) -> str:
     return github.read_output("api", _issue_endpoint(ref), "--jq", ".state").upper()
 
 
+def _issue_title(ref: IssueRef) -> str:
+    """Return an issue's title (used to tell a live ad-hoc epic from an archive)."""
+    return github.read_output("api", _issue_endpoint(ref), "--jq", ".title")
+
+
+def _issue_closed_at(ref: IssueRef) -> str:
+    """Return an issue's ISO-8601 ``closed_at`` string, or ``""`` when still open."""
+    return github.read_output("api", _issue_endpoint(ref), "--jq", '.closed_at // ""')
+
+
 def _ref_from_node(node: Any) -> IssueRef:
     """Build an ``IssueRef`` from a GraphQL issue node (number + repository)."""
     repo = node["repository"]
@@ -662,12 +672,27 @@ def rollup(task: IssueRef) -> None:
 
     A no-op unless the task has an ``epic``-labeled parent (the transition gate):
     legacy issues have no epic parent, so finalize never rolls them up. An
-    ``ad-hoc`` epic is perpetual and never auto-closes.
+    ``ad-hoc`` epic is perpetual and never auto-closes; instead, when the
+    just-closed child's parent is the **live** ad-hoc epic, drain that one child
+    into its close-quarter archive (the steady-state event path). A parent that
+    is itself a stamped archive is terminal and left untouched.
     """
     parent = parent_of(task)
     if parent is None or not is_epic(parent):
         return
     if "ad-hoc" in _labels(parent):
+        owner, home_repo = parent.owner, parent.repo
+        title = _issue_title(parent)
+        # Only the LIVE canonical ad-hoc epic drains; archives (stamped) are terminal.
+        if _ADHOC_ARCHIVE_RE.match(title):
+            return
+        closed_at = _issue_closed_at(task)
+        if not closed_at:
+            return
+        archive = ensure_adhoc_archive(f"{owner}/{home_repo}", quarter_of(closed_at))
+        if archive != parent:
+            add_child(archive, task)
+            remove_child(parent, task)
         return
     if all_children_closed(parent):
         print(f"Rolling up epic {parent.slug} — all child tasks closed.")

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -334,6 +334,18 @@ def test_issue_state_uppercases() -> None:
         assert epics._issue_state(EPIC) == "CLOSED"
 
 
+def test_issue_title_reads_via_rest() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value="Epic (ad hoc): repo") as m:
+        assert epics._issue_title(EPIC) == "Epic (ad hoc): repo"
+    assert m.call_args.args == ("api", "repos/org/.github/issues/40", "--jq", ".title")
+
+
+def test_issue_closed_at_reads_via_rest() -> None:
+    with patch("vergil_tooling.lib.github.read_output", return_value="2026-05-01T00:00:00Z") as m:
+        assert epics._issue_closed_at(TASK) == "2026-05-01T00:00:00Z"
+    assert m.call_args.args == ("api", "repos/org/repo-a/issues/101", "--jq", '.closed_at // ""')
+
+
 def test_reflink_skips_results_without_repo() -> None:
     search = [
         {
@@ -548,16 +560,72 @@ def test_rollup_holds_epic_open_while_validation_child_open() -> None:
     mock_run.assert_not_called()  # epic stays open — a validation child is still open
 
 
-def test_rollup_skips_adhoc_epic() -> None:
+def test_rollup_archives_closed_child_under_live_adhoc() -> None:
+    task = IssueRef("org", ".github", 101)
+    live = IssueRef("org", ".github", 40)
+    arch = IssueRef("org", ".github", 88)
     with (
-        patch("vergil_tooling.lib.epics.parent_of", return_value=EPIC),
-        patch("vergil_tooling.lib.epics.is_epic", return_value=True),
+        patch("vergil_tooling.lib.epics.parent_of", return_value=live),
         patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
-        patch("vergil_tooling.lib.epics.all_children_closed", return_value=True),
-        patch("vergil_tooling.lib.github.run") as mock_run,
+        patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
+        patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
+    ):
+        epics.rollup(task)
+    mock_ens.assert_called_once_with("org/.github", "2026-Q2")
+    mock_add.assert_called_once_with(arch, task)
+    mock_rm.assert_called_once_with(live, task)
+
+
+def test_rollup_noop_when_parent_is_adhoc_archive() -> None:
+    task = IssueRef("org", ".github", 101)
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=IssueRef("org", ".github", 88)),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
+        patch(
+            "vergil_tooling.lib.epics._issue_title",
+            return_value="Epic (ad hoc): .github — 2026-Q2",
+        ),
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+    ):
+        epics.rollup(task)
+    mock_add.assert_not_called()
+
+
+def test_rollup_noop_when_closed_child_lacks_closed_at() -> None:
+    # Defensive: a rollup event with no resolvable closed_at drains nothing.
+    live = IssueRef("org", ".github", 40)
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=live),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
+        patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
+        patch("vergil_tooling.lib.epics._issue_closed_at", return_value=""),
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive") as mock_ens,
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
     ):
         epics.rollup(TASK)
-    mock_run.assert_not_called()
+    mock_ens.assert_not_called()
+    mock_add.assert_not_called()
+
+
+def test_rollup_skips_reparent_when_archive_is_the_live_epic() -> None:
+    # Defensive guard: if the resolved archive is the live epic itself, never
+    # re-parent the child into its own parent (add_child/remove_child skipped).
+    live = IssueRef("org", ".github", 40)
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=live),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
+        patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
+        patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=live),
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
+    ):
+        epics.rollup(TASK)
+    mock_add.assert_not_called()
+    mock_rm.assert_not_called()
 
 
 def test_rollup_skips_when_children_remain_open() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- rollup() now archives a just-closed child of a live ad-hoc epic into its close-quarter archive, while archive and finite parents stay unchanged.

## Issue Linkage

- Closes #2680

## Notes

- Task 6 of epic vergil-project/.github#238. Adds _issue_title/_issue_closed_at readers and rewrites the ad-hoc branch of rollup(): live epic drains one child (add-before-remove) into ensure_adhoc_archive; stamped archives are terminal; missing closed_at and archive==parent are no-ops. All four new branches plus the two reader bodies are covered; validation green at 100% (4726 passed).