### PR TITLE
feat(languages): TypeScript registry entry (node)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ constraint-dependencies = ["msgpack>=1.2.1"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-vergil_tooling = ["data/*.json", "data/*.md", "data/*.sh", "data/licenses/*.txt", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml", "configs/cpp/.clang-format", "configs/cpp/.clang-tidy", "configs/cpp/*.txt", "configs/cpp/*.cfg"]
+vergil_tooling = ["data/*.json", "data/*.md", "data/*.sh", "data/licenses/*.txt", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml", "configs/cpp/.clang-format", "configs/cpp/.clang-tidy", "configs/cpp/*.txt", "configs/cpp/*.cfg", "configs/typescript/*.json", "configs/typescript/*.mjs"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/vergil_tooling/configs/typescript/eslint.config.mjs
+++ b/src/vergil_tooling/configs/typescript/eslint.config.mjs
@@ -1,0 +1,40 @@
+// Vergil shareable ESLint flat config for TypeScript (epic
+// vergil-project/.github#284, T4). Type-aware linting via typescript-eslint's
+// recommendedTypeChecked, plus the no-standing-suppression rule
+// (@typescript-eslint/ban-ts-comment) that bans bare `@ts-ignore`/`@ts-nocheck`
+// and requires a description on `@ts-expect-error` (spec §3.2).
+//
+// Referenced by the registry LINT command as `eslint . --config
+// {configs}/typescript/eslint.config.mjs`; the packages it imports
+// (@eslint/js, typescript-eslint) ship in the `prod-ts-node:*` images (T1).
+// `projectService: true` auto-discovers the consumer's nearest tsconfig, so the
+// type-aware rules resolve type information without a hard-coded project path.
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist/", "coverage/", "node_modules/"],
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+    extends: [js.configs.recommended, ...tseslint.configs.recommendedTypeChecked],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    rules: {
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-expect-error": "allow-with-description",
+          "ts-ignore": true,
+          "ts-nocheck": true,
+          "ts-check": false,
+        },
+      ],
+    },
+  },
+);

--- a/src/vergil_tooling/configs/typescript/prettier.config.json
+++ b/src/vergil_tooling/configs/typescript/prettier.config.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/src/vergil_tooling/configs/typescript/tsconfig.base.json
+++ b/src/vergil_tooling/configs/typescript/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -152,6 +152,31 @@ _CPP_LICENSES_ALLOWLIST = ";".join(
     ]
 )
 
+# TypeScript / npm license allowlist (epic vergil-project/.github#284 §4).
+# Mirrors the C++ pattern exactly: npm has no turnkey allowlist-enforcing gate
+# with reliable metadata (npm package license fields are inconsistent), so v1
+# license checking is *best-effort surfacing* (see the AUDIT commands below) and
+# hardened gating is deferred (spec §9 ledger #7). This constant is the reviewed
+# allowlist the TypeScript standards docs (T8) reference and that a future
+# hardened gate (e.g. ``license-checker --onlyAllow``, which consumes this exact
+# ``;``-separated form) will enforce; keeping it here alongside the other
+# language allowlists preserves the single-source-of-truth contract.
+_TYPESCRIPT_LICENSES_ALLOWLIST = ";".join(
+    [
+        "0BSD",
+        "Apache-2.0",
+        "BlueOak-1.0.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "CC0-1.0",
+        "ISC",
+        "MIT",
+        "MPL-2.0",
+        "Python-2.0",
+        "Unlicense",
+    ]
+)
+
 # -- C++ warning set (epic vergil-project/.github#207 §3.2, owned by T5) -------
 #
 # "Warnings to 11" resolved to a concrete, reviewable list. The floor is
@@ -545,6 +570,99 @@ _REGISTRY: dict[str, Language] = {
         # and TEST are the two-diagnostics engine → per compiler×version, which
         # is the PER_VERSION default, so they are intentionally omitted here.
         cardinality={
+            CheckKind.LINT: Cardinality.ONCE,
+            CheckKind.AUDIT: Cardinality.ONCE,
+        },
+    ),
+    # TypeScript (epic vergil-project/.github#284, T4). Node.js runtime with a
+    # single canonical typechecker (``tsc``); the expensive matrix axis is the
+    # Node major version, so — unlike C++ — TYPECHECK/LINT/AUDIT run **once**
+    # and only TEST fans out per Node version (§3.1/§3.6). The per-kind
+    # cardinality machinery is inherited from C++ (this entry only *declares*
+    # cardinalities, it builds none).
+    #
+    # **Warnings to 11 live in the shareable base tsconfig.** The curated
+    # strictness set — ``strict`` plus ``noUncheckedIndexedAccess``,
+    # ``exactOptionalPropertyTypes``, ``noImplicitOverride``,
+    # ``noImplicitReturns``, ``noFallthroughCasesInSwitch``,
+    # ``noPropertyAccessFromIndexSignature``, ``noUnusedLocals``,
+    # ``noUnusedParameters`` (spec §3.2) — is authored and tested in the
+    # packaged ``{configs}/typescript/tsconfig.base.json`` that consumers
+    # ``extends``. TYPECHECK is therefore a bare ``tsc --noEmit`` that reads the
+    # consumer's own ``tsconfig.json`` (which extends the base); the strict set
+    # is enforced through that inheritance, the direct analog of C++ threading
+    # ``-Wall -Wextra -Werror -Wpedantic``-plus-extras onto every compile line.
+    # T8 *documents* this already-decided set; it does not re-choose it.
+    "typescript": Language(
+        name="typescript",
+        checks={
+            # Clean, lockfile-pinned install from ``package-lock.json``.
+            CheckKind.INSTALL: [["npm", "ci"]],
+            # LINT runs *once* (§3.6): Prettier for format, then ESLint's flat
+            # config with type-aware typescript-eslint rules. Both point at the
+            # packaged configs; the ESLint flat config carries
+            # ``@typescript-eslint/ban-ts-comment`` (the no-standing-suppression
+            # rule, §3.2). Prettier and ESLint ignore ``node_modules`` by
+            # default.
+            CheckKind.LINT: [
+                [
+                    "prettier",
+                    "--check",
+                    ".",
+                    "--config",
+                    "{configs}/typescript/prettier.config.json",
+                ],
+                ["eslint", ".", "--config", "{configs}/typescript/eslint.config.mjs"],
+            ],
+            # TYPECHECK runs *once* (§3.6) — one canonical type engine. The
+            # curated "warnings to 11" set lives in the packaged base tsconfig
+            # the consumer extends (see the class comment above); this command
+            # reads the consumer's ``tsconfig.json`` and never emits output.
+            CheckKind.TYPECHECK: [["tsc", "--noEmit"]],
+            # TEST runs *per Node version* (§3.6) — the only fan-out stage,
+            # because runtime behavior differs across Node majors. Vitest with
+            # the V8 coverage provider, held to a **100% line** threshold so the
+            # gate fails under 100% (spec §5). Contingency (spec §4 caveat 2): if
+            # V8's byte-range→TS-source-map mapping proves imprecise at the 100%
+            # bar, switch the provider to ``@vitest/coverage-istanbul`` (which
+            # instruments source directly). Decided against the real gate in T10.
+            CheckKind.TEST: [
+                [
+                    "vitest",
+                    "run",
+                    "--coverage",
+                    "--coverage.provider=v8",
+                    "--coverage.thresholds.lines=100",
+                ],
+            ],
+            # AUDIT runs *once* (§3.6). ``npm audit`` is the CVE scan, scoped to
+            # production dependencies (``--omit=dev`` — dev-only advisories must
+            # not gate, spec §4 caveat 1) with an explicit severity threshold
+            # (``--audit-level=high``). Contingency (spec §4 caveat 1): if
+            # ``npm audit``'s signal/noise is unworkable, fall back to
+            # OSV-Scanner over ``package-lock.json`` — the switch is proven or
+            # rejected against a known CVE in T10, not asserted here. License
+            # checking stays best-effort surfacing in v1 (``license-checker
+            # --summary``, non-gating — npm license metadata is inconsistent);
+            # hardened gating against ``_TYPESCRIPT_LICENSES_ALLOWLIST`` is
+            # deferred (spec §9 ledger #7).
+            CheckKind.AUDIT: [
+                ["npm", "audit", "--audit-level=high", "--omit=dev"],
+                ["license-checker", "--production", "--summary"],
+            ],
+        },
+        ecosystem=EcosystemInfo(
+            # v1 mandates no bundler/emit step — ``tsc --noEmit`` covers
+            # compile-correctness — and no publish target (spec §8, ledger #6).
+            build_cmd=None,
+            publish_cmd=None,
+            publish_env_var=None,
+        ),
+        # TYPECHECK/LINT/AUDIT are runtime-agnostic → one gate each (§3.6). Only
+        # TEST is per Node version, which is the PER_VERSION default, so it is
+        # intentionally omitted here.
+        cardinality={
+            CheckKind.TYPECHECK: Cardinality.ONCE,
             CheckKind.LINT: Cardinality.ONCE,
             CheckKind.AUDIT: Cardinality.ONCE,
         },

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from vergil_tooling.lib.languages import (
+    _TYPESCRIPT_LICENSES_ALLOWLIST,
     COVERAGE_REPORT,
     JUNIT_REPORT,
     LICENSES_REPORT,
@@ -447,6 +449,173 @@ def test_cpp_std_stdlib_are_threaded_from_config() -> None:
     assert "--std=c++17" in cppcheck_cmd
 
 
+# -- TypeScript (epic vergil-project/.github#284, T4) -------------------------
+
+
+def _ts_config_path(name: str) -> Path:
+    """Resolve a packaged ``configs/typescript/<name>`` path.
+
+    Derives the packaged ``typescript/`` config directory from a LINT argument
+    that carries the expanded ``{configs}`` placeholder, then joins *name* — so
+    it resolves files (like ``tsconfig.base.json``) that no command references
+    directly, without hard-coding the package layout.
+    """
+    for cmd in language_commands("typescript", CheckKind.LINT):
+        for arg in cmd:
+            token = arg.split("=", 1)[-1]
+            if "/typescript/" in token:
+                return Path(token).parent / name
+    msg = "no LINT arg references the typescript configs dir"
+    raise AssertionError(msg)
+
+
+def test_typescript_is_supported() -> None:
+    assert "typescript" in supported_languages()
+
+
+def test_typescript_install_commands() -> None:
+    cmds = language_commands("typescript", CheckKind.INSTALL)
+    assert cmds == [["npm", "ci"]]
+
+
+def test_typescript_lint_commands() -> None:
+    cmds = language_commands("typescript", CheckKind.LINT)
+    joined = _joined(cmds)
+    # Prettier format check + ESLint, each against a packaged config.
+    assert any(c.startswith("prettier --check .") for c in joined)
+    assert any(c.startswith("eslint .") for c in joined)
+    # Both reference a packaged {configs}/typescript/* config.
+    assert any("/typescript/prettier.config.json" in c for c in joined)
+    assert any("/typescript/eslint.config.mjs" in c for c in joined)
+
+
+def test_typescript_lint_ban_ts_comment_rule_present() -> None:
+    """The no-standing-suppression rule is wired via the packaged ESLint config."""
+    text = _ts_config_path("eslint.config.mjs").read_text()
+    assert "@typescript-eslint/ban-ts-comment" in text
+    # Bare @ts-ignore / @ts-nocheck are banned; @ts-expect-error needs a reason.
+    assert '"ts-ignore": true' in text
+    assert '"ts-nocheck": true' in text
+    assert '"ts-expect-error": "allow-with-description"' in text
+    # Type-aware linting is enabled.
+    assert "recommendedTypeChecked" in text
+    assert "projectService" in text
+
+
+def test_typescript_lint_uses_packaged_configs() -> None:
+    """Every LINT tool points at a packaged {configs}/typescript/* file that exists."""
+    cmds = language_commands("typescript", CheckKind.LINT)
+    flat = [arg for cmd in cmds for arg in cmd]
+    # No unresolved placeholder survives expansion.
+    assert all("{configs}" not in arg for arg in flat)
+    referenced = [arg for arg in flat if "/typescript/" in arg]
+    assert len(referenced) == 2
+    for arg in referenced:
+        path = arg.split("=", 1)[-1]
+        assert Path(path).exists(), f"packaged config missing: {path}"
+
+
+def test_typescript_typecheck_commands() -> None:
+    cmds = language_commands("typescript", CheckKind.TYPECHECK)
+    # One canonical type engine; strict set lives in the base tsconfig consumers
+    # extend, so the command is a bare --noEmit typecheck.
+    assert cmds == [["tsc", "--noEmit"]]
+
+
+def test_typescript_base_tsconfig_curated_extras() -> None:
+    """The curated 'warnings to 11' set is authored in the packaged base tsconfig.
+
+    This task (T4) owns and tests the concrete strictness set (spec §3.2); T8
+    only documents it. Every option must be present and enabled, and each is a
+    real ``tsc`` 5.x compiler option.
+    """
+    base = _ts_config_path("tsconfig.base.json")
+    # tsconfig.base.json is authored as pure JSON (no comments) so it is both
+    # tsc-loadable and directly parseable here — the file *is* the source of
+    # truth for the strict set.
+    opts = json.loads(base.read_text())["compilerOptions"]
+    curated = (
+        "strict",
+        "noUncheckedIndexedAccess",
+        "exactOptionalPropertyTypes",
+        "noImplicitOverride",
+        "noImplicitReturns",
+        "noFallthroughCasesInSwitch",
+        "noPropertyAccessFromIndexSignature",
+        "noUnusedLocals",
+        "noUnusedParameters",
+    )
+    for opt in curated:
+        assert opts.get(opt) is True, f"base tsconfig missing/disabled: {opt}"
+
+
+def test_typescript_test_commands() -> None:
+    cmds = language_commands("typescript", CheckKind.TEST)
+    joined = _joined(cmds)
+    # Vitest with the V8 coverage provider.
+    assert any(c.startswith("vitest run --coverage") for c in joined)
+    assert any("--coverage.provider=v8" in c for c in joined)
+
+
+def test_typescript_test_enforces_100_line_coverage() -> None:
+    """The gate must fail under 100% line coverage (spec §5)."""
+    cmds = language_commands("typescript", CheckKind.TEST)
+    vitest_cmd = [c for c in cmds if c[0] == "vitest"]
+    assert len(vitest_cmd) == 1
+    assert "--coverage.thresholds.lines=100" in vitest_cmd[0]
+
+
+def test_typescript_audit_commands() -> None:
+    cmds = language_commands("typescript", CheckKind.AUDIT)
+    joined = _joined(cmds)
+    # npm audit is the CVE scan, scoped to prod deps with an explicit severity
+    # threshold (spec §4 caveat 1).
+    npm_audit = [c for c in cmds if c[:2] == ["npm", "audit"]]
+    assert len(npm_audit) == 1
+    assert "--omit=dev" in npm_audit[0]
+    assert any(arg.startswith("--audit-level=") for arg in npm_audit[0])
+    # OSV-Scanner is the documented contingency, not the v1 default.
+    assert not any("osv-scanner" in c for c in joined)
+    # Best-effort license-metadata surfacing (hardened gating deferred, §9 #7).
+    assert any("license-checker" in c for c in joined)
+
+
+def test_typescript_audit_license_allowlist_reviewed_set() -> None:
+    """The TS license allowlist constant carries the reviewed permissive set."""
+    licenses = _TYPESCRIPT_LICENSES_ALLOWLIST.split(";")
+    assert "MIT" in licenses
+    assert "Apache-2.0" in licenses
+    assert "ISC" in licenses
+    # Semicolon-separated (the form license-checker --onlyAllow consumes).
+    assert ";" in _TYPESCRIPT_LICENSES_ALLOWLIST
+
+
+def test_typescript_ecosystem_metadata() -> None:
+    info = ecosystem_metadata("typescript")
+    # v1 mandates no bundler/emit and no publish target (spec §8, ledger #6).
+    assert info.build_cmd is None
+    assert info.publish_cmd is None
+    assert info.publish_env_var is None
+
+
+def test_typescript_cardinality_typecheck_lint_audit_run_once() -> None:
+    assert check_cardinality("typescript", CheckKind.TYPECHECK) is Cardinality.ONCE
+    assert check_cardinality("typescript", CheckKind.LINT) is Cardinality.ONCE
+    assert check_cardinality("typescript", CheckKind.AUDIT) is Cardinality.ONCE
+
+
+def test_typescript_cardinality_test_is_per_version() -> None:
+    # Only TEST fans out per Node version (§3.6).
+    assert check_cardinality("typescript", CheckKind.TEST) is Cardinality.PER_VERSION
+
+
+def test_typescript_no_unresolved_placeholders() -> None:
+    for kind in CheckKind:
+        for cmd in language_commands("typescript", kind):
+            for arg in cmd:
+                assert "{configs}" not in arg, f"Unresolved placeholder in: {arg}"
+
+
 # -- Edge cases ---------------------------------------------------------------
 
 
@@ -489,7 +658,7 @@ def test_configs_placeholder_resolves_to_existing_directory() -> None:
 
 def test_supported_languages_includes_cpp() -> None:
     langs = supported_languages()
-    assert langs == frozenset({"python", "go", "java", "ruby", "rust", "cpp"})
+    assert langs == frozenset({"python", "go", "java", "ruby", "rust", "cpp", "typescript"})
 
 
 def test_supported_languages_is_frozen() -> None:
@@ -536,11 +705,11 @@ def test_single_image_languages_default_to_per_version_cardinality() -> None:
     """Every single-image language defaults to per-version for every check kind.
 
     This backward-compatibility guarantee is what keeps their generated CI
-    gates byte-identical after the cardinality concept was introduced. C++ is
-    the one matrix language that legitimately declares ONCE kinds, so it is
-    excluded here and covered by the C++-specific cardinality tests.
+    gates byte-identical after the cardinality concept was introduced. C++ and
+    TypeScript are the matrix languages that legitimately declare ONCE kinds, so
+    they are excluded here and covered by their own cardinality tests.
     """
-    for lang in supported_languages() - {"cpp"}:
+    for lang in supported_languages() - {"cpp", "typescript"}:
         for kind in CheckKind:
             assert check_cardinality(lang, kind) is Cardinality.PER_VERSION
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add the TypeScript language registry entry — every INSTALL/LINT/TYPECHECK/TEST/AUDIT stage command, the declared per-kind cardinalities, and the packaged shareable strict base tsconfig plus ESLint/Prettier configs consumers extend.

## Issue Linkage

- Closes #2743

## Notes

- Curated warnings-to-11 extras authored + tested in tsconfig.base.json (strict + noUncheckedIndexedAccess, exactOptionalPropertyTypes, noImplicitOverride, noImplicitReturns, noFallthroughCasesInSwitch, noPropertyAccessFromIndexSignature, noUnusedLocals, noUnusedParameters), all valid tsc 5.x options. Cardinality declared via the existing field: TYPECHECK/LINT/AUDIT once, TEST per-version (inverse of C++). AUDIT uses npm audit --audit-level=high --omit=dev (dev advisories do not gate, spec §4 caveat 1) with the OSV-Scanner contingency noted; license checking is best-effort surfacing (license-checker --summary) with a _TYPESCRIPT_LICENSES_ALLOWLIST constant kept for the deferred hardened gate (ledger #7), mirroring C++. TEST holds 100% line via vitest V8 provider with the istanbul contingency noted. LINT ships @typescript-eslint/ban-ts-comment (no-suppression rule). Packaged configs live in src/vergil_tooling/configs/typescript/ and are added to pyproject package-data. Tests: tests/vergil_tooling/test_languages.py (the plan's tests/lib/ path is stale). vrg-validate fully green (4880 passed, 100% coverage). tsc-against-real-project end-to-end proof is T10.