### PR TITLE
fix(repo-init): stop treating CWD as authoritative for clone target and resume state

### DIFF
--- a/src/vergil_tooling/bin/vrg_github_repo_init.py
+++ b/src/vergil_tooling/bin/vrg_github_repo_init.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
 from vergil_tooling.lib import identity_mode
 from vergil_tooling.lib.config import _ENUMS
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
+    foreign_repo_refusal,
     prompt_choice,
     prompt_free_text,
     prompt_yes_no,
@@ -47,6 +49,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--visibility",
         choices=("public", "private"),
         help="Repository visibility, new repos only (default: public)",
+    )
+    parser.add_argument(
+        "--target-dir",
+        help="Parent directory to clone into (new repos only; default: current "
+        "directory). Names the clone location explicitly so it does not depend on "
+        "where the command is run.",
     )
 
     # Wizard-prompt flags. Each overrides the matching interactive prompt exactly
@@ -129,6 +137,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     if args.adopt and args.repo:
         parser.error("--adopt cannot be used with a repo argument")
 
+    if args.target_dir is not None:
+        if args.adopt:
+            parser.error("--target-dir cannot be used with --adopt (adopt uses the current dir)")
+        if not Path(args.target_dir).is_dir():
+            parser.error(f"--target-dir is not an existing directory: {args.target_dir}")
+
     if not args.adopt and not args.repo:
         parser.error("provide ORG/NAME or use --adopt from inside a clone")
 
@@ -194,6 +208,8 @@ def main(argv: list[str] | None = None) -> int:
     else:
         org, name = args.repo.split("/", 1)
         ctx = RepoInitContext(org=org, name=name)
+        if args.target_dir is not None:
+            ctx.target_dir = Path(args.target_dir)
 
         if args.visibility:
             ctx.visibility = args.visibility
@@ -230,6 +246,14 @@ def main(argv: list[str] | None = None) -> int:
     ctx.opt_vergil_version = args.vergil_version
     ctx.opt_license_type = args.license
     ctx.opt_initial_version = args.initial_version
+
+    # Refuse a new-repo run launched from inside an unrelated repo before any side
+    # effect (notably before step 1 creates the remote), unless --target-dir names
+    # where the clone goes (#2717). Adopt runs and --target-dir runs return None.
+    refusal = foreign_repo_refusal(ctx)
+    if refusal is not None:
+        print(refusal, file=sys.stderr)
+        return 1
 
     run_wizard(ctx)
     return 0

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import textwrap
 from dataclasses import dataclass, field
 from importlib import resources
@@ -32,6 +33,11 @@ class RepoInitContext:
     visibility: str = "public"
     description: str = ""
     work_dir: Path | None = None
+    # Where the clone's parent directory is. ``None`` means "use CWD" — the
+    # historical default. An explicit ``--target-dir`` names the parent so the
+    # clone target is a property of the caller's intent, not of wherever they
+    # happened to be standing (#2717).
+    target_dir: Path | None = None
     completed_steps: set[int] = field(default_factory=set)
 
     # vergil.toml fields (populated by step 3 prompts)
@@ -83,6 +89,49 @@ def detect_completed_steps(log_output: str) -> set[int]:
         if m:
             steps.add(int(m.group(1)))
     return steps
+
+
+def cwd_repo_slug() -> str | None:
+    """Return the ``OWNER/REPO`` of the current directory's git remote, or None.
+
+    Used to tell whether the caller is standing inside a git repository and, if
+    so, which one — the fact that resolves both #2717 hazards: resume state must
+    only be trusted when CWD *is* the target's clone, and a new-repo bootstrap
+    must not run from inside an unrelated repo. Returns None when CWD is not a
+    git repo, has no remote, or ``gh`` is unavailable — every "cannot tell"
+    outcome maps to "not inside a known repo", which the callers treat as the
+    safe, non-blocking default.
+    """
+    try:
+        slug = github.current_repo()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return slug or None
+
+
+def foreign_repo_refusal(ctx: RepoInitContext) -> str | None:
+    """Refusal message if a *new-repo* run would bootstrap from inside another repo.
+
+    Bootstrapping a new repo derives its clone target from CWD and (historically)
+    its resume state too. Running from inside an unrelated Vergil/git repo makes
+    both wrong: the clone would nest inside that repo, and the resume scan would
+    read that repo's `chore(init): step N -` commits (#2717). Refuse *before* any
+    side effect — notably before step 1 creates the remote — unless ``--target-dir``
+    names where the clone goes. Returns None when there is nothing to refuse: an
+    adopt run (CWD is the target by design), an explicit ``--target-dir``, CWD not
+    inside a repo, or CWD already inside the target's own clone.
+    """
+    if ctx.adopt or ctx.target_dir is not None:
+        return None
+    inside = cwd_repo_slug()
+    if inside is None or inside.lower() == ctx.repo.lower():
+        return None
+    return (
+        f"Refusing to bootstrap {ctx.repo} from inside {inside}: the current "
+        "directory is a different repository, so the clone would nest inside it and "
+        "resume state would be read from the wrong repo. Run from the parent "
+        "directory where sibling repos live, or pass --target-dir <parent>."
+    )
 
 
 def prompt_choice(label: str, options: list[str], *, default: str = "") -> str:
