### PR TITLE
fix(epics): atomically re-parent ad-hoc children via replaceParent

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -156,6 +156,14 @@ mutation($parent: ID!, $child: ID!) {
 }
 """
 
+_REPARENT_SUBISSUE = """
+mutation($parent: ID!, $child: ID!) {
+  addSubIssue(input: {issueId: $parent, subIssueId: $child, replaceParent: true}) {
+    subIssue { number }
+  }
+}
+"""
+
 
 def _issue_endpoint(ref: IssueRef) -> str:
     return f"repos/{ref.owner}/{ref.repo}/issues/{ref.number}"
@@ -320,6 +328,19 @@ def add_child(epic: IssueRef, task: IssueRef) -> None:
 def remove_child(epic: IssueRef, task: IssueRef) -> None:
     """Unlink *task* from *epic* (remove the native sub-issue relationship)."""
     github.graphql(_REMOVE_SUBISSUE, parent=_node_id(epic), child=_node_id(task))
+
+
+def reparent_child(new_parent: IssueRef, task: IssueRef) -> None:
+    """Atomically move *task* from its current parent under *new_parent*.
+
+    GitHub's native sub-issues enforce a single parent, so an add-before-remove
+    re-parent is rejected while the child is still linked to its old parent
+    ("Sub issue may only have one parent"). ``replaceParent: true`` performs the
+    move in one call — no orphan window, no separate remove (issue #2691, proven
+    live via #2677). Only ever targets the current-quarter archive, which is
+    always open, so no reopen-if-closed is needed here.
+    """
+    github.graphql(_REPARENT_SUBISSUE, parent=_node_id(new_parent), child=_node_id(task))
 
 
 def all_children_closed(epic: IssueRef) -> bool:
@@ -558,19 +579,19 @@ def plan_adhoc_drain(target_repo: str, *, now: datetime) -> DrainPlan | None:
 
 
 def apply_adhoc_drain(target_repo: str, plan: DrainPlan) -> None:
-    """Execute *plan*: ensure each archive, re-parent add-before-remove, close past.
+    """Execute *plan*: ensure each archive, atomically re-parent, close past.
 
-    Each closed child is added to its quarter's archive before being removed from
-    the live epic, so it is never orphaned under neither. Past archives are then
-    closed. ``YYYY-Qn`` is lexicographically chronological, so ``q < cur`` in the
-    plan is a correct "quarter is past" test.
+    Each closed child is atomically re-parented from the live epic into its
+    quarter's archive via :func:`reparent_child` (``replaceParent: true``) — one
+    call, no orphan window, no separate remove (issue #2691). Past archives are
+    then closed. ``YYYY-Qn`` is lexicographically chronological, so ``q < cur`` in
+    the plan is a correct "quarter is past" test.
     """
     for child, quarter in plan.moves:
         archive = ensure_adhoc_archive(target_repo, quarter)
         if archive == plan.live:
             continue  # defensive: never re-parent into the live epic
-        add_child(archive, child)  # add before remove: never orphan-under-neither
-        remove_child(plan.live, child)
+        reparent_child(archive, child)
     for archive in plan.close:
         github.run(
             "issue", "close", str(archive.number), "--repo", f"{archive.owner}/{archive.repo}"
@@ -691,8 +712,7 @@ def rollup(task: IssueRef) -> None:
             return
         archive = ensure_adhoc_archive(f"{owner}/{home_repo}", quarter_of(closed_at))
         if archive != parent:
-            add_child(archive, task)
-            remove_child(parent, task)
+            reparent_child(archive, task)  # atomic move: single-parent safe (#2691)
         return
     if all_children_closed(parent):
         print(f"Rolling up epic {parent.slug} — all child tasks closed.")

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -570,13 +570,16 @@ def test_rollup_archives_closed_child_under_live_adhoc() -> None:
         patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
         patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
         patch("vergil_tooling.lib.epics.add_child") as mock_add,
         patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
     ):
         epics.rollup(task)
     mock_ens.assert_called_once_with("org/.github", "2026-Q2")
-    mock_add.assert_called_once_with(arch, task)
-    mock_rm.assert_called_once_with(live, task)
+    # Atomic single-parent-safe re-parent — no separate add/remove (#2691).
+    mock_reparent.assert_called_once_with(arch, task)
+    mock_add.assert_not_called()
+    mock_rm.assert_not_called()
 
 
 def test_rollup_noop_when_parent_is_adhoc_archive() -> None:
@@ -588,10 +591,10 @@ def test_rollup_noop_when_parent_is_adhoc_archive() -> None:
             "vergil_tooling.lib.epics._issue_title",
             return_value="Epic (ad hoc): .github — 2026-Q2",
         ),
-        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
     ):
         epics.rollup(task)
-    mock_add.assert_not_called()
+    mock_reparent.assert_not_called()
 
 
 def test_rollup_noop_when_closed_child_lacks_closed_at() -> None:
@@ -603,16 +606,16 @@ def test_rollup_noop_when_closed_child_lacks_closed_at() -> None:
         patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
         patch("vergil_tooling.lib.epics._issue_closed_at", return_value=""),
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive") as mock_ens,
-        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
     ):
         epics.rollup(TASK)
     mock_ens.assert_not_called()
