### PR TITLE
feat(container): TypeScript image resolution + detection

### DIFF
--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import platform
 import shutil
@@ -25,6 +26,11 @@ _DEFAULT_VERSIONS: dict[str, str] = {
     # vergil-project/.github#207 §6). The built-in default is the primary Clang
     # image, so default_image("cpp") resolves to prod-cpp-clang:20.
     "cpp": "clang-20",
+    # TypeScript carries its Node major on the version tag as a `node-` prefix
+    # (epic vergil-project/.github#284). The runtime family is the fixed
+    # `ts-node` image suffix and the numeric major is the tag, so the primary
+    # default default_image("typescript") resolves to prod-ts-node:24.
+    "typescript": "node-24",
 }
 
 _DEFAULT_PREFIX = "prod"
@@ -43,6 +49,10 @@ _DEFAULT_TEST_COMMANDS: dict[str, str] = {
         "&& cmake --build build --parallel "
         "&& ctest --test-dir build --output-on-failure"
     ),
+    # vrg-container-test runs this via `bash -c`, so `&&` chaining is valid.
+    # `npm ci` installs from the lockfile, then Vitest runs the suite once
+    # under the selected Node image (epic vergil-project/.github#284).
+    "typescript": "npm ci && vitest run",
 }
 
 
@@ -77,6 +87,25 @@ def container_platform() -> str:
 docker_platform = container_platform
 
 
+def _package_json_has_typescript_dep(package_json: Path) -> bool:
+    """Return True when *package_json* declares ``typescript`` as a devDependency.
+
+    A plain ``package.json`` (any Node project) is not a TypeScript marker on its
+    own — only the presence of the ``typescript`` devDependency is. A malformed or
+    unreadable manifest is treated as "no TypeScript dep" (detection must not crash
+    on a stray file); this is a bounded, documented fallback, not a swallowed error
+    that would surface later as a wrong image.
+    """
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    dev_deps = data.get("devDependencies")
+    return isinstance(dev_deps, dict) and "typescript" in dev_deps
+
+
 def detect_language(repo_root: Path) -> str:
     """Detect the project language from repo contents."""
     if (repo_root / "Gemfile").is_file():
@@ -96,7 +125,35 @@ def detect_language(repo_root: Path) -> str:
         (repo_root / "conanfile.py").is_file() or (repo_root / "conanfile.txt").is_file()
     ):
         return "cpp"
+    # TypeScript is identified by a tsconfig.json, or a package.json that carries
+    # a `typescript` devDependency (epic vergil-project/.github#284 §3.3). A plain
+    # package.json alone (a JS-only Node project) must NOT misdetect as TypeScript.
+    if (repo_root / "tsconfig.json").is_file():
+        return "typescript"
+    package_json = repo_root / "package.json"
+    if package_json.is_file() and _package_json_has_typescript_dep(package_json):
+        return "typescript"
     return ""
