### PR TITLE
feat(adhoc-epic): add 'archive' subcommand

### DIFF
--- a/src/vergil_tooling/bin/vrg_adhoc_epic.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_epic.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from datetime import UTC, datetime
 
 from vergil_tooling.lib import epics, github
 
@@ -33,6 +34,38 @@ def cmd_ensure(args: argparse.Namespace) -> int:
     return 0
 
 
+def _render_plan(plan: epics.DrainPlan) -> str:
+    lines = [f"{plan.live.slug}: {len(plan.moves)} closed child(ren) to archive"]
+    for child, quarter in plan.moves:
+        lines.append(f"  {child.slug} -> {quarter}")
+    for archive in plan.close:
+        lines.append(f"  close past archive {archive.slug}")
+    return "\n".join(lines)
+
+
+def cmd_archive(args: argparse.Namespace) -> int:
+    now = datetime.now(UTC)
+    verb = "APPLY" if args.apply else "DRY-RUN"
+    if args.all_in:
+        # Scope the App token to the org before any mutation, mirroring
+        # vrg-epic-move / vrg-issue-create (spec §7).
+        with github.target_org(args.all_in):
+            plans = epics.drain_adhoc_org(args.all_in, apply=args.apply, now=now)
+        print(f"[{verb}] {args.all_in}: {len(plans)} ad-hoc epic(s) with work to archive")
+        for plan in plans:
+            print(_render_plan(plan))
+        return 0
+    repo = args.repo or github.current_repo()
+    if "/" not in repo:
+        print(f"vrg-adhoc-epic: --repo must be 'owner/repo' (got {repo!r})", file=sys.stderr)
+        return 1
+    owner = repo.split("/", 1)[0]
+    with github.target_org(owner):
+        repo_plan = epics.drain_adhoc_repo(repo, apply=args.apply, now=now)
+    print(f"[{verb}] " + (_render_plan(repo_plan) if repo_plan else f"{repo}: no ad-hoc epic"))
+    return 0
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -50,6 +83,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p_ensure.add_argument("--repo", help="Target repo owner/name (defaults to the current repo)")
     p_ensure.set_defaults(func=cmd_ensure)
+    p_arch = sub.add_parser(
+        "archive",
+        help="Drain closed children into per-quarter archives (dry-run unless --apply).",
+    )
+    scope = p_arch.add_mutually_exclusive_group()
+    scope.add_argument("--repo", help="Target repo owner/name (defaults to the current repo)")
+    scope.add_argument("--all-in", metavar="ORG", help="Sweep every repo in ORG")
+    p_arch.add_argument("--apply", action="store_true", help="Execute (default: dry-run)")
+    p_arch.set_defaults(func=cmd_archive)
     return parser.parse_args(argv)
 
 

--- a/tests/vergil_tooling/test_vrg_adhoc_epic.py
+++ b/tests/vergil_tooling/test_vrg_adhoc_epic.py
@@ -77,3 +77,100 @@ def test_ensure_private_repo_echoes_self_home(capsys: pytest.CaptureFixture[str]
     out = capsys.readouterr().out
     assert "epic home: org/lab [PRIVATE]" in out
     assert "org/lab#3" in out
+
+
+def test_archive_repo_dry_run_default(capsys: pytest.CaptureFixture[str]) -> None:
+    plan = epics.DrainPlan(
+        epics.IssueRef("org", ".github", 40),
+        moves=[(epics.IssueRef("org", ".github", 101), "2026-Q2")],
+        close=[],
+    )
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/tooling"),
+        patch(f"{_MOD}.github.target_org") as mock_scope,  # MagicMock is a ctx manager
+        patch(f"{_MOD}.epics.drain_adhoc_repo", return_value=plan) as mock_drain,
+    ):
+        rc = main(["archive"])
+    assert rc == 0
+    assert mock_drain.call_args.kwargs["apply"] is False
+    assert mock_scope.call_args.args[0] == "org"  # token scoped to the owner
+    assert "org/.github#101" in capsys.readouterr().out
+
+
+def test_archive_repo_override_apply(capsys: pytest.CaptureFixture[str]) -> None:
+    plan = epics.DrainPlan(
+        epics.IssueRef("org", ".github", 40),
+        moves=[],
+        close=[epics.IssueRef("org", ".github", 88)],
+    )
+    with (
+        patch(f"{_MOD}.github.current_repo") as mock_cur,
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.drain_adhoc_repo", return_value=plan) as mock_drain,
+    ):
+        rc = main(["archive", "--repo", "org/tooling", "--apply"])
+    assert rc == 0
+    mock_cur.assert_not_called()
+    assert mock_drain.call_args.args[0] == "org/tooling"
+    assert mock_drain.call_args.kwargs["apply"] is True
+    assert mock_scope.call_args.args[0] == "org"
+    out = capsys.readouterr().out
+    assert "[APPLY]" in out
+    assert "close past archive org/.github#88" in out
+
+
+def test_archive_repo_no_epic(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/tooling"),
+        patch(f"{_MOD}.github.target_org"),
+        patch(f"{_MOD}.epics.drain_adhoc_repo", return_value=None),
+    ):
+        rc = main(["archive"])
+    assert rc == 0
+    assert "org/tooling: no ad-hoc epic" in capsys.readouterr().out
+
+
+def test_archive_malformed_repo_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="noslash"),
+        patch(f"{_MOD}.epics.drain_adhoc_repo") as mock_drain,
+    ):
+        rc = main(["archive"])
+    assert rc == 1
+    assert "owner/repo" in capsys.readouterr().err
+    mock_drain.assert_not_called()
+
+
+def test_archive_all_in_apply(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.drain_adhoc_org", return_value=[]) as mock_org,
+    ):
+        rc = main(["archive", "--all-in", "org", "--apply"])
+    assert rc == 0
+    assert mock_org.call_args.args[0] == "org"
+    assert mock_org.call_args.kwargs["apply"] is True
+    assert mock_scope.call_args.args[0] == "org"  # token scoped to the org
+
+
+def test_archive_all_in_renders_each_plan(capsys: pytest.CaptureFixture[str]) -> None:
+    plan = epics.DrainPlan(
+        epics.IssueRef("org", ".github", 40),
+        moves=[(epics.IssueRef("org", ".github", 101), "2026-Q2")],
+        close=[],
+    )
+    with (
+        patch(f"{_MOD}.github.target_org"),
+        patch(f"{_MOD}.epics.drain_adhoc_org", return_value=[plan]),
+    ):
+        rc = main(["archive", "--all-in", "org"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[DRY-RUN]" in out
+    assert "org: 1 ad-hoc epic(s) with work to archive" in out
+    assert "org/.github#101 -> 2026-Q2" in out
+
+
+def test_archive_repo_and_all_in_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["archive", "--repo", "org/tooling", "--all-in", "org"])


### PR DESCRIPTION
# Pull Request

## Summary

- Add the vrg-adhoc-epic archive subcommand that drains closed ad-hoc epic children into per-quarter archives, dry-run by default with --apply to execute and --repo or --all-in for scope.

## Issue Linkage

- Closes #2681

## Notes

- Task 7 of epic vergil-project/.github#238. Builds on the merged drain engine (epics.drain_adhoc_repo/drain_adhoc_org/DrainPlan from #2679). Wraps mutations in github.target_org for App-token scoping. Full vrg-validate green: 4745 tests, 100% branch coverage. Covered branches: --all-in org path, --repo/current-repo path, malformed-repo error, dry-run vs --apply verb, and the plan-vs-no-epic print path.