### PR TITLE
fix(pr-workflow): resolve a bare --issue N before the report-ready epic/operational guards

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -21,6 +21,7 @@ from vergil_tooling.lib.linkage import (
     freetext_linkage_error,
     normalize_linkage,
 )
+from vergil_tooling.lib.pr_body import normalize_issue_ref
 from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import WorkflowError
 from vergil_tooling.lib.pr_workflow.github_transport import GitHubTransport
@@ -38,7 +39,7 @@ def _emit(payload: dict[str, object]) -> None:
     print(json.dumps(payload, indent=2))
 
 
-def _reject_cross_repo_issue(issue: str) -> None:
+def _reject_cross_repo_issue(issue_ref: str) -> None:
     """Refuse a cross-repo --issue at report time — a PR closes only same-repo issues.
 
     Mirrors vrg-submit-pr's guard so the error surfaces where the value is entered
@@ -47,9 +48,10 @@ def _reject_cross_repo_issue(issue: str) -> None:
     cross-repo close would shut an unrelated same-numbered issue — a genuine
     mis-close hazard. Best-effort: if the current repo cannot be resolved (no
     remote, no gh auth — an offline run), defer silently to vrg-submit-pr's
-    authoritative check. A bare ``#N`` (or a plain number) resolves to the
-    current repo and always passes; the compare is case-insensitive so a
-    differently cased spelling of the current repo is not a false refusal.
+    authoritative check. *issue_ref* is the canonical ref (``#N`` or
+    ``owner/repo#N``); a same-repo ``#N`` resolves to the current repo and always
+    passes; the compare is case-insensitive so a differently cased spelling of the
+    current repo is not a false refusal.
     """
     try:
         current = github.current_repo()
@@ -57,10 +59,10 @@ def _reject_cross_repo_issue(issue: str) -> None:
         return
     if not current:
         return
-    try:
-        ref = epics.parse_issue_ref(issue, default_repo=current)
-    except ValueError:
-        return
+    # *issue_ref* is already the canonical form (normalize_issue_ref ran upstream)
+    # and *current* is non-empty, so parse_issue_ref cannot raise here — a bare
+    # number was the only unparseable shape, and it is now '#N' before this guard.
+    ref = epics.parse_issue_ref(issue_ref, default_repo=current)
     if f"{ref.owner}/{ref.repo}".lower() != current.lower():
         raise WorkflowError(
             f"--issue ({ref.slug}) is in a different repo than this PR ({current}); "
@@ -69,41 +71,44 @@ def _reject_cross_repo_issue(issue: str) -> None:
         )
 
 
-def _reject_epic_issue(issue: str) -> None:
+def _reject_epic_issue(issue_ref: str) -> None:
     """Refuse an epic linkage at report time — a PR links a task, not an epic.
 
     Mirrors vrg-submit-pr's guard so the error surfaces where the value is
-    entered (report time) rather than later at submit time. Best-effort: if
-    epic-ness cannot be determined (no remote, no gh auth — e.g. an offline
-    run), it defers silently to vrg-submit-pr's authoritative check rather than
-    blocking report-ready.
+    entered (report time) rather than later at submit time. *issue_ref* is the
+    canonical ref (``#N`` or ``owner/repo#N``) so a bare number no longer slips
+    past ``parse_issue_ref`` (#2213). Best-effort: if epic-ness cannot be
+    determined (no remote, no gh auth — e.g. an offline run), it defers silently
+    to vrg-submit-pr's authoritative check rather than blocking report-ready.
     """
     try:
-        links_epic = epics.is_epic_linkage(issue, default_repo=github.current_repo())
+        links_epic = epics.is_epic_linkage(issue_ref, default_repo=github.current_repo())
     except (subprocess.CalledProcessError, OSError):
         return
     if links_epic:
         raise WorkflowError(
-            f"--issue links an epic (#{issue}); link a task, not an epic "
+            f"--issue links an epic ({issue_ref}); link a task, not an epic "
             "(epics are closed by rollup when their tasks complete)."
         )
 
 
-def _reject_operational_issue(issue: str) -> None:
+def _reject_operational_issue(issue_ref: str) -> None:
     """Refuse an operational-task linkage at report time — it is not PR-workable.
 
     Mirrors vrg-submit-pr's guard so the error surfaces where the value is
-    entered. Best-effort: if operational-ness cannot be determined (no remote, no
-    gh auth — e.g. an offline run), defer silently to vrg-submit-pr's
-    authoritative check rather than blocking report-ready.
+    entered. *issue_ref* is the canonical ref (``#N`` or ``owner/repo#N``) so a
+    bare number no longer slips past ``parse_issue_ref`` (#2213). Best-effort: if
+    operational-ness cannot be determined (no remote, no gh auth — e.g. an offline
+    run), defer silently to vrg-submit-pr's authoritative check rather than
+    blocking report-ready.
     """
     try:
