### PR TITLE
fix(ts): resolve packaged ESLint flat config from the consumer repo

### DIFF
--- a/src/vergil_tooling/configs/typescript/eslint.config.mjs
+++ b/src/vergil_tooling/configs/typescript/eslint.config.mjs
@@ -4,9 +4,14 @@
 // (@typescript-eslint/ban-ts-comment) that bans bare `@ts-ignore`/`@ts-nocheck`
 // and requires a description on `@ts-expect-error` (spec §3.2).
 //
-// Referenced by the registry LINT command as `eslint . --config
-// {configs}/typescript/eslint.config.mjs`; the packages it imports
-// (@eslint/js, typescript-eslint) ship in the `prod-ts-node:*` images (T1).
+// The registry LINT command stages this file into the consumer repo root at
+// lint time and runs `eslint . --config ./.vergil-eslint.config.mjs` there
+// (see the LINT wiring in languages.py, #2771). Staging is required because
+// this is an ESM config: Node resolves its bare imports (@eslint/js,
+// typescript-eslint) relative to *this file's own directory*, so it must live
+// inside the repo tree for those imports to resolve against the consumer's
+// repo-local node_modules (populated by `npm ci`) — the packaged path inside
+// the vergil-tooling Python package has no adjacent node_modules.
 // `projectService: true` auto-discovers the consumer's nearest tsconfig, so the
 // type-aware rules resolve type information without a hard-coded project path.
 

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -604,6 +604,28 @@ _REGISTRY: dict[str, Language] = {
             # ``@typescript-eslint/ban-ts-comment`` (the no-standing-suppression
             # rule, §3.2). Prettier and ESLint ignore ``node_modules`` by
             # default.
+            #
+            # **ESLint config staging (#2771).** The flat config is ESM, and
+            # Node resolves its bare imports (``@eslint/js``,
+            # ``typescript-eslint``) **relative to the config file's own
+            # directory**, not the repo cwd. The packaged config lives inside
+            # the vergil-tooling Python package, which has no adjacent
+            # ``node_modules`` — so, referenced by its packaged path, those
+            # imports fail with ``ERR_MODULE_NOT_FOUND`` for every consumer
+            # (and ``NODE_PATH`` does not help: ESM ignores it). Option 1 fix:
+            # stage the packaged config into the repo root at lint time so ESM
+            # resolution walks up to the consumer's repo-local ``node_modules``
+            # (populated by ``npm ci``), then remove it. The ``EXIT`` trap
+            # fires on success, failure, or signal and preserves eslint's exit
+            # code; the ``.mjs`` extension forces ESM loading regardless of the
+            # consumer's ``package.json`` ``"type"``; and the dot-prefixed name
+            # is matched by no config entry, so eslint never lints the staged
+            # file itself. This is the ``sh -c`` wrapper idiom already used by
+            # the C++ clang-format LINT command (commands exec directly, with
+            # no shell). Shipping the config's deps in the image globals
+            # (rejected here) would not work anyway given the ESM/``NODE_PATH``
+            # fact; a real ``@vergil/eslint-config`` npm package is the
+            # follow-on (deferred, vergil-project/.github#286).
             CheckKind.LINT: [
                 [
                     "prettier",
@@ -612,7 +634,14 @@ _REGISTRY: dict[str, Language] = {
                     "--config",
                     "{configs}/typescript/prettier.config.json",
                 ],
-                ["eslint", ".", "--config", "{configs}/typescript/eslint.config.mjs"],
+                [
+                    "sh",
+                    "-c",
+                    "cfg=./.vergil-eslint.config.mjs; "
+                    "trap 'rm -f \"$cfg\"' EXIT; "
+                    'cp "{configs}/typescript/eslint.config.mjs" "$cfg"; '
+                    'eslint . --config "$cfg"',
+                ],
             ],
             # TYPECHECK runs *once* (§3.6) — one canonical type engine. The
             # curated "warnings to 11" set lives in the packaged base tsconfig

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -483,10 +483,37 @@ def test_typescript_lint_commands() -> None:
     joined = _joined(cmds)
     # Prettier format check + ESLint, each against a packaged config.
     assert any(c.startswith("prettier --check .") for c in joined)
-    assert any(c.startswith("eslint .") for c in joined)
+    # ESLint runs inside an ``sh -c`` staging wrapper (see below); the
+    # invocation itself is still ``eslint . --config <staged .mjs>``.
+    assert any("eslint . --config" in c for c in joined)
     # Both reference a packaged {configs}/typescript/* config.
     assert any("/typescript/prettier.config.json" in c for c in joined)
     assert any("/typescript/eslint.config.mjs" in c for c in joined)
+
+
+def test_typescript_eslint_staged_into_repo_for_esm_resolution() -> None:
+    """ESLint's ESM flat config is staged into the repo so its bare imports
+    (@eslint/js, typescript-eslint) resolve against the consumer's repo-local
+    node_modules rather than the packaged path with no adjacent node_modules
+    (#2771)."""
+    cmds = language_commands("typescript", CheckKind.LINT)
+    eslint = [c for c in cmds if "eslint" in " ".join(c)]
+    assert len(eslint) == 1
+    wrapper = eslint[0]
+    # A shell wrapper is required to copy-in / copy-out the config.
+    assert wrapper[:2] == ["sh", "-c"]
+    script = wrapper[2]
+    staged = "./.vergil-eslint.config.mjs"
+    # The packaged config is copied into the repo tree, eslint points at the
+    # staged copy (not the packaged path), and the staged file is cleaned up
+    # on exit via a trap so nothing is left in the consumer tree.
+    assert "cp " in script and "/typescript/eslint.config.mjs" in script
+    assert 'eslint . --config "$cfg"' in script
+    assert f"cfg={staged}" in script
+    assert "trap 'rm -f" in script
+    # The staged name is dot-prefixed and .mjs so it is loaded as ESM and is
+    # matched by no config entry (never linted as a source file).
+    assert staged.endswith(".mjs")
 
 
 def test_typescript_lint_ban_ts_comment_rule_present() -> None:
@@ -508,11 +535,13 @@ def test_typescript_lint_uses_packaged_configs() -> None:
     flat = [arg for cmd in cmds for arg in cmd]
     # No unresolved placeholder survives expansion.
     assert all("{configs}" not in arg for arg in flat)
-    referenced = [arg for arg in flat if "/typescript/" in arg]
-    assert len(referenced) == 2
-    for arg in referenced:
-        path = arg.split("=", 1)[-1]
-        assert Path(path).exists(), f"packaged config missing: {path}"
+    # Both packaged configs the LINT stage relies on must exist on disk.
+    for name in ("prettier.config.json", "eslint.config.mjs"):
+        assert _ts_config_path(name).exists(), f"packaged config missing: {name}"
+    # Each config is referenced by exactly one LINT tool — prettier by its
+    # ``--config`` arg directly, eslint by path inside the staging wrapper.
+    assert any("/typescript/prettier.config.json" in arg for arg in flat)
+    assert any("/typescript/eslint.config.mjs" in arg for arg in flat)
 
 
 def test_typescript_typecheck_commands() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- The TypeScript LINT stage now stages the packaged ESLint flat config into the consumer repo root at lint time so Node's ESM resolution finds the config's bare imports (@eslint/js, typescript-eslint) in the repo-local node_modules that npm ci populates, instead of the packaged path inside the vergil-tooling Python package where they are unresolvable.

## Issue Linkage

- Closes #2771

## Notes

- Option 1 (tooling-side, no npm package, no container change): the eslint LINT command is now an sh -c wrapper (same idiom as the C++ clang-format command) that copies {configs}/typescript/eslint.config.mjs to ./.vergil-eslint.config.mjs in the repo, runs eslint against the staged copy, and removes it via an EXIT trap that preserves eslint's exit code. Because the staged config lives in the repo tree, ESM resolution walks up to the consumer's repo-local node_modules; the dot-prefixed .mjs name forces ESM loading regardless of package.json type and is matched by no config entry, so it is never linted and never left behind (no repo-local shim, no residue). Unit tests updated in test_languages.py (staging wrapper asserted; two eslint-command-shape tests adjusted). vrg-validate green: 4921 passed, 100% coverage, all stages. End-to-end cold proof in prod-ts-node:24 on a minimal npm-installed TS repo: the OLD packaged-path command reproduces ERR_MODULE_NOT_FOUND for @eslint/js (exit 2); the NEW staged command exits 0 and leaves no staged file. Unblocks the held-open T10 end-to-end validation re-run (#2747).