@@ -816,7 +865,9 @@ def step_create_repo(ctx: RepoInitContext) -> None:
 def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
     """Step 2: Clone the repo locally or verify an existing clone."""
     if parent_dir is None:
-        parent_dir = Path.cwd()
+        # An explicit --target-dir names the clone's parent; otherwise fall back
+        # to CWD (the historical default). #2717.
+        parent_dir = ctx.target_dir or Path.cwd()
 
     target = parent_dir / ctx.name
 
@@ -832,6 +883,21 @@ def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
         return
 
     resolved = target.resolve()
+
+    # Refuse to clone into an occupied path rather than letting `git clone` raise
+    # a cryptic CalledProcessError. In the wild this collided with a legitimate
+    # `docs/` directory inside a `.github` repo — two unrelated things named the
+    # same (#2717). Name the resolved path so the operator sees exactly what is in
+    # the way. (An existing clone of this repo was already handled above.)
+    if target.exists() and any(target.iterdir()):
+        print(
+            f"Step 2: Refusing to clone {ctx.repo} into {resolved}: the path already "
+            "exists and is not empty. Pick an empty location with --target-dir, or "
+            "remove what is there.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     # Under --non-interactive/--yes the clone confirmation is auto-accepted.
     if not ctx.non_interactive and not prompt_yes_no(f"Step 2: Clone to {resolved}?", default=True):
         print("Aborted. Re-run from the directory where you want the clone.")
@@ -1279,11 +1345,20 @@ def _check_remote_steps(ctx: RepoInitContext) -> set[int]:
 
 def run_wizard(ctx: RepoInitContext) -> None:
     """Run all wizard steps, skipping completed ones."""
-    try:
-        log_output = git.read_output("log", "--oneline")
-    except subprocess.CalledProcessError:
-        log_output = ""
-    local_completed = detect_completed_steps(log_output)
+    # Resume state is a property of the TARGET, not of wherever the operator is
+    # standing. Only trust the local checkpoint commits when CWD is the target's
+    # own clone (or an adopt run, which uses CWD by design); an unrelated repo's
+    # `chore(init): step N -` commits would otherwise be misread as this repo's
+    # progress and silently skip vergil.toml / config / CI steps (#2717).
+    cwd_slug = cwd_repo_slug()
+    if ctx.adopt or (cwd_slug is not None and cwd_slug.lower() == ctx.repo.lower()):
+        try:
+            log_output = git.read_output("log", "--oneline")
+        except subprocess.CalledProcessError:
+            log_output = ""
+        local_completed = detect_completed_steps(log_output)
+    else:
+        local_completed = set()
 
     remote_completed = _check_remote_steps(ctx)
 

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -21,7 +21,9 @@ from vergil_tooling.lib.repo_init import (
     _remote_branch_exists,
     _resolve,
     _sync_labels,
+    cwd_repo_slug,
     detect_completed_steps,
+    foreign_repo_refusal,
     prompt_choice,
     prompt_free_text,
     prompt_language,
@@ -207,6 +209,59 @@ class TestDetectCompletedSteps:
         )
         result = detect_completed_steps(log_output)
         assert result == {3}
+
+
+class TestCwdRepoSlug:
+    def test_returns_slug(self) -> None:
+        with patch("vergil_tooling.lib.repo_init.github.current_repo", return_value="org/repo"):
+            assert cwd_repo_slug() == "org/repo"
+
+    def test_returns_none_when_not_a_repo(self) -> None:
+        with patch(
+            "vergil_tooling.lib.repo_init.github.current_repo",
+            side_effect=subprocess.CalledProcessError(1, "gh"),
+        ):
+            assert cwd_repo_slug() is None
+
+    def test_returns_none_when_empty(self) -> None:
+        with patch("vergil_tooling.lib.repo_init.github.current_repo", return_value=""):
+            assert cwd_repo_slug() is None
+
+
+class TestForeignRepoRefusal:
+    def test_adopt_never_refuses(self) -> None:
+        ctx = RepoInitContext(org="org", name="repo", adopt=True)
+        with patch("vergil_tooling.lib.repo_init.cwd_repo_slug") as mock_slug:
+            assert foreign_repo_refusal(ctx) is None
+        mock_slug.assert_not_called()  # short-circuits before touching CWD
+
+    def test_target_dir_never_refuses(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="org", name="repo", target_dir=tmp_path)
+        with patch("vergil_tooling.lib.repo_init.cwd_repo_slug") as mock_slug:
+            assert foreign_repo_refusal(ctx) is None
+        mock_slug.assert_not_called()
+
+    def test_none_outside_a_repo(self) -> None:
+        ctx = RepoInitContext(org="org", name="repo")
+        with patch("vergil_tooling.lib.repo_init.cwd_repo_slug", return_value=None):
+            assert foreign_repo_refusal(ctx) is None
+
+    def test_none_when_cwd_is_target(self) -> None:
+        ctx = RepoInitContext(org="Org", name="Repo")  # case-insensitive match
+        with patch("vergil_tooling.lib.repo_init.cwd_repo_slug", return_value="org/repo"):
+            assert foreign_repo_refusal(ctx) is None
+
+    def test_refuses_inside_a_foreign_repo(self) -> None:
+        ctx = RepoInitContext(org="mnemosys-project", name="docs")
+        with patch(
+            "vergil_tooling.lib.repo_init.cwd_repo_slug",
+            return_value="mnemosys-project/.github",
+        ):
+            msg = foreign_repo_refusal(ctx)
+        assert msg is not None
+        assert "mnemosys-project/docs" in msg
+        assert "mnemosys-project/.github" in msg
+        assert "--target-dir" in msg
 
 
 class TestRenderVergilToml:
@@ -830,6 +885,52 @@ class TestStepClone:
             patch("vergil_tooling.lib.repo_init.os.chdir"),
         ):
             step_clone(ctx, parent_dir=tmp_path)
