### PR TITLE
feat(config): add [container].build-command + build-cache-files keys

### DIFF
--- a/src/vergil_tooling/lib/config.py
+++ b/src/vergil_tooling/lib/config.py
@@ -83,7 +83,9 @@ _KNOWN_KEYS: dict[str, frozenset[str]] = {
     "markdownlint": frozenset({"ignore"}),
     "ci": frozenset({"versions", "integration-tests"}),
     "publish": frozenset({"release", "docs", "consumer-refresh"}),
-    "container": frozenset({"env-prefixes", "system-packages"}),
+    "container": frozenset(
+        {"env-prefixes", "system-packages", "build-command", "build-cache-files"}
+    ),
     "validation": frozenset({"container-command"}),
     "actions": frozenset({"extra-allowed-patterns"}),
     "cpp": frozenset({"std", "stdlib"}),
@@ -131,6 +133,15 @@ class ContainerConfig:
     # vergil-project/.github#272). Names only, from the base image's existing apt
     # sources; default [].
     system_packages: list[str]
+    # A single shell command a repo declares in [container].build-command, run in
+    # the container setup step after the vergil-tooling install and before warmup
+    # (epic vergil-project/.github#291). Bakes non-apt deps into the image the way
+    # system-packages bakes apt ones. Must install OUTSIDE /workspace (the runtime
+    # bind-mount masks workspace paths). Default None ⇒ no build step.
+    build_command: str | None = None
+    # Repo-relative files the build-command reads (e.g. a lockfile), folded into
+    # the image cache hash so a dependency bump rebuilds. Default [].
+    build_cache_files: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -578,7 +589,22 @@ def _parse_raw_config(raw: dict[str, Any], source: str = CONFIG_FILE) -> VergilC
         ):
             msg = f"{source}: [container].system-packages must be a list of strings"
             raise ConfigError(msg)
-        container = ContainerConfig(env_prefixes=env_prefixes, system_packages=system_packages)
+        build_command = container_raw.get("build-command")
+        if build_command is not None and not isinstance(build_command, str):
+            msg = f"{source}: [container].build-command must be a string"
+            raise ConfigError(msg)
+        build_cache_files = container_raw.get("build-cache-files", [])
+        if not isinstance(build_cache_files, list) or not all(
+            isinstance(p, str) for p in build_cache_files
+        ):
+            msg = f"{source}: [container].build-cache-files must be a list of strings"
+            raise ConfigError(msg)
+        container = ContainerConfig(
+            env_prefixes=env_prefixes,
+            system_packages=system_packages,
+            build_command=build_command,
+            build_cache_files=build_cache_files,
+        )
     else:
         container = ContainerConfig(env_prefixes=[], system_packages=[])
 
@@ -701,6 +727,33 @@ def container_system_packages(repo_root: Path) -> list[str]:
     except FileNotFoundError:
         return []
     return cfg.container.system_packages
+
+
+def container_build_command(repo_root: Path) -> str | None:
+    """Return ``[container].build-command`` from vergil.toml, or ``None``.
+
+    The single reader of the key; the local cache build and the CI setup step
+    both resolve the command through this. Must install outside ``/workspace``
+    (the runtime bind-mount masks workspace paths). Epic vergil-project/.github#291.
+    """
+    try:
+        cfg = read_config(repo_root)
+    except FileNotFoundError:
+        return None
+    return cfg.container.build_command
+
+
+def container_build_cache_files(repo_root: Path) -> list[str]:
+    """Return ``[container].build-cache-files`` from vergil.toml, or ``[]``.
+
+    Repo-relative files the build-command reads; folded into the image cache
+    hash so a dependency bump rebuilds. Epic vergil-project/.github#291.
+    """
+    try:
+        cfg = read_config(repo_root)
+    except FileNotFoundError:
+        return []
+    return cfg.container.build_cache_files
 
 
 def validation_container_command(repo_root: Path) -> str:

