### PR TITLE
docs(github-issues): note once-per-quarter archive guarantee and duplicate tolerance

### DIFF
--- a/docs/site/docs/standards/github-issues.md
+++ b/docs/site/docs/standards/github-issues.md
@@ -154,7 +154,11 @@ ad-hoc epic ends up holding only its still-open children.
 - **Idempotent and dry-run by default.** Every step is check-before-act
   (archives are create-if-missing by exact title, an already-parented child is
   skipped, an already-closed past archive is skipped), so a run that dies
-  partway is repaired by the next one. Empty quarters get no archive.
+  partway is repaired by the next one. Empty quarters get no archive. A single
+  drain creates **at most one archive per quarter** however many same-quarter
+  children it moves, and if a duplicate archive ever exists the **oldest is
+  reused** rather than the run failing on the ambiguity — so the drain is safe
+  to re-run and self-heals.
 
 #### Running the drain
 


### PR DESCRIPTION
# Pull Request

## Summary

- Extends the ad-hoc archiving idempotency note to document the once-per-quarter archive guarantee and duplicate-tolerant resolver delivered by the #259 hardening.

## Issue Linkage

- Closes #2697

## Notes

- Documentation-review bookend of epic vergil-project/.github#259. Single-line-ish addition to the existing archiving section in standards/github-issues.md; the rest of the section (from part-one #2676) already describes the post-fix behavior accurately. No per-repo doc tasks needed. vrg-validate green.