-        is_operational = epics.is_operational_task(issue, default_repo=github.current_repo())
+        is_operational = epics.is_operational_task(issue_ref, default_repo=github.current_repo())
     except (subprocess.CalledProcessError, OSError):
         return
     if is_operational:
         raise WorkflowError(
-            f"--issue (#{issue}) is an operational task (validation/deployment), which "
+            f"--issue ({issue_ref}) is an operational task (validation/deployment), which "
             "is not PR-workable; record the Outcome as a comment (issue-validate / "
             "issue-deploy) instead of preparing a PR."
         )
@@ -136,9 +141,20 @@ def _push_relay_ref(state: WorkflowState, base: str) -> None:
 
 
 def cmd_report_ready(args: argparse.Namespace, transport: LocalFileTransport) -> int:
-    _reject_cross_repo_issue(str(args.issue))
-    _reject_epic_issue(str(args.issue))
-    _reject_operational_issue(str(args.issue))
+    # Resolve --issue to a canonical ref (bare number -> '#N') before the guards,
+    # mirroring vrg-submit-pr. The guards call epics.parse_issue_ref, which rejects
+    # a bare number (no '#') and would silently return False — letting a
+    # bare-number epic/operational issue bypass the report-time guard (#2213). The
+    # raw args.issue is still what gets *stored* (vrg-submit-pr's resolve_issue_ref
+    # re-normalizes it and rejects a leading '#'), so only the guards see the
+    # canonical form.
+    try:
+        issue_ref = normalize_issue_ref(str(args.issue))
+    except ValueError as exc:
+        raise WorkflowError(f"report-ready: {exc}") from exc
+    _reject_cross_repo_issue(issue_ref)
+    _reject_epic_issue(issue_ref)
+    _reject_operational_issue(issue_ref)
     try:
         linkage, linkage_warning = normalize_linkage(args.linkage)
     except ValueError as exc:

--- a/src/vergil_tooling/lib/pr_body.py
+++ b/src/vergil_tooling/lib/pr_body.py
@@ -16,14 +16,32 @@ _ISSUE_PLAIN_RE = re.compile(r"^[1-9]\d*$")
 _ISSUE_CROSS_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[1-9]\d*$")
 
 
-def resolve_issue_ref(issue: str) -> str:
-    """Validate and normalize the issue reference."""
+def normalize_issue_ref(issue: str) -> str:
+    """Normalize ``--issue`` to a canonical ref (``#N`` or ``owner/repo#N``).
+
+    A bare number is scoped to the current repo as ``#N``; a cross-repo
+    ``owner/repo#N`` passes through unchanged. Raises ``ValueError`` on any other
+    shape, so each caller surfaces the malformed value in its own error
+    convention — ``resolve_issue_ref`` (``vrg-submit-pr``) as a ``SystemExit``,
+    ``vrg-pr-workflow report-ready`` as a ``WorkflowError``. The canonical form is
+    what ``epics.parse_issue_ref`` — and thus the epic/operational guards — can
+    parse; a bare number cannot (it has no ``#``), which is the report-time guard
+    bypass #2213 closes.
+    """
     if _ISSUE_PLAIN_RE.match(issue):
         return f"#{issue}"
     if _ISSUE_CROSS_RE.match(issue):
         return issue
     msg = f"--issue must be a number (42) or cross-repo ref (owner/repo#42), got '{issue}'."
-    raise SystemExit(msg)
+    raise ValueError(msg)
+
+
+def resolve_issue_ref(issue: str) -> str:
+    """Validate and normalize the issue reference; abort (``SystemExit``) if malformed."""
+    try:
+        return normalize_issue_ref(issue)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def build_pr_body(*, summary: str, linkage: str, issue_ref: str, notes: str) -> str:

