### PR TITLE
docs(container): complete the [container].build-command site docs (trust model, CLI, CI, TS xref)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,9 @@ it in a thin `scripts/dev/test.sh`. Environment overrides:
 
 Env-var passthrough is configured per-repo via `[container].env-prefixes`
 in `vergil.toml` (see `docs/specs/2026-05-25-configurable-container-env-passthrough-design.md`).
+The sibling `[container]` keys — `system-packages` (apt names) and
+`build-command`/`build-cache-files` (a non-apt provisioning step) — are documented
+in `docs/site/docs/reference/container-config.md`.
 
 ### Claude Code Hook Guard
 

--- a/docs/site/docs/guides/ci-architecture.md
+++ b/docs/site/docs/guides/ci-architecture.md
@@ -395,3 +395,31 @@ Two things matter for the CI/container model here:
   has no install candidate for the build architecture, the build (local) and the
   CI step both **fail closed**, naming the package and the architecture — no
   silent skip.
+
+### Repo-specific build steps
+
+For a dependency that is **not** an apt package — a JS library a test driver
+consumes at runtime, say — a repo declares a `build-command` (with optional
+`build-cache-files`) instead of `system-packages`:
+
+```toml
+[container]
+build-command = "npm install -g @coderline/alphatab"
+build-cache-files = ["package-lock.json"]
+```
+
+The full key reference — the out-of-workspace contract, the `NODE_PATH` handling
+for baked npm libraries, the trust model, and the cache-key behaviour — lives in
+[Container Config Reference → `build-command`](../reference/container-config.md#build-command).
+It follows the **same two-paths, one-declaration** shape as `system-packages`:
+
+- **Two paths, one declaration.** Locally the command is **baked** into the
+  per-branch cached dev image, so its artifact is present for every check in that
+  one image. In CI the command is **run per job** on the test jobs — the job
+  obtains it with `vrg-container-build-command --script` and runs it against the
+  base-image container before the tests. The two paths agree on *what* is
+  provisioned (the same command string) even though they differ on *when* — baked
+  once locally vs run per test job in CI.
+- **Fail-closed.** A non-zero exit from the command **fails the build** (local)
+  and the CI step, rather than producing an image whose missing dependency only
+  surfaces mysteriously inside a test.

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -234,6 +234,59 @@ repos, wraps with `uv sync --group docs`.
 | Exit codes | 0 (help), 1 error; command exit code after `execvp` |
 | Status | Active |
 
+### vrg-container-build-command
+
+Print a repo's declared `[container].build-command` verbatim, for CI
+consumption. The CI test jobs call `--script` to obtain the exact
+provisioning command to run per job — the same command the local cache
+build bakes into the per-branch image — so the two paths run one
+declaration. Prints nothing when the repo declares no `build-command`.
+See [Container Config Reference → `build-command`](container-config.md#build-command).
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_container_build_command` |
+| Args | `--script` (explicit CI intent; identical output), `--repo-root` (default: CWD) |
+| Preconditions | A readable `vergil.toml` at the repo root (absent/empty key prints nothing) |
+| Failure mode | argparse error on unknown flags; no failure for an unset key |
+| Exit codes | 0 always |
+| Status | Active |
+
+### vrg-container-system-packages
+
+Print a repo's declared `[container].system-packages`, for CI
+consumption. Default mode prints the package names one per line;
+`--install-script` prints the exact apt install snippet — the single
+speller shared with the local cache build — which the CI test jobs run.
+See [Container Config Reference → `system-packages`](container-config.md#system-packages).
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_container_system_packages` |
+| Args | `--install-script` (apt snippet instead of the name list), `--repo-root` (default: CWD) |
+| Preconditions | A readable `vergil.toml` at the repo root (absent/empty key prints nothing) |
+| Failure mode | argparse error on unknown flags; no failure for an unset key |
+| Exit codes | 0 always |
+| Status | Active |
+
+### vrg-container-cache
+
+Manage the per-branch cached container image (base image plus
+vergil-tooling, `system-packages`, and the `build-command` artifact) that
+`vrg-container-run` builds over. Subcommands: `build` (build/refresh the
+cached image for the current branch), `clean` (remove it), `status` (show
+cache state and the expected tag), and `clean-all` (remove every image it
+manages).
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_container_cache` |
+| Args | `build` \| `clean` \| `status` \| `clean-all` |
+| Preconditions | Git repo; a container runtime (`docker`/`nerdctl`) available for `build`/`clean`/`clean-all` |
+| Failure mode | Runtime-unavailable error; propagates the runtime's build/remove failures |
+| Exit codes | 0 success, non-zero on runtime or build failure |
+| Status | Active |
+
 ### vrg-generate-commands
 
 Generate MQSC command methods for all language ports (Python, Ruby,

--- a/docs/site/docs/reference/container-config.md
+++ b/docs/site/docs/reference/container-config.md
@@ -201,3 +201,50 @@ the cache-sensitive file set, so a change forces an image rebuild. When the comm
 reads a lockfile whose *contents* (not the command string) determine what gets
 installed, list that lockfile in `build-cache-files` so a dependency bump also
 invalidates the cache.
+
+### Trust model
+
+`build-command` is a deliberate **broadening** of the surface `system-packages`
+grants. Where `system-packages` is names-only — Debian packages installed from
+the base image's existing sources, with no allowlist because the surface is
+already constrained — `build-command` is **arbitrary shell, run as root, at
+image-build time**. It can fetch URLs, run installers, and write anywhere in the
+image. That is the point (it is the escape hatch for a dependency apt cannot
+express), and it is what makes it a larger grant.
+
+The controls that keep it sound:
+
+- **Reviewed via the `vergil.toml` PR diff.** The command is a plain string in
+  the repo's own `vergil.toml`; adding or changing it is a config change read and
+  approved like any other in the PR diff. There is **no separate allowlist**
+  (unlike the names-only `system-packages` surface, none is needed) — the diff is
+  the review surface.
+- **The fail-closed build is the backstop.** The command runs while the cached
+  image is built; a non-zero exit **fails the build** rather than producing a
+  degraded image, exactly as the `system-packages` apt step does. A broken
+  provisioning step stops the build, it does not leak into a mysteriously failing
+  test.
+- **Artifacts are image-resident and out-of-workspace.** Whatever the command
+  installs lands in the image outside `/workspace` (see the out-of-workspace
+  contract above); it never writes into the mounted repo tree at run time.
+- **No build-time network secrets by default.** The build step runs with the
+  image build's environment, not the run-time forward set — a `build-command`
+  sees a host secret only if the repo deliberately forwards it. Keep credentials
+  out of the command string, which is stored in `vergil.toml` verbatim.
+
+### Inspecting the declared command
+
+`vrg-container-build-command` reads the key through the same single accessor the
+local bake and CI both use (`container_build_command` in
+[`config.py`](https://github.com/vergil-project/vergil-tooling/blob/develop/src/vergil_tooling/lib/config.py)):
+
+```bash
+vrg-container-build-command            # the declared command (nothing if unset)
+vrg-container-build-command --script   # the same command, emitted for CI to run
+```
+
+Both modes print the command verbatim; a repo that declares no `build-command`
+prints nothing. `--script` is the CI-consumption entry point — the CI test jobs
+call it to obtain the exact command to run per job (see
+[CI Architecture → Repo-specific build steps](../guides/ci-architecture.md#repo-specific-build-steps)),
+mirroring how `vrg-container-system-packages --install-script` feeds the apt step.

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -21,6 +21,9 @@ the dev-tree override venv.
 | [vrg-container-run](cli-tools-overview.md#vrg-container-run) | Run commands inside a dev container |
 | [vrg-container-test](cli-tools-overview.md#vrg-container-test) | Run test suite inside a dev container |
 | [vrg-container-docs](cli-tools-overview.md#vrg-container-docs) | Preview/build MkDocs in a dev container |
+| [vrg-container-build-command](cli-tools-overview.md#vrg-container-build-command) | Print the declared `[container].build-command` (CI consumption) |
+| [vrg-container-system-packages](cli-tools-overview.md#vrg-container-system-packages) | Print the declared `[container].system-packages` (CI consumption) |
+| [vrg-container-cache](cli-tools-overview.md#vrg-container-cache) | Manage the per-branch cached dev image |
 | [vrg-generate-commands](cli-tools-overview.md#vrg-generate-commands) | Generate MQSC command methods |
 
 ## Container tools

--- a/docs/site/docs/standards/development/typescript/overview.md
+++ b/docs/site/docs/standards/development/typescript/overview.md
@@ -45,6 +45,31 @@ Package management is **npm**, chosen for universality at zero adoption barrier:
   native ES modules resolved the way modern Node resolves them. A repository's
   `package.json` declares `"type": "module"` to match.
 
+### Baking a non-npm dependency into the dev image
+
+A repo occasionally needs a JS library present in the dev image itself — for
+example a package a test driver loads at runtime that is not part of the repo's
+own `package-lock.json`. That is a `[container].build-command` in `vergil.toml`,
+not an apt package:
+
+```toml
+[container]
+build-command = "npm install -g @coderline/alphatab"
+build-cache-files = ["package-lock.json"]
+```
+
+One TypeScript-specific caveat is load-bearing. A global `npm install -g` puts a
+library's **executables** on `PATH`, but does **not** add the npm global root
+(`/usr/lib/node_modules`) to Node's module-resolution path. So `vrg-container-run`
+sets `NODE_PATH` to that root whenever the repo declares a `build-command`, which
+makes a baked library resolvable **via CommonJS `require`** — but `NODE_PATH` is
+honoured only by `require`. **ESM `import` ignores `NODE_PATH`.** Since Vergil
+repositories are native ESM (per the npm + ESM Layout section above), a baked
+library consumed through `import` needs a different mechanism (a repo-local
+`node_modules`, or staging the module where ESM resolution walks up to it). The
+full contract and the runtime details are in
+[Container Config Reference → `build-command`](../../../reference/container-config.md#build-command).
+
 ## Prebuilt Toolchains Only
 
 Node toolchains come **exclusively from prebuilt stable binary packages — never


### PR DESCRIPTION
# Pull Request

## Summary

- Round out the human-facing site docs for [container].build-command / build-cache-files so the reference matches the shipped feature.

## Issue Linkage

- Closes #2756

## Notes

- Docs-only sweep for epic vergil-project/.github#291. container-config.md gains a Trust model subsection (broadening vs system-packages: arbitrary shell, root, build-time; reviewed via the vergil.toml diff, no allowlist; fail-closed build; out-of-workspace artifacts; no build-time secrets by default) and an Inspecting the declared command subsection for vrg-container-build-command --script. ci-architecture.md gains a Repo-specific build steps section (two-paths/one-declaration: baked locally, run per test job in CI). cli-tools-overview.md and reference/index.md now document vrg-container-build-command plus the pre-existing gaps vrg-container-system-packages and vrg-container-cache. typescript/overview.md notes baking a non-npm dep into the dev image with the NODE_PATH CommonJS-require vs ESM-import caveat. CLAUDE.md points the [container] keys line at the container reference. vrg-validate green; no nav or new-page changes needed.