### PR TITLE
feat(validate): extend markdownlint coverage to the epics/ directory

### DIFF
--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -2,8 +2,8 @@
 
 Runs inside the dev container via ``vrg-container-run``:
   1. Repository profile validation (includes README structural checks)
-  2. markdownlint on published markdown (docs/site/, README.md) using
-     the bundled canonical config
+  2. markdownlint on published markdown (docs/site/, epics/, README.md)
+     using the bundled canonical config
   3. shellcheck on all shell scripts under ``scripts/``
   4. yamllint on YAML files under ``.github/`` and ``docs/`` using
      the bundled canonical config (issue #302, #590)
@@ -47,13 +47,21 @@ def _find_shell_files(repo_root: Path) -> list[str]:
 
 
 def _find_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> list[str]:
-    """Discover published markdown files: docs/site/**/*.md and README.md."""
+    """Discover published markdown files: docs/site/**/*.md, epics/**/*.md,
+    and README.md."""
     found: list[str] = []
     ignore_paths = [repo_root / p for p in (ignore or [])]
 
     site_dir = repo_root / "docs" / "site"
     if site_dir.is_dir():
         for path in site_dir.rglob("*.md"):
+            if any(path.is_relative_to(ip) for ip in ignore_paths):
+                continue
+            found.append(str(path))
+
+    epics_dir = repo_root / "epics"
+    if epics_dir.is_dir():
+        for path in epics_dir.rglob("*.md"):
             if any(path.is_relative_to(ip) for ip in ignore_paths):
                 continue
             found.append(str(path))
@@ -213,7 +221,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
     # "(N files)" as "N markdown files I changed" and reporting a phantom
     # off-by-one when a changed file fell outside the scope (issue #2601).
     if md_files:
-        print(f"Running: markdownlint ({len(md_files)} files in docs/site/, README.md)")
+        print(f"Running: markdownlint ({len(md_files)} files in docs/site/, epics/, README.md)")
         config = files("vergil_tooling.configs") / "markdownlint.yaml"
         cmd: list[str] = ["markdownlint", "--config", str(config), *md_files]
         result = subprocess.run(cmd, check=False)  # noqa: S603, S607

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -185,6 +185,49 @@ def test_find_markdown_files_ignore_empty_list(tmp_path: Path) -> None:
     assert len(result) == 1
 
 
+def test_find_markdown_files_epics(tmp_path: Path) -> None:
+    epic = tmp_path / "epics" / "epic-1"
+    epic.mkdir(parents=True)
+    (epic / "spec.md").write_text("# Spec\n")
+    result = _find_markdown_files(tmp_path)
+    assert len(result) == 1
+    assert result[0].endswith("spec.md")
+
+
+def test_find_markdown_files_epics_nested(tmp_path: Path) -> None:
+    epics = tmp_path / "epics"
+    (epics / "epic-1").mkdir(parents=True)
+    (epics / "epic-2").mkdir(parents=True)
+    (epics / "epic-1" / "spec.md").write_text("# Spec\n")
+    (epics / "epic-1" / "plan.md").write_text("# Plan\n")
+    (epics / "epic-2" / "retrospective.md").write_text("# Retro\n")
+    result = _find_markdown_files(tmp_path)
+    assert len(result) == 3
+
+
+def test_find_markdown_files_all_scopes(tmp_path: Path) -> None:
+    site = tmp_path / "docs" / "site"
+    site.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    epic = tmp_path / "epics" / "epic-1"
+    epic.mkdir(parents=True)
+    (epic / "spec.md").write_text("# Spec\n")
+    (tmp_path / "README.md").write_text("# Project\n")
+    result = _find_markdown_files(tmp_path)
+    assert len(result) == 3
+
+
+def test_find_markdown_files_epics_honors_ignore(tmp_path: Path) -> None:
+    epics = tmp_path / "epics"
+    (epics / "epic-1").mkdir(parents=True)
+    (epics / "archived").mkdir(parents=True)
+    (epics / "epic-1" / "spec.md").write_text("# Spec\n")
+    (epics / "archived" / "old.md").write_text("# Old\n")
+    result = _find_markdown_files(tmp_path, ignore=["epics/archived"])
+    assert len(result) == 1
+    assert result[0].endswith("spec.md")
+
+
 # -- main --------------------------------------------------------------------
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Extend the vrg-validate common-checks markdownlint pass so _find_markdown_files also discovers epics/**/*.md (honouring [markdownlint].ignore) alongside docs/site/ and README.md, bringing the durable per-epic design record under lint.

## Issue Linkage

- Closes #2731

## Notes

- Mirrors the existing docs/site discovery block in src/vergil_tooling/bin/validate_common.py, adds an epics/ rglob branch that reuses the same ignore_paths logic, updates the module docstring and the markdownlint progress line to name epics/, and extends the _find_markdown_files tests (epics discovery, nested epics, all-scopes, and epics ignore handling). Validation is green: 4930 tests, 100% coverage, all common/lint/typecheck/audit stages pass. This same shared-driver fix also resolves the cross-repo issue vergil-project/.github#193; no changes to .github are needed.