+
+    def test_refuses_occupied_non_clone_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # An existing, non-empty directory that is NOT a clone (e.g. a legitimate
+        # docs/ dir) must not be clobbered — refuse loudly, naming the path (#2717).
+        ctx = RepoInitContext(org="vergil-project", name="docs")
+        ctx.non_interactive = True
+        collision = tmp_path / "docs"
+        collision.mkdir()
+        (collision / "index.md").write_text("hello\n")
+
+        with (
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=AssertionError("must not clone into an occupied path"),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            step_clone(ctx, parent_dir=tmp_path)
+        assert str(collision.resolve()) in capsys.readouterr().err
+
+    def test_target_dir_used_as_clone_parent(self, tmp_path: Path) -> None:
+        # With no explicit parent_dir, the clone parent comes from ctx.target_dir,
+        # not CWD (#2717).
+        parent = tmp_path / "sibling-root"
+        parent.mkdir()
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm", target_dir=parent)
+        ctx.non_interactive = True
+        target = parent / "vergil-vm"
+
+        def mock_subprocess_run(cmd: Any, **kw: Any) -> None:
+            target.mkdir(exist_ok=True)
+            (target / ".git").mkdir()
+
+        with (
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=mock_subprocess_run,
+            ),
+            patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=tmp_path / "elsewhere"),
+            patch("vergil_tooling.lib.repo_init.os.chdir"),
+        ):
+            step_clone(ctx)
+
+        assert ctx.work_dir == target
 
         assert ctx.work_dir == target
 
@@ -1486,6 +1587,12 @@ class TestRunWizard:
             patch("vergil_tooling.lib.repo_init.step_github_config", side_effect=mock_step(8)),
             patch("vergil_tooling.lib.repo_init.step_github_pages", side_effect=mock_step(9)),
             patch("vergil_tooling.lib.repo_init._check_remote_steps", return_value=set()),
