### PR TITLE
feat(epics): support --blocked-by on plain tasks and classify all open children

### DIFF
--- a/docs/site/docs/standards/github-issues.md
+++ b/docs/site/docs/standards/github-issues.md
@@ -362,7 +362,10 @@ Shared rules (both kinds):
   epic until it succeeds, so rollup is honest.
 - **Records dependencies as `Blocked-by:` reflinks.** `vrg-epic-audit` reads them
   to report each as *runnable* (dependencies closed) or *blocked*, tagged by
-  kind.
+  kind. The same `Blocked-by:` reflink works on a **plain task** too — pass
+  `--blocked-by` to `vrg-issue-create --kind task` and it is appended to the task
+  body — so an epic driver's plain-task frontier (which open tasks have every
+  dependency closed) is machine-derivable, not inferred from plan prose.
 
 Create one with the sanctioned path — never hand-roll the body:
 

--- a/src/vergil_tooling/bin/vrg_issue_create.py
+++ b/src/vergil_tooling/bin/vrg_issue_create.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import sys
 from importlib import resources
+from pathlib import Path
 
 from vergil_tooling.lib import epics, github
 
@@ -44,8 +45,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="append",
         default=[],
         metavar="REF",
-        help="Dependency ref this operational task is blocked by "
-        "(repeatable; validation/deployment only)",
+        help="Dependency ref this task is blocked by; stamps a portable "
+        "Blocked-by: reflink (repeatable; not valid for --kind retrospective)",
     )
     return parser.parse_args(argv)
 
@@ -89,6 +90,19 @@ def _render_scaffold_body(*, kind: str, intro: str, deps: list[epics.IssueRef]) 
     return template.format(intro=intro or _SCAFFOLD_INTRO[kind], blocked_by=blocked_by)
 
 
+def _append_blocked_by(base: str, deps: list[epics.IssueRef]) -> str:
+    """Append a machine-parseable ``Blocked-by:`` reflink section to *base*.
+
+    A plain task has no scaffold template, so its dependencies are stamped by
+    appending the same portable ``Blocked-by: owner/repo#N`` reflinks the
+    operational scaffolds use (``epics.render_blocked_by``) under a Dependencies
+    heading. The reflink is what ``epics.blockers_of`` parses, so a plain task's
+    dependency becomes as machine-readable as an operational one (#2269).
+    """
+    section = "## Dependencies\n\n" + epics.render_blocked_by(deps)
+    return f"{base.rstrip()}\n\n{section}" if base.strip() else section
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo = args.repo or github.current_repo()
@@ -119,7 +133,28 @@ def main(argv: list[str] | None = None) -> int:
     labels = list(args.label)
     body = args.body
     body_file = args.body_file
-    if args.kind != "task":
+    deps: list[epics.IssueRef] = []
+    if args.kind == "task" and args.blocked_by:
+        # A plain task carries its dependencies as the same portable Blocked-by:
+        # reflinks the operational scaffolds use, appended to the caller's body
+        # (#2269). The dependency machinery (epics.blockers_of) is already
+        # generic; this is purely unlocking the creation edge for plain tasks.
+        try:
+            deps = [epics.parse_issue_ref(ref, default_repo=repo) for ref in args.blocked_by]
+        except ValueError as exc:
+            print(f"vrg-issue-create: invalid --blocked-by ref: {exc}", file=sys.stderr)
+            return 1
+        if body_file is not None:
+            try:
+                base = Path(body_file).read_text(encoding="utf-8")
+            except OSError as exc:
+                print(f"vrg-issue-create: cannot read --body-file: {exc}", file=sys.stderr)
+                return 1
+        else:
+            base = body
+        body = _append_blocked_by(base, deps)
+        body_file = None
+    elif args.kind != "task":
         if args.body_file:
             print(
                 f"vrg-issue-create: --body-file is not compatible with --kind {args.kind} "
@@ -127,7 +162,6 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
-        deps: list[epics.IssueRef] = []
         if args.kind in _OPERATIONAL_KINDS:
             try:
                 deps = [epics.parse_issue_ref(ref, default_repo=repo) for ref in args.blocked_by]

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -165,6 +165,35 @@ def operational_status(epic: epics.IssueRef) -> OperationalStatus:
     )
 
 
