### PR TITLE
feat(github-config): support typescript for CodeQL + repo-init

### DIFF
--- a/src/vergil_tooling/lib/github_config.py
+++ b/src/vergil_tooling/lib/github_config.py
@@ -232,6 +232,16 @@ _CODEQL_SUPPORTED_LANGUAGES = frozenset(
         # cpp aligns this list with repo_init._CODEQL_LANGUAGES, which already
         # lists cpp — the two must agree (epic vergil-project/.github#207 T7).
         "cpp",
+        # typescript is keyed by the *primary-language* name here, because this
+        # set is tested against ``project.primary_language`` (see
+        # ``desired_ci_gates_ruleset`` below). The CodeQL analysis identifier is
+        # ``javascript-typescript``, but that ``typescript → javascript-typescript``
+        # mapping belongs to the reusable CI Action (epic
+        # vergil-project/.github#284 T7), not here — the emitted ``ci.yml``
+        # ``language:`` stays ``typescript`` for container resolution. Like cpp,
+        # this list must stay aligned with repo_init._CODEQL_LANGUAGES, which
+        # already lists typescript (epic vergil-project/.github#284 T6).
+        "typescript",
     }
 )
 

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -472,18 +472,50 @@ def _cpp_family_and_version(versions: list[str] | None) -> tuple[str, str] | Non
     return parse_cpp_version_tag(versions[0])
 
 
+def _node_major(versions: list[str] | None) -> str | None:
+    """Parse the primary Node major from a ``node-``-prefixed ``[ci].versions`` tag.
+
+    TypeScript carries its Node major on ``[ci].versions`` as a ``node-``
+    prefixed tag (e.g. ``node-24``), matching the ``prod-ts-node:<major>``
+    images T1/T2 build in vergil-containers (epic vergil-project/.github#284).
+    The first entry is the representative primary that drives the single
+    top-level ``container-suffix``/``container-tag`` in generated CI. Returns
+    the numeric major (e.g. ``"24"``) or ``None`` when the primary entry
+    carries no recognized ``node-`` prefix.
+
+    The container image-resolution side of this parse lives in
+    :mod:`container` and lands with T5; this local helper keeps the CI
+    scaffolding path self-contained on the ``typescript`` primary-language
+    name alone.
+    """
+    if not versions:
+        return None
+    prefix = "node-"
+    primary = versions[0]
+    if primary.startswith(prefix):
+        return primary[len(prefix) :]
+    return None
+
+
 def _container_suffix(language: str | None, versions: list[str] | None = None) -> str:
     """Map primary language to dev container image suffix.
 
     C++ is compiler-family-aware: the suffix resolves to ``cpp-clang`` /
     ``cpp-gcc`` from the ``clang-``/``gcc-`` prefix on the primary
-    ``[ci].versions`` entry (vergil-project/.github#207 §6).
+    ``[ci].versions`` entry (vergil-project/.github#207 §6). TypeScript resolves
+    to the fixed ``ts-node`` runtime-family suffix (the Node major rides the
+    *tag*, like cpp's numeric version), matching the ``prod-ts-node:<major>``
+    images (epic vergil-project/.github#284). A primary tag without a
+    recognized ``node-`` prefix falls back to ``base``, like an unknown
+    language.
     """
     if language is None:
         return "base"
     if language == "cpp":
         parsed = _cpp_family_and_version(versions)
         return f"cpp-{parsed[0]}" if parsed else "base"
+    if language == "typescript":
+        return "ts-node" if _node_major(versions) else "base"
     suffix_map = {
         "python": "python",
         "go": "go",
@@ -523,6 +555,11 @@ def _container_tag(language: str | None, versions: list[str]) -> str:
     if language == "cpp":
         parsed = _cpp_family_and_version(versions)
         return parsed[1] if parsed else "latest"
+    if language == "typescript":
+        # The Node major is the tag; the ``ts-node`` family rides the suffix,
+        # so ``node-24`` resolves to ``prod-ts-node:24`` (epic
+        # vergil-project/.github#284). A malformed tag falls back to ``latest``.
+        return _node_major(versions) or "latest"
     if language == "python" and versions:
         return versions[-1]
     return "latest"
@@ -944,6 +981,11 @@ def _default_ci_versions(language: str | None) -> str:
         # default seeds a single primary Clang image, matching the primary
         # major built in vergil-containers.
         "cpp": "clang-20",
+        # TypeScript carries the Node major here as a ``node-`` prefixed tag so
+        # the derived suffix/tag are runtime-aware; the default seeds the two v1
+        # LTS majors (primary first), matching the ``prod-ts-node:<major>``
+        # images built in vergil-containers (epic vergil-project/.github#284).
+        "typescript": "node-24, node-22",
     }
     return defaults.get(language, "latest")
 

--- a/tests/vergil_tooling/test_github_config_lib.py
+++ b/tests/vergil_tooling/test_github_config_lib.py
@@ -343,6 +343,33 @@ def test_ci_gates_codeql_for_cpp() -> None:
     assert "CodeQL" in names
 
 
