### PR TITLE
fix(container): expose NODE_PATH so baked out-of-workspace npm libs resolve

### DIFF
--- a/docs/site/docs/reference/container-config.md
+++ b/docs/site/docs/reference/container-config.md
@@ -4,9 +4,11 @@ A repo customizes its **dev container** through the `[container]` section of its
 `vergil.toml`. The section is optional; every key defaults to empty, so a repo
 that omits `[container]` behaves exactly as it would with an empty table.
 
-Both keys describe the *same* container from two angles: `env-prefixes` controls
+The keys describe the *same* container from a few angles: `env-prefixes` controls
 which host environment variables `vrg-container-run` forwards **into** the
-container, and `system-packages` declares Debian packages installed **inside** it.
+container, `system-packages` declares Debian packages installed **inside** it, and
+`build-command` runs a repo-declared provisioning step when the cached dev image
+is built (with `build-cache-files` naming the inputs that invalidate the cache).
 
 ## Structure
 
@@ -14,6 +16,8 @@ container, and `system-packages` declares Debian packages installed **inside** i
 [container]
 env-prefixes = ["CONAN_AUDIT_PROVIDER_TOKEN"]   # forward matching host env vars
 system-packages = ["lilypond"]                  # install Debian packages
+build-command = "npm install -g @coderline/alphatab"  # provision non-apt deps
+build-cache-files = ["package-lock.json"]       # inputs that invalidate the cache
 ```
 
 ## Keys
@@ -22,6 +26,8 @@ system-packages = ["lilypond"]                  # install Debian packages
 |---|---|---|---|
 | `env-prefixes` | list of strings | `[]` | Host env-var name **prefixes** `vrg-container-run` forwards into the container (accumulates) |
 | `system-packages` | list of strings | `[]` | Debian `apt` package **names** baked into the local cached dev image and installed on CI test jobs (see below) |
+| `build-command` | string | *(unset)* | A shell command run while the cached dev image is built, to provision a non-apt dependency **outside `/workspace`** (see below) |
+| `build-cache-files` | list of strings | `[]` | Repo-relative files the `build-command` reads; folded into the image cache hash so a bump forces a rebuild |
 
 ## `env-prefixes`
 
@@ -129,3 +135,69 @@ vrg-container-system-packages --install-script  # the exact apt snippet CI runs
 The plain-list mode is a human-facing inspection affordance ("what would this
 repo install?"); `--install-script` emits the single, shared apt speller that
 both the local image build and the CI step execute verbatim.
+
+## `build-command`
+
+A shell command run once while the per-branch cached dev image is built (after the
+`system-packages` apt step and the vergil-tooling install, before the language
+warmup). It is the escape hatch for a dependency that is **not** an apt package and
+**not** a language package the base image already carries — for example a JS
+library a test driver consumes at runtime (epic
+[vergil-project/.github#291](https://github.com/vergil-project/.github/issues/291)).
+
+### The out-of-workspace contract
+
+`vrg-container-run` bind-mounts the repo over `/workspace` at run time, which
+**masks** anything the build wrote under `/workspace`. So a `build-command` must
+install its artifact **outside `/workspace`** (a global/system location baked into
+the image), or the run-time mount hides it. A global install is the usual way to
+land outside the workspace — e.g. `npm install -g <pkg>` writes to
+`/usr/lib/node_modules`, which is image-resident and survives the mount.
+
+Landing the artifact outside `/workspace` makes it **present**, but *present* is
+not the same as *resolvable*, and the two differ by artifact kind:
+
+- **Executables** are on `PATH`. A globally-installed CLI (`npm install -g` of a
+  package with a `bin`, a `pip install` console script, a Go binary in
+  `/usr/local/bin`) is on `PATH` and runs as-is — no extra configuration.
+- **Libraries are not automatically on the language's module-resolution path.**
+  This is the correction to the earlier contract wording: a global `npm install -g`
+  of a *library* is **not** "on the default resolution path." A global npm install
+  puts *executables* on `PATH` but does **not** add the npm global root
+  (`/usr/lib/node_modules`) to Node's `require` search path. Without help,
+  `require("<lib>")` / `require.resolve("<lib>")` returns `MODULE_NOT_FOUND` even
+  though the package is baked into the image (validated in
+  [vergil-project/vergil-tooling#2766](https://github.com/vergil-project/vergil-tooling/issues/2766);
+  this also corrects the design spec's §4, tracked for the epic doc-sweep
+  [#2756](https://github.com/vergil-project/vergil-tooling/issues/2756)).
+
+### `NODE_PATH` for baked npm libraries
+
+To make a baked npm **library** resolvable, `vrg-container-run` sets `NODE_PATH`
+to the npm global root (`/usr/lib/node_modules`, i.e. `npm root -g` on the vergil
+base images) **whenever the repo declares a `build-command`**, so
+`require.resolve("<lib>")` resolves out of the box. A repo that declares no
+`build-command` is unaffected — no `NODE_PATH` is set, and its container
+environment is byte-for-byte unchanged.
+
+Two caveats:
+
+- **CommonJS only.** `NODE_PATH` is honoured by CommonJS `require`; **ESM `import`
+  ignores it**. A library consumed via ESM `import` needs a different mechanism
+  (e.g. a repo-local `node_modules` populated by `npm ci`, or staging the module
+  into a directory ESM resolution walks up to).
+- **Overridable.** An explicit `NODE_PATH` in the host environment wins, so a
+  consumer can point resolution at a different location at run time.
+
+The value rides the container **run** invocation rather than being baked into the
+image with `commit --change ENV`, because the `nerdctl` runtime's `commit --change`
+supports only `CMD`/`ENTRYPOINT` directives (not `ENV`); setting it on the run
+path works identically across the `docker` and `nerdctl` runtimes.
+
+### Cache key
+
+Like `system-packages`, editing `build-command` changes `vergil.toml`, which is in
+the cache-sensitive file set, so a change forces an image rebuild. When the command
+reads a lockfile whose *contents* (not the command string) determine what gets
+installed, list that lockfile in `build-cache-files` so a dependency bump also
+invalidates the cache.

--- a/src/vergil_tooling/lib/container.py
+++ b/src/vergil_tooling/lib/container.py
@@ -35,6 +35,20 @@ _DEFAULT_VERSIONS: dict[str, str] = {
 
 _DEFAULT_PREFIX = "prod"
 
+# npm's global prefix on the vergil base images is ``/usr``, so ``npm root -g``
+# is ``/usr/lib/node_modules``. A library baked there by a
+# ``[container].build-command`` global install (``npm install -g <lib>``) is
+# **not** on Node's default module-resolution path — a global install puts
+# *executables* on ``PATH`` but does not put *libraries* on the ``require``
+# search path — so ``require()`` / ``require.resolve()`` returns
+# ``MODULE_NOT_FOUND`` unless ``NODE_PATH`` points at the global root. We expose
+# it on the run path (below) so a baked library resolves out of the box. Two
+# caveats worth knowing: ``NODE_PATH`` is honoured by CommonJS ``require`` only —
+# ESM ``import`` ignores it — and a consumer can override the location by setting
+# ``NODE_PATH`` in the host environment. (issue #2781, epic
+# vergil-project/.github#291)
+_NPM_GLOBAL_ROOT = "/usr/lib/node_modules"
+
 _DEFAULT_TEST_COMMANDS: dict[str, str] = {
     "ruby": "bundle install --jobs 4 && bundle exec rake",
     "python": "uv sync && uv run pytest tests/ -v",
@@ -303,6 +317,21 @@ def build_container_args(
     # host UV_LINK_MODE wins, so an operator can still override it. (#2461)
     uv_link_mode = os.environ.get("UV_LINK_MODE", "copy")
     container_args.extend(["-e", f"UV_LINK_MODE={uv_link_mode}"])
+
+    # Expose the npm global root on NODE_PATH so a library baked out-of-workspace
+    # by a [container].build-command global install resolves via CommonJS
+    # `require` at runtime (see _NPM_GLOBAL_ROOT). Gated on a declared
+    # build-command so every repo that declares none is byte-for-byte unchanged.
+    # An explicit host NODE_PATH wins, letting a consumer override the location.
+    # This lives on the run path rather than being baked into the cached image
+    # because nerdctl's `commit --change` supports only CMD/ENTRYPOINT, not ENV
+    # (verified: `unknown change directive "ENV"`), so a commit-time ENV would not
+    # be portable across the docker/nerdctl runtimes. (issue #2781)
+    from vergil_tooling.lib.config import container_build_command
+
+    if container_build_command(repo_root) is not None:
+        node_path = os.environ.get("NODE_PATH", _NPM_GLOBAL_ROOT)
+        container_args.extend(["-e", f"NODE_PATH={node_path}"])
 
     # Mount host git config so git identity is available in the container.
     gitconfig = Path.home() / ".gitconfig"

--- a/tests/vergil_tooling/test_container.py
+++ b/tests/vergil_tooling/test_container.py
@@ -11,6 +11,7 @@ import pytest
 from vergil_tooling.lib.container import (
     _DEFAULT_TEST_COMMANDS,
     _DEFAULT_VERSIONS,
+    _NPM_GLOBAL_ROOT,
     assert_docker_available,
     build_container_args,
     build_docker_args,
@@ -451,6 +452,81 @@ def test_build_container_args_omits_venv_mask_for_non_python(tmp_path: Path) -> 
     with patch.dict("os.environ", {}, clear=True):
         args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
     assert "/workspace/.venv" not in args
+
+
+_TOML_WITH_BUILD_COMMAND = """\
+[project]
+repository-type = "library"
+versioning-scheme = "semver"
+branching-model = "library-release"
+release-model = "tagged-release"
+primary-language = "typescript"
+
+[dependencies]
+vergil = "v2.0"
+
+[ci]
+versions = ["node-24"]
+
+[container]
+env-prefixes = []
+build-command = "npm install -g is-number"
+"""
+
+
+def test_build_container_args_sets_node_path_when_build_command_declared(
+    tmp_path: Path,
+) -> None:
+    # A [container].build-command global install bakes a library outside
+    # /workspace but off Node's default require path; NODE_PATH points at the
+    # npm global root so it resolves (#2781).
+    (tmp_path / "vergil.toml").write_text(_TOML_WITH_BUILD_COMMAND)
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(args, "NODE_PATH") == _NPM_GLOBAL_ROOT
+    assert _NPM_GLOBAL_ROOT == "/usr/lib/node_modules"
+
+
+def test_build_container_args_no_node_path_without_build_command(tmp_path: Path) -> None:
+    # No build-command ⇒ behaviour is byte-identical to before: no NODE_PATH is
+    # injected for any repo that declares none (#2781).
+    baseline = None
+    with patch.dict("os.environ", {}, clear=True):
+        baseline = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(baseline, "NODE_PATH") is None
+    assert "NODE_PATH" not in " ".join(baseline)
+
+
+def test_build_container_args_no_node_path_when_config_has_no_build_command(
+    tmp_path: Path,
+) -> None:
+    # A vergil.toml present, with a [container] table but no build-command, is
+    # still unchanged — the gate is the build-command, not the table.
+    (tmp_path / "vergil.toml").write_text(
+        _TOML_WITH_BUILD_COMMAND.replace('build-command = "npm install -g is-number"\n', "")
+    )
+    with patch.dict("os.environ", {}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(args, "NODE_PATH") is None
+
+
+def test_build_container_args_host_node_path_overrides_default(tmp_path: Path) -> None:
+    # An explicit host NODE_PATH wins over the npm-global-root default, so a
+    # consumer can point resolution elsewhere (#2781).
+    (tmp_path / "vergil.toml").write_text(_TOML_WITH_BUILD_COMMAND)
+    with patch.dict("os.environ", {"NODE_PATH": "/custom/modules"}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(args, "NODE_PATH") == "/custom/modules"
+
+
+def test_build_container_args_host_node_path_ignored_without_build_command(
+    tmp_path: Path,
+) -> None:
+    # The gate is the declared build-command, not the host env: a host NODE_PATH
+    # alone does not inject the flag for a repo that declares no build-command.
+    with patch.dict("os.environ", {"NODE_PATH": "/custom/modules"}, clear=True):
+        args = build_container_args(tmp_path, "img:1", ["cmd"], runtime="docker")
+    assert _env_value(args, "NODE_PATH") is None
 
 
 def test_build_docker_args_basic(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-container-run now sets NODE_PATH to the npm global root (/usr/lib/node_modules) whenever a repo declares a [container].build-command, so a globally-installed npm library baked outside /workspace resolves via CommonJS require at runtime.

## Issue Linkage

- Closes #2781

## Notes

- Mechanism: run-path fallback, not commit-time image ENV. Verified nerdctl commit --change supports only CMD/ENTRYPOINT (it rejects ENV with 'unknown change directive ENV'), and nerdctl is a primary runtime, so a baked ENV would not be portable; setting -e NODE_PATH on the container run works identically across docker and nerdctl. Gated strictly on a declared build-command — repos declaring none get a byte-identical container env (tested). Host NODE_PATH overrides the default. Caveat documented: NODE_PATH is honored by CommonJS require only; ESM import ignores it. Docs: added the [container].build-command section to docs/site/docs/reference/container-config.md, correcting the earlier 'on the default resolution path' wording and flagging the spec §4 correction for the #2756 doc-sweep. A vergil-tooling release is needed before validation #2766 can re-run (consuming repos pull the released host tool). Validation was fully green (4926 passed, 100% coverage).