### PR TITLE
feat(epics): reclassify per-quarter ad-hoc buckets as archives

### DIFF
--- a/src/vergil_tooling/bin/vrg_adhoc_epic.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_epic.py
@@ -66,14 +66,26 @@ def cmd_archive(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_normalize(args: argparse.Namespace) -> int:
+    verb = "APPLY" if args.apply else "DRY-RUN"
+    with github.target_org(args.all_in):
+        conversions = epics.normalize_adhoc_archives(args.all_in, apply=args.apply)
+    print(f"[{verb}] {args.all_in}: {len(conversions)} archive(s) to normalize")
+    for conv in conversions:
+        print(f"  {conv.ref.slug}: {conv.old_title!r} -> {conv.new_title!r}")
+    return 0
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         prog="vrg-adhoc-epic",
         description=(
-            "Manage a repo's ad-hoc epic (Epic (ad hoc): <repo>, labelled "
-            "epic + ad-hoc, homed by visibility: <org>/.github for a public "
-            "repo, the repo itself when private)."
+            "Manage a repo's ad-hoc epic. The live epic is 'Epic (ad hoc): "
+            "<repo>' labelled epic + ad-hoc; stamped per-quarter buckets are "
+            "'Archive (ad hoc): <repo> — YYYY-Qn' labelled archive + ad-hoc. "
+            "Homed by visibility: <org>/.github for a public repo, the repo "
+            "itself when private."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
@@ -92,6 +104,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     scope.add_argument("--all-in", metavar="ORG", help="Sweep every repo in ORG")
     p_arch.add_argument("--apply", action="store_true", help="Execute (default: dry-run)")
     p_arch.set_defaults(func=cmd_archive)
+    p_norm = sub.add_parser(
+        "normalize",
+        help=(
+            "Convert legacy 'Epic (ad hoc): … — Qn' archives to the "
+            "'Archive (ad hoc): …' form (dry-run unless --apply)."
+        ),
+    )
+    p_norm.add_argument(
+        "--all-in", metavar="ORG", required=True, help="Sweep every repo in ORG"
+    )
+    p_norm.add_argument("--apply", action="store_true", help="Execute (default: dry-run)")
+    p_norm.set_defaults(func=cmd_normalize)
     return parser.parse_args(argv)
 
 

--- a/src/vergil_tooling/bin/vrg_adhoc_epic.py
+++ b/src/vergil_tooling/bin/vrg_adhoc_epic.py
@@ -111,9 +111,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "'Archive (ad hoc): …' form (dry-run unless --apply)."
         ),
     )
-    p_norm.add_argument(
-        "--all-in", metavar="ORG", required=True, help="Sweep every repo in ORG"
-    )
+    p_norm.add_argument("--all-in", metavar="ORG", required=True, help="Sweep every repo in ORG")
     p_norm.add_argument("--apply", action="store_true", help="Execute (default: dry-run)")
     p_norm.set_defaults(func=cmd_normalize)
     return parser.parse_args(argv)

--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -12,6 +12,7 @@
     {"name": "observability", "color": "1d76db", "description": "Monitoring, reporting, health checks"},
     {"name": "epic", "color": "6f42c1", "description": "Umbrella issue; finite epics close when all sub-issues close"},
     {"name": "ad-hoc", "color": "5319e7", "description": "Perpetual umbrella for ad-hoc work; never auto-closes"},
+    {"name": "archive", "color": "6a737d", "description": "Terminal per-quarter archive of closed ad-hoc work; historical record"},
     {"name": "triage", "color": "d93f0b", "description": "Uncurated intake; not yet folded into the epic/task model"},
     {"name": "idea", "color": "fef2c0", "description": "Seed to be expanded into an epic"},
     {"name": "hotfix", "color": "b60205", "description": "Emergency fix that skipped formal planning; flagged for retroactive review"},

--- a/src/vergil_tooling/lib/epic_audit.py
+++ b/src/vergil_tooling/lib/epic_audit.py
@@ -303,13 +303,14 @@ def epic_outside_dotgithub(org: str) -> list[str]:
 def stray_dotgithub_issue(org: str, *, home: str | None = None) -> list[str]:
     """Open issues in the epic *home* that violate invariant 2 (epic #85).
 
-    The home holds only epics, intake (``triage``/``idea``/``research``), and
-    managed tasks whose closing PR lands there (a task linked under an epic). An
-    open issue that is none of these — an unlinked, non-epic, non-intake issue —
-    is a stray; returns their slugs. *home* defaults to ``<org>/.github``; a
-    ``--repo``-targeted audit passes the repo's resolved home. When a candidate's
-    parent cannot be confirmed as an epic it is reported (fail-loud, the human
-    decides).
+    The home holds only epics, intake (``triage``/``idea``/``research``), the
+    ``archive``-labelled per-quarter buckets (a legitimate top-level home issue,
+    skipped like epics and intake), and managed tasks whose closing PR lands there
+    (a task linked under an epic). An open issue that is none of these — an
+    unlinked, non-epic, non-archive, non-intake issue — is a stray; returns their
+    slugs. *home* defaults to ``<org>/.github``; a ``--repo``-targeted audit passes
+    the repo's resolved home. When a candidate's parent cannot be confirmed as an
+    epic it is reported (fail-loud, the human decides).
     """
     if home is None:
         home = f"{org}/.github"