--- a/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
+++ b/tests/vergil_tooling/pr_workflow/test_cli_e2e.py
@@ -207,6 +207,96 @@ def test_report_ready_rejects_operational_task(
     assert "operational task" in capsys.readouterr().err.lower()
 
 
+def test_report_ready_bare_number_epic_is_caught(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # #2213 regression: a bare --issue number must be resolved to '#N' before the
+    # epic guard. Patching the deeper epics.is_epic (not is_epic_linkage) exercises
+    # the real parse_issue_ref path — which rejects a bare number, so on the old
+    # code the guard silently no-ops and this would pass through (rc 0).
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=True) as mock_is_epic,
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "120",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "epic" in err.lower()
+    assert "#120" in err  # the canonical ref, not a doubled '##120'
+    # The guard actually reached the epic-ness check with a parseable ref.
+    assert mock_is_epic.call_args.args[0].number == 120
+
+
+def test_report_ready_bare_number_operational_is_caught(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # #2213 regression, operational variant: a bare --issue number must resolve
+    # before the operational guard. epics.is_operational is patched so real
+    # parse_issue_ref runs; the epic check (is_epic) is left to return False.
+    with (
+        patch("vergil_tooling.bin.vrg_pr_workflow.github.current_repo", return_value="org/repo"),
+        patch("vergil_tooling.lib.epics.is_epic", return_value=False),
+        patch("vergil_tooling.lib.epics.is_operational", return_value=True),
+    ):
+        rc = vrg_pr_workflow.main(
+            [
+                "--base",
+                "develop",
+                "report-ready",
+                "--issue",
+                "120",
+                "--title",
+                "t",
+                "--summary",
+                "s",
+                "--notes",
+                "n",
+            ]
+        )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "operational task" in err.lower()
+    assert "#120" in err
+
+
+def test_report_ready_rejects_malformed_issue(
+    in_git_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A --issue that is neither a number nor a cross-repo ref fails loudly at
+    # report time (WorkflowError), rather than being stored and deferred (#2213).
+    rc = vrg_pr_workflow.main(
+        [
+            "--base",
+            "develop",
+            "report-ready",
+            "--issue",
+            "not-a-ref",
+            "--title",
+            "t",
+            "--summary",
+            "s",
+            "--notes",
+            "n",
+        ]
+    )
+    assert rc == 1
+    assert "must be a number" in capsys.readouterr().err.lower()
+
+
 def test_report_ready_rejects_cross_repo_issue(
     in_git_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/vergil_tooling/test_pr_body.py
+++ b/tests/vergil_tooling/test_pr_body.py
@@ -48,6 +48,21 @@ def test_resolve_issue_ref_zero() -> None:
         pr_body.resolve_issue_ref("0")
 
 
+def test_normalize_issue_ref_plain_number() -> None:
+    assert pr_body.normalize_issue_ref("42") == "#42"
+
+
+def test_normalize_issue_ref_cross_repo() -> None:
+    assert pr_body.normalize_issue_ref("owner/repo#42") == "owner/repo#42"
+
+
+def test_normalize_issue_ref_invalid_raises_value_error() -> None:
+    # Unlike resolve_issue_ref (SystemExit), the shared normalizer raises
+    # ValueError so each caller surfaces it in its own error convention (#2213).
+    with pytest.raises(ValueError, match="must be a number"):
+        pr_body.normalize_issue_ref("bad-ref")
+
+
 def test_build_pr_body_rejects_linkage_keyword_in_notes() -> None:
     with pytest.raises(SystemExit) as exc:
         pr_body.build_pr_body(summary="s", linkage="Closes", issue_ref="#42", notes="Ref #99")


### PR DESCRIPTION
# Pull Request

## Summary

- report-ready now resolves --issue to a canonical ref (bare number -> #N) before its epic/operational guards, closing the hole where a bare-number epic or operational issue bypassed the report-time guard because parse_issue_ref silently rejected the bare number.

## Issue Linkage

- Closes #2213

## Notes

- Root cause: the guards called is_epic_linkage/is_operational_task with the raw --issue; a bare number has no '#' so parse_issue_ref raised and the guard returned False. Fix mirrors vrg-submit-pr. Design points for review: (1) extracted pr_body.normalize_issue_ref (raises ValueError) as the single normalizer; resolve_issue_ref delegates and re-raises SystemExit so submit-pr behavior is byte-for-byte unchanged. (2) The RAW --issue is still what report-ready stores — submit-pr's resolve_issue_ref rejects a leading '#', so storing '#120' would break submit; only the guards see the canonical form. (3) A malformed --issue now fails loud (WorkflowError) at report time. (4) Removed the cross-repo guard's now-unreachable unparseable-ref branch since normalization guarantees a parseable ref. Regression tests patch the deeper epics.is_epic/is_operational so real parse_issue_ref runs — they pass through (rc 0) on the old code and are caught (rc 1) with the fix. Validation green: 4772 tests, 100% coverage.