### PR TITLE
fix(labels): add bug and docs to complete the canonical kind axis

### DIFF
--- a/src/vergil_tooling/data/labels.json
+++ b/src/vergil_tooling/data/labels.json
@@ -1,6 +1,8 @@
 {
   "labels": [
+    {"name": "bug", "color": "d73a4a", "description": "Defect or incorrect behavior to fix"},
     {"name": "feature", "color": "0e8a16", "description": "New feature or capability"},
+    {"name": "docs", "color": "0075ca", "description": "Documentation-only change"},
     {"name": "style", "color": "bfdadc", "description": "Formatting, whitespace, no code change"},
     {"name": "refactor", "color": "d4c5f9", "description": "Code restructuring, no behavior change"},
     {"name": "test", "color": "fbca04", "description": "Adding or updating tests"},

--- a/tests/vergil_tooling/test_data_labels.py
+++ b/tests/vergil_tooling/test_data_labels.py
@@ -23,3 +23,14 @@ def test_archive_label_present_and_wellformed() -> None:
 def test_label_names_are_unique() -> None:
     names = [entry["name"] for entry in _labels()]
     assert len(names) == len(set(names)), "duplicate label names in labels.json"
+
+
+def test_registry_includes_full_kind_axis() -> None:
+    # The canonical registry must own the *complete* kind axis so a repo's first
+    # ``vrg-ensure-label --sync`` seeds a consistent set without relying on GitHub
+    # default labels (which may be renamed or deleted). ``bug`` and ``docs`` were
+    # historically absent — ``bug`` leaned on GitHub's default and ``docs`` had to
+    # be created ad hoc mid-migration (issue #1971).
+    names = {entry["name"] for entry in _labels()}
+    for kind in {"bug", "feature", "docs", "refactor", "chore", "research"}:
+        assert kind in names, f"kind label missing from labels.json: {kind}"

--- a/tests/vergil_tooling/test_labels.py
+++ b/tests/vergil_tooling/test_labels.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from vergil_tooling.lib.labels import load_labels
 
 # GitHub default labels that must not collide with the registry.
+#
+# ``bug`` is intentionally omitted: the registry now owns ``bug`` canonically as
+# part of the full kind axis (issue #1971) rather than leaning on GitHub's
+# default, so ``--sync`` provisions a complete, consistent set regardless of
+# which defaults a repo happens to have. ``documentation`` stays on the list
+# because the registry's documentation kind is ``docs``, not ``documentation``.
 _GITHUB_DEFAULTS = frozenset(
     {
-        "bug",
         "documentation",
         "duplicate",
         "good first issue",

--- a/tests/vergil_tooling/test_vrg_ensure_label.py
+++ b/tests/vergil_tooling/test_vrg_ensure_label.py
@@ -129,8 +129,9 @@ def test_main_sync_provisions_all_labels() -> None:
     label_calls = [c for c in mock_run.call_args_list if c.args[1] == "create"]
     # 18 before retiring the deprecated 'standing' alias (retire-standing task);
     # 18 again after adding the 'retrospective' kind label;
-    # 19 after adding the 'archive' label (adhoc-archive-rename epic #281).
-    assert len(label_calls) == 19
+    # 19 after adding the 'archive' label (adhoc-archive-rename epic #281);
+    # 21 after adding 'bug' and 'docs' to complete the kind axis (issue #1971).
+    assert len(label_calls) == 21
 
 
 def test_main_sync_uses_force_with_color_description() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Add canonical bug and docs entries to data/labels.json so vrg-ensure-label --sync provisions the complete kind axis (bug, feature, docs, refactor, chore, research) rather than leaning on GitHub default labels.

## Issue Linkage

- Closes #1971

## Notes

- labels.json gains bug (d73a4a) and docs (0075ca). Because the registry now owns bug canonically, it is removed from the test_labels.py collision guard (documentation stays, since the registry uses docs, not documentation). Tests updated: test_data_labels.py asserts the full kind axis is present; test_vrg_ensure_label.py sync provisioning count 19 -> 21. No code change to vrg-ensure-label was needed — --sync already provisions whatever the registry defines. Validation green: 4927 passed, 100% coverage.