### PR TITLE
fix(repo-init): emit docs/docs on PR and guard required-context parity

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 import subprocess
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from vergil_tooling.lib.config import CiConfig, ProjectConfig, VergilConfig
 
@@ -358,6 +359,118 @@ def desired_ci_gates_ruleset(
             },
         ],
     )
+
+
+# ---------------------------------------------------------------------------
+# CI-gate producibility cross-check (issue #2720)
+# ---------------------------------------------------------------------------
+#
+# The CI-gates ruleset (``desired_ci_gates_ruleset``) and the generated
+# ``ci.yml`` workflow are two artifacts derived from the same identity along two
+# independent paths. When they disagree — the ruleset *requires* a status check
+# the workflow never *emits on ``pull_request``* — the branch is unmergeable by
+# construction, with every check that does run green. Two flags have produced
+# this: ``integration-tests`` (no producing job at all) and ``publish-docs``
+# (the docs job ran on push, not on ``pull_request``). See issue #2720.
+#
+# ``unproducible_required_contexts`` reads the generated ci.yml, derives the set
+# of contexts each reusable workflow it invokes actually emits on a PR, and
+# returns any required context that set cannot produce. repo-init fails loudly on
+# a non-empty result instead of shipping a repository that cannot merge its first
+# PR with every check green.
+
+_CI_JOB_RE = re.compile(r"^ {2}([a-z][a-z0-9_-]*):\s*$")
+_CI_USES_RE = re.compile(r"^ {4}uses:\s+\S+/([a-z0-9-]+\.yml)@")
+
+
+def _ci_caller_jobs(ci_workflow_yaml: str) -> list[tuple[str, str]]:
+    """Parse a generated ci.yml into ``(caller_job, reusable_workflow_file)`` pairs.
+
+    Only jobs that delegate to a reusable workflow via ``uses:`` are returned.
+    The check-run context a reusable-workflow job produces is
+    ``<caller_job> / <reusable job name>``, so the caller job id is the first
+    segment of every context that job emits.
+    """
+    pairs: list[tuple[str, str]] = []
+    current: str | None = None
+    for line in ci_workflow_yaml.splitlines():
+        job = _CI_JOB_RE.match(line)
+        if job:
+            current = job.group(1)
+            continue
+        uses = _CI_USES_RE.match(line)
+        if uses and current is not None:
+            pairs.append((current, uses.group(1)))
+            current = None
+    return pairs
+
+
+def _reusable_pr_contexts(
+    reusable_file: str, caller_job: str, *, ghas: bool
+) -> tuple[set[str], set[str]]:
+    """Contexts a reusable CI workflow emits on ``pull_request`` under ``caller_job``.
+
+    Returns ``(exact, prefixes)``: a required context is producible when it
+    equals a member of ``exact`` or starts with a member of ``prefixes`` (the
+    version-parameterized families). The table mirrors what each
+    ``vergil-actions`` reusable workflow actually reports on a PR — notably
+    ``ci-test.yml`` emits ``unit`` but **not** ``integration``, which is what
+    flags an ``integration-tests`` repo whose ruleset requires
+    ``test / integration / <v>`` with no producing job (issue #2720).
+    """
+    j = caller_job
+    if reusable_file == "ci-quality.yml":
+        return ({f"{j} / common"}, {f"{j} / lint / ", f"{j} / typecheck / "})
+    if reusable_file == "ci-audit.yml":
+        return (set(), {f"{j} / dependencies / "})
+    if reusable_file == "ci-test.yml":
+        return (set(), {f"{j} / unit / "})
+    if reusable_file == "ci-docs.yml":
+        return ({f"{j} / docs"}, set())
+    if reusable_file == "ci-security.yml":
+        exact = {f"{j} / trivy", f"{j} / semgrep", f"{j} / codeql"}
+        if ghas:
+            # GHAS-app check runs carry no ``<job> /`` prefix (created by the
+            # GitHub Advanced Security app, not the workflow) but do report on a
+            # PR when the security job uploads SARIF.
+            exact |= {"Trivy", "Semgrep OSS", "CodeQL"}
+        return (exact, set())
+    if reusable_file == "ci-version-bump.yml":
+        return ({f"{j} / version-bump"}, set())
+    return (set(), set())
+
+
+def required_status_contexts(ruleset: DesiredRuleset) -> list[str]:
+    """The required status-check context names declared by a CI-gates ruleset."""
+    checks = _extract_status_checks(ruleset.rules) or []
+    return [str(c.get("context", "")) for c in checks if c.get("context")]
+
+
+def unproducible_required_contexts(
+    ci_workflow_yaml: str, required_contexts: Iterable[str], *, ghas: bool
+) -> list[str]:
+    """Required status-check contexts the generated ci.yml cannot emit on a PR.
+
+    A non-empty result means the CI-gates ruleset and the generated workflow
+    disagree: the ruleset requires a context no ``pull_request`` job produces, so
+    every merge is blocked with green checks (issue #2720). Returned sorted for a
+    stable, deduplicated error message.
+    """
+    exact: set[str] = set()
+    prefixes: set[str] = set()
+    for caller_job, reusable_file in _ci_caller_jobs(ci_workflow_yaml):
+        e, p = _reusable_pr_contexts(reusable_file, caller_job, ghas=ghas)
+        exact |= e
+        prefixes |= p
+
+    missing: set[str] = set()
+    for ctx in required_contexts:
+        if ctx in exact:
+            continue
+        if any(ctx.startswith(pre) for pre in prefixes):
+            continue
+        missing.add(ctx)
+    return sorted(missing)
 
 
 # ---------------------------------------------------------------------------

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from vergil_tooling.lib.github_config import DesiredState
+
 from vergil_tooling.lib import git, github, repo_config
 from vergil_tooling.lib.config import _ENUMS
 from vergil_tooling.lib.vergil_refs import EXPECTED_MARKETPLACE_REF
