### PR TITLE
fix(epics): derive ad-hoc archive repo from epic title; skip non-repo epics

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -720,15 +720,25 @@ def rollup(task: IssueRef) -> None:
     if parent is None or not is_epic(parent):
         return
     if "ad-hoc" in _labels(parent):
-        owner, home_repo = parent.owner, parent.repo
         title = _issue_title(parent)
         # Only the LIVE canonical ad-hoc epic drains; archives (stamped) are terminal.
         if _ADHOC_ARCHIVE_RE.match(title):
             return
+        # Derive the target repo from the epic's OWN bare name, not parent.repo:
+        # a public repo's ad-hoc epic lives in <org>/.github, so parent.repo is
+        # always ".github" and would misfile every public-repo child into one
+        # ".github" bucket (#2709). Drain only for a canonical per-repo epic —
+        # <bare> must be a real repo. A repo name has no space or "/", so reject
+        # those fast (also skips non-repo special epics whose bare is a prose
+        # description); then confirm via a direct existence probe (repo_exists,
+        # not list membership, so a self-homed private repo still passes).
+        bare = title.removeprefix(_ADHOC_EPIC_TITLE_PREFIX)
+        if " " in bare or "/" in bare or not github.repo_exists(parent.owner, bare):
+            return
         closed_at = _issue_closed_at(task)
         if not closed_at:
             return
-        archive = ensure_adhoc_archive(f"{owner}/{home_repo}", quarter_of(closed_at))
+        archive = ensure_adhoc_archive(f"{parent.owner}/{bare}", quarter_of(closed_at))
         if archive != parent:
             reparent_child(archive, task)  # atomic move: single-parent safe (#2691)
         return

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -132,6 +132,25 @@ def is_public(name_with_owner: str) -> bool:
     return repo_visibility(name_with_owner) == "PUBLIC"
 
 
