### PR TITLE
feat(config): add typescript primary-language + [typescript] block

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -27,7 +27,7 @@ _ENUMS: dict[str, set[str]] = {
     "versioning-scheme": {"library", "semver", "application", "none"},
     "branching-model": {"library-release", "application-promotion", "docs-single-branch"},
     "release-model": {"artifact-publishing", "tagged-release", "environment-promotion", "none"},
-    "primary-language": {"python", "go", "java", "ruby", "rust", "cpp"},
+    "primary-language": {"python", "go", "java", "ruby", "rust", "cpp", "typescript"},
 }
 
 # The [cpp] block (epic vergil-project/.github#207 §3.3). The compiler family ×
@@ -40,6 +40,17 @@ DEFAULT_CPP_STD = "c++20"
 DEFAULT_CPP_STDLIB = "libstdc++"
 _CPP_STD_VALUES = frozenset({"c++17", "c++20", "c++23"})
 _CPP_STDLIB_VALUES = frozenset({"libstdc++"})
+
+# The [typescript] block (epic vergil-project/.github#284 §3.3), mirroring the
+# [cpp] std/stdlib precedent. The Node major × version axis rides [ci].versions
+# (the ``node-`` tag prefix); the two cheap in-config axes are single-valued
+# [typescript] keys. v1 pins module = esm and target = es2022. cjs stays on the
+# spec §9 deferral ledger and is therefore rejected, not silently ignored; the
+# target set is likewise restricted to the pinned value in v1.
+DEFAULT_TYPESCRIPT_MODULE = "esm"
+DEFAULT_TYPESCRIPT_TARGET = "es2022"
+_TYPESCRIPT_MODULE_VALUES = frozenset({"esm"})
+_TYPESCRIPT_TARGET_VALUES = frozenset({"es2022"})
 
 _REQUIRED_PROJECT_FIELDS = (
     "repository-type",
@@ -61,6 +72,7 @@ _KNOWN_SECTIONS = frozenset(
         "validation",
         "actions",
         "cpp",
+        "typescript",
         "vm",
     },
 )
@@ -75,6 +87,7 @@ _KNOWN_KEYS: dict[str, frozenset[str]] = {
     "validation": frozenset({"container-command"}),
     "actions": frozenset({"extra-allowed-patterns"}),
     "cpp": frozenset({"std", "stdlib"}),
+    "typescript": frozenset({"module", "target"}),
 }
 
 
@@ -136,6 +149,16 @@ class CppConfig:
 
 
 @dataclass
+class TypeScriptConfig:
+    # The two cheap in-config TypeScript axes (epic vergil-project/.github#284
+    # §3.3), mirroring [cpp]'s std/stdlib: ``module`` is the module system and
+    # ``target`` is the compile target. Both are single string values in v1;
+    # the Node major × version axis is carried by [ci].versions, not here.
+    module: str
+    target: str
+
+
+@dataclass
 class ActionsConfig:
     # Extra allowed-action patterns unioned into the repo's GitHub Actions
     # allowed-actions policy, on top of the base + per-language defaults in
@@ -156,6 +179,11 @@ class VergilConfig:
     actions: ActionsConfig = field(default_factory=lambda: ActionsConfig(extra_allowed_patterns=[]))
     cpp: CppConfig = field(
         default_factory=lambda: CppConfig(std=DEFAULT_CPP_STD, stdlib=DEFAULT_CPP_STDLIB)
+    )
+    typescript: TypeScriptConfig = field(
+        default_factory=lambda: TypeScriptConfig(
+            module=DEFAULT_TYPESCRIPT_MODULE, target=DEFAULT_TYPESCRIPT_TARGET
+        )
     )
     vm: VmStanza | None = None
 
@@ -408,6 +436,41 @@ def _parse_cpp_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> CppConf
     )
 
 
+def _parse_typescript_str_value(
+    raw: dict[str, Any], key: str, allowed: frozenset[str], default: str, source: str
+) -> str:
+    """Return a validated single-string [typescript] value, or its default when absent.
+
+    Raises ConfigError if present but non-string, or if it is not one of the
+    ``allowed`` values (rejection, not a silent fallback — a bogus module/target
+    would otherwise be dropped into the build unnoticed), mirroring [cpp].
+    """
+    if key not in raw:
+        return default
+    value = raw[key]
+    if not isinstance(value, str):
+        msg = f"{source}: [typescript].{key} must be a string (got {type(value).__name__})"
+        raise ConfigError(msg)
+    if value not in allowed:
+        allowed_str = ", ".join(sorted(allowed))
+        msg = f"{source}: invalid [typescript].{key} '{value}' (allowed: {allowed_str})"
+        raise ConfigError(msg)
+    return value
+
+
+def _parse_typescript_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> TypeScriptConfig:
+    """Parse the ``[typescript]`` block, defaulting to the v1 pins when it is absent."""
+    ts_raw = raw.get("typescript", {})
+    return TypeScriptConfig(
+        module=_parse_typescript_str_value(
+            ts_raw, "module", _TYPESCRIPT_MODULE_VALUES, DEFAULT_TYPESCRIPT_MODULE, source
+        ),
+        target=_parse_typescript_str_value(
+            ts_raw, "target", _TYPESCRIPT_TARGET_VALUES, DEFAULT_TYPESCRIPT_TARGET, source
+        ),
+    )
+
+
 def _warn_unrecognized_keys(raw: dict[str, Any], source: str = CONFIG_FILE) -> None:
     for section in raw:
         if section not in _KNOWN_SECTIONS:
@@ -562,6 +625,7 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
         validation=validation,
         actions=actions,
         cpp=_parse_cpp_config(raw, source),