@@ -329,7 +330,7 @@ def stray_dotgithub_issue(org: str, *, home: str | None = None) -> list[str]:
     strays: list[str] = []
     for item in raw if isinstance(raw, list) else []:
         labels = {str((label or {}).get("name", "")) for label in (item.get("labels") or [])}
-        if "epic" in labels or (labels & _INTAKE_LABELS):
+        if "epic" in labels or "archive" in labels or (labels & _INTAKE_LABELS):
             continue
         number = int(item["number"])
         parent = epics.parent_of(epics.IssueRef(home_owner, home_repo, number))

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -398,17 +399,33 @@ def resolve_epic_home(org: str, target_repo: str) -> str:
 
 _ADHOC_EPIC_TITLE_PREFIX = "Epic (ad hoc): "
 _ADHOC_EPIC_LABELS = ("epic", "ad-hoc")
+_ADHOC_ARCHIVE_TITLE_PREFIX = "Archive (ad hoc): "
+_ADHOC_ARCHIVE_LABELS = ("archive", "ad-hoc")
 _ADHOC_EPIC_BODY = (
     "Perpetual umbrella for ad-hoc work in {repo}. Created and reused "
     "idempotently; tasks routed to the ad-hoc epic are linked here.\n"
 )
-# A stamped per-quarter archive epic: "Epic (ad hoc): <bare> — <YYYY>-Qn". The
+# A stamped per-quarter archive: "Archive (ad hoc): <bare> — <YYYY>-Qn". The
 # separator is a space, U+2014 em-dash, space. Matching this distinguishes a
 # terminal archive from the live canonical ad-hoc epic (which has no stamp).
-_ADHOC_ARCHIVE_RE = re.compile(r"^Epic \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$")
+_ADHOC_ARCHIVE_RE = re.compile(
+    r"^Archive \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$"
+)
+# Legacy pre-rename archive title ("Epic (ad hoc): <bare> — <YYYY>-Qn"), used
+# ONLY by the self-healing creation path and the normalize sweep to find
+# archives still in the old form. Steady-state code keys off _ADHOC_ARCHIVE_RE.
+_LEGACY_ADHOC_ARCHIVE_RE = re.compile(
+    r"^Epic \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$"
+)
 
 
-def _find_epic_by_title(home: str, title: str, *, prefer_oldest: bool = False) -> IssueRef | None:
+def _find_epic_by_title(
+    home: str,
+    title: str,
+    *,
+    prefer_oldest: bool = False,
+    labels: Sequence[str] = ("epic", "ad-hoc"),
+) -> IssueRef | None:
     """Return the open ``ad-hoc`` epic in *home* whose title is exactly *title*.
 
     Shared title search for the ad-hoc epic finders. Scoped to open ``epic`` +
@@ -425,10 +442,7 @@ def _find_epic_by_title(home: str, title: str, *, prefer_oldest: bool = False) -
         "list",
         "--repo",
         home,
-        "--label",
-        "epic",
-        "--label",
-        "ad-hoc",
+        *[arg for label in labels for arg in ("--label", label)],
         "--state",
         "open",
         "--json",
@@ -496,26 +510,58 @@ def find_adhoc_epic(target_repo: str) -> IssueRef | None:
     return _find_epic_by_title(home, f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}")
 
 
-def ensure_adhoc_archive(target_repo: str, quarter: str) -> IssueRef:
-    """Return *target_repo*'s ``— <quarter>`` archive epic, creating it if absent.
+def _normalize_archive_in_place(ref: IssueRef, new_title: str) -> None:
+    """Convert a legacy-form archive to the new form: retitle, +archive, -epic.
 
-    The archive is the stamped sibling of the live ad-hoc epic — same home, same
-    ``epic`` + ``ad-hoc`` labels — into which closed children of *quarter* are
-    re-parented. Idempotent: an existing stamped archive is reused; pre-existing
-    duplicate archives (the list-consistency race, #2698) collapse to the oldest.
+    Keeps ``ad-hoc``. Works on open or closed issues (``gh issue edit`` permits
+    editing a closed issue's title and labels).
+    """
+    github.run(
+        "issue",
+        "edit",
+        str(ref.number),
+        "--repo",
+        f"{ref.owner}/{ref.repo}",
+        "--title",
+        new_title,
+        "--add-label",
+        "archive",
+        "--remove-label",
+        "epic",
+    )
+
+
+def ensure_adhoc_archive(target_repo: str, quarter: str) -> IssueRef:
+    """Return *target_repo*'s ``— <quarter>`` archive, creating it if absent.
+
+    The archive is the stamped sibling of the live ad-hoc epic — same home,
+    labelled ``archive`` + ``ad-hoc`` — into which closed children of *quarter*
+    are re-parented. Self-healing and idempotent: an existing new-form archive is
+    reused; else a legacy-form archive (old ``Epic (ad hoc): … — Qn`` title,
+    ``epic`` + ``ad-hoc``) is normalized in place and returned; else a fresh
+    new-form archive is created. This makes creation race-free regardless of
+    whether the bulk normalize sweep has run. Pre-existing duplicate archives
+    (the list-consistency race, #2698) collapse to the oldest.
     """
     owner, bare = target_repo.split("/", 1)
     home = resolve_epic_home(owner, bare)
     home_repo = home.split("/", 1)[1]
