### PR TITLE
fix(repo-init): derive clone target from the org layout, not CWD

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -125,6 +125,13 @@ def foreign_repo_refusal(ctx: RepoInitContext) -> str | None:
     """
     if ctx.adopt or ctx.target_dir is not None:
         return None
+    # If the clone's org-layout parent is derivable from CWD, the clone lands
+    # correctly beside sibling repos (step_clone derives it) and resume state is
+    # already CWD-guarded in run_wizard, so launching from a subdirectory — even
+    # another repo's clone, like the org .github — is safe. Only refuse when the
+    # layout is NOT derivable and CWD sits inside an unrelated repo (#2225, #2717).
+    if derive_clone_parent(ctx.org) is not None:
+        return None
     inside = cwd_repo_slug()
     if inside is None or inside.lower() == ctx.repo.lower():
         return None
@@ -915,19 +922,53 @@ def step_create_repo(ctx: RepoInitContext) -> None:
     print(f"  Created {ctx.repo}.")
 
 
+def derive_clone_parent(org: str, start: Path | None = None) -> Path | None:
+    """Return the org-layout parent directory for a fresh clone, or ``None``.
+
+    Every managed repo lives at ``<projects>/<org>/<repo>``, so a new clone's
+    parent is the ancestor directory named ``<org>``. Walk up from ``start``
+    (CWD by default), inclusive, and return the first ancestor whose name is
+    ``org`` — letting the operator launch from anywhere inside the org tree, not
+    only the org root (#2225). Return ``None`` when no ancestor is named ``org``;
+    callers turn that into a loud refusal rather than silently cloning into an
+    arbitrary CWD.
+    """
+    base = (start if start is not None else Path.cwd()).resolve()
+    for candidate in (base, *base.parents):
+        if candidate.name == org:
+            return candidate
+    return None
+
+
 def step_clone(ctx: RepoInitContext, *, parent_dir: Path | None = None) -> None:
     """Step 2: Clone the repo locally or verify an existing clone."""
-    if parent_dir is None:
-        # An explicit --target-dir names the clone's parent; otherwise fall back
-        # to CWD (the historical default). #2717.
-        parent_dir = ctx.target_dir or Path.cwd()
-
-    target = parent_dir / ctx.name
-
     if ctx.adopt:
         ctx.work_dir = Path.cwd()
         print("Step 2: Using current directory as working directory.")
         return
+
+    if parent_dir is None:
+        if ctx.target_dir is not None:
+            # An explicit --target-dir names the clone's parent (#2717).
+            parent_dir = ctx.target_dir
+        else:
+            # No explicit target: derive the parent from the org layout so the
+            # clone lands beside sibling repos regardless of which subdirectory
+            # the operator launched from (#2225). Fail loud rather than silently
+            # cloning into an arbitrary CWD when the layout is not derivable.
+            parent_dir = derive_clone_parent(ctx.org)
+            if parent_dir is None:
+                cwd = Path.cwd()
+                print(
+                    f"Step 2: Cannot derive a clone location for {ctx.repo} from {cwd}: "
+                    f"no ancestor directory is named {ctx.org!r}. Managed repos live at "
+                    f"<projects>/{ctx.org}/{ctx.name}. Re-run from inside the {ctx.org!r} "
+                    "directory (or any subdirectory of it), or pass --target-dir <parent>.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+
+    target = parent_dir / ctx.name
 
     if (target / ".git").is_dir():
         ctx.work_dir = target

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -23,6 +23,7 @@ from vergil_tooling.lib.repo_init import (
     _resolve,
     _sync_labels,
     cwd_repo_slug,
+    derive_clone_parent,
     detect_completed_steps,
     foreign_repo_refusal,
     prompt_choice,
@@ -263,6 +264,42 @@ class TestForeignRepoRefusal:
         assert "mnemosys-project/docs" in msg
         assert "mnemosys-project/.github" in msg
         assert "--target-dir" in msg
+
+    def test_none_when_org_layout_derivable_inside_foreign_repo(self, tmp_path: Path) -> None:
+        # Launched from the org .github clone: cwd_repo_slug reports a foreign
+        # repo, but the org-layout parent is derivable, so the clone will land
+        # correctly beside sibling repos — no refusal (#2225).
+        org_dir = tmp_path / "mnemosys-project"
+        nested = org_dir / ".github"
+        nested.mkdir(parents=True)
+        ctx = RepoInitContext(org="mnemosys-project", name="docs")
+
+        with (
+            patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=nested),
+            patch(
+                "vergil_tooling.lib.repo_init.cwd_repo_slug",
+                return_value="mnemosys-project/.github",
+            ),
+        ):
+            assert foreign_repo_refusal(ctx) is None
+
+
+class TestDeriveCloneParent:
+    def test_returns_org_root_when_cwd_is_org_dir(self, tmp_path: Path) -> None:
+        org_dir = tmp_path / "vergil-project"
+        org_dir.mkdir()
+        assert derive_clone_parent("vergil-project", org_dir) == org_dir.resolve()
+
+    def test_walks_up_to_org_root_from_nested_cwd(self, tmp_path: Path) -> None:
+        org_dir = tmp_path / "vergil-project"
+        nested = org_dir / ".github" / "workflows"
+        nested.mkdir(parents=True)
+        assert derive_clone_parent("vergil-project", nested) == org_dir.resolve()
+
+    def test_returns_none_when_no_ancestor_matches_org(self, tmp_path: Path) -> None:
+        stray = tmp_path / "somewhere-else"
+        stray.mkdir()
+        assert derive_clone_parent("vergil-project", stray) is None
 
 
 class TestRenderVergilToml:
@@ -977,9 +1014,13 @@ class TestStepClone:
         step_clone(ctx)
         assert ctx.work_dir is not None
 
-    def test_default_parent_dir(self, tmp_path: Path) -> None:
+    def test_derives_parent_from_org_root(self, tmp_path: Path) -> None:
+        # No --target-dir: launched from the org directory itself. The clone
+        # lands beside sibling repos under <projects>/<org>/ (#2225).
+        org_dir = tmp_path / "vergil-project"
+        org_dir.mkdir()
+        target = org_dir / "vergil-vm"
         ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
-        target = tmp_path / "vergil-vm"
 
         def mock_subprocess_run(cmd: Any, **kw: Any) -> None:
             target.mkdir(exist_ok=True)
@@ -990,13 +1031,59 @@ class TestStepClone:
                 "vergil_tooling.lib.repo_init.subprocess.run",
                 side_effect=mock_subprocess_run,
             ),
-            patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=tmp_path),
+            patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=org_dir),
             patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
             patch("vergil_tooling.lib.repo_init.os.chdir"),
         ):
             step_clone(ctx)
 
         assert ctx.work_dir == target
+
+    def test_derives_parent_from_nested_cwd(self, tmp_path: Path) -> None:
+        # Launched from a subdirectory of the org tree (e.g. the org .github
+        # clone). The clone still lands beside sibling repos, not nested in the
+        # subdirectory the operator happened to be in (#2225).
+        org_dir = tmp_path / "vergil-project"
+        nested = org_dir / ".github"
+        nested.mkdir(parents=True)
+        target = org_dir / "vergil-vm"
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+
+        def mock_subprocess_run(cmd: Any, **kw: Any) -> None:
+            target.mkdir(exist_ok=True)
+            (target / ".git").mkdir()
+
+        with (
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=mock_subprocess_run,
+            ),
+            patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=nested),
+            patch("vergil_tooling.lib.repo_init.prompt_yes_no", return_value=True),
+            patch("vergil_tooling.lib.repo_init.os.chdir"),
+        ):
+            step_clone(ctx)
+
+        assert ctx.work_dir == target
+
+    def test_fails_loud_when_org_layout_not_derivable(self, tmp_path: Path) -> None:
+        # No --target-dir and no ancestor named after the org: refuse loudly
+        # rather than silently cloning into an arbitrary CWD (#2225).
+        stray = tmp_path / "somewhere-else"
+        stray.mkdir()
+        ctx = RepoInitContext(org="vergil-project", name="vergil-vm")
+
+        with (
+            patch("vergil_tooling.lib.repo_init.Path.cwd", return_value=stray),
+            patch(
+                "vergil_tooling.lib.repo_init.subprocess.run",
+                side_effect=AssertionError("must not clone when the layout is underivable"),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            step_clone(ctx)
+
+        assert excinfo.value.code == 1
 
     def test_clone_changes_cwd(self, tmp_path: Path) -> None:
         ctx = RepoInitContext(org="vergil-project", name="vergil-vm")


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-github-repo-init now derives a new repo's clone parent by walking up from CWD to the ancestor directory named after the org, so the clone lands beside the org's sibling repos regardless of which subdirectory the wizard was launched from.

## Issue Linkage

- Closes #2225

## Notes

- New derive_clone_parent(org) helper walks up from CWD (inclusive) to the ancestor named <org>; step_clone uses it when no --target-dir is given and fails loud with SystemExit(1) plus guidance when the org layout is not derivable, instead of silently cloning into an arbitrary CWD. foreign_repo_refusal (from #2717) now defers to the same derivation so the reported repro — launching from the org .github clone — is auto-corrected rather than merely refused; it still refuses when the layout is not derivable and CWD sits inside an unrelated repo. Resume-state safety is unchanged (run_wizard only trusts local checkpoints when CWD is the target's own clone). Tests added: derivation from the org root, from a nested CWD, the fail-loud path, derive_clone_parent unit tests, and a foreign-repo no-refusal case. Full validation green (4932 passed, 100% coverage).