### PR TITLE
fix(pr-workflow): gate batch ready selection on is_frozen so unfrozen worktrees are excluded

### DIFF
--- a/src/vergil_tooling/lib/pr_workflow/submission.py
+++ b/src/vergil_tooling/lib/pr_workflow/submission.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from vergil_tooling.lib.pr_workflow import engine
 from vergil_tooling.lib.pr_workflow.errors import AlreadySubmittedError, WorkflowError
+from vergil_tooling.lib.pr_workflow.freeze import is_frozen
 from vergil_tooling.lib.pr_workflow.local_transport import LocalFileTransport
 from vergil_tooling.lib.pr_workflow.state import WorkflowState
 
@@ -51,8 +52,13 @@ def read_pr_fields(worktree_root: Path) -> dict[str, str]:
 
     Raises ``FileNotFoundError`` if the state file does not exist,
     ``AlreadySubmittedError`` if it is marked submitted (its PR is in flight),
-    and ``WorkflowError`` if it carries no PR metadata yet (the USER agent must
-    ``report-ready`` first).
+    and ``WorkflowError`` if it is not in the ready state — either it carries no
+    PR metadata yet, or it was deliberately reopened via ``vrg-pr-workflow
+    unfreeze`` (``status == "implementing"``) even though it still retains PR
+    metadata from an earlier ``report-ready``. The ready gate here is
+    :func:`freeze.is_frozen` — the single authoritative predicate — so the
+    batch/single submission selectors can never drift from the freeze the rest
+    of the tooling enforces (issue #2741).
     """
     path = _state_path(worktree_root)
     if not path.is_file():
@@ -68,6 +74,18 @@ def read_pr_fields(worktree_root: Path) -> dict[str, str]:
         raise WorkflowError(
             "the workflow has no PR metadata yet; the USER agent must run "
             "`report-ready` before the PR can be submitted"
+        )
+    # Route the ready gate through the authoritative predicate: a worktree that
+    # retains PR metadata is still submittable only when ``is_frozen`` holds
+    # (``status == "ready"`` and not submitted). This excludes a post-``unfreeze``
+    # ``implementing`` tree even though it kept its earlier ``pr_metadata`` —
+    # otherwise the batch selector would sweep in-progress work (issue #2741).
+    if not is_frozen(state):
+        raise WorkflowError(
+            f"the workflow is not ready (status={state.status!r}); the USER "
+            "agent must run `report-ready` before the PR can be submitted "
+            "(a branch reopened with `vrg-pr-workflow unfreeze` is back in "
+            "`implementing` and stays excluded until it is reported ready again)"
         )
     return {
         "issue": state.issue,

--- a/tests/vergil_tooling/pr_workflow/test_submission.py
+++ b/tests/vergil_tooling/pr_workflow/test_submission.py
@@ -57,6 +57,23 @@ def test_read_pr_fields_errors_when_state_has_no_metadata(tmp_path: Path) -> Non
         submission.read_pr_fields(tmp_path)
 
 
+def test_read_pr_fields_excludes_unfrozen_worktree_that_kept_metadata(tmp_path: Path) -> None:
+    """Regression for issue #2741: a worktree reported ready and then reopened
+    via ``vrg-pr-workflow unfreeze`` drops to ``status == "implementing"`` while
+    *retaining* its ``pr_metadata``. That mid-flight state must be classified as
+    not-ready so ``vrg-submit-pr --all`` never sweeps it into a batch."""
+    _write_state(tmp_path, with_metadata=True)
+    state = LocalFileTransport(tmp_path, base="develop").read()
+    assert state is not None
+    engine.apply_unfreeze(state, now=_NOW)
+    LocalFileTransport(tmp_path, base="develop").write(state)
+    # Metadata is retained (unfreeze keeps it), but status is now implementing.
+    assert state.status == "implementing"
+    assert state.pr_metadata is not None
+    with pytest.raises(WorkflowError, match="not ready"):
+        submission.read_pr_fields(tmp_path)
+
+
 def test_read_pr_fields_raises_when_state_file_absent(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         submission.read_pr_fields(tmp_path)


### PR DESCRIPTION
# Pull Request

## Summary

- Route read_pr_fields through freeze.is_frozen so a worktree reopened via vrg-pr-workflow unfreeze (status=implementing, retained pr_metadata) is classified not-ready and excluded from vrg-submit-pr --all/--select batches.

## Issue Linkage

- Closes #2741

## Notes

- Root cause: read_pr_fields checked submitted/pr_metadata but never status, so a post-unfreeze implementing tree that kept its metadata passed the batch selector (_ready_worktrees). Fix routes the ready gate through the authoritative predicate freeze.is_frozen (status == ready and not submitted) so the submission selectors can no longer drift from the freeze the rest of the tooling enforces; a not-ready tree now raises WorkflowError and buckets under Not ready. The fresh-implementing (no metadata) path keeps its original 'no PR metadata yet' message. Added a regression test for the status=implementing + retained-pr_metadata post-unfreeze case. Validation green: 4927 passed, 100% coverage.