-    title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare} — {quarter}"
-    existing = _find_epic_by_title(home, title, prefer_oldest=True)
+    title = f"{_ADHOC_ARCHIVE_TITLE_PREFIX}{bare} — {quarter}"
+    existing = _find_epic_by_title(
+        home, title, prefer_oldest=True, labels=_ADHOC_ARCHIVE_LABELS
+    )
     if existing is not None:
         return existing
+    legacy_title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare} — {quarter}"
+    legacy = _find_epic_by_title(home, legacy_title, prefer_oldest=True)
+    if legacy is not None:
+        _normalize_archive_in_place(legacy, title)
+        return legacy
     url = github.create_issue(
         repo=home,
         title=title,
         body=f"Ad-hoc work in {target_repo} finished in {quarter}. Managed automatically.\n",
-        labels=list(_ADHOC_EPIC_LABELS),
+        labels=list(_ADHOC_ARCHIVE_LABELS),
     )
     return IssueRef(owner=owner, repo=home_repo, number=int(url.rstrip("/").rsplit("/", 1)[-1]))
 
@@ -533,10 +579,7 @@ def list_open_adhoc_archives(home: str) -> list[tuple[IssueRef, str]]:
         "list",
         "--repo",
         home,
-        "--label",
-        "epic",
-        "--label",
-        "ad-hoc",
+        *[arg for label in _ADHOC_ARCHIVE_LABELS for arg in ("--label", label)],
         "--state",
         "open",
         "--json",
@@ -648,6 +691,81 @@ def drain_adhoc_org(org: str, *, apply: bool, now: datetime) -> list[DrainPlan]:
         if plan is not None:
             plans.append(plan)
     return plans
+
+
+@dataclass(frozen=True)
+class ArchiveConversion:
+    """A single legacy archive to convert: where it is and its new title."""
+
+    ref: IssueRef
+    old_title: str
+    new_title: str
+
+
+def plan_normalize_adhoc(org: str) -> list[ArchiveConversion]:
+    """Every legacy-form archive across *org*, open or closed, to convert.
+
+    Pure/read-only. Resolves each repo's own epic home (public → ``<org>/.github``,
+    private → itself) the way :func:`drain_adhoc_org` does, deduping homes so a
+    shared ``.github`` is scanned once. A legacy archive is an issue whose title
+    matches :data:`_LEGACY_ADHOC_ARCHIVE_RE`; the unstamped live epic never matches.
+    """
+    homes: dict[str, tuple[str, str]] = {}
+    for bare in github.list_org_repos(org):
+        home = resolve_epic_home(org, bare)
+        homes[home] = tuple(home.split("/", 1))  # type: ignore[assignment]
+    homes.setdefault(f"{org}/.github", (org, ".github"))
+    conversions: list[ArchiveConversion] = []
+    for home, (owner, home_repo) in homes.items():
+        raw: Any = github.read_json(
+            "issue",
+            "list",
+            "--repo",
+            home,
+            "--label",
+            "epic",
+            "--label",
+            "ad-hoc",
+            "--state",
+            "all",
+            "--limit",
+            "500",
+            "--json",
+            "number,title",
+        )
+        for item in raw if isinstance(raw, list) else []:
+            if not isinstance(item, dict):
+                continue
+            old_title = str(item.get("title", ""))
+            if not _LEGACY_ADHOC_ARCHIVE_RE.match(old_title):
+                continue
+            new_title = _ADHOC_ARCHIVE_TITLE_PREFIX + old_title.removeprefix(
+                _ADHOC_EPIC_TITLE_PREFIX
+            )
+            conversions.append(
+                ArchiveConversion(
+                    IssueRef(owner, home_repo, int(item["number"])), old_title, new_title
+                )
+            )
+    return conversions
+
+
+def apply_normalize(conversions: list[ArchiveConversion]) -> None:
+    """Convert each planned archive in place (retitle, +archive, -epic)."""
+    for conv in conversions:
+        _normalize_archive_in_place(conv.ref, conv.new_title)
+
+
+def normalize_adhoc_archives(org: str, *, apply: bool) -> list[ArchiveConversion]:
+    """Plan (and, when *apply*, execute) the org-wide legacy-archive conversion.
+
+    Idempotent: an already-migrated archive is new-form, does not match the legacy
+    recognizer, and is skipped — so re-running is a no-op.
+    """
+    conversions = plan_normalize_adhoc(org)
+    if apply:
+        apply_normalize(conversions)
+    return conversions
 
 
 def is_epic_linkage(ref: str, *, default_repo: str) -> bool:

