### PR TITLE
fix(epics): ensure ad-hoc archive once per quarter; tolerate duplicate archives

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -408,12 +408,16 @@ _ADHOC_EPIC_BODY = (
 _ADHOC_ARCHIVE_RE = re.compile(r"^Epic \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$")
 
 
-def _find_epic_by_title(home: str, title: str) -> IssueRef | None:
+def _find_epic_by_title(home: str, title: str, *, prefer_oldest: bool = False) -> IssueRef | None:
     """Return the open ``ad-hoc`` epic in *home* whose title is exactly *title*.
 
     Shared title search for the ad-hoc epic finders. Scoped to open ``epic`` +
-    ``ad-hoc`` issues in *home*; returns None when absent, raises when two share
-    the title (ambiguous — name an explicit ref rather than guess).
+    ``ad-hoc`` issues in *home*; returns None when absent. On more than one match
+    the default raises (ambiguous — name an explicit ref rather than guess), which
+    is correct for the *live* ad-hoc epic where two rows is real corruption. When
+    *prefer_oldest* is True the lowest-numbered match is returned instead: archive
+    resolution tolerates the transient duplicate archives produced by the
+    list-consistency race (#2698) and reuses the oldest.
     """
     owner, home_repo = home.split("/", 1)
     raw: Any = github.read_json(
@@ -436,6 +440,9 @@ def _find_epic_by_title(home: str, title: str) -> IssueRef | None:
         else []
     )
     if len(rows) > 1:
+        if prefer_oldest:
+            oldest = min(int(r["number"]) for r in rows)
+            return IssueRef(owner=owner, repo=home_repo, number=oldest)
         nums = ", ".join(f"#{r['number']}" for r in rows)
         raise ValueError(
             f"multiple ad-hoc epics titled {title!r} in {home} ({nums}) — pass an explicit --epic"
@@ -494,13 +501,14 @@ def ensure_adhoc_archive(target_repo: str, quarter: str) -> IssueRef:
 
     The archive is the stamped sibling of the live ad-hoc epic — same home, same
     ``epic`` + ``ad-hoc`` labels — into which closed children of *quarter* are
-    re-parented. Idempotent: an existing stamped archive is reused.
+    re-parented. Idempotent: an existing stamped archive is reused; pre-existing
+    duplicate archives (the list-consistency race, #2698) collapse to the oldest.
     """
     owner, bare = target_repo.split("/", 1)
     home = resolve_epic_home(owner, bare)
     home_repo = home.split("/", 1)[1]
     title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare} — {quarter}"
-    existing = _find_epic_by_title(home, title)
+    existing = _find_epic_by_title(home, title, prefer_oldest=True)
     if existing is not None:
         return existing
     url = github.create_issue(
@@ -586,9 +594,19 @@ def apply_adhoc_drain(target_repo: str, plan: DrainPlan) -> None:
     call, no orphan window, no separate remove (issue #2691). Past archives are
     then closed. ``YYYY-Qn`` is lexicographically chronological, so ``q < cur`` in
     the plan is a correct "quarter is past" test.
+
+    Each distinct quarter's archive is ensured **once** and cached, not once per
+    child: :func:`ensure_adhoc_archive` is find-or-create by title, and the list
+    index lags issue creation, so calling it per child let many same-quarter
+    children each create their own archive before the first became visible
+    (duplicate archives, #2698). Ensuring once per quarter closes that race.
     """
+    archives: dict[str, IssueRef] = {}
     for child, quarter in plan.moves:
-        archive = ensure_adhoc_archive(target_repo, quarter)
+        archive = archives.get(quarter)
+        if archive is None:
+            archive = ensure_adhoc_archive(target_repo, quarter)
+            archives[quarter] = archive
         if archive == plan.live:
             continue  # defensive: never re-parent into the live epic
         reparent_child(archive, child)

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -847,6 +847,39 @@ def test_find_adhoc_epic_repo_without_owner_raises() -> None:
         epics.find_adhoc_epic("tooling")
 
 
+def test_find_epic_by_title_prefer_oldest_returns_lowest() -> None:
+    # Two open rows share the archive title (the list-consistency race that
+    # produced duplicate archives). With prefer_oldest the lowest-numbered wins;
+    # without it the ambiguity still raises (live-epic finders keep that guard).
+    title = "Epic (ad hoc): tooling — 2026-Q3"
+    rows = [{"number": 91, "title": title}, {"number": 88, "title": title}]
+    with patch("vergil_tooling.lib.github.read_json", return_value=rows):
+        assert epics._find_epic_by_title("org/.github", title, prefer_oldest=True) == IssueRef(
+            "org", ".github", 88
+        )
+    with (
+        patch("vergil_tooling.lib.github.read_json", return_value=rows),
+        pytest.raises(ValueError, match="multiple ad-hoc epics"),
+    ):
+        epics._find_epic_by_title("org/.github", title)
+
+
+def test_ensure_adhoc_archive_reuses_oldest_duplicate() -> None:
+    # Duplicate archives already exist; ensure_adhoc_archive reuses the oldest
+    # (lowest-numbered) and never creates another.
+    title = "Epic (ad hoc): tooling — 2026-Q3"
+    rows = [{"number": 91, "title": title}, {"number": 88, "title": title}]
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=rows),
+        patch("vergil_tooling.lib.github.create_issue") as mock_create,
+    ):
+        assert epics.ensure_adhoc_archive("org/tooling", "2026-Q3") == IssueRef(
+            "org", ".github", 88
+        )
+    mock_create.assert_not_called()
+
+
 def test_ensure_adhoc_archive_creates_stamped_title() -> None:
     created = "https://github.com/org/.github/issues/88"
     with (
@@ -1007,6 +1040,57 @@ def test_apply_drain_skips_archive_equal_to_live() -> None:
         epics.apply_adhoc_drain("org/tooling", plan)
     mock_reparent.assert_not_called()  # defensive: never re-parent into the live epic
     mock_run.assert_not_called()
+
+
+def test_apply_drain_ensures_archive_once_per_quarter() -> None:
+    # Many closed children in the SAME quarter must ensure that quarter's archive
+    # exactly ONCE (cache by quarter), then re-parent each child — the fix for the
+    # duplicate-archive race (#2698).
+    live = IssueRef("org", ".github", 40)
+    arch = IssueRef("org", ".github", 88)
+    kids = [IssueRef("org", ".github", n) for n in (101, 102, 103)]
+    plan = epics.DrainPlan(
+        live=live,
+        moves=[(k, "2026-Q2") for k in kids],
+        close=[],
+    )
+    with (
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
+    ):
+        epics.apply_adhoc_drain("org/tooling", plan)
+    mock_ens.assert_called_once_with("org/tooling", "2026-Q2")
+    assert mock_reparent.call_count == len(kids)
+    assert [c.args for c in mock_reparent.call_args_list] == [(arch, k) for k in kids]
+
+
+def test_apply_drain_two_quarters_ensures_twice() -> None:
+    # Moves spanning two distinct quarters ensure once PER quarter (2 total).
+    live = IssueRef("org", ".github", 40)
+    archives = {
+        "2026-Q2": IssueRef("org", ".github", 88),
+        "2026-Q3": IssueRef("org", ".github", 91),
+    }
+    plan = epics.DrainPlan(
+        live=live,
+        moves=[
+            (IssueRef("org", ".github", 101), "2026-Q2"),
+            (IssueRef("org", ".github", 102), "2026-Q2"),
+            (IssueRef("org", ".github", 103), "2026-Q3"),
+        ],
+        close=[],
+    )
+    with (
+        patch(
+            "vergil_tooling.lib.epics.ensure_adhoc_archive",
+            side_effect=lambda _repo, q: archives[q],
+        ) as mock_ens,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
+    ):
+        epics.apply_adhoc_drain("org/tooling", plan)
+    assert mock_ens.call_count == 2
+    assert {c.args[1] for c in mock_ens.call_args_list} == {"2026-Q2", "2026-Q3"}
+    assert mock_reparent.call_count == 3
 
 
 def test_drain_adhoc_repo_applies_when_apply_true() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Ensure each (repo, quarter) ad-hoc archive once per drain by caching it by quarter, and make ensure_adhoc_archive reuse the oldest open archive on pre-existing duplicates via a prefer_oldest flag on _find_epic_by_title, closing the list-consistency race that spawned duplicate archives.

## Issue Linkage

- Closes #2698

## Notes

- Scope is deliberately narrow: only ensure_adhoc_archive (archive resolution) passes prefer_oldest=True; the live ad-hoc epic finders (find_adhoc_epic, ensure_adhoc_epic) keep the default raise, so two live epics remains real corruption and is not masked. TDD: four new tests in test_epics.py (prefer_oldest returns lowest / still raises without flag; ensure reuses oldest duplicate without creating; drain ensures once per quarter with N reparents; drain across two quarters ensures twice). No existing tests needed adjustment. vrg-validate green: 4755 passed, 100% branch coverage.