### PR TITLE
docs(ts): TypeScript development standards

### DIFF
--- a/docs/site/docs/standards/development/typescript/naming-conventions.md
+++ b/docs/site/docs/standards/development/typescript/naming-conventions.md
@@ -1,0 +1,238 @@
+# TypeScript Naming Conventions
+
+## Purpose
+
+Provide naming rules that optimize for clarity, consistency, and accessibility.
+
+## TypeScript Conventions Baseline
+
+Follow idiomatic TypeScript/Node casing as the default, with the house rules
+below:
+
+- Types (classes, interfaces, type aliases, enums): `PascalCase`
+- Enum members: `PascalCase`
+- Functions and methods: `camelCase`
+- Local variables and parameters: `camelCase`
+- Class fields: `camelCase`; use the `#private` prefix (or `private`) for
+  non-public members rather than a naming hack
+- Module-level constants: `UPPER_SNAKE_CASE` for true compile-time constants
+  (`MAX_RETRIES`); `camelCase` for everything else, including `const` bindings
+  that merely happen not to be reassigned
+- Type parameters: single uppercase letter (`T`, `U`) or short `PascalCase` when
+  more descriptive (`Element`, `Key`)
+- Acronyms in `PascalCase`/`camelCase` contexts: capitalize only the first
+  letter (`HttpClient`, not `HTTPClient`; `jsonParser`, not `jSONParser`)
+- Do **not** prefix interfaces with `I` (`Instrument`, not `IInstrument`) — the
+  structural type system makes the Hungarian prefix noise
+- File names: `kebab-case.ts` (`exercise-state.ts`), matching the ESM import
+  paths that reference them
+
+Prefer the platform's own spelling for concepts it already names; do not invent a
+competing house term for something the standard library or DOM already calls by a
+clear name.
+
+## Casing Convention Note
+
+The variable naming rules below are adapted from Damian Conway's "Perl Best
+Practices" (2005). Conway's original rules assume `snake_case` for all
+identifiers. TypeScript uses `camelCase` for variables and functions and
+`PascalCase` for types; where Conway specifies casing, the house casing above
+takes precedence. Conway's underlying principles (descriptive names, minimum
+length, complete words, grammatical consistency) are fully adopted.
+
+## Variable Naming Rules
+
+These rules are based on Damian Conway's "Perl Best Practices" (2005), adapted
+for TypeScript and validated over long-term use.
+
+### 1. Type-to-Variable Mapping
+
+Variables representing a class or type instance use the `camelCase` version of
+the type name.
+
+```ts
+// Correct
+const instrument = new Instrument();
+const exerciseState = new ExerciseState();
+const practiceBlock = new PracticeBlock();
+
+// Wrong
+const inst = new Instrument();
+const exState = new ExerciseState();
+const block = new PracticeBlock();
+```
+
+### 2. Minimum Length: 3+ Characters
+
+One- and two-character variable names are prohibited because they reduce
+readability and accessibility.
+
+```ts
+// Correct
+for (let index = 0; index < 10; index += 1) {
+  const instrument = instruments[index];
+  process(instrument);
+}
+
+for (const [instrumentIndex, instrument] of instruments.entries()) {
+  process(instrument);
+}
+
+// Wrong
+for (let i = 0; i < 10; i += 1) {
+  const x = xs[i];
+  process(x);
+}
+```
+
+Exceptions:
+
+- Well-established mathematical variables in limited scope (`x`, `y` for a
+  five-line coordinate algorithm).
+- Common domain abbreviations used across a codebase may appear as tokens:
+  `id`, `db`, `api`, `env`, `app`, `url`. Use these only as clear tokens (for
+  example, `instrumentId`, `dbSession`, `apiRouter`, `envName`, `appState`), not
+  as single-character variables.
+
+### 3. Complete English Words
+
+Use complete English words, not abbreviations.
+
+```ts
+// Correct
+const configuration = loadConfiguration();
+const databaseSession = getSession();
+let instrumentIndex = 0;
+
+// Wrong
+const cfg = loadConfiguration(); // Use configuration
+const db = getSession();         // Use databaseSession
+let idx = 0;                     // Use index or instrumentIndex
+```
+
+Exception: allowed domain abbreviations (for example, `id`, `db`, `api`) may
+appear as tokens in identifiers. Other acronyms are acceptable only when they are
+official domain terms (for example, `UTC`) and should not be shortened further.
+
+### 4. Import Collision Handling
+
+When two modules export the same name, disambiguate with an import alias or a
+namespace import — never rely on a shadowing local.
+
+```ts
+// Correct
+import { Session as DbSession } from "./db.js";
+import { Session as RestSession } from "./rest.js";
+
+const dbSession = new DbSession();
+const restSession = new RestSession();
+
+// Wrong
+import { Session } from "./db.js";
+// ...and a second `Session` from elsewhere — one silently wins
+const session = new Session();
+```
+
+Alias prefixes are chosen contextually (for example, `Db`, `Rest`, `Net`).
+
+### 5. Boolean Variables
+
+Prefer `is*`, `has*`, or `can*` prefixes when they make the name read more
+naturally as a true/false condition:
+
+- `is*`: state or condition (`isValid`, `isEmpty`, `isActive`)
+- `has*`: possession or presence (`hasPermission`, `hasItems`, `hasError`)
+- `can*`: capability or permission (`canDelete`, `canWrite`, `canEdit`)
+
+```ts
+// Prefixes improve clarity — use them
+const isValid = validate(instrument);
+const hasPermission = checkAccess(user);
+const canDelete = user.isAdmin || resource.owner === user;
+
+if (isValid && hasPermission && canDelete) {
+  remove(resource);
+}
+```
+
+Omit the prefix when the name already reads unambiguously as a boolean without
+it. Names that are verbs, verb phrases, or adjective phrases often convey boolean
+intent on their own:
+
+```ts
+// Already clear without a prefix
+const verifyTls = true;
+const mapAttributes = true;
+const strict = true;
+```
+
+Avoid bare nouns or adjectives that could be mistaken for the thing itself rather
+than a condition about it:
+
+```ts
+// Ambiguous without a prefix
+const valid = validate(instrument);    // Use isValid
+const permission = checkAccess(user);  // Use hasPermission
+const deletable = user.isAdmin;        // Use canDelete
+```
+
+### 6. Collections: Plural vs. Singular
+
+Name collections based on how they are primarily used.
+
+Plural for collective processing (arrays):
+
+```ts
+const instruments = query.all();
+for (const instrument of instruments) {
+  process(instrument);
+}
+
+const exerciseIds = exercises.map((exercise) => exercise.id);
+```
+
+Singular with `By` suffix for individual access (maps / lookup records):
+
+```ts
+const instrumentById = new Map<number, Instrument>();
+for (const instrument of instruments) {
+  instrumentById.set(instrument.id, instrument);
+}
+const instrument = instrumentById.get(42);
+
+const exerciseByName = new Map<string, Exercise>();
+const exercise = exerciseByName.get("Chromatic Scale");
+```
+
+### 7. Consistency Rules
+
+- Syntactic consistency: if one variable uses `adjectiveNoun`, all similar
+  variables use `adjectiveNoun`.
+- Semantic consistency: names convey what data represents, not just its type.
+- Cross-codebase consistency: the same concept uses the same name everywhere.
+
+```ts
+// Correct
+function createInstrument(name: string): Instrument {
+  const instrument = new Instrument(name);
+  dbSession.create(instrument);
+  return instrument;
+}
+
+function updateInstrument(instrument: Instrument, name: string): void {
+  instrument.name = name;
+  dbSession.save(instrument);
+}
+
+// Wrong
+function createInstrument(name: string): Instrument {
+  const inst = new Instrument(name);
+  dbSession.create(inst);
+  return inst;
+}
+
+function updateInstrument(instrument: Instrument, name: string): void {
+  instrument.name = name;
+  dbSession.save(instrument);
+}
+```