--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import re
 import sys
-from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from vergil_tooling.lib import github
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @dataclass(frozen=True)
@@ -408,9 +410,7 @@ _ADHOC_EPIC_BODY = (
 # A stamped per-quarter archive: "Archive (ad hoc): <bare> — <YYYY>-Qn". The
 # separator is a space, U+2014 em-dash, space. Matching this distinguishes a
 # terminal archive from the live canonical ad-hoc epic (which has no stamp).
-_ADHOC_ARCHIVE_RE = re.compile(
-    r"^Archive \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$"
-)
+_ADHOC_ARCHIVE_RE = re.compile(r"^Archive \(ad hoc\): (?P<bare>.+) — (?P<quarter>\d{4}-Q[1-4])$")
 # Legacy pre-rename archive title ("Epic (ad hoc): <bare> — <YYYY>-Qn"), used
 # ONLY by the self-healing creation path and the normalize sweep to find
 # archives still in the old form. Steady-state code keys off _ADHOC_ARCHIVE_RE.
@@ -547,9 +547,7 @@ def ensure_adhoc_archive(target_repo: str, quarter: str) -> IssueRef:
     home = resolve_epic_home(owner, bare)
     home_repo = home.split("/", 1)[1]
     title = f"{_ADHOC_ARCHIVE_TITLE_PREFIX}{bare} — {quarter}"
-    existing = _find_epic_by_title(
-        home, title, prefer_oldest=True, labels=_ADHOC_ARCHIVE_LABELS
-    )
+    existing = _find_epic_by_title(home, title, prefer_oldest=True, labels=_ADHOC_ARCHIVE_LABELS)
     if existing is not None:
         return existing
     legacy_title = f"{_ADHOC_EPIC_TITLE_PREFIX}{bare} — {quarter}"
@@ -713,7 +711,8 @@ def plan_normalize_adhoc(org: str) -> list[ArchiveConversion]:
     homes: dict[str, tuple[str, str]] = {}
     for bare in github.list_org_repos(org):
         home = resolve_epic_home(org, bare)
-        homes[home] = tuple(home.split("/", 1))  # type: ignore[assignment]
+        home_owner, home_repo = home.split("/", 1)
+        homes[home] = (home_owner, home_repo)
     homes.setdefault(f"{org}/.github", (org, ".github"))
     conversions: list[ArchiveConversion] = []
     for home, (owner, home_repo) in homes.items():

--- a/tests/vergil_tooling/test_data_labels.py
+++ b/tests/vergil_tooling/test_data_labels.py
@@ -7,9 +7,7 @@ from importlib import resources
 
 
 def _labels() -> list[dict[str, str]]:
-    data = json.loads(
-        resources.files("vergil_tooling.data").joinpath("labels.json").read_text()
-    )
+    data = json.loads(resources.files("vergil_tooling.data").joinpath("labels.json").read_text())
     return data["labels"]
 
 

--- a/tests/vergil_tooling/test_data_labels.py
+++ b/tests/vergil_tooling/test_data_labels.py
@@ -1,0 +1,27 @@
+"""Tests for the packaged label definitions (data/labels.json)."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+
+
+def _labels() -> list[dict[str, str]]:
+    data = json.loads(
+        resources.files("vergil_tooling.data").joinpath("labels.json").read_text()
+    )
+    return data["labels"]
+
+
+def test_archive_label_present_and_wellformed() -> None:
+    by_name = {entry["name"]: entry for entry in _labels()}
+    assert "archive" in by_name, "labels.json must define the 'archive' label"
+    archive = by_name["archive"]
+    assert set(archive) == {"name", "color", "description"}
+    assert archive["color"]  # non-empty hex
+    assert "archive" in archive["description"].lower()
+
+
+def test_label_names_are_unique() -> None:
+    names = [entry["name"] for entry in _labels()]
+    assert len(names) == len(set(names)), "duplicate label names in labels.json"

--- a/tests/vergil_tooling/test_epic_audit.py
+++ b/tests/vergil_tooling/test_epic_audit.py
@@ -302,6 +302,17 @@ def test_stray_dotgithub_issue_flags_unlinked_non_epic_non_intake() -> None:
     assert result == ["vergil-project/.github#7"]
 
 
+def test_stray_skips_open_archive() -> None:
+    # An open, top-level 'archive'-labelled per-quarter bucket has no parent and
+    # is not epic-labelled, but it is a legitimate home issue, not a stray.
+    rows = [
+        {"number": 88, "labels": [{"name": "archive"}, {"name": "ad-hoc"}]},
+    ]
+    with patch("vergil_tooling.lib.github.read_json", return_value=rows):
+        strays = epic_audit.stray_dotgithub_issue("org", home="org/.github")
+    assert strays == []  # an archive is not a stray
+
+
 # -- closed-epic-with-open-child invariant + reopen remediation (issue #2259) --
 
 

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -632,13 +632,15 @@ def test_rollup_skips_non_repo_adhoc_epic() -> None:
 
 
 def test_rollup_noop_when_parent_is_adhoc_archive() -> None:
+    # A stamped archive (new-form title) is terminal: the _ADHOC_ARCHIVE_RE guard
+    # short-circuits the drain even if the archive still carries the epic label.
     task = IssueRef("org", ".github", 101)
     with (
         patch("vergil_tooling.lib.epics.parent_of", return_value=IssueRef("org", ".github", 88)),
         patch("vergil_tooling.lib.epics._labels", return_value={"epic", "ad-hoc"}),
         patch(
             "vergil_tooling.lib.epics._issue_title",
-            return_value="Epic (ad hoc): .github — 2026-Q2",
+            return_value="Archive (ad hoc): .github — 2026-Q2",
         ),
         patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
     ):
@@ -991,9 +993,7 @@ def test_find_epic_by_title_uses_supplied_labels() -> None:
     title = "Archive (ad hoc): tooling — 2026-Q3"
     rows = [{"number": 42, "title": title}]
     with patch("vergil_tooling.lib.github.read_json", return_value=rows) as mock_list:
-        got = epics._find_epic_by_title(
-            "org/.github", title, labels=("archive", "ad-hoc")
-        )
+        got = epics._find_epic_by_title("org/.github", title, labels=("archive", "ad-hoc"))
     assert got == IssueRef("org", ".github", 42)
     # The label filters passed to gh reflect the supplied labels, not epic+ad-hoc.
     args = list(mock_list.call_args.args)
@@ -1067,9 +1067,12 @@ def test_plan_normalize_dedupes_homes_and_finds_legacy_all_states() -> None:
         home = args[args.index("--repo") + 1]
         if home == "org/.github":
             return [
+                # legacy archive (closed) -> converts
                 {"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q2", "state": "CLOSED"},
-                {"number": 90, "title": "Epic (ad hoc): tooling", "state": "OPEN"},  # live epic
-                {"number": 91, "title": "Archive (ad hoc): actions — 2026-Q3", "state": "OPEN"},  # already migrated
+                # live epic (unstamped) -> never matches
+                {"number": 90, "title": "Epic (ad hoc): tooling", "state": "OPEN"},
+                # already migrated (new form) -> skipped
+                {"number": 91, "title": "Archive (ad hoc): actions — 2026-Q3", "state": "OPEN"},
             ]
         if home == "org/private":
             return [
@@ -1077,8 +1080,9 @@ def test_plan_normalize_dedupes_homes_and_finds_legacy_all_states() -> None:
             ]
         return []
 
+    repos = ["tooling", "actions", "private"]
     with (
-        patch("vergil_tooling.lib.github.list_org_repos", return_value=["tooling", "actions", "private"]),
+        patch("vergil_tooling.lib.github.list_org_repos", return_value=repos),
         patch("vergil_tooling.lib.epics.resolve_epic_home", side_effect=fake_home),
         patch("vergil_tooling.lib.github.read_json", side_effect=fake_list),
     ):
@@ -1093,12 +1097,12 @@ def test_plan_normalize_dedupes_homes_and_finds_legacy_all_states() -> None:
 
 
 def test_apply_normalize_calls_in_place_for_each() -> None:
-    conv = [
-        epics.ArchiveConversion(IssueRef("org", ".github", 88), "old", "Archive (ad hoc): tooling — 2026-Q2"),
-    ]
+    ref = IssueRef("org", ".github", 88)
+    new_title = "Archive (ad hoc): tooling — 2026-Q2"
+    conv = [epics.ArchiveConversion(ref, "old", new_title)]
     with patch("vergil_tooling.lib.epics._normalize_archive_in_place") as mock_heal:
         epics.apply_normalize(conv)
-    mock_heal.assert_called_once_with(IssueRef("org", ".github", 88), "Archive (ad hoc): tooling — 2026-Q2")
+    mock_heal.assert_called_once_with(ref, new_title)
 
 
 def test_normalize_adhoc_archives_dry_run_does_not_mutate() -> None:
@@ -1110,6 +1114,41 @@ def test_normalize_adhoc_archives_dry_run_does_not_mutate() -> None:
     assert out == []
     mock_plan.assert_called_once_with("org")
     mock_apply.assert_not_called()
+
+
+def test_normalize_adhoc_archives_apply_executes_conversions() -> None:
+    conv = [
+        epics.ArchiveConversion(
+            IssueRef("org", ".github", 88), "old", "Archive (ad hoc): tooling — 2026-Q2"
+        )
+    ]
+    with (
+        patch("vergil_tooling.lib.epics.plan_normalize_adhoc", return_value=conv),
+        patch("vergil_tooling.lib.epics.apply_normalize") as mock_apply,
+    ):
+        out = epics.normalize_adhoc_archives("org", apply=True)
+    assert out == conv
+    mock_apply.assert_called_once_with(conv)
+
+
+def test_plan_normalize_tolerates_non_list_and_non_dict_rows() -> None:
+    # A non-dict row is skipped; a home whose listing is not a list yields nothing.
+    def fake_home(org, bare):
+        return "org/.github" if bare == "tooling" else f"org/{bare}"
+
+    def fake_list(*args, **kwargs):
+        home = args[args.index("--repo") + 1]
+        if home == "org/.github":
+            return [None, {"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q2"}]
+        return {}  # non-list result for the private home
+
+    with (
+        patch("vergil_tooling.lib.github.list_org_repos", return_value=["tooling", "private"]),
+        patch("vergil_tooling.lib.epics.resolve_epic_home", side_effect=fake_home),
+        patch("vergil_tooling.lib.github.read_json", side_effect=fake_list),
+    ):
+        plan = epics.plan_normalize_adhoc("org")
+    assert [(c.ref.repo, c.ref.number) for c in plan] == [(".github", 88)]
 
 
 # -- resolve_epic_home (epic #130) -------------------------------------------

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -918,7 +918,7 @@ def test_find_epic_by_title_prefer_oldest_returns_lowest() -> None:
 def test_ensure_adhoc_archive_reuses_oldest_duplicate() -> None:
     # Duplicate archives already exist; ensure_adhoc_archive reuses the oldest
     # (lowest-numbered) and never creates another.
-    title = "Epic (ad hoc): tooling — 2026-Q3"
+    title = "Archive (ad hoc): tooling — 2026-Q3"
     rows = [{"number": 91, "title": title}, {"number": 88, "title": title}]
     with (
         patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
@@ -940,12 +940,12 @@ def test_ensure_adhoc_archive_creates_stamped_title() -> None:
     ):
         ref = epics.ensure_adhoc_archive("org/tooling", "2026-Q3")
     assert ref == IssueRef("org", ".github", 88)
-    assert mock_create.call_args.kwargs["title"] == "Epic (ad hoc): tooling — 2026-Q3"
-    assert mock_create.call_args.kwargs["labels"] == ["epic", "ad-hoc"]
+    assert mock_create.call_args.kwargs["title"] == "Archive (ad hoc): tooling — 2026-Q3"
+    assert mock_create.call_args.kwargs["labels"] == ["archive", "ad-hoc"]
 
 
 def test_ensure_adhoc_archive_reuses_existing_stamped() -> None:
-    rows = [{"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q3"}]
+    rows = [{"number": 88, "title": "Archive (ad hoc): tooling — 2026-Q3"}]
     with (
         patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
         patch("vergil_tooling.lib.github.read_json", return_value=rows),
@@ -959,15 +959,157 @@ def test_ensure_adhoc_archive_reuses_existing_stamped() -> None:
 
 def test_list_open_adhoc_archives_parses_quarter() -> None:
     rows = [
-        {"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q2"},
+        {"number": 88, "title": "Archive (ad hoc): tooling — 2026-Q2"},
         {"number": 90, "title": "Epic (ad hoc): tooling"},  # live, not an archive
-        {"number": 91, "title": "Epic (ad hoc): tooling — 2026-Q3"},
+        {"number": 91, "title": "Archive (ad hoc): tooling — 2026-Q3"},
     ]
     with patch("vergil_tooling.lib.github.read_json", return_value=rows):
         got = epics.list_open_adhoc_archives("org/.github")
     assert (IssueRef("org", ".github", 88), "2026-Q2") in got
     assert (IssueRef("org", ".github", 91), "2026-Q3") in got
     assert all(q for _, q in got) and len(got) == 2
+
+
+# -- archive rename: recognizers and parameterized title search (Task 2) ------
+
+
+def test_archive_regex_matches_new_form_only() -> None:
+    assert epics._ADHOC_ARCHIVE_RE.match("Archive (ad hoc): tooling — 2026-Q3")
+    # Live epic and legacy archive titles must NOT match the new-form regex.
+    assert epics._ADHOC_ARCHIVE_RE.match("Epic (ad hoc): tooling") is None
+    assert epics._ADHOC_ARCHIVE_RE.match("Epic (ad hoc): tooling — 2026-Q3") is None
+
+
+def test_legacy_archive_regex_matches_old_form_only() -> None:
+    m = epics._LEGACY_ADHOC_ARCHIVE_RE.match("Epic (ad hoc): tooling — 2026-Q3")
+    assert m and m.group("bare") == "tooling" and m.group("quarter") == "2026-Q3"
+    assert epics._LEGACY_ADHOC_ARCHIVE_RE.match("Archive (ad hoc): tooling — 2026-Q3") is None
+    assert epics._LEGACY_ADHOC_ARCHIVE_RE.match("Epic (ad hoc): tooling") is None
+
+
+def test_find_epic_by_title_uses_supplied_labels() -> None:
+    title = "Archive (ad hoc): tooling — 2026-Q3"
+    rows = [{"number": 42, "title": title}]
+    with patch("vergil_tooling.lib.github.read_json", return_value=rows) as mock_list:
+        got = epics._find_epic_by_title(
+            "org/.github", title, labels=("archive", "ad-hoc")
+        )
+    assert got == IssueRef("org", ".github", 42)
+    # The label filters passed to gh reflect the supplied labels, not epic+ad-hoc.
+    args = list(mock_list.call_args.args)
+    assert "archive" in args and "ad-hoc" in args and "epic" not in args
+
+
+# -- archive rename: rollup no-ops under a converted archive parent (Task 3) ---
+
+
+def test_rollup_noop_for_child_under_archive_parent() -> None:
+    # A converted archive is not epic-labelled, so rollup returns without draining.
+    task = IssueRef("org", ".github", 200)
+    archive = IssueRef("org", ".github", 88)
+    with (
+        patch("vergil_tooling.lib.epics.parent_of", return_value=archive),
+        patch("vergil_tooling.lib.epics._labels", return_value={"archive", "ad-hoc"}),
+        patch("vergil_tooling.lib.epics.ensure_adhoc_archive") as mock_ensure,
+        patch("vergil_tooling.lib.epics.reparent_child") as mock_reparent,
+    ):
+        epics.rollup(task)
+    mock_ensure.assert_not_called()
+    mock_reparent.assert_not_called()
+
+
+# -- archive rename: self-healing creation (Task 4) ---------------------------
+
+
+def test_normalize_archive_in_place_edits_title_and_labels() -> None:
+    ref = IssueRef("org", ".github", 88)
+    with patch("vergil_tooling.lib.github.run") as mock_run:
+        epics._normalize_archive_in_place(ref, "Archive (ad hoc): tooling — 2026-Q3")
+    args = list(mock_run.call_args.args)
+    assert args[:2] == ["issue", "edit"] and "88" in args
+    assert "--title" in args and "Archive (ad hoc): tooling — 2026-Q3" in args
+    assert args[args.index("--add-label") + 1] == "archive"
+    assert args[args.index("--remove-label") + 1] == "epic"
+
+
+def test_ensure_adhoc_archive_heals_legacy_in_place() -> None:
+    # No new-form archive exists, but a legacy one does: heal it, don't create.
+    def fake_find(home, title, *, prefer_oldest=False, labels=("epic", "ad-hoc")):
+        if tuple(labels) == ("archive", "ad-hoc"):
+            return None  # no new-form archive yet
+        if title == "Epic (ad hoc): tooling — 2026-Q3":
+            return IssueRef("org", ".github", 88)  # legacy archive found
+        return None
+
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.epics._find_epic_by_title", side_effect=fake_find),
+        patch("vergil_tooling.lib.epics._normalize_archive_in_place") as mock_heal,
+        patch("vergil_tooling.lib.github.create_issue") as mock_create,
+    ):
+        got = epics.ensure_adhoc_archive("org/tooling", "2026-Q3")
+    assert got == IssueRef("org", ".github", 88)
+    mock_heal.assert_called_once_with(
+        IssueRef("org", ".github", 88), "Archive (ad hoc): tooling — 2026-Q3"
+    )
+    mock_create.assert_not_called()
+
+
+# -- archive rename: org-wide normalize sweep (Task 5) ------------------------
+
+
+def test_plan_normalize_dedupes_homes_and_finds_legacy_all_states() -> None:
+    # Two public repos share the .github home; one private repo self-homes.
+    def fake_home(org, bare):
+        return "org/.github" if bare in {"tooling", "actions"} else f"org/{bare}"
+
+    def fake_list(*args, **kwargs):
+        home = args[args.index("--repo") + 1]
+        if home == "org/.github":
+            return [
+                {"number": 88, "title": "Epic (ad hoc): tooling — 2026-Q2", "state": "CLOSED"},
+                {"number": 90, "title": "Epic (ad hoc): tooling", "state": "OPEN"},  # live epic
+                {"number": 91, "title": "Archive (ad hoc): actions — 2026-Q3", "state": "OPEN"},  # already migrated
+            ]
+        if home == "org/private":
+            return [
+                {"number": 5, "title": "Epic (ad hoc): private — 2026-Q1", "state": "CLOSED"},
+            ]
+        return []
+
+    with (
+        patch("vergil_tooling.lib.github.list_org_repos", return_value=["tooling", "actions", "private"]),
+        patch("vergil_tooling.lib.epics.resolve_epic_home", side_effect=fake_home),
+        patch("vergil_tooling.lib.github.read_json", side_effect=fake_list),
+    ):
+        plan = epics.plan_normalize_adhoc("org")
+    refs = {(c.ref.repo, c.ref.number): c for c in plan}
+    # Legacy archives (public-homed + private self-homed) are converted; the live
+    # epic and the already-migrated archive are not.
+    assert (".github", 88) in refs and ("private", 5) in refs
+    assert refs[(".github", 88)].new_title == "Archive (ad hoc): tooling — 2026-Q2"
+    assert (".github", 90) not in refs and (".github", 91) not in refs
+    assert len(plan) == 2
+
+
+def test_apply_normalize_calls_in_place_for_each() -> None:
+    conv = [
+        epics.ArchiveConversion(IssueRef("org", ".github", 88), "old", "Archive (ad hoc): tooling — 2026-Q2"),
+    ]
+    with patch("vergil_tooling.lib.epics._normalize_archive_in_place") as mock_heal:
+        epics.apply_normalize(conv)
+    mock_heal.assert_called_once_with(IssueRef("org", ".github", 88), "Archive (ad hoc): tooling — 2026-Q2")
+
+
+def test_normalize_adhoc_archives_dry_run_does_not_mutate() -> None:
+    with (
+        patch("vergil_tooling.lib.epics.plan_normalize_adhoc", return_value=[]) as mock_plan,
+        patch("vergil_tooling.lib.epics.apply_normalize") as mock_apply,
+    ):
+        out = epics.normalize_adhoc_archives("org", apply=False)
+    assert out == []
+    mock_plan.assert_called_once_with("org")
+    mock_apply.assert_not_called()
 
 
 # -- resolve_epic_home (epic #130) -------------------------------------------

--- a/tests/vergil_tooling/test_vrg_adhoc_epic.py
+++ b/tests/vergil_tooling/test_vrg_adhoc_epic.py
@@ -174,3 +174,33 @@ def test_archive_all_in_renders_each_plan(capsys: pytest.CaptureFixture[str]) ->
 def test_archive_repo_and_all_in_mutually_exclusive() -> None:
     with pytest.raises(SystemExit):
         parse_args(["archive", "--repo", "org/tooling", "--all-in", "org"])
+
+
+def test_normalize_dry_run_lists_conversions(capsys: pytest.CaptureFixture[str]) -> None:
+    conv = [
+        epics.ArchiveConversion(
+            epics.IssueRef("org", ".github", 88),
+            "Epic (ad hoc): tooling — 2026-Q2",
+            "Archive (ad hoc): tooling — 2026-Q2",
+        )
+    ]
+    with (
+        patch(f"{_MOD}.github.target_org"),
+        patch(f"{_MOD}.epics.normalize_adhoc_archives", return_value=conv) as mock_norm,
+    ):
+        rc = main(["normalize", "--all-in", "org"])
+    assert rc == 0
+    mock_norm.assert_called_once_with("org", apply=False)
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out and "1 archive(s)" in out
+    assert "org/.github#88" in out and "Archive (ad hoc): tooling — 2026-Q2" in out
+
+
+def test_normalize_apply_passes_apply_true() -> None:
+    with (
+        patch(f"{_MOD}.github.target_org"),
+        patch(f"{_MOD}.epics.normalize_adhoc_archives", return_value=[]) as mock_norm,
+    ):
+        rc = main(["normalize", "--all-in", "org", "--apply"])
+    assert rc == 0
+    mock_norm.assert_called_once_with("org", apply=True)

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -128,8 +128,9 @@ def test_main_sync_provisions_all_labels() -> None:
     # Should have called once per label + once for the delete
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
     # 18 before retiring the deprecated 'standing' alias (retire-standing task);
-    # 18 again after adding the 'retrospective' kind label.
-    assert len(label_calls) == 18
+    # 18 again after adding the 'retrospective' kind label;
+    # 19 after adding the 'archive' label (adhoc-archive-rename epic #281).
+    assert len(label_calls) == 19
 
 
 def test_main_sync_uses_force_with_color_description() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Retitle and relabel the terminal per-quarter ad-hoc buckets as 'Archive (ad hoc): <repo> — YYYY-Qn' with an 'archive'+'ad-hoc' label pair (new 'archive' label) instead of 'epic', so label:epic stops surfacing historical buckets; the live ad-hoc epic is untouched.

## Issue Linkage

- Closes #2739

## Notes

- Self-healing creation (new-form lookup → legacy heal-in-place → create) makes the drain race-free vs. the migration sweep. Adds an org-wide idempotent 'vrg-adhoc-epic normalize' sweep (per-repo home traversal, open+closed) and fixes stray_dotgithub_issue to skip archive-labelled buckets. Code only — the org-wide migration + label sync runs as the paired deployment task #2740 after merge. Follows the TDD plan in epics/281-adhoc-archive-rename/plan.md. vrg-validate green.