+            # Local resume state is trusted only when CWD is the target's own
+            # clone (#2717); here it is, so the step 3/4 markers apply.
+            patch(
+                "vergil_tooling.lib.repo_init.cwd_repo_slug",
+                return_value="vergil-project/test",
+            ),
             patch(
                 "vergil_tooling.lib.repo_init.git.read_output",
                 return_value=(
@@ -1499,6 +1606,53 @@ class TestRunWizard:
         assert 3 not in steps_run
         assert 4 not in steps_run
         assert 5 in steps_run
+
+    def test_ignores_foreign_repo_resume_state(self) -> None:
+        # #2717 regression: when CWD is a DIFFERENT repo, its own bootstrap
+        # commits must not be read as this repo's progress — every step runs.
+        ctx = RepoInitContext(org="mnemosys-project", name="docs")
+
+        steps_run: list[int] = []
+
+        def mock_step(step_num: int) -> Any:
+            def inner(*a: Any, **kw: Any) -> None:
+                steps_run.append(step_num)
+
+            return inner
+
+        with (
+            patch("vergil_tooling.lib.repo_init.step_create_repo", side_effect=mock_step(1)),
+            patch("vergil_tooling.lib.repo_init.step_clone", side_effect=mock_step(2)),
+            patch("vergil_tooling.lib.repo_init.step_generate_config", side_effect=mock_step(3)),
+            patch(
+                "vergil_tooling.lib.repo_init.step_scaffold_config_files",
+                side_effect=mock_step(4),
+            ),
+            patch("vergil_tooling.lib.repo_init.step_ci_cd_workflows", side_effect=mock_step(5)),
+            patch("vergil_tooling.lib.repo_init.step_docs_site", side_effect=mock_step(6)),
+            patch("vergil_tooling.lib.repo_init.step_branch_structure", side_effect=mock_step(7)),
+            patch("vergil_tooling.lib.repo_init.step_github_config", side_effect=mock_step(8)),
+            patch("vergil_tooling.lib.repo_init.step_github_pages", side_effect=mock_step(9)),
+            patch("vergil_tooling.lib.repo_init._check_remote_steps", return_value=set()),
+            # Standing inside the `.github` repo, whose log carries step 3/4/5
+            # markers that must be ignored for the unrelated `docs` target.
+            patch(
+                "vergil_tooling.lib.repo_init.cwd_repo_slug",
+                return_value="mnemosys-project/.github",
+            ),
+            patch(
+                "vergil_tooling.lib.repo_init.git.read_output",
+                return_value=(
+                    "abc chore(init): step 3 - vergil.toml\n"
+                    "def chore(init): step 4 - config files\n"
+                    "ghi chore(init): step 5 - CI/CD workflows\n"
+                ),
+            ) as mock_log,
+        ):
+            run_wizard(ctx)
+
+        assert {3, 4, 5}.issubset(steps_run)  # none skipped
+        mock_log.assert_not_called()  # the foreign log is not even read
 
     def test_handles_git_log_failure(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
@@ -1525,6 +1679,12 @@ class TestRunWizard:
             patch("vergil_tooling.lib.repo_init.step_github_config", side_effect=mock_step(8)),
             patch("vergil_tooling.lib.repo_init.step_github_pages", side_effect=mock_step(9)),
             patch("vergil_tooling.lib.repo_init._check_remote_steps", return_value=set()),
+            # CWD is the target's own clone, so the log is read — and its failure
+            # degrades to "no local completions" rather than raising.
+            patch(
+                "vergil_tooling.lib.repo_init.cwd_repo_slug",
+                return_value="vergil-project/test",
+            ),
             patch(
                 "vergil_tooling.lib.repo_init.git.read_output",
                 side_effect=subprocess.CalledProcessError(1, "git"),
@@ -1558,6 +1718,9 @@ class TestRunWizard:
             patch("vergil_tooling.lib.repo_init.step_github_config", side_effect=mock_step(8)),
             patch("vergil_tooling.lib.repo_init.step_github_pages", side_effect=mock_step(9)),
             patch("vergil_tooling.lib.repo_init._check_remote_steps", return_value=set()),
+            # CWD is not the target's clone, so local resume state is not trusted
+            # and the git log is not even read.
+            patch("vergil_tooling.lib.repo_init.cwd_repo_slug", return_value=None),
             patch(
                 "vergil_tooling.lib.repo_init.git.read_output",
                 side_effect=subprocess.CalledProcessError(1, "git"),

--- a/tests/vergil_tooling/test_vrg_github_repo_init.py
+++ b/tests/vergil_tooling/test_vrg_github_repo_init.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from vergil_tooling.bin.vrg_github_repo_init import main, parse_args
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestParseArgs:
@@ -33,6 +37,19 @@ class TestParseArgs:
     def test_no_args_is_error(self) -> None:
         with pytest.raises(SystemExit):
             parse_args([])
+
+    def test_target_dir_parses(self, tmp_path: Path) -> None:
+        args = parse_args(["org/repo", "--target-dir", str(tmp_path)])
+        assert args.target_dir == str(tmp_path)
+
+    def test_target_dir_with_adopt_is_error(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit):
+            parse_args(["--adopt", "--target-dir", str(tmp_path)])
+
+    def test_target_dir_must_exist(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope"
+        with pytest.raises(SystemExit):
+            parse_args(["org/repo", "--target-dir", str(missing)])
 
     def test_wizard_flags_parse(self) -> None:
         args = parse_args(
@@ -219,6 +236,10 @@ class TestMain:
     def test_new_repo_with_visibility_arg(self) -> None:
         with (
             patch("vergil_tooling.bin.vrg_github_repo_init.prompt_free_text", return_value="desc"),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.foreign_repo_refusal",
+                return_value=None,
+            ),
             patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
         ):
             result = main(["org/repo", "--visibility", "private"])
@@ -228,6 +249,46 @@ class TestMain:
         assert ctx.visibility == "private"
         assert ctx.description == "desc"
 
+    def test_new_repo_target_dir_threads_into_ctx(self, tmp_path: Path) -> None:
+        # --target-dir is carried onto the context and, being set, lifts the
+        # foreign-repo guard without any CWD lookup (#2717).
+        with (
+            patch("vergil_tooling.bin.vrg_github_repo_init.prompt_free_text", return_value="desc"),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.prompt_choice",
+                return_value="public",
+            ),
+            patch("vergil_tooling.lib.repo_init.cwd_repo_slug") as mock_slug,
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(["org/repo", "--target-dir", str(tmp_path)])
+
+        assert result == 0
+        ctx = mock_wizard.call_args[0][0]
+        assert ctx.target_dir == tmp_path
+        mock_slug.assert_not_called()  # --target-dir short-circuits the guard
+
+    def test_new_repo_refused_inside_foreign_repo(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # When the guard returns a refusal, main aborts with code 1 before the
+        # wizard runs — nothing is created (#2717).
+        with (
+            patch("vergil_tooling.bin.vrg_github_repo_init.prompt_free_text", return_value="desc"),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.prompt_choice",
+                return_value="public",
+            ),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.foreign_repo_refusal",
+                return_value="Refusing to bootstrap org/repo from inside other/repo",
+            ),
+            patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
+        ):
+            result = main(["org/repo"])
+
+        assert result == 1
+        mock_wizard.assert_not_called()
+        assert "Refusing to bootstrap" in capsys.readouterr().err
+
     def test_new_repo_prompts_visibility(self) -> None:
         with (
             patch(
@@ -235,6 +296,10 @@ class TestMain:
                 return_value="public",
             ),
             patch("vergil_tooling.bin.vrg_github_repo_init.prompt_free_text", return_value="desc"),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.foreign_repo_refusal",
+                return_value=None,
+            ),
             patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
         ):
             result = main(["org/repo"])
@@ -273,6 +338,10 @@ class TestMain:
         ]
         with (
             patch("builtins.input", side_effect=AssertionError("prompted in non-interactive mode")),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.foreign_repo_refusal",
+                return_value=None,
+            ),
             patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
         ):
             result = main(argv)
@@ -311,6 +380,10 @@ class TestMain:
         ]
         with (
             patch("builtins.input", side_effect=AssertionError("prompted in non-interactive mode")),
+            patch(
+                "vergil_tooling.bin.vrg_github_repo_init.foreign_repo_refusal",
+                return_value=None,
+            ),
             patch("vergil_tooling.bin.vrg_github_repo_init.run_wizard") as mock_wizard,
         ):
             result = main(argv)


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-github-repo-init no longer misreads an unrelated repo's git log as the new repo's resume state (the silent-misconfiguration path), refuses to clone into an occupied path, adds --target-dir, and refuses a new-repo run launched from inside a different repo before any side effect.

## Issue Linkage

- Closes #2717

## Notes

- Bug #2717: run from inside an existing clone, the wizard (1) read CWD's git log and skipped already-'done' steps that belonged to the other repo — a silent half-configured repo — and (2) cloned into CWD/<name>, colliding with a same-named dir. All four suggested fixes implemented: resume state trusted only when CWD is the target's clone (or adopt); step_clone refuses an occupied non-clone path naming it; new --target-dir names the clone parent (validated: existing dir, not with --adopt); main refuses a new-repo run from inside a foreign repo BEFORE step 1 creates the remote, with --target-dir as the escape hatch. New lib helpers cwd_repo_slug()/foreign_repo_refusal() centralize the CWD-vs-target check (case-insensitive; 'cannot tell' → treated as not-inside-a-repo, the safe non-blocking default). Guard lives at the CLI boundary so it fires before any remote is created. Existing new-repo main tests updated to stub the guard; added a symptom-2 regression test asserting a foreign repo's step markers do NOT skip steps. Validation green: 4790 tests, 100% coverage. Note: I applied ruff format to the two changed test files to satisfy the format gate.