+def repo_exists(owner: str, name: str) -> bool:
+    """True iff ``<owner>/<name>`` is a real repository the caller can see.
+
+    A direct existence probe, not list membership: a **private** repo the caller
+    is authorized for still returns True, so a self-homed private repo is never
+    wrongly reported absent (which ``list_org_repos`` would do when it cannot see
+    private repos). No silent failure — only GitHub's genuine "not found" answer
+    yields False; every other error (auth, network, rate limit) propagates.
+    """
+    try:
+        repo_visibility(f"{owner}/{name}")
+    except GitHubAPIError as exc:
+        detail = ((exc.stderr or "") + (exc.stdout or "")).lower()
+        if "could not resolve to a repository" in detail or "not found" in detail:
+            return False
+        raise
+    return True
+
+
 def _jwt_api_request(endpoint: str, jwt_token: str, *, method: str = "GET") -> Any:
     """Make a GitHub API request with JWT Bearer authentication.
 

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -560,7 +560,33 @@ def test_rollup_holds_epic_open_while_validation_child_open() -> None:
     mock_run.assert_not_called()  # epic stays open — a validation child is still open
 
 
-def test_rollup_archives_closed_child_under_live_adhoc() -> None:
+def test_rollup_public_repo_epic_archives_into_own_bucket() -> None:
+    # A public repo's ad-hoc epic lives in <org>/.github (so parent.repo is
+    # ".github"), but the archive target must come from the epic TITLE's bare
+    # name — the child is filed into <org>/some-repo, NOT the ".github" bucket
+    # (#2709). ``some-repo`` is a real repo, so the drain proceeds.
+    task = IssueRef("org", ".github", 101)
+    live = IssueRef("org", ".github", 40)
+    arch = IssueRef("org", "some-repo", 88)
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=live),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
+        patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): some-repo"),
+        patch("vergil_tooling.lib.github.repo_exists", return_value=True) as mock_exists,
+        patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
+    ):
+        epics.rollup(task)
+    mock_exists.assert_called_once_with("org", "some-repo")
+    mock_ens.assert_called_once_with("org/some-repo", "2026-Q2")
+    mock_reparent.assert_called_once_with(arch, task)
+
+
+def test_rollup_dotgithub_own_epic_unchanged() -> None:
+    # Regression guard: the .github repo's OWN ad-hoc epic has bare ".github",
+    # so the target resolves to "org/.github" exactly as before — the one case
+    # the old parent.repo-based path got right.
     task = IssueRef("org", ".github", 101)
     live = IssueRef("org", ".github", 40)
     arch = IssueRef("org", ".github", 88)
@@ -568,6 +594,7 @@ def test_rollup_archives_closed_child_under_live_adhoc() -> None:
         patch("vergil_tooling.lib.epics.parent_of", return_value=live),
         patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
         patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
+        patch("vergil_tooling.lib.github.repo_exists", return_value=True) as mock_exists,
         patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=arch) as mock_ens,
         patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
@@ -575,11 +602,33 @@ def test_rollup_archives_closed_child_under_live_adhoc() -> None:
         patch("vergil_tooling.lib.epics.remove_child") as mock_rm,
     ):
         epics.rollup(task)
+    mock_exists.assert_called_once_with("org", ".github")
     mock_ens.assert_called_once_with("org/.github", "2026-Q2")
     # Atomic single-parent-safe re-parent — no separate add/remove (#2691).
     mock_reparent.assert_called_once_with(arch, task)
     mock_add.assert_not_called()
     mock_rm.assert_not_called()
+
+
+def test_rollup_skips_non_repo_adhoc_epic() -> None:
+    # A non-repo special epic (its bare name is a prose description, not a repo)
+    # is skipped: the space in the bare name fast-rejects before any API call,
+    # so nothing is archived or re-parented (#2709).
+    task = IssueRef("org", ".github", 101)
+    live = IssueRef("org", ".github", 40)
+    title = "Epic (ad hoc): Lab lifecycle reliability — cold rebuild / boot / repoint / deploy"
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=live),
+        patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
+        patch("vergil_tooling.lib.epics._issue_title", return_value=title),
+        patch("vergil_tooling.lib.github.repo_exists") as mock_exists,
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive") as mock_ens,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
+    ):
+        epics.rollup(task)
+    mock_exists.assert_not_called()  # fast-rejected on the space, no API probe
+    mock_ens.assert_not_called()
+    mock_reparent.assert_not_called()
 
 
 def test_rollup_noop_when_parent_is_adhoc_archive() -> None:
@@ -604,6 +653,7 @@ def test_rollup_noop_when_closed_child_lacks_closed_at() -> None:
         patch("vergil_tooling.lib.epics.parent_of", return_value=live),
         patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
         patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
+        patch("vergil_tooling.lib.github.repo_exists", return_value=True),
         patch("vergil_tooling.lib.epics._issue_closed_at", return_value=""),
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive") as mock_ens,
         patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
@@ -621,6 +671,7 @@ def test_rollup_skips_reparent_when_archive_is_the_live_epic() -> None:
         patch("vergil_tooling.lib.epics.parent_of", return_value=live),
         patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
         patch("vergil_tooling.lib.epics._issue_title", return_value="Epic (ad hoc): .github"),
+        patch("vergil_tooling.lib.github.repo_exists", return_value=True),
         patch("vergil_tooling.lib.epics._issue_closed_at", return_value="2026-05-01T00:00:00Z"),
         patch("vergil_tooling.lib.epics.ensure_adhoc_archive", return_value=live),
         patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -1757,3 +1757,31 @@ def test_repo_visibility_fails_loud_on_empty() -> None:
         pytest.raises(github.GitHubAPIError),
     ):
         github.repo_visibility("org/repo")
+
+
+# -- repo_exists (issue #2709) -----------------------------------------------
+def test_repo_exists_true_for_real_repo() -> None:
+    github.repo_visibility.cache_clear()
+    with patch("vergil_tooling.lib.github.read_json", return_value={"visibility": "PRIVATE"}):
+        # A private repo the caller CAN see still exists — direct probe, not
+        # list membership.
+        assert github.repo_exists("org", "priv-repo") is True
+
+
+def test_repo_exists_false_for_missing_repo() -> None:
+    github.repo_visibility.cache_clear()
+    not_found = github.GitHubAPIError(
+        1, ["gh", "repo", "view"], stderr="GraphQL: Could not resolve to a Repository"
+    )
+    with patch("vergil_tooling.lib.github.read_json", side_effect=not_found):
+        assert github.repo_exists("org", "ghost-repo") is False
+
+
+def test_repo_exists_reraises_other_errors() -> None:
+    github.repo_visibility.cache_clear()
+    other = github.GitHubAPIError(1, ["gh", "repo", "view"], stderr="HTTP 401: Bad credentials")
+    with (
+        patch("vergil_tooling.lib.github.read_json", side_effect=other),
+        pytest.raises(github.GitHubAPIError, match="Bad credentials"),
+    ):
+        github.repo_exists("org", "repo")


### PR DESCRIPTION
# Pull Request

## Summary

- Ad-hoc rollup now derives the archive target repo from the epic title's bare name and drains only when that bare name is a real repo, so public-repo children file into their own per-repo bucket and non-repo special epics are skipped.

## Issue Linkage

- Closes #2709

## Notes

- In rollup()'s ad-hoc branch, parse the target repo from the parent's 'Epic (ad hoc): <bare>' title instead of parent.repo (which is always .github for public repos). Guard: skip fast when <bare> contains a space or slash, then confirm via new github.repo_exists(owner, name) — a direct existence probe (not list membership) so a self-homed private repo still passes; it returns False only on GitHub's genuine not-found and re-raises all other errors. The .github-own epic still resolves to <org>/.github (unchanged). Tests added/updated in test_epics.py (public-repo, .github-own regression, non-repo skip) and test_github.py (repo_exists true/not-found/re-raise). Full vrg-validate green: 4774 passed, 100% branch coverage.