--- a/docs/site/docs/standards/development/typescript/overview.md
+++ b/docs/site/docs/standards/development/typescript/overview.md
@@ -1,0 +1,137 @@
+# TypeScript Development Standards Overview
+
+## Purpose
+
+Define consistent TypeScript standards that emphasize type safety, portability,
+maintainability, and long-term survivability across repositories.
+
+## Core Principles
+
+- Strict typing is the baseline, not a luxury. Code must typecheck clean under
+  `tsc` with the curated strict set promoted to errors.
+- Portability and correctness override cleverness or brevity.
+- Readability overrides micro-optimization.
+- Suppressions must be explicit, documented, and justified.
+
+## The Single-`tsc`, Single-Runtime Model
+
+TypeScript has **no Clang-vs-GCC analog** — there is exactly one canonical
+typechecker, `tsc`. The C++ "two independent diagnostic engines" become
+**`tsc` (structural typing) plus typescript-eslint (type-aware lint)**, and both
+run **once**, not per runtime.
+
+Because there is one typechecker, the expensive matrix axis is the **Node major
+version**, not the compiler. This makes TypeScript *lighter* than C++ on the
+matrix:
+
+- **TYPECHECK, LINT, and AUDIT run once.** There is nothing runtime-specific to
+  gain from typechecking, formatting, or scanning dependencies more than once —
+  `tsc --noEmit`, Prettier + ESLint, and `npm audit` each run a single time.
+- **Only TEST fans out per Node version.** Runtime behavior differs across Node
+  majors, so the test-and-coverage stage runs once per supported Node major (v1:
+  `node-22` and `node-24`, with `node-24` as the primary). See
+  [Testing and Coverage](testing-and-coverage.md).
+
+## npm + ESM Layout
+
+Package management is **npm**, chosen for universality at zero adoption barrier:
+
+- **INSTALL is `npm ci`** — a clean, lockfile-pinned install from
+  `package-lock.json`. The lockfile is the pinned dependency graph; `npm ci`
+  installs exactly what it records and fails if `package.json` and the lockfile
+  disagree.
+- **Modules are ESM.** The shipped base tsconfig sets `module` and
+  `moduleResolution` to `nodenext` and targets `es2022`, so repositories are
+  native ES modules resolved the way modern Node resolves them. A repository's
+  `package.json` declares `"type": "module"` to match.
+
+## Prebuilt Toolchains Only
+
+Node toolchains come **exclusively from prebuilt stable binary packages — never
+built from source**. Building a runtime from source in the validation path is
+slow, non-reproducible, and a supply-chain liability; the dev images pin
+prebuilt official stable Node binaries for each supported major instead
+(`prod-ts-node:<major>`).
+
+The analysis-tool layer pins a **stable TypeScript 5.x release** alongside
+`eslint` + `typescript-eslint`, `prettier`, and the Vitest runner, so every
+repository typechecks and lints against the same pinned tool versions rather
+than whatever floats in from a fresh install.
+
+## `tsc --noEmit`: Compile-Correctness Without a Bundler
+
+v1 mandates **no bundler and no emit step**. `tsc --noEmit` covers
+compile-correctness — it reads the consumer's `tsconfig.json` and reports type
+errors without writing any output — and there is no publish target. Bundling,
+emit, and published-artifact validation (tsup / esbuild / rollup) are
+deliberately deferred (spec §8, deferral ledger #6).
+
+## Extending the Shareable Base tsconfig
+
+The curated strict set is delivered as a **shareable strict base tsconfig
+shipped by Vergil** that consumers `extends` — the direct analog to C++
+enforcing a concrete `-Wall -Wextra -Werror -Wpedantic`-plus-extras warning set
+through a shared flag list.
+
+A consuming repository authors a minimal `tsconfig.json` that extends the
+Vergil-shipped base and adds only repo-local paths:
+
+```json
+{
+  "extends": "<vergil>/typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+```
+
+The strict set lives in the base and is inherited through `extends`, so
+TYPECHECK is a bare `tsc --noEmit` that reads the consumer's own
+`tsconfig.json`. A repository never re-declares the strict flags — it inherits
+them, exactly as a C++ repository inherits the warning set threaded onto every
+compile line. The concrete set the base carries is documented in
+[Toolchain and Strictness](toolchain-and-strictness.md).
+
+## Testing: Vitest Runner, V8 Coverage Default
+
+**Vitest is the mandated test runner**, run with the V8 coverage provider and
+held to a **100% line threshold per Node version**:
+
+```bash
+vitest run --coverage --coverage.provider=v8 --coverage.thresholds.lines=100
+```
+
+The gate is a forcing function for explicitness, not a claim that every line was
+exercised — see [Testing and Coverage](testing-and-coverage.md) for the 100%
+philosophy and the `/* v8 ignore */` exclusion discipline.
+
+## CI Gates
+
+See [Source Control Guidelines](../../source-control-guidelines.md#ci-gates)
+for the hard-gates-only standard: every CI check is a hard gate, and the only
+sanctioned non-blocking category is the advisory-on-unsupported-versions
+carve-out (see the
+[Runtime Version Support Policy](../runtime-version-support-policy.md)).
+
+TypeScript hard gates:
+
+- **TYPECHECK** (once) — `tsc --noEmit` with the curated strict set inherited
+  from the base tsconfig (see
+  [Toolchain and Strictness](toolchain-and-strictness.md)).
+- **LINT** (once) — Prettier `--check` for format, then ESLint's flat config
+  with type-aware typescript-eslint rules, carrying the no-standing-suppression
+  rule (`@typescript-eslint/ban-ts-comment`).
+- **TEST** (per Node version) — Vitest with the V8 coverage provider, held to
+  100% line coverage per Node major (see
+  [Testing and Coverage](testing-and-coverage.md)).
+- **AUDIT** (once) — `npm audit --audit-level=high --omit=dev`, plus a
+  best-effort license summary.
+
+## Document Map
+
+- Toolchain and strictness:
+  [toolchain-and-strictness.md](toolchain-and-strictness.md)
+- Testing and coverage: [testing-and-coverage.md](testing-and-coverage.md)
+- Naming conventions: [naming-conventions.md](naming-conventions.md)

--- a/docs/site/docs/standards/development/typescript/testing-and-coverage.md
+++ b/docs/site/docs/standards/development/typescript/testing-and-coverage.md
@@ -1,0 +1,107 @@
+# TypeScript Testing and Coverage
+
+## Core Principle
+
+Maintain 100% line coverage **per Node version**, where 100% means: you tested
+everything you could, and positively acknowledged the things you could not.
+
+> **100% means "you tested everything you could, and positively acknowledged the
+> things you couldn't."** Setting the bar at 90% moves the ambiguity into the
+> untracked 10% — nobody can tell whether that gap is legitimately untestable or
+> merely skipped. Holding 100% + explicit markers forces every gap to be a
+> deliberate, reviewable decision instead of silent forgotten code.
+
+## Test Runner and Coverage Provider
+
+Tests run through **Vitest**, the mandated runner, with the **V8 coverage
+provider**:
+
+```bash
+vitest run --coverage --coverage.provider=v8 --coverage.thresholds.lines=100
+```
+
+The `--coverage.thresholds.lines=100` flag is the gate: Vitest exits non-zero
+when line coverage drops below 100%, so anything under the bar fails the stage.
+
+## The 100%-Per-Node-Version Gate
+
+Coverage is enforced at **100% line coverage, bound per Node version (per image)
+— never on a single merged report**. TEST is the **only** stage that fans out
+across the Node matrix (v1: `node-22` and `node-24`), precisely because runtime
+behavior differs across Node majors; TYPECHECK, LINT, and AUDIT run once.
+
+**Why per-Node-version, not merged.** A merged report hides gaps. If a line is
+exercised under `node-24` but not under `node-22`, a single combined report
+still shows it as covered, and the `node-22`-only gap disappears. Binding the
+gate to each Node version's own report forces every line to be reached under
+**every** supported Node major — the whole point of testing across the matrix is
+that a line is only protected on a runtime if the tests actually run it there.
+
+The 100%-per-version gate is affordable because TypeScript support targets
+**greenfield Vergil components with a limited set of use cases** — not a
+grandfathered legacy import where a 100% bar would be pure friction.
+
+### Coverage-provider contingency
+
+The V8 provider maps native byte-range coverage back to TypeScript source
+through source maps. If that mapping proves imprecise at the 100% bar (spec §4
+caveat 2), the provider switches to `@vitest/coverage-istanbul`, which
+instruments the source directly. That switch is proven or rejected against the
+real gate in T10 — it is a known contingency, not a default.
+
+## Exclusion Discipline
+
+A legitimate coverage gap is acknowledged narrowly and visibly with a V8 ignore
+marker: `/* v8 ignore next */` for a single line, or a matched
+`/* v8 ignore start */` / `/* v8 ignore stop */` pair for a small contiguous
+region.
+
+An exclusion is a **positive acknowledgment of a specific untestable branch**,
+not a way to make the number go up. Markers are reserved for
+**genuinely-unreachable runtime branches** — a defensive `default:` on an
+exhaustive `switch`, code after an `assertNever`, an impossible-condition guard.
+
+**Legitimate** — narrow, adjacent to the untestable code, and self-explaining:
+
+```ts
+switch (state) {
+  case State.Ready:
+    return handleReady();
+  case State.Closed:
+    return handleClosed();
+}
+// Unreachable: the union is exhaustively handled above; this guard exists only
+// to catch a future variant added without a matching case.
+/* v8 ignore next */
+throw new Error(`unreachable state: ${state as string}`);
+```
+
+A legitimate exclusion covers the smallest possible region, sits right on the
+branch it excuses, and reads clearly as "this specific path cannot be exercised,
+and here is why."
+
+**Abuse** — anything that exempts more than the untestable branch itself:
+
+- **Whole-file exemptions.** Excluding an entire file (or wrapping a whole file
+  in a `start`/`stop` pair, or reaching for a coverage `exclude` glob to drop a
+  source file from the denominator) removes real, testable code from the count.
+  This is the primary abuse pattern to reject in review — it converts a coverage
+  gate into a coverage suggestion.
+- **Unexplained markers.** An `/* v8 ignore */` with no comment, or a vague one
+  ("hard to test"), is not an acknowledgment — it is a mute. State the concrete
+  reason the branch cannot be reached.
+- **Exclusions standing in for missing tests.** If a branch *can* be tested,
+  test it. An exclusion is for the genuinely unreachable or the genuinely
+  untestable, not for code the author did not get around to covering.
+
+The discipline is the same shape as the no-standing-suppression rule for
+[type errors](toolchain-and-strictness.md#no-standing-suppression-list): gaps
+are acknowledged one at a time, in place, with a reason — never blanketed. It is
+the written norm for both human and agent authors.
+
+## Tests Must Assert Behavior
+
+100% coverage is necessary but not sufficient. A line counted as covered by a
+test that asserts nothing is a false signal — the gate proves a line *ran*, not
+that it did the right thing. Tests must assert correct behavior, not merely
+execute code to satisfy the threshold.

--- a/docs/site/docs/standards/development/typescript/toolchain-and-strictness.md
+++ b/docs/site/docs/standards/development/typescript/toolchain-and-strictness.md
@@ -1,0 +1,135 @@
+# TypeScript Toolchain and Strictness
+
+## Purpose
+
+Document the concrete strictness set enforced in the TYPECHECK stage and the
+no-standing-suppression rule that governs it. This page **describes** the set; it
+does not choose it. The set is decided and tested in the shareable base tsconfig
+(`src/vergil_tooling/configs/typescript/tsconfig.base.json`) and the language
+registry (`src/vergil_tooling/lib/languages.py`), and this page mirrors that
+single source of truth.
+
+## TYPECHECK Is "The Compiler"
+
+For TypeScript, the TYPECHECK stage is `tsc --noEmit`: a full typecheck under the
+one canonical type engine with the curated strict set turned on. There is no
+Clang-vs-GCC analog — there is exactly one `tsc` — so the two-diagnostics win
+comes instead from pairing `tsc` (structural typing) with typescript-eslint
+(type-aware lint), each run once.
+
+The strict flags are not passed on the `tsc` command line. They live in the
+**shareable base tsconfig** that every consumer `extends`, so the whole set lands
+on every repository through inheritance — the direct analog of C++ threading its
+warning set onto every translation unit's compile line. TYPECHECK is therefore a
+bare `tsc --noEmit` that reads the consumer's own `tsconfig.json`, which extends
+the base.
+
+## The Curated Strict Set
+
+The floor is `strict: true`, tuned upward with a curated set of extras. `strict`
+already implies a family of checks:
+
+```text
+# strict: true implies
+noImplicitAny
+strictNullChecks
+strictFunctionTypes
+strictBindCallApply
+strictPropertyInitialization
+noImplicitThis
+useUnknownInCatchVariables
+alwaysStrict
+```
+
+On top of the `strict` floor, the base tsconfig enables a curated set of extras.
+The complete set enforced today:
+
+```text
+# Floor
+strict
+
+# Curated extras
+noUncheckedIndexedAccess
+exactOptionalPropertyTypes
+noImplicitOverride
+noImplicitReturns
+noFallthroughCasesInSwitch
+noPropertyAccessFromIndexSignature
+noUnusedLocals
+noUnusedParameters
+```
+
+What each extra buys:
+
+| Option | Catches |
+| --- | --- |
+| `noUncheckedIndexedAccess` | an index access (`arr[i]`, `map[key]`) treated as always-present when it may be `undefined` |
+| `exactOptionalPropertyTypes` | assigning explicit `undefined` to an optional property declared without `\| undefined` |
+| `noImplicitOverride` | a method that overrides a base member without the `override` keyword |
+| `noImplicitReturns` | a code path through a function that falls off the end without returning a value |
+| `noFallthroughCasesInSwitch` | a non-empty `switch` case falling through without `break`/`return` |
+| `noPropertyAccessFromIndexSignature` | dotted access to an index-signature member, which hides that the key may not exist |
+| `noUnusedLocals` | a declared local that is never read |
+| `noUnusedParameters` | a function parameter that is never read (prefix with `_` to intend it) |
+
+The base pins these against a **stable TypeScript 5.x release** (pinned in the
+dev images), so the set means the same thing on every run.
+
+## Ownership Lives in the Base tsconfig
+
+This page describes the set; it does not choose it. The set is authored and
+tested in the packaged `tsconfig.base.json` — that is the single source of truth,
+and this document mirrors it. If the set changes, it changes in the base
+tsconfig first and this page is updated to match, never the other way around.
+
+Consumers do not restate the set. A repository's `tsconfig.json` extends the base
+and inherits the strict set through that inheritance; enforcing it is the base's
+job, not each repo's. This is the direct analog of a C++ repository inheriting
+the shared warning flags rather than re-declaring `-Wall -Wextra` on its own
+compile lines.
+
+## No Standing Suppression List
+
+There is **no project-wide standing suppression list** for type errors. A type
+error is fixed, not muted. The strict set is turned on precisely so an error
+cannot accumulate as ignored noise — under `tsc --noEmit` it fails the gate until
+the code is corrected.
+
+The no-standing-suppression rule is enforced two ways — as the written norm here,
+and mechanically by the ESLint flat config through
+`@typescript-eslint/ban-ts-comment`:
+
+- **`// @ts-ignore` is banned outright.** It mutes an error with no record of
+  what it was.
+- **`// @ts-nocheck` is banned outright.** It silences an entire file — the
+  whole-file abuse pattern, exactly the one the coverage rule also rejects.
+- **`// @ts-expect-error` is allowed only with a description.** The rule is
+  configured `allow-with-description`, so a bare `@ts-expect-error` fails lint. A
+  legitimate suppression states the concrete reason inline and is narrow — it
+  sits on the single line it excuses and fails lint again the moment the error it
+  documents goes away (because the expected error no longer occurs).
+
+`eslint-disable` follows the same discipline: local, narrow, and reasoned — never
+a file-level or repo-level blanket that hides a whole rule.
+
+The discipline mirrors the coverage exclusion rule in
+[Testing and Coverage](testing-and-coverage.md#exclusion-discipline): gaps are
+acknowledged narrowly and visibly, one at a time, with a reason — never
+blanketed away.
+
+## Relationship to the LINT Stage
+
+The strict set is distinct from the LINT stage, which runs **Prettier** (format)
+and **ESLint** (type-aware typescript-eslint rules) once:
+
+- **Prettier** runs `prettier --check` against the packaged Prettier config
+  (`semi: true`, `singleQuote: false`, `trailingComma: "all"`,
+  `printWidth: 100`) — formatting only, no logic judgments.
+- **ESLint** runs its flat config with `js.configs.recommended` plus
+  typescript-eslint's `recommendedTypeChecked` (type-aware rules resolved via
+  `projectService: true`, which auto-discovers the nearest `tsconfig`), and
+  carries the `ban-ts-comment` rule above.
+
+TYPECHECK is `tsc`'s own soundness judgment; LINT is dedicated static analysis.
+Both gate a change; neither substitutes for the other. Together they are the
+TypeScript stand-in for C++'s two independent diagnostic engines.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -124,6 +124,11 @@ nav:
           - Shell:
               - Overview: standards/development/shell/overview.md
               - Naming Conventions: standards/development/shell/naming-conventions.md
+          - TypeScript:
+              - Overview: standards/development/typescript/overview.md
+              - Toolchain and Strictness: standards/development/typescript/toolchain-and-strictness.md
+              - Testing and Coverage: standards/development/typescript/testing-and-coverage.md
+              - Naming Conventions: standards/development/typescript/naming-conventions.md
           - Database:
               - Overview: standards/development/database/overview.md
               - Conventions: standards/development/database/conventions.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add the per-language TypeScript standards docs (overview, toolchain-and-strictness, testing-and-coverage, naming-conventions) under docs/site/docs/standards/development/typescript/ and wire them into the mkdocs nav, documenting the strict base tsconfig and tool commands decided in T4.

## Issue Linkage

- Closes #2746

## Notes

- Four docs mirroring the python/ and cpp/ pattern. overview: npm + ESM layout, single-tsc/single-runtime model (TYPECHECK/LINT/AUDIT once, TEST per Node version), prebuilt-only rule, Vitest default, and extending the shareable base tsconfig. toolchain-and-strictness: describes (does not choose) the T4-decided curated strict set (strict + noUncheckedIndexedAccess, exactOptionalPropertyTypes, noImplicitOverride, noImplicitReturns, noFallthroughCasesInSwitch, noPropertyAccessFromIndexSignature, noUnusedLocals, noUnusedParameters) and the no-suppression rule via @typescript-eslint/ban-ts-comment; notes the pinned stable TypeScript 5.x line. testing-and-coverage: 100%-per-Node-version V8 gate plus the /* v8 ignore */ exclusion discipline (legitimate narrow marker vs whole-file abuse). naming-conventions: Conway rules adapted to TS/Node. Validation green (markdownlint on all docs, tests 100%). Ownership of the set stays in T4; this task only documents it.