### PR TITLE
fix(triage-create): scope App token to --repo org (also epic-create)

### DIFF
--- a/src/vergil_tooling/bin/vrg_epic_create.py
+++ b/src/vergil_tooling/bin/vrg_epic_create.py
@@ -63,16 +63,20 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     owner, bare = target.split("/", 1)
     home = epics.resolve_epic_home(owner, bare)
-    print(f"-> epic home: {home} [{github.repo_visibility(home)}]")
     labels = list(dict.fromkeys(["epic", *args.label]))
-    url = github.create_issue(
-        repo=home,
-        title=args.title,
-        body=args.body,
-        body_file=args.body_file,
-        labels=labels,
-        assignees=args.assignee,
-    )
+    # Scope every App-token call to the target's org, not the cwd org (mirrors
+    # issue-create, #2070). Without this a cross-org epic mints the token for the
+    # wrong org and either fails to write or misreports the epic's location (#2722).
+    with github.target_org(owner):
+        print(f"-> epic home: {home} [{github.repo_visibility(home)}]")
+        url = github.create_issue(
+            repo=home,
+            title=args.title,
+            body=args.body,
+            body_file=args.body_file,
+            labels=labels,
+            assignees=args.assignee,
+        )
     print(f"Created {url} (epic).")
     return 0
 

--- a/src/vergil_tooling/bin/vrg_triage_create.py
+++ b/src/vergil_tooling/bin/vrg_triage_create.py
@@ -69,14 +69,19 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         repo = f"{org}/.github"
     labels = list(dict.fromkeys([args.kind, *args.label]))
-    url = github.create_issue(
-        repo=repo,
-        title=args.title,
-        body=args.body,
-        body_file=args.body_file,
-        labels=labels,
-        assignees=args.assignee,
-    )
+    owner = repo.split("/")[0]
+    # Scope the App token to --repo's org, not the cwd org (mirrors issue-create,
+    # #2070). Without this the token is minted for the wrong org and a cross-org
+    # create either fails to write or misreports the issue's location (#2722).
+    with github.target_org(owner):
+        url = github.create_issue(
+            repo=repo,
+            title=args.title,
+            body=args.body,
+            body_file=args.body_file,
+            labels=labels,
+            assignees=args.assignee,
+        )
     print(f"Created {url} ({args.kind}).")
     return 0
 

--- a/tests/vergil_tooling/test_vrg_epic_create.py
+++ b/tests/vergil_tooling/test_vrg_epic_create.py
@@ -33,6 +33,23 @@ def test_default_target_is_current_repo_public_goes_to_dotgithub() -> None:
     assert mock_create.call_args.kwargs["labels"] == ["epic"]
 
 
+def test_main_scopes_token_to_target_owner() -> None:
+    """Epic creation runs under the --repo owner's App installation (#2722).
+
+    Without target_org(owner) the App token is minted for the cwd org, so a
+    cross-org epic misroutes or misreports the epic's location.
+    """
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.epics.resolve_epic_home", return_value="other-org/.github"),
+        patch(f"{_MOD}.github.repo_visibility", return_value="PUBLIC"),
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+    ):
+        rc = main(["--repo", "other-org/repo", "--title", "T"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
 def test_explicit_private_target_homes_in_self() -> None:
     with (
         patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab") as home,

--- a/tests/vergil_tooling/test_vrg_triage_create.py
+++ b/tests/vergil_tooling/test_vrg_triage_create.py
@@ -50,6 +50,33 @@ def test_main_kind_idea() -> None:
     assert mock_create.call_args.kwargs["labels"] == ["idea"]
 
 
+def test_main_scopes_token_to_repo_owner() -> None:
+    """Issue creation runs under the --repo owner's App installation (#2722).
+
+    Without target_org(owner) the App token is minted for the cwd org, so a
+    cross-org create misroutes or misreports the issue's location.
+    """
+    with (
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+    ):
+        rc = main(["--title", "T", "--repo", "other-org/repo"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("other-org")
+
+
+def test_main_scopes_token_to_default_dotgithub_org() -> None:
+    """The default <org>/.github route is also scoped to that org's token (#2722)."""
+    with (
+        patch(f"{_MOD}.github.detect_org", return_value="org"),
+        patch(f"{_MOD}.github.target_org") as mock_scope,
+        patch(f"{_MOD}.github.create_issue", return_value=_URL),
+    ):
+        rc = main(["--title", "T"])
+    assert rc == 0
+    mock_scope.assert_called_once_with("org")
+
+
 def test_main_repo_override_skips_detect_org() -> None:
     with (
         patch(f"{_MOD}.github.detect_org") as mock_detect,


### PR DESCRIPTION
# Pull Request

## Summary

- Wrap the create call in target_org(owner) derived from the resolved --repo so the App installation token is minted for the target org rather than falling back to the cwd repo's org, fixing cross-org misroutes and mis-reported URLs.

## Issue Linkage

- Closes #2722

## Notes

- Root cause: vrg-triage-create called github.create_issue without target_org(owner), so _gh_env() fell back to the cwd org's token; the same gap existed in vrg-epic-create (repo_visibility + create_issue). Both now mirror vrg-issue-create. Regression tests assert target_org is entered with the --repo owner (triage-create also covers the default <org>/.github route). Full validation green: 4793 passed, 100% coverage.