+def test_ci_gates_codeql_for_typescript() -> None:
+    # typescript is CodeQL-supported (epic vergil-project/.github#284 T6). It is
+    # keyed by the *primary-language* name (`typescript`), NOT the CodeQL
+    # analysis identifier `javascript-typescript`: this set is tested against
+    # `project.primary_language`, and the `typescript → javascript-typescript`
+    # mapping belongs to the reusable CI Action (T7), not here.
+    r = desired_ci_gates_ruleset(
+        _project(language="typescript"), _ci(versions=["node-24", "node-22"]), ghas=True
+    )
+    names = _check_names(r)
+    assert "security / codeql" in names
+    assert "CodeQL" in names
+
+
+def test_codeql_supported_languages_align_with_repo_init() -> None:
+    # The github_config gate-emission set and repo_init's CI-rendering set must
+    # agree on typescript, or a TS repo would get a required CodeQL check with no
+    # job to satisfy it (or vice versa). Assert alignment on both cpp and
+    # typescript (epic vergil-project/.github#284 T6, #207 T7).
+    from vergil_tooling.lib.github_config import _CODEQL_SUPPORTED_LANGUAGES
+    from vergil_tooling.lib.repo_init import _CODEQL_LANGUAGES
+
+    for lang in ("cpp", "typescript"):
+        assert lang in _CODEQL_SUPPORTED_LANGUAGES
+        assert lang in _CODEQL_LANGUAGES
+
+
 def test_ci_gates_no_codeql_without_language() -> None:
     r = desired_ci_gates_ruleset(_project(language=None), _ci(), ghas=True)
     names = _check_names(r)

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -459,6 +459,22 @@ class TestRenderCiWorkflow:
         # cpp is CodeQL-supported, so run-codeql must NOT be disabled.
         assert "run-codeql: false" not in content
 
+    def test_typescript_workflow(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="test")
+        ctx.primary_language = "typescript"
+        ctx.ci_versions = ["node-24", "node-22"]
+        ctx.release_model = "tagged-release"
+        content = render_ci_workflow(ctx)
+        # The emitted ci.yml carries the *primary-language* name for container
+        # resolution — NOT the CodeQL identifier `javascript-typescript` (that
+        # mapping is the reusable Action's job, epic vergil-project/.github#284 T7).
+        assert "language: typescript" in content
+        # Node-family suffix + numeric major tag → prod-ts-node:24.
+        assert "container-suffix: ts-node" in content
+        assert "container-tag: '24'" in content
+        # typescript is CodeQL-supported, so run-codeql must NOT be disabled.
+        assert "run-codeql: false" not in content
+
     def test_no_language_workflow(self) -> None:
         ctx = RepoInitContext(org="vergil-project", name="test")
         ctx.ci_versions = ["latest"]
@@ -715,6 +731,41 @@ class TestContainerHelpers:
         versions = [v.strip() for v in default.split(",")]
         assert _container_suffix("cpp", versions) == "cpp-clang"
         assert _container_tag("cpp", versions) == "20"
+
+    def test_container_suffix_typescript_is_ts_node(self) -> None:
+        # TypeScript's runtime family (node) rides the suffix; the Node major
+        # rides the tag, so node-24 resolves to prod-ts-node:24 (epic
+        # vergil-project/.github#284).
+        assert _container_suffix("typescript", ["node-24"]) == "ts-node"
+        assert _container_suffix("typescript", ["node-22"]) == "ts-node"
+
+    def test_container_suffix_typescript_uses_first_entry_as_primary(self) -> None:
+        # The representative top-level suffix comes from the primary (first) entry.
+        assert _container_suffix("typescript", ["node-22", "node-24"]) == "ts-node"
+
+    def test_container_suffix_typescript_unparseable_falls_back_to_base(self) -> None:
+        assert _container_suffix("typescript", ["latest"]) == "base"
+        assert _container_suffix("typescript", []) == "base"
+
+    def test_container_tag_typescript_is_numeric_major(self) -> None:
+        # The tag carries only the numeric Node major; the family lives in the
+        # suffix, so node-24 resolves to prod-ts-node:24.
+        assert _container_tag("typescript", ["node-24"]) == "24"
+        assert _container_tag("typescript", ["node-22"]) == "22"
+
+    def test_container_tag_typescript_unparseable_falls_back_to_latest(self) -> None:
+        assert _container_tag("typescript", ["latest"]) == "latest"
+        assert _container_tag("typescript", []) == "latest"
+
+    def test_default_ci_versions_typescript_seeds_node_primary(self) -> None:
+        # The typescript default must be node-/prefixed tags (primary first) so
+        # the derived suffix/tag are runtime-aware; a bare "latest" would render
+        # a base image.
+        default = _default_ci_versions("typescript")
+        assert default == "node-24, node-22"
+        versions = [v.strip() for v in default.split(",")]
+        assert _container_suffix("typescript", versions) == "ts-node"
+        assert _container_tag("typescript", versions) == "24"
 
 
 class TestRenderCdWorkflow:


### PR DESCRIPTION
# Pull Request

## Summary

- Add typescript to the CodeQL gate-emission set and wire repo-init container scaffolding to resolve node- prefixed [ci].versions tags to the ts-node image suffix and numeric Node major (node-24 to prod-ts-node:24).

## Issue Linkage

- Closes #2744

## Notes

- TypeScript is the first language whose primary-language name (typescript) differs from its CodeQL analysis identifier (javascript-typescript); this task keys the gate on the primary-language name because _CODEQL_SUPPORTED_LANGUAGES is tested against project.primary_language and the emitted ci.yml language: must stay typescript for container resolution. The typescript to javascript-typescript Action-side mapping is deferred to T7. An alignment test asserts the github_config and repo_init CodeQL sets agree on typescript.