### PR TITLE
fix(validate): detect Ansible content under a top-level ansible/ directory

### DIFF
--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -119,7 +119,13 @@ _ANSIBLE_FILE_SIGNALS = (
     ".ansible-lint.yaml",
     "galaxy.yml",
 )
-_ANSIBLE_DIR_SIGNALS = ("playbooks", "roles")
+# ``ansible`` is listed first: a top-level ``ansible/`` directory is the most
+# common convention for standardizing Ansible layout (playbooks + a nested
+# ``ansible/roles`` tree), more common than bare root-level
+# ``playbooks/``/``roles/``. Detecting it also covers the nested
+# ``ansible/roles`` and ``ansible/playbooks`` layouts, since those imply a
+# top-level ``ansible/`` directory (issue #1906).
+_ANSIBLE_DIR_SIGNALS = ("ansible", "playbooks", "roles")
 
 
 def _has_ansible_content(repo_root: Path) -> bool:
@@ -127,9 +133,10 @@ def _has_ansible_content(repo_root: Path) -> bool:
 
     Detection is signal-based: a recognized config/manifest file at the
     repo root (``ansible.cfg``, ``.ansible-lint*``, ``galaxy.yml``), a
-    role/collection metadata file (``meta/main.yml``), or a ``playbooks/``
-    or ``roles/`` directory. Mirrors the conditional-skip behavior of the
-    other common checks — no Ansible content means the check is skipped.
+    role/collection metadata file (``meta/main.yml``), or an ``ansible/``,
+    ``playbooks/``, or ``roles/`` directory. Mirrors the conditional-skip
+    behavior of the other common checks — no Ansible content means the
+    check is skipped.
     """
     if any((repo_root / name).is_file() for name in _ANSIBLE_FILE_SIGNALS):
         return True

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -709,6 +709,23 @@ def test_has_ansible_content_roles_dir(tmp_path: Path) -> None:
     assert _has_ansible_content(tmp_path) is True
 
 
+def test_has_ansible_content_ansible_dir(tmp_path: Path) -> None:
+    # A top-level ``ansible/`` directory is the common convention for
+    # standardizing Ansible layout (issue #1906).
+    (tmp_path / "ansible").mkdir()
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_nested_ansible_roles(tmp_path: Path) -> None:
+    (tmp_path / "ansible" / "roles").mkdir(parents=True)
+    assert _has_ansible_content(tmp_path) is True
+
+
+def test_has_ansible_content_nested_ansible_playbooks(tmp_path: Path) -> None:
+    (tmp_path / "ansible" / "playbooks").mkdir(parents=True)
+    assert _has_ansible_content(tmp_path) is True
+
+
 def test_has_ansible_content_signal_file_must_be_file(tmp_path: Path) -> None:
     # A directory named like a file signal must not count as content.
     (tmp_path / "ansible.cfg").mkdir()


### PR DESCRIPTION
# Pull Request

## Summary

- Add "ansible" to _has_ansible_content's directory signals so vrg-validate recognizes repos that nest all Ansible content under a top-level ansible/ directory and runs ansible-lint instead of silently skipping it.

## Issue Linkage

- Closes #1906

## Notes

- Root cause: _ANSIBLE_DIR_SIGNALS only checked root-level playbooks/ and roles/, so the common ansible/ layout (e.g. ansible/site-*.yml plus ansible/roles/) matched no signal and ansible-lint was silently skipped. Fix adds "ansible" as the first directory signal, which also covers nested ansible/roles and ansible/playbooks since those imply a top-level ansible/ dir. TDD: three new _has_ansible_content tests (top-level ansible/, nested ansible/roles, nested ansible/playbooks) added first, then the fix. Full validation green (4929 tests, 100% coverage). Follow-up to #1667.