+        typescript=_parse_typescript_config(raw, source),
         vm=parse_vm_stanza(raw, source),
     )
 

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -10,12 +10,15 @@ import pytest
 from vergil_tooling.lib.config import (
     DEFAULT_CPP_STD,
     DEFAULT_CPP_STDLIB,
+    DEFAULT_TYPESCRIPT_MODULE,
+    DEFAULT_TYPESCRIPT_TARGET,
     DEFAULT_VALIDATION_COMMAND,
     CiConfig,
     ConfigError,
     ContainerConfig,
     CppConfig,
     MarkdownlintConfig,
+    TypeScriptConfig,
     ValidationConfig,
     VmStanza,
     _warn_unrecognized_keys,
@@ -249,6 +252,28 @@ def test_config_warns_on_unknown_language_after_cpp_added(
     cfg = read_config(tmp_path)
     assert cfg.project.primary_language is None
     assert "unrecognized primary-language 'cobol'" in capsys.readouterr().err
+
+
+def test_config_accepts_typescript_language(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``primary-language = "typescript"`` is a recognized language (no warning)."""
+    toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "typescript"')
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language == "typescript"
+    assert "unrecognized primary-language" not in capsys.readouterr().err
+
+
+def test_config_warns_on_unknown_language_after_typescript_added(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Adding typescript does not weaken the enum — an unknown value still warns."""
+    toml = _VALID_TOML.replace('primary-language = "python"', 'primary-language = "fortran"')
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.project.primary_language is None
+    assert "unrecognized primary-language 'fortran'" in capsys.readouterr().err
 
 
 # -- [markdownlint] section ---------------------------------------------------
@@ -1266,3 +1291,103 @@ def test_cpp_block_not_flagged_as_unrecognized_section(
     (tmp_path / "vergil.toml").write_text(toml)
     read_config(tmp_path)
     assert "unrecognized section [cpp]" not in capsys.readouterr().err
+
+
+# -- [typescript] section (epic vergil-project/.github#284, T3) ----------------
+
+_TYPESCRIPT_BASE_TOML = """\
+[project]
+repository-type = "application"
+versioning-scheme = "semver"
+branching-model = "application-promotion"
+release-model = "environment-promotion"
+primary-language = "typescript"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["node-24", "node-22"]
+"""
+
+
+def test_typescript_block_defaults_when_absent(tmp_path: Path) -> None:
+    """With no [typescript] block, module/target fall back to the v1 pins."""
+    (tmp_path / "vergil.toml").write_text(_TYPESCRIPT_BASE_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.typescript == TypeScriptConfig(
+        module=DEFAULT_TYPESCRIPT_MODULE, target=DEFAULT_TYPESCRIPT_TARGET
+    )
+    assert cfg.typescript.module == "esm"
+    assert cfg.typescript.target == "es2022"
+
+
+def test_typescript_block_parsed(tmp_path: Path) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\nmodule = "esm"\ntarget = "es2022"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.typescript == TypeScriptConfig(module="esm", target="es2022")
+
+
+def test_typescript_block_module_only_target_defaults(tmp_path: Path) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\nmodule = "esm"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.typescript.module == "esm"
+    assert cfg.typescript.target == DEFAULT_TYPESCRIPT_TARGET
+
+
+def test_typescript_block_target_only_module_defaults(tmp_path: Path) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\ntarget = "es2022"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.typescript.module == DEFAULT_TYPESCRIPT_MODULE
+    assert cfg.typescript.target == "es2022"
+
+
+def test_typescript_module_rejects_nonsense(tmp_path: Path) -> None:
+    # cjs is deferred (spec §9 ledger): not yet a valid value, so it is
+    # rejected rather than silently ignored.
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\nmodule = "cjs"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[typescript\]\.module 'cjs'"):
+        read_config(tmp_path)
+
+
+def test_typescript_module_non_string_rejected(tmp_path: Path) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + "\n[typescript]\nmodule = 6\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[typescript\]\.module must be a string"):
+        read_config(tmp_path)
+
+
+def test_typescript_target_rejects_nonsense(tmp_path: Path) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\ntarget = "banana"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[typescript\]\.target 'banana'"):
+        read_config(tmp_path)
+
+
+def test_typescript_target_non_string_rejected(tmp_path: Path) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + "\n[typescript]\ntarget = 2022\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[typescript\]\.target must be a string"):
+        read_config(tmp_path)
+
+
+def test_warns_unrecognized_typescript_key(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\nmodule = "esm"\nlib = "es2022"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    read_config(tmp_path)
+    assert "unrecognized key 'lib' in [typescript]" in capsys.readouterr().err
+
+
+def test_typescript_block_not_flagged_as_unrecognized_section(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    toml = _TYPESCRIPT_BASE_TOML + '\n[typescript]\nmodule = "esm"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    read_config(tmp_path)
+    assert "unrecognized section [typescript]" not in capsys.readouterr().err


### PR DESCRIPTION
# Pull Request

## Summary

- Adds "typescript" to the primary-language enum and a [typescript] config block (module/target) so vergil.toml accepts TypeScript repos, unblocking epic #284 tasks T4/T5.

## Issue Linkage

- Closes #2742

## Notes

- Mirrors the existing [cpp] std/stdlib precedent exactly: _parse_typescript_config/TypeScriptConfig alongside _parse_cpp_config/CppConfig, with a shared single-string validator. v1 pins module=esm and target=es2022 as single allowed values; cjs is deferred (spec §9 ledger) so non-pinned module/target values are rejected, not silently ignored. Absent block defaults to the pins; unknown primary-language still warns. Tests cover enum acceptance, defaults, valid values, and rejection of nonsense/non-string values.