### PR TITLE
docs(github-issues): note archiving targets only canonical per-repo ad-hoc epics

### DIFF
--- a/docs/site/docs/standards/github-issues.md
+++ b/docs/site/docs/standards/github-issues.md
@@ -147,6 +147,13 @@ ad-hoc epic ends up holding only its still-open children.
   filed in it.
 - **The live epic is never renamed, recreated, or closed.** It only loses its
   closed children to the archives; it stays the one perpetual umbrella per repo.
+- **Only canonical per-repo ad-hoc epics are archived.** Both the batch drain and
+  the on-close event path key on the repo named in the `Epic (ad hoc): <repo>`
+  title, so a closed child always lands in *its own repo's* quarter archive — even
+  for a public repo whose ad-hoc epic is homed centrally in `.github`. A
+  special-purpose `ad-hoc`-labelled epic whose title bare-name is a description
+  rather than a real repo (e.g. a standing reliability collection) is **left
+  untouched** — it is not treated as a drainable ad-hoc epic.
 - **Past-quarter archives are closed; the current-quarter archive stays open.**
   A closed archive is a stable historical record; the current one keeps
   receiving this quarter's closures. A late straggler whose close-quarter


### PR DESCRIPTION
# Pull Request

## Summary

- Documents that both drain paths archive a closed child into its own repo's quarter bucket and that special-purpose non-repo ad-hoc epics are left untouched, reflecting the #266 hook repo-derivation fix.

## Issue Linkage

- Closes #2706

## Notes

- Documentation-review bookend of epic vergil-project/.github#266. One bullet added to the archiving section of standards/github-issues.md. No per-repo doc tasks needed. vrg-validate green.