-    mock_add.assert_not_called()
+    mock_reparent.assert_not_called()
 
 
 def test_rollup_skips_reparent_when_archive_is_the_live_epic() -> None:
     # Defensive guard: if the resolved archive is the live epic itself, never
-    # re-parent the child into its own parent (add_child/remove_child skipped).
+    # re-parent the child into its own parent (reparent_child skipped).
     live = IssueRef("org", ".github", 40)
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=live),
@@ -620,12 +623,10 @@ def test_rollup_skips_reparent_when_archive_is_the_live_epic() -> None:
         patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
         patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=live),
-        patch("vergil_tooling.lib.epics.add_child") as mock_add,
-        patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
     ):
         epics.rollup(TASK)
-    mock_add.assert_not_called()
-    mock_rm.assert_not_called()
+    mock_reparent.assert_not_called()
 
 
 def test_rollup_skips_when_children_remain_open() -> None:
@@ -693,6 +694,26 @@ def test_remove_child_issues_removesubissue_mutation() -> None:
     mock_graphql.assert_called_once()
     assert "removeSubIssue" in mock_graphql.call_args.args[0]
     assert mock_graphql.call_args.kwargs == {"parent": "EPIC_ID", "child": "TASK_ID"}
+
+
+# -- reparent_child (atomic single-parent-safe move, #2691) ------------------
+
+
+def test_reparent_mutation_uses_replace_parent() -> None:
+    # GitHub's single-parent rule makes add-before-remove impossible; the atomic
+    # move rides addSubIssue with replaceParent: true (issue #2691, proven live).
+    assert "replaceParent: true" in epics._REPARENT_SUBISSUE
+
+
+def test_reparent_child_issues_replace_parent_mutation() -> None:
+    with (
+        patch("vergil_tooling.lib.epics._node_id", side_effect=["ARCHIVE_ID", "TASK_ID"]),
+        patch("vergil_tooling.lib.github.graphql") as mock_graphql,
+    ):
+        epics.reparent_child(EPIC, TASK)
+    mock_graphql.assert_called_once()
+    assert "replaceParent: true" in mock_graphql.call_args.args[0]
+    assert mock_graphql.call_args.kwargs == {"parent": "ARCHIVE_ID", "child": "TASK_ID"}
 
 
 # -- resolve_epic_ref / ensure_adhoc_epic ------------------------------------
@@ -954,26 +975,19 @@ def test_apply_drain_ensures_archive_moves_then_closes() -> None:
         close=[IssueRef("org", ".github", 88)],
     )
     arch = IssueRef("org", ".github", 88)
-    calls: list[tuple[str, IssueRef, IssueRef]] = []
     with (
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
-        patch(
-            "vergil_tooling.lib.epics.add_child",
-            side_effect=lambda e, t: calls.append(("add", e, t)),
-        ),
-        patch(
-            "vergil_tooling.lib.epics.remove_child",
-            side_effect=lambda e, t: calls.append(("rm", e, t)),
-        ),
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
+        patch("vergil_tooling.lib.epics.add_child") as mock_add,
+        patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
         patch("vergil_tooling.lib.github.run") as mock_run,
     ):
         epics.apply_adhoc_drain("org/tooling", plan)
     mock_ens.assert_called_once_with("org/tooling", "2026-Q2")
-    # add_child before remove_child (never orphan-under-neither)
-    assert calls == [
-        ("add", arch, IssueRef("org", ".github", 101)),
-        ("rm", live, IssueRef("org", ".github", 101)),
-    ]
+    # Single atomic re-parent — no add-before-remove (single-parent safe, #2691).
+    mock_reparent.assert_called_once_with(arch, IssueRef("org", ".github", 101))
+    mock_add.assert_not_called()
+    mock_rm.assert_not_called()
     assert mock_run.call_args.args[:2] == ("issue", "close")
     assert "88" in mock_run.call_args.args
 
@@ -987,13 +1001,11 @@ def test_apply_drain_skips_archive_equal_to_live() -> None:
     )
     with (
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=live),
-        patch("vergil_tooling.lib.epics.add_child") as mock_add,
-        patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
         patch("vergil_tooling.lib.github.run") as mock_run,
     ):
         epics.apply_adhoc_drain("org/tooling", plan)
-    mock_add.assert_not_called()  # defensive: never re-parent into the live epic
-    mock_rm.assert_not_called()
+    mock_reparent.assert_not_called()  # defensive: never re-parent into the live epic
     mock_run.assert_not_called()
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the deadlocked add-before-remove re-parent in the ad-hoc drain and rollup event path with a single atomic addSubIssue replaceParent:true call, fixing the GitHub single-parent rejection.

## Issue Linkage

- Closes #2691

## Notes

- Root cause: GitHub native sub-issues enforce one parent, so add_child(archive) was rejected while the child was still under the live epic (Sub issue may only have one parent), deadlocking the drain. Fix adds reparent_child() using replaceParent:true and swaps it into both apply_adhoc_drain and rollup()'s ad-hoc branch; add_child/remove_child stay for other callers. This exact mutation was proven live against real GitHub via the #2677 validation. Unit tests mock the GitHub boundary so they cannot re-prove the API behavior; that is re-verified by re-running #2677 after merge. Tests rewritten to assert a single reparent call plus a direct reparent_child test and a replaceParent:true assertion. Full container gate green: 4751 passed, 100% branch coverage.