+
+
+def _parse_node_version_tag(tag: str) -> str | None:
+    """Extract the Node major from a ``node-`` prefixed version tag.
+
+    TypeScript carries its Node major on ``[ci].versions`` as a ``node-`` prefixed
+    tag (e.g. ``node-24`` → ``"24"``, ``node-22`` → ``"22"``), matching the
+    ``prod-ts-node:<major>`` images T1/T2 build in vergil-containers (epic
+    vergil-project/.github#284). Returns ``None`` when *tag* carries no recognized
+    ``node-`` prefix.
+
+    This is the container-side counterpart of ``repo_init._node_major`` and mirrors
+    its ``node-`` → major parse exactly; it is kept local so the container path stays
+    self-contained (T5), the way ``repo_init`` keeps its own copy for the CI
+    scaffolding path.
+    """
+    prefix = "node-"
+    if tag.startswith(prefix):
+        return tag[len(prefix) :]
+    return None
 
 
 def default_image(
@@ -139,6 +196,17 @@ def default_image(
             return _fallback_image(prefix) if fallback else ""
         family, ver = parsed
         return f"{_GHCR}/{prefix}-cpp-{family}:{ver}"
+    # TypeScript carries its Node major on the version tag: `node-24` resolves to
+    # `prod-ts-node:24` — the runtime family is the fixed `ts-node` image suffix
+    # and only the numeric major is the tag (epic vergil-project/.github#284,
+    # matching the images T1/T2 build in vergil-containers). A malformed tag (no
+    # `node-` prefix, or an empty major) must not build a `prod-ts-node:` image
+    # with an empty major, so it falls back like an unknown language.
+    if lang == "typescript":
+        major = _parse_node_version_tag(resolved)
+        if not major:
+            return _fallback_image(prefix) if fallback else ""
+        return f"{_GHCR}/{prefix}-ts-node:{major}"
     return f"{_GHCR}/{prefix}-{lang}:{resolved}"
 
 

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -115,6 +115,44 @@ def test_detect_cpp_requires_conanfile(tmp_path: Path) -> None:
     assert detect_language(tmp_path) == ""
 
 
+def test_detect_typescript_tsconfig(tmp_path: Path) -> None:
+    # A tsconfig.json is a sufficient TypeScript marker on its own.
+    (tmp_path / "tsconfig.json").write_text("{}")
+    assert detect_language(tmp_path) == "typescript"
+
+
+def test_detect_typescript_package_json_dev_dep(tmp_path: Path) -> None:
+    # A package.json carrying a `typescript` devDependency is a TypeScript marker.
+    (tmp_path / "package.json").write_text('{"devDependencies": {"typescript": "^5.4.0"}}')
+    assert detect_language(tmp_path) == "typescript"
+
+
+def test_detect_typescript_package_json_without_ts_dep_not_detected(tmp_path: Path) -> None:
+    # A plain (JS-only) package.json with no `typescript` devDependency must NOT
+    # misdetect as TypeScript.
+    (tmp_path / "package.json").write_text('{"devDependencies": {"eslint": "^9.0.0"}}')
+    assert detect_language(tmp_path) == ""
+
+
+def test_detect_typescript_bare_package_json_not_detected(tmp_path: Path) -> None:
+    # A package.json with no devDependencies block at all is not a TS marker.
+    (tmp_path / "package.json").write_text('{"name": "example"}')
+    assert detect_language(tmp_path) == ""
+
+
+def test_detect_typescript_malformed_package_json_not_detected(tmp_path: Path) -> None:
+    # A malformed package.json must not crash detection nor claim TypeScript.
+    (tmp_path / "package.json").write_text("{not json")
+    assert detect_language(tmp_path) == ""
+
+
+def test_detect_typescript_non_object_package_json_not_detected(tmp_path: Path) -> None:
+    # A package.json that is valid JSON but not an object (e.g. an array) is not
+    # a TypeScript marker and must not crash detection.
+    (tmp_path / "package.json").write_text('["typescript"]')
+    assert detect_language(tmp_path) == ""
+
+
 # -- default_image ------------------------------------------------------------
 
 
@@ -271,6 +309,65 @@ def test_cpp_default_test_command_is_conan_cmake_ctest() -> None:
     # or the Debug config finds no matching binary (fmt/format.h not found). (#2572)
     assert "conan install . -s build_type=Debug --build=missing" in cmd
     assert "-DCMAKE_BUILD_TYPE=Debug" in cmd
+
+
+# -- typescript node image resolution -----------------------------------------
+
+
+def test_default_image_typescript_uses_builtin_node_default() -> None:
+    # _DEFAULT_VERSIONS["typescript"] is the primary Node tag (node-24), so the
+    # runtime family rides the image suffix and the numeric major is the tag.
+    assert default_image("typescript") == "ghcr.io/vergil-project/prod-ts-node:24"
+
+
+def test_default_image_typescript_node24_declared_version() -> None:
+    assert default_image("typescript", version="node-24") == (
+        "ghcr.io/vergil-project/prod-ts-node:24"
+    )
+
+
+def test_default_image_typescript_node22_declared_version() -> None:
+    # node-22 → prod-ts-node:22, matching the second image T2 produces.
+    assert default_image("typescript", version="node-22") == (
+        "ghcr.io/vergil-project/prod-ts-node:22"
+    )
+
+
+def test_default_image_typescript_respects_prefix() -> None:
+    assert default_image("typescript", prefix="dev", version="node-24") == (
+        "ghcr.io/vergil-project/dev-ts-node:24"
+    )
+
+
+def test_default_image_typescript_unparseable_version_no_fallback() -> None:
+    # A malformed node tag (no node- prefix) must not build a malformed
+    # prod-ts-node: image — it returns empty without fallback.
+    assert default_image("typescript", version="latest") == ""
+
+
+def test_default_image_typescript_empty_major_no_fallback() -> None:
+    # A `node-` prefix with no major must not build prod-ts-node: with an empty
+    # major — it falls back like an unknown language.
+    assert default_image("typescript", version="node-") == ""
+
+
+def test_default_image_typescript_unparseable_version_with_fallback() -> None:
+    assert default_image("typescript", version="latest", fallback=True) == (
+        "ghcr.io/vergil-project/prod-base:latest"
+    )
+
+
+def test_typescript_default_version_is_primary_node() -> None:
+    # The built-in default drives default_image("typescript") when no [ci].versions
+    # is declared — it must be the primary Node tag.
+    assert _DEFAULT_VERSIONS["typescript"] == "node-24"
+
+
+def test_typescript_default_test_command_is_npm_ci_vitest() -> None:
+    # vrg-container-test runs this via `bash -c`, so `&&` chaining is valid.
+    cmd = _DEFAULT_TEST_COMMANDS["typescript"]
+    assert "npm ci" in cmd
+    assert "vitest run" in cmd
 
 
 # -- workspace_mount_args -----------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Teach the container maps to detect TypeScript projects and resolve the correct prod-ts-node image from the node- version tag, so vrg-container-run and vrg-container-test select the right Node image for TypeScript repos.

## Issue Linkage

- Closes #2745

## Notes

- Detection: detect_language returns "typescript" on tsconfig.json, or a package.json carrying a typescript devDependency; a plain/JS-only, bare, malformed, or non-object package.json does not misdetect. Image resolution: default_image parses the node- prefix from the version tag into prod-ts-node:<major> (node-24 -> prod-ts-node:24, node-22 -> prod-ts-node:22); a malformed tag or empty major falls back like an unknown language. The node- -> major parse is a local _parse_node_version_tag helper kept self-contained in container.py, mirroring repo_init._node_major's parse behavior (prefix strip, truthiness-gated fallback) rather than importing it. Defaults: _DEFAULT_VERSIONS[typescript]=node-24 (primary) and _DEFAULT_TEST_COMMANDS[typescript]=npm ci && vitest run. Validation green at 100% coverage.