+@dataclass(frozen=True)
+class ChildStatus:
+    """An epic's open children, split runnable vs blocked by their Blocked-by deps."""
+
+    epic: epics.IssueRef
+    runnable: tuple[epics.IssueRef, ...]  # open children, all blockers closed
+    blocked: tuple[epics.IssueRef, ...]  # open children, a blocker still open
+
+
+def child_status(epic: epics.IssueRef) -> ChildStatus:
+    """Classify *every* open child of *epic* as runnable vs blocked.
+
+    Where :func:`operational_status` is scoped to operational children (its
+    runnable/blocked split feeds the "operation-pending" report), this classifies
+    *all* open children — plain tasks included — through the already-generic
+    :func:`epics.all_blockers_closed`. It makes an epic driver's plain-task
+    frontier (the open tasks whose every ``Blocked-by`` dependency is closed)
+    machine-derivable instead of inferred from plan prose (#2269).
+    """
+    runnable: list[epics.IssueRef] = []
+    blocked: list[epics.IssueRef] = []
+    for child in epics.child_states(epic):
+        if child.state != "OPEN":
+            continue
+        target = runnable if epics.all_blockers_closed(child.ref) else blocked
+        target.append(child.ref)
+    return ChildStatus(epic=epic, runnable=tuple(runnable), blocked=tuple(blocked))
+
+
 def operational_pending(org: str, *, home: str | None = None) -> list[OperationalStatus]:
     """Open finite epics with outstanding operational children.
 

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -556,6 +556,44 @@ def test_operational_status_tags_kind() -> None:
     assert status.by_kind[dep] == "deployment"
 
 
+def test_child_status_classifies_every_open_child() -> None:
+    epic = epics.IssueRef("org", ".github", 99)
+    plain_runnable = epics.IssueRef("org", "repo", 10)
+    plain_blocked = epics.IssueRef("org", "repo", 11)
+    op_runnable = epics.IssueRef("org", "repo", 12)  # operational, but not special-cased here
+    children = [
+        epics.ChildState(plain_runnable, "OPEN"),
+        epics.ChildState(plain_blocked, "OPEN"),
+        epics.ChildState(op_runnable, "OPEN"),
+        epics.ChildState(epics.IssueRef("org", "repo", 13), "CLOSED"),  # closed -> ignored
+    ]
+
+    def all_blockers_closed(ref: epics.IssueRef) -> bool:
+        return ref.number != 11  # only #11 is still blocked
+
+    with (
+        patch("vergil_tooling.lib.epics.child_states", return_value=children),
+        patch("vergil_tooling.lib.epics.all_blockers_closed", side_effect=all_blockers_closed),
+    ):
+        status = epic_audit.child_status(epic)
+    # Every open child is classified, plain tasks included — no kind gating.
+    assert status.runnable == (plain_runnable, op_runnable)
+    assert status.blocked == (plain_blocked,)
+
+
+def test_child_status_empty_when_no_open_children() -> None:
+    epic = epics.IssueRef("org", ".github", 99)
+    children = [epics.ChildState(epics.IssueRef("org", "repo", 1), "CLOSED")]
+    with (
+        patch("vergil_tooling.lib.epics.child_states", return_value=children),
+        patch("vergil_tooling.lib.epics.all_blockers_closed", return_value=True) as mock_blockers,
+    ):
+        status = epic_audit.child_status(epic)
+    assert status.runnable == ()
+    assert status.blocked == ()
+    mock_blockers.assert_not_called()  # closed children are never queried
+
+
 def test_operational_pending_collects_only_epics_with_open_validations() -> None:
     val = epics.IssueRef("org", "repo", 7)
 

--- a/tests/vergil_tooling/test_vrg_issue_create.py
+++ b/tests/vergil_tooling/test_vrg_issue_create.py
@@ -239,6 +239,129 @@ def test_kind_defaults_to_task_without_validation_label() -> None:
     assert mock_create.call_args.kwargs["labels"] == ["bug"]  # no validation label added
 
 
+def test_plain_task_stamps_blocked_by_reflink_from_body() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--title",
+                "T",
+                "--body",
+                "Do the thing.",
+                "--blocked-by",
+                "org/repo#5",
+                "--blocked-by",
+                "org/repo#6",
+            ]
+        )
+    assert rc == 0
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["body_file"] is None  # inlined so the appended reflinks survive
+    body = kwargs["body"]
+    assert body.startswith("Do the thing.")  # caller's body preserved
+    assert "Blocked-by: org/repo#5" in body
+    assert "Blocked-by: org/repo#6" in body
+
+
+def test_plain_task_blocked_by_with_empty_body_is_just_the_section() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--epic", "adhoc", "--title", "T", "--blocked-by", "org/repo#5"])
+    assert rc == 0
+    body = mock_create.call_args.kwargs["body"]
+    assert body.startswith("## Dependencies")
+    assert "Blocked-by: org/repo#5" in body
+
+
+def test_plain_task_blocked_by_appends_to_body_file(tmp_path: Path) -> None:
+    body_file = tmp_path / "b.md"
+    body_file.write_text("From a file.\n")
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--title",
+                "T",
+                "--body-file",
+                str(body_file),
+                "--blocked-by",
+                "org/repo#5",
+            ]
+        )
+    assert rc == 0
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["body_file"] is None  # file contents were read and inlined
+    body = kwargs["body"]
+    assert body.startswith("From a file.")
+    assert "Blocked-by: org/repo#5" in body
+
+
+def test_plain_task_without_blocked_by_leaves_body_file_passthrough(tmp_path: Path) -> None:
+    body_file = tmp_path / "b.md"
+    body_file.write_text("From a file.\n")
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.epics.resolve_epic_ref", return_value=EPIC),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL) as mock_create,
+        patch(f"{_MOD}.epics.add_child"),
+    ):
+        rc = main(["--epic", "adhoc", "--title", "T", "--body-file", str(body_file)])
+    assert rc == 0
+    # No --blocked-by: the file is handed straight to gh, unchanged.
+    assert mock_create.call_args.kwargs["body_file"] == str(body_file)
+
+
+def test_plain_task_rejects_invalid_blocked_by() -> None:
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(["--epic", "adhoc", "--title", "T", "--blocked-by", "not-a-ref"])
+    assert rc == 1
+    mock_create.assert_not_called()
+
+
+def test_plain_task_blocked_by_reports_unreadable_body_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "nope.md"
+    with (
+        patch(f"{_MOD}.github.current_repo", return_value="org/repo"),
+        patch(f"{_MOD}.github.create_issue") as mock_create,
+    ):
+        rc = main(
+            [
+                "--epic",
+                "adhoc",
+                "--title",
+                "T",
+                "--body-file",
+                str(missing),
+                "--blocked-by",
+                "org/repo#5",
+            ]
+        )
+    assert rc == 1
+    mock_create.assert_not_called()
+    assert "cannot read --body-file" in capsys.readouterr().err
+
+
 def test_main_adhoc_sentinel_skips_cross_org_guard() -> None:
     # 'adhoc' resolves within the repo's org (.github), so it must skip the
     # explicit-ref cross-org guard and link.


### PR DESCRIPTION
# Pull Request

## Summary

- Unlocks the Blocked-by dependency edges for plain tasks — --blocked-by now stamps the portable reflink on --kind task, and a new epic_audit.child_status() classifies every open child runnable-vs-blocked — making an epic driver's plain-task frontier machine-derivable.

## Issue Linkage

- Closes #2269

## Notes

- Three deliverables from the issue. (1) vrg-issue-create: --blocked-by on a plain task appends epics.render_blocked_by reflinks to the caller's body (both --body and --body-file; unreadable --body-file errors loudly, no silent drop). Previously silently ignored. Retrospective still rejects --blocked-by. (2) Item 2 (fail-loud) is moot now that (1) lands; the only kind rejecting --blocked-by is retrospective. (3) Added epic_audit.child_status() + ChildStatus as a SIBLING of operational_status rather than extending it — operational_status must stay operational-scoped so operational_pending keeps its 'code-complete, operation-pending' meaning; child_status classifies all open children via the generic epics.all_blockers_closed. Also documented the plain-task reflink in the github-issues standard. Validation green: 4763 tests, 100% coverage, lint/typecheck/audit clean.