--- a/tests/vergil_tooling/test_config.py
+++ b/tests/vergil_tooling/test_config.py
@@ -22,6 +22,8 @@ from vergil_tooling.lib.config import (
     ValidationConfig,
     VmStanza,
     _warn_unrecognized_keys,
+    container_build_cache_files,
+    container_build_command,
     container_env_prefixes,
     container_system_packages,
     parse_vm_stanza,
@@ -734,6 +736,80 @@ def test_container_system_packages_accessor(tmp_path: Path) -> None:
 
 def test_container_system_packages_no_file(tmp_path: Path) -> None:
     assert container_system_packages(tmp_path) == []
+
+
+# -- [container].build-command + build-cache-files (epic .github#291) ----------
+
+
+def test_read_config_container_build_command(tmp_path: Path) -> None:
+    toml = (
+        _VALID_TOML
+        + "[container]\nenv-prefixes = []\n"
+        + 'build-command = "npm install -g @coderline/alphatab"\n'
+        + 'build-cache-files = ["melete-render/package-lock.json"]\n'
+    )
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.container.build_command == "npm install -g @coderline/alphatab"
+    assert cfg.container.build_cache_files == ["melete-render/package-lock.json"]
+
+
+def test_read_config_container_build_command_defaults(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[container]\nenv-prefixes = []\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    cfg = read_config(tmp_path)
+    assert cfg.container.build_command is None
+    assert cfg.container.build_cache_files == []
+
+
+def test_read_config_container_no_section_build_command_defaults(tmp_path: Path) -> None:
+    (tmp_path / "vergil.toml").write_text(_VALID_TOML)
+    cfg = read_config(tmp_path)
+    assert cfg.container.build_command is None
+    assert cfg.container.build_cache_files == []
+
+
+def test_read_config_container_build_command_not_string(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '[container]\nenv-prefixes = []\nbuild-command = ["a", "b"]\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[container\]\.build-command must be a string"):
+        read_config(tmp_path)
+
+
+def test_read_config_container_build_cache_files_not_list(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '[container]\nenv-prefixes = []\nbuild-cache-files = "lock"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[container\]\.build-cache-files must be a list"):
+        read_config(tmp_path)
+
+
+def test_read_config_container_build_cache_files_not_strings(tmp_path: Path) -> None:
+    toml = _VALID_TOML + "[container]\nenv-prefixes = []\nbuild-cache-files = [1, 2]\n"
+    (tmp_path / "vergil.toml").write_text(toml)
+    with pytest.raises(ConfigError, match=r"\[container\]\.build-cache-files must be a list"):
+        read_config(tmp_path)
+
+
+def test_container_build_command_accessor(tmp_path: Path) -> None:
+    toml = _VALID_TOML + '[container]\nenv-prefixes = []\nbuild-command = "make deps"\n'
+    (tmp_path / "vergil.toml").write_text(toml)
+    assert container_build_command(tmp_path) == "make deps"
+
+
+def test_container_build_command_no_file(tmp_path: Path) -> None:
+    assert container_build_command(tmp_path) is None
+
+
+def test_container_build_cache_files_accessor(tmp_path: Path) -> None:
+    toml = (
+        _VALID_TOML + '[container]\nenv-prefixes = []\nbuild-cache-files = ["a.lock", "b.lock"]\n'
+    )
+    (tmp_path / "vergil.toml").write_text(toml)
+    assert container_build_cache_files(tmp_path) == ["a.lock", "b.lock"]
+
+
+def test_container_build_cache_files_no_file(tmp_path: Path) -> None:
+    assert container_build_cache_files(tmp_path) == []
 
 
 # -- [validation] section -----------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Add two optional [container] keys — build-command (a single shell string) and build-cache-files (its input files) — with validation and single-reader accessors, as Task 1 of epic vergil-project/.github#291.

## Issue Linkage

- Closes #2762

## Notes

- Config-only, no behaviour change yet: surfaces the keys for Task 2 (local cache-build bake) and Task 3 (CI speller). ContainerConfig gains build_command (default None) and build_cache_files (default []) as defaulted dataclass fields, so the 5 existing ContainerConfig(...) constructions and their equality tests are untouched. Validation mirrors system-packages (string / list-of-strings, fail-closed). 100% coverage held; full vrg-validate green.