@@ -644,6 +646,20 @@ def render_ci_workflow(ctx: RepoInitContext) -> str:
     if ctx.primary_language not in _CODEQL_LANGUAGES:
         lines.append("      run-codeql: false\n")
 
+    # Docs build gate — emitted on pull_request when the repo publishes docs, so
+    # the ``docs / docs`` context the CI-gates ruleset requires actually reports
+    # on a PR. Without it the ruleset waits on a context only the push-triggered
+    # cd.yml produces, blocking every merge with green checks (issue #2720).
+    # ci-docs.yml self-guards to a no-op pass when there is no mkdocs config.
+    if ctx.publish_docs:
+        lines.extend(
+            [
+                "\n",
+                "  docs:\n",
+                "    uses: vergil-project/vergil-actions/.github/workflows/ci-docs.yml@v2.1\n",
+            ]
+        )
+
     if has_test:
         lines.extend(
             [
@@ -1268,6 +1284,45 @@ def _sync_labels(repo: str) -> None:
         github.run(*cmd)
 
 
+def _assert_ci_gates_producible(ctx: RepoInitContext, desired: DesiredState, *, ghas: bool) -> None:
+    """Fail loudly when the CI-gates ruleset requires a check ci.yml never emits.
+
+    Cross-checks the required status-check contexts of the derived ``CI gates``
+    ruleset against the contexts the generated ``.github/workflows/ci.yml``
+    actually produces on a ``pull_request``. A mismatch means the repository
+    cannot merge any PR — every check that runs is green while the merge stays
+    blocked on a context that never reports (issue #2720).
+    """
+    from vergil_tooling.lib.github_config import (
+        required_status_contexts,
+        unproducible_required_contexts,
+    )
+
+    if ctx.work_dir is None:  # pragma: no cover
+        raise RuntimeError("work_dir not set")
+    ci_gates = next((rs for rs in desired.rulesets if rs.name == "CI gates"), None)
+    if ci_gates is None:  # pragma: no cover - the CI-gates ruleset is always derived
+        return
+
+    ci_yaml = (ctx.work_dir / ".github" / "workflows" / "ci.yml").read_text()
+    unproducible = unproducible_required_contexts(
+        ci_yaml, required_status_contexts(ci_gates), ghas=ghas
+    )
+    if unproducible:
+        raise RuntimeError(
+            "GitHub CI-gates ruleset requires status checks that "
+            ".github/workflows/ci.yml never emits on a pull_request, so the "
+            "repository could not merge any PR (every check that runs would be "
+            "green while the merge stays blocked).\n"
+            "  Unproducible required contexts: " + ", ".join(unproducible) + "\n"
+            "Every required context must correspond to a job the generated ci.yml "
+            "runs on pull_request. Likely cause:\n"
+            "  - integration-tests = true: ci.yml has no integration job yet "
+            "(vergil-project/vergil-tooling#2721) — set integration-tests = false "
+            "in vergil.toml until it is a first-class feature."
+        )
+
+
 def step_github_config(ctx: RepoInitContext) -> None:
     """Step 8: Apply GitHub config and labels."""
     from vergil_tooling.lib import config as config_module
@@ -1275,6 +1330,7 @@ def step_github_config(ctx: RepoInitContext) -> None:
         apply_desired_state,
         compute_desired_state,
         fetch_actual_state,
+        ghas_available,
     )
 
     print("Step 8: Applying GitHub config...")
@@ -1285,6 +1341,14 @@ def step_github_config(ctx: RepoInitContext) -> None:
     result = fetch_actual_state(ctx.repo)
     is_org = result.owner_type == "Organization"
     desired = compute_desired_state(cfg, visibility=result.visibility, is_org=is_org)
+    # Refuse to apply a CI-gates ruleset whose required status checks the
+    # generated ci.yml never emits on a pull_request — the defect that ships a
+    # repository which cannot merge its first PR with every check green (#2720).
+    # Checked before the ruleset is written, so a mismatch fails at creation
+    # rather than at the first merge.
+    _assert_ci_gates_producible(
+        ctx, desired, ghas=ghas_available(cfg, visibility=result.visibility)
+    )
     removed = apply_desired_state(ctx.repo, desired)
     if removed:
         print(f"  Legacy protection removed: {', '.join(removed)}")

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -47,6 +47,8 @@ from vergil_tooling.lib.github_config import (
     format_rules_delta,
     ghas_available,
     required_evidence_gates,
+    required_status_contexts,
+    unproducible_required_contexts,
 )
 
 
@@ -413,6 +415,107 @@ def test_ci_gates_no_language_has_no_versioned_checks() -> None:
 
 def test_lang_has_check_returns_false_for_unknown_check() -> None:
     assert _lang_has_check("python", "nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# CI-gate producibility cross-check tests (issue #2720)
+# ---------------------------------------------------------------------------
+
+
+def _ci_yaml(*, jobs: dict[str, str]) -> str:
+    """A minimal generated-ci.yml fragment: one `<job>:` → reusable-workflow use.
+
+    Mirrors the shape `render_ci_workflow` emits (2-space job id, 4-space
+    ``uses:`` pinned to a ``vergil-actions`` reusable workflow), enough for the
+    caller-job parser without pulling in the full renderer.
+    """
+    lines = ["name: CI\n", "on:\n", "  pull_request:\n", "jobs:\n"]
+    for job, reusable in jobs.items():
+        lines.append(f"  {job}:\n")
+        lines.append(f"    uses: vergil-project/vergil-actions/.github/workflows/{reusable}@v2.1\n")
+    return "".join(lines)
+
+
+_FULL_CI_JOBS = {
+    "audit": "ci-audit.yml",
+    "quality": "ci-quality.yml",
+    "security": "ci-security.yml",
+    "docs": "ci-docs.yml",
+    "test": "ci-test.yml",
+    "version": "ci-version-bump.yml",
+}
+
+
+def test_required_status_contexts_extracts_names() -> None:
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=True)
+    contexts = required_status_contexts(ruleset)
+    assert "quality / common" in contexts
+    assert "test / unit / 3.14" in contexts
+    # No empty strings from malformed entries.
+    assert all(contexts)
+
+
+def test_producible_when_all_required_contexts_have_a_pr_job() -> None:
+    """A docs-publishing python repo whose ci.yml emits every required context
+    (including `docs / docs`) has nothing unproducible."""
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=True, docs=True)
+    ci_yaml = _ci_yaml(jobs=_FULL_CI_JOBS)
+    assert (
+        unproducible_required_contexts(ci_yaml, required_status_contexts(ruleset), ghas=True) == []
+    )
+
+
+def test_integration_context_is_flagged_unproducible() -> None:
+    """`test / integration / <v>` is required when integration-tests=true, but
+    ci-test.yml emits only `unit` — so the context can never report (#2720)."""
+    ruleset = desired_ci_gates_ruleset(
+        _project(), _ci(integration_tests=True), ghas=True, docs=True
+    )
+    ci_yaml = _ci_yaml(jobs=_FULL_CI_JOBS)
+    missing = unproducible_required_contexts(ci_yaml, required_status_contexts(ruleset), ghas=True)
+    assert missing == ["test / integration / 3.14"]
+
+
+def test_docs_context_flagged_when_ci_lacks_docs_job() -> None:
+    """The pre-fix `publish-docs` defect: the ruleset requires `docs / docs`, but
+    a ci.yml with no docs job never reports it on a PR (#2720)."""
+    ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=True, docs=True)
+    jobs_without_docs = {k: v for k, v in _FULL_CI_JOBS.items() if k != "docs"}
+    ci_yaml = _ci_yaml(jobs=jobs_without_docs)
+    missing = unproducible_required_contexts(ci_yaml, required_status_contexts(ruleset), ghas=True)
+    assert missing == ["docs / docs"]
+
+
+def test_ghas_literal_contexts_producible_only_with_ghas() -> None:
+    """The GHAS-app checks (`Trivy`, `Semgrep OSS`, `CodeQL`) report on a PR only
+    when GHAS is on — the ruleset requires them under the same condition, so both
+    the ghas and non-ghas derivations must come out clean."""
+    ci_yaml = _ci_yaml(jobs=_FULL_CI_JOBS)
+    for ghas in (True, False):
+        ruleset = desired_ci_gates_ruleset(_project(), _ci(), ghas=ghas, docs=True)
+        assert (
+            unproducible_required_contexts(ci_yaml, required_status_contexts(ruleset), ghas=ghas)
+            == []
+        )
+
+
+def test_versioned_contexts_producible_across_all_versions() -> None:
+    ruleset = desired_ci_gates_ruleset(
+        _project(), _ci(versions=["3.12", "3.13", "3.14"]), ghas=True, docs=True
+    )
+    ci_yaml = _ci_yaml(jobs=_FULL_CI_JOBS)
+    assert (
+        unproducible_required_contexts(ci_yaml, required_status_contexts(ruleset), ghas=True) == []
+    )
+
+
+def test_unrecognized_reusable_workflow_produces_no_contexts() -> None:
+    """A job wired to an unknown reusable workflow contributes nothing to the
+    producible set, so any required context is flagged (the safe default)."""
+    ci_yaml = _ci_yaml(jobs={"mystery": "ci-mystery.yml"})
+    assert unproducible_required_contexts(ci_yaml, ["quality / common"], ghas=True) == [
+        "quality / common"
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -9,9 +9,10 @@ from unittest.mock import patch
 
 import pytest
 
-from vergil_tooling.lib.config import _parse_raw_config
+from vergil_tooling.lib.config import CiConfig, ProjectConfig, _parse_raw_config
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
+    _assert_ci_gates_producible,
     _cd_release_secrets,
     _check_remote_steps,
     _container_suffix,
@@ -547,6 +548,128 @@ class TestRenderCiWorkflow:
         content = render_ci_workflow(ctx)
         assert "@v2.0" not in content
         assert "ci-security.yml@v2.1" in content
+
+    def test_publish_docs_emits_ci_docs_job(self) -> None:
+        """A docs-publishing repo must invoke ci-docs.yml from ci.yml so the
+        `docs / docs` gate reports on pull_request (issue #2720)."""
+        ctx = RepoInitContext(org="mnemosys-project", name="docs")
+        ctx.ci_versions = ["latest"]
+        ctx.release_model = "none"
+        ctx.publish_docs = True
+        content = render_ci_workflow(ctx)
+        assert "ci-docs.yml@v2.1" in content
+        assert "\n  docs:\n" in content
+
+    def test_no_publish_docs_omits_ci_docs_job(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="dotgithub")
+        ctx.ci_versions = ["latest"]
+        ctx.release_model = "none"
+        ctx.publish_docs = False
+        content = render_ci_workflow(ctx)
+        assert "ci-docs.yml" not in content
+
+
+class TestCiGatesProducibility:
+    """The generated ci.yml must emit every context the CI-gates ruleset
+    requires on a pull_request — the parity #2720 restores and guards."""
+
+    @staticmethod
+    def _unproducible(ctx: RepoInitContext, *, ghas: bool, docs: bool) -> list[str]:
+        from vergil_tooling.lib.github_config import (
+            desired_ci_gates_ruleset,
+            required_status_contexts,
+            unproducible_required_contexts,
+        )
+
+        project = ProjectConfig(
+            repository_type="documentation",
+            versioning_scheme="semver",
+            branching_model="gitflow",
+            release_model=ctx.release_model,
+            primary_language=ctx.primary_language,
+        )
+        ci = CiConfig(versions=ctx.ci_versions, integration_tests=ctx.integration_tests)
+        ruleset = desired_ci_gates_ruleset(project, ci, ghas=ghas, docs=docs)
+        result: list[str] = unproducible_required_contexts(
+            render_ci_workflow(ctx), required_status_contexts(ruleset), ghas=ghas
+        )
+        return result
+
+    def test_docs_repo_is_fully_producible(self) -> None:
+        """End-to-end: a python docs repo's generated ci.yml produces every
+        required context, so nothing is unproducible (the mnemosys/docs case)."""
+        ctx = RepoInitContext(org="mnemosys-project", name="docs")
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.14"]
+        ctx.release_model = "tagged-release"
+        ctx.publish_docs = True
+        assert self._unproducible(ctx, ghas=True, docs=True) == []
+
+    def test_private_docs_repo_is_fully_producible(self) -> None:
+        ctx = RepoInitContext(org="logical-minds-foundry", name="docs", visibility="private")
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.14"]
+        ctx.release_model = "tagged-release"
+        ctx.publish_docs = True
+        assert self._unproducible(ctx, ghas=False, docs=True) == []
+
+    def test_integration_tests_leave_an_unproducible_context(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.14"]
+        ctx.release_model = "tagged-release"
+        ctx.integration_tests = True
+        ctx.publish_docs = True
+        assert self._unproducible(ctx, ghas=True, docs=True) == ["test / integration / 3.14"]
+
+
+class TestAssertCiGatesProducible:
+    def _ctx_with_ci(self, tmp_path: Path, ctx: RepoInitContext) -> RepoInitContext:
+        ctx.work_dir = tmp_path
+        wf = tmp_path / ".github" / "workflows"
+        wf.mkdir(parents=True, exist_ok=True)
+        (wf / "ci.yml").write_text(render_ci_workflow(ctx))
+        return ctx
+
+    def _desired(self, ctx: RepoInitContext, *, ghas: bool) -> Any:
+        """A minimal desired-state stand-in: the guard only reads ``.rulesets``."""
+        from types import SimpleNamespace
+
+        from vergil_tooling.lib.github_config import desired_ci_gates_ruleset
+
+        project = ProjectConfig(
+            repository_type="documentation",
+            versioning_scheme="semver",
+            branching_model="gitflow",
+            release_model=ctx.release_model,
+            primary_language=ctx.primary_language,
+        )
+        ci = CiConfig(versions=ctx.ci_versions, integration_tests=ctx.integration_tests)
+        ruleset = desired_ci_gates_ruleset(project, ci, ghas=ghas, docs=ctx.publish_docs)
+        return SimpleNamespace(rulesets=[ruleset])
+
+    def test_passes_for_a_docs_repo(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="mnemosys-project", name="docs")
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.14"]
+        ctx.release_model = "tagged-release"
+        ctx.publish_docs = True
+        self._ctx_with_ci(tmp_path, ctx)
+        # Does not raise.
+        _assert_ci_gates_producible(ctx, self._desired(ctx, ghas=True), ghas=True)
+
+    def test_raises_for_integration_tests(self, tmp_path: Path) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "python"
+        ctx.ci_versions = ["3.14"]
+        ctx.release_model = "tagged-release"
+        ctx.integration_tests = True
+        ctx.publish_docs = True
+        self._ctx_with_ci(tmp_path, ctx)
+        with pytest.raises(RuntimeError) as exc:
+            _assert_ci_gates_producible(ctx, self._desired(ctx, ghas=True), ghas=True)
+        assert "test / integration / 3.14" in str(exc.value)
+        assert "2721" in str(exc.value)
 
 
 class TestContainerHelpers:


### PR DESCRIPTION
# Pull Request

## Summary

- Generate the docs job in ci.yml so the docs / docs gate reports on pull_request, and add an init/adopt cross-check that fails loudly when the CI-gates ruleset requires a status check the generated workflow never emits on a PR.

## Issue Linkage

- Closes #2720

## Notes

- Scope decision (agreed with maintainer): fixes the publish-docs instance and adds the systemic guard; defers integration-tests first-class support to #2721 (the guard now refuses that flag rather than silently bricking a repo). Does NOT touch the already-broken mnemosys-project/docs repo — its bad ci.yml is already on disk; unblock it separately after release via re-adopt or a one-line workflow PR adding the docs job. The broader vrg-github-repo-config audit rulesets-in-desired-state work is out of scope here and may warrant its own issue.