### PR TITLE
docs(ts): documentation-review sweep for TypeScript language support

### DIFF
--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -321,6 +321,15 @@ repository.
 :   Base: `debian:trixie-slim`. Includes g++, gcov, CMake, Conan 2,
     cppcheck, and gcovr.
 
+**`dev-ts-node`** (22, 24)
+:   Base: `debian:trixie-slim` + prebuilt Node from NodeSource (never
+    built from source). Includes Node.js, npm, TypeScript (`tsc`),
+    ESLint + typescript-eslint, Prettier, Vitest, `@vitest/coverage-v8`,
+    and license-checker. The runtime family rides the `ts-node` image
+    suffix and the Node major is the tag (`node-24` → `prod-ts-node:24`);
+    `node-24` is the primary, `node-22` the second (epic
+    [vergil-project/.github#284](https://github.com/vergil-project/.github/issues/284)).
+
 C++ is the one language with a compiler-family axis: it ships **two**
 image families (`dev-cpp-clang` / `dev-cpp-gcc`, and matching `prod-`
 images) so TYPECHECK and TEST run per compiler and per version. The

--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -164,7 +164,7 @@ Required attributes and accepted values:
 | `branching_model` | `library-release`, `application-promotion`, `docs-single-branch` | Determines which branch prefixes `vrg-commit` allows. |
 | `release_model` | `tagged-release`, `continuous-deploy`, `none` | Affects release-flow tooling expectations. |
 | `supported_release_lines` | integer (commonly `1`) | How many concurrent major lines you support. |
-| `primary_language` | `python`, `go`, `java`, `rust`, `ruby`, `cpp`, `shell`, `none` | Determines which per-language validators run. |
+| `primary_language` | `python`, `go`, `java`, `rust`, `ruby`, `cpp`, `typescript`, `shell`, `none` | Determines which per-language validators run. |
 
 The `AI co-authors` section defines which `Co-Authored-By` trailer
 values `vrg-commit` accepts for `--agent`. Add one line per accepted

--- a/docs/site/docs/reference/lint/repo-profile.md
+++ b/docs/site/docs/reference/lint/repo-profile.md
@@ -25,7 +25,7 @@ The following attributes must be present and non-empty:
 | `branching_model` | `library-release`, `application-promotion` |
 | `release_model` | `tagged-release`, `continuous-deploy` |
 | `supported_release_lines` | `1`, `2` |
-| `primary_language` | `python`, `go`, `java`, `rust`, `ruby`, `cpp`, `shell` |
+| `primary_language` | `python`, `go`, `java`, `rust`, `ruby`, `cpp`, `typescript`, `shell` |
 
 ## Validation Rules
 


### PR DESCRIPTION
# Pull Request

## Summary

- Reflect the shipped TypeScript language support in vergil-tooling's consumer-facing docs (primary_language tables, dev-ts-node image catalog) and spawn per-repo doc sibling tasks for the fleet's other repos.

## Issue Linkage

- Closes #2738

## Notes

- vergil-tooling edits (this PR): added typescript to the primary_language value lists in docs/site/docs/guides/consuming-repo-setup.md and docs/site/docs/reference/lint/repo-profile.md (matches the config.py enum); added the dev-ts-node (Node 22, 24) entry to the dev-image catalog in docs/site/docs/guides/ci-architecture.md. Verified T8's TypeScript standards docs (overview, toolchain-and-strictness, testing-and-coverage, naming-conventions) are complete and correctly wired into mkdocs nav.

Spawned sibling doc tasks under epic .github#284: vergil-project/.github#296 (add TypeScript to the profile README supported-languages list, mirroring the C++ precedent #217); vergil-project/docs#21 (higher-level TypeScript summary docs, spec §7); vergil-project/vergil-containers#542 (add dev-ts-node to the README Available Images catalog).

Audited and found already adequate (no task): vergil-actions — its docs treat 'language' as a documented free-form input, the CodeQL doc already names JavaScript/TypeScript, and ci-audit already cites npm audit; there is no misleading supported-languages enumeration omitting TypeScript.