### PR TITLE
fix(pr-await): detect orphaned check-run instead of hanging forever

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_await.py
+++ b/src/vergil_tooling/bin/vrg_pr_await.py
@@ -4,13 +4,18 @@
 counterpart to ``vrg-await`` (§9 of the Vergil 2.1 workflow design). It polls
 the GitHub API and returns when the PR settles: all checks reach a terminal
 conclusion, **or** the head SHA moves (a new commit), **or** a new review
-appears. The baselines let the caller thread "what I last saw" so a settle on
-a fresh commit/review is detected even when checks are already terminal.
+appears, **or** the PR is wedged by an orphaned check-run (``reason`` is
+``orphaned_check``: it is ``BLOCKED`` with every pending check stuck
+non-terminal after its backing run completed). The baselines let the caller
+thread "what I last saw" so a settle on a fresh commit/review is detected even
+when checks are already terminal.
 
 On settle it prints a JSON object (``reason``, ``head_sha``, ``review_count``,
-``checks``, ``failed_checks``, ``all_checks_passed``) for the wrapping skill to
-reconcile, and exits 0. Like ``vrg-await`` it blocks patiently and
-indefinitely — a wait that never returns means the PR has not changed.
+``checks``, ``failed_checks``, ``all_checks_passed``, ``merge_state_status``,
+``orphaned_checks``) for the wrapping skill to reconcile, and exits 0. Like
+``vrg-await`` it blocks patiently and indefinitely — but the ``orphaned_check``
+settle deliberately breaks that block, since an orphaned check emits no further
+event and the wait would otherwise never return.
 
 If any poll (including the first) finds the PR already merged, it aborts with
 an error and exits 1: a merged PR can never settle into actionable output, and

--- a/src/vergil_tooling/lib/pr_await.py
+++ b/src/vergil_tooling/lib/pr_await.py
@@ -2,8 +2,18 @@
 
 There is no webhook ingress on a laptop, so ``vrg-pr-await`` polls the GitHub
 API. It blocks until the PR *settles*: all checks reach a terminal conclusion,
-**or** a new commit appears (the head SHA moves), **or** a new review appears.
-On settle it returns the observed state so the wrapping skill can reconcile.
+**or** a new commit appears (the head SHA moves), **or** a new review appears,
+**or** the PR is wedged by an *orphaned check-run* (every still-pending check is
+stuck non-terminal after its backing workflow run already completed, while
+``mergeStateStatus`` is ``BLOCKED``). On settle it returns the observed state so
+the wrapping skill can reconcile.
+
+The orphaned-check settle is the one that keeps the loop from hanging forever:
+an orphaned check-run emits no further event, so waiting for a state transition
+that will never arrive would block indefinitely. Detecting it lets ``pr-watch``
+surface the condition (close/reopen the PR to re-run the gate) instead of
+spinning silently. The detection reuses ``github.orphaned_check_names`` — the
+same signal ``vrg-finalize-pr`` uses — rather than re-deriving it.
 
 A merged PR can never settle into anything actionable — continued polling
 would just spin as an orphaned watcher — so every poll (including the first)
@@ -27,6 +37,8 @@ _POLL_INTERVAL = 15.0
 _FAILED_BUCKETS = frozenset({"fail", "cancel"})
 _PENDING_BUCKET = "pending"
 _MERGED_STATE = "MERGED"
+_BLOCKED_STATE = "BLOCKED"
+_ORPHANED_CHECK_REASON = "orphaned_check"
 
 
 class PrMergedError(Exception):
@@ -45,11 +57,17 @@ class PrState:
     checks: list[dict[str, str]] = field(default_factory=list)
     reviews: list[dict[str, object]] = field(default_factory=list)
     pr_state: str = "OPEN"
+    merge_state_status: str = ""
 
     @property
     def merged(self) -> bool:
         """True when the PR has been merged."""
         return self.pr_state == _MERGED_STATE
+
+    @property
+    def blocked(self) -> bool:
+        """True when the PR's ``mergeStateStatus`` is ``BLOCKED``."""
+        return self.merge_state_status == _BLOCKED_STATE
 
     @property
     def has_checks(self) -> bool:
@@ -60,6 +78,11 @@ class PrState:
     def checks_pending(self) -> bool:
         """True when any check is still running (bucket ``pending``)."""
         return any(c.get("bucket") == _PENDING_BUCKET for c in self.checks)
+
+    @property
+    def pending_check_names(self) -> list[str]:
+        """Names of checks still in the ``pending`` bucket."""
+        return [str(c["name"]) for c in self.checks if c.get("bucket") == _PENDING_BUCKET]
 
     @property
     def failed_checks(self) -> list[str]:
@@ -79,6 +102,7 @@ def gather_state(pr: str) -> PrState:
         checks=github.pr_checks(pr),
         reviews=github.pr_reviews(pr),
         pr_state=github.pr_state(pr),
+        merge_state_status=github.merge_state_status(pr),
     )
 
 
@@ -102,6 +126,31 @@ def settle_reason(
     return None
 
 
+def is_orphaned_block(state: PrState, pr: str) -> bool:
+    """True when *pr* is wedged by an orphaned check-run and would hang the watch.
+
+    The condition is: ``mergeStateStatus`` is ``BLOCKED``, at least one check is
+    still pending, and **every** pending check is an orphan — stuck non-terminal
+    after its backing workflow run already completed. Only then is continued
+    polling futile: an orphaned check emits no further event, so waiting for a
+    transition that will never arrive blocks forever.
+
+    The orphan set comes from ``github.orphaned_check_names`` (the same detector
+    ``vrg-finalize-pr`` uses). It excludes app-posted statuses that have no
+    backing Actions run, so a pending app status genuinely still running is
+    *not* an orphan — the ``all(...)`` guard then keeps the watch waiting rather
+    than declaring a false orphaned settle. The GitHub API call is made only
+    once the cheap local predicates (blocked + pending) already hold.
+    """
+    if not state.blocked:
+        return False
+    pending = state.pending_check_names
+    if not pending:
+        return False
+    orphans = set(github.orphaned_check_names(pr))
+    return all(name in orphans for name in pending)
+
+
 def wait_for_settle(
     pr: str,
     *,
@@ -114,6 +163,12 @@ def wait_for_settle(
     Raises :class:`PrMergedError` as soon as any poll (including the first)
     observes the PR merged — a merged PR aborts the watch even when a settle
     reason exists, since no settle verdict on a merged PR is actionable.
+
+    Beyond the pure :func:`settle_reason` verdicts, a poll also settles with
+    reason ``"orphaned_check"`` when :func:`is_orphaned_block` holds — the PR is
+    ``BLOCKED`` and every pending check is an orphaned check-run. That settle
+    exists so the watch reports the wedge instead of hanging forever on an event
+    that will never fire.
     """
     while True:
         state = gather_state(pr)
@@ -122,11 +177,21 @@ def wait_for_settle(
         reason = settle_reason(state, since_sha=since_sha, since_reviews=since_reviews)
         if reason is not None:
             return state, reason
+        if is_orphaned_block(state, pr):
+            return state, _ORPHANED_CHECK_REASON
         time.sleep(poll_interval)
 
 
 def to_output(state: PrState, reason: str) -> dict[str, object]:
-    """Build the JSON-serializable result emitted by ``vrg-pr-await``."""
+    """Build the JSON-serializable result emitted by ``vrg-pr-await``.
+
+    On an ``"orphaned_check"`` settle, ``orphaned_checks`` names the wedged
+    check-runs so ``pr-watch`` can report exactly which gates are stuck. Those
+    are the still-pending checks: :func:`is_orphaned_block` only returns the
+    reason when every pending check is an orphan, so the pending set *is* the
+    orphan set. For every other reason the list is empty.
+    """
+    orphaned_checks = state.pending_check_names if reason == _ORPHANED_CHECK_REASON else []
     return {
         "reason": reason,
         "head_sha": state.head_sha,
@@ -134,4 +199,6 @@ def to_output(state: PrState, reason: str) -> dict[str, object]:
         "checks": state.checks,
         "failed_checks": state.failed_checks,
         "all_checks_passed": state.all_checks_passed,
+        "merge_state_status": state.merge_state_status,
+        "orphaned_checks": orphaned_checks,
     }

--- a/tests/vergil_tooling/test_pr_await.py
+++ b/tests/vergil_tooling/test_pr_await.py
@@ -39,6 +39,17 @@ def test_state_all_checks_passed() -> None:
     assert not PrState("sha", [], []).all_checks_passed
 
 
+def test_state_pending_check_names() -> None:
+    state = PrState("sha", _checks("pass", "pending", "pending"), [])
+    assert state.pending_check_names == ["check-1", "check-2"]
+
+
+def test_state_blocked() -> None:
+    assert PrState("sha", [], [], merge_state_status="BLOCKED").blocked
+    assert not PrState("sha", [], [], merge_state_status="CLEAN").blocked
+    assert not PrState("sha", [], []).blocked
+
+
 def test_settle_reason_new_commit() -> None:
     state = PrState("new-sha", _checks("pending"), [])
     assert settle_reason(state, since_sha="old-sha", since_reviews=None) == "new_commit"
@@ -111,12 +122,14 @@ def test_gather_state_reads_github() -> None:
         patch(f"{_MOD}.github.pr_checks", return_value=checks),
         patch(f"{_MOD}.github.pr_reviews", return_value=reviews),
         patch(f"{_MOD}.github.pr_state", return_value="OPEN"),
+        patch(f"{_MOD}.github.merge_state_status", return_value="CLEAN"),
     ):
         state = pr_await.gather_state("PR")
     assert state.head_sha == "abc123"
     assert state.checks == checks
     assert state.reviews == reviews
     assert state.pr_state == "OPEN"
+    assert state.merge_state_status == "CLEAN"
 
 
 def test_wait_for_settle_aborts_when_merged_at_start() -> None:
@@ -155,10 +168,95 @@ def test_wait_for_settle_merged_abort_wins_over_settle() -> None:
 
 
 def test_to_output_shape() -> None:
-    state = PrState("abc123", _checks("pass", "fail"), [{"id": "r1"}])
+    state = PrState("abc123", _checks("pass", "fail"), [{"id": "r1"}], merge_state_status="DIRTY")
     out = to_output(state, "checks_terminal")
     assert out["reason"] == "checks_terminal"
     assert out["head_sha"] == "abc123"
     assert out["review_count"] == 1
     assert out["failed_checks"] == ["check-1"]
     assert out["all_checks_passed"] is False
+    assert out["merge_state_status"] == "DIRTY"
+    # Only an orphaned_check settle populates orphaned_checks.
+    assert out["orphaned_checks"] == []
+
+
+def test_to_output_orphaned_checks_lists_pending_checks() -> None:
+    checks = _checks("pass", "pending", "pending")
+    state = PrState("abc123", checks, [], merge_state_status="BLOCKED")
+    out = to_output(state, "orphaned_check")
+    assert out["reason"] == "orphaned_check"
+    assert out["orphaned_checks"] == ["check-1", "check-2"]
+    assert out["merge_state_status"] == "BLOCKED"
+
+
+def test_is_orphaned_block_true_when_blocked_and_all_pending_orphaned() -> None:
+    state = PrState("sha", _checks("pass", "pending", "pending"), [], merge_state_status="BLOCKED")
+    orphans = ["check-1", "check-2"]
+    with patch(f"{_MOD}.github.orphaned_check_names", return_value=orphans) as detect:
+        assert pr_await.is_orphaned_block(state, "PR") is True
+    detect.assert_called_once_with("PR")
+
+
+def test_is_orphaned_block_false_when_not_blocked() -> None:
+    state = PrState("sha", _checks("pending"), [], merge_state_status="CLEAN")
+    with patch(f"{_MOD}.github.orphaned_check_names") as detect:
+        assert pr_await.is_orphaned_block(state, "PR") is False
+    # No API call when the cheap local predicate already fails.
+    detect.assert_not_called()
+
+
+def test_is_orphaned_block_false_when_no_pending_checks() -> None:
+    state = PrState("sha", _checks("pass"), [], merge_state_status="BLOCKED")
+    with patch(f"{_MOD}.github.orphaned_check_names") as detect:
+        assert pr_await.is_orphaned_block(state, "PR") is False
+    detect.assert_not_called()
+
+
+def test_is_orphaned_block_false_when_a_pending_check_is_not_orphaned() -> None:
+    # One pending check is a genuinely-running app status (not in the orphan
+    # set); the watch must keep waiting rather than declare a false orphan.
+    state = PrState("sha", _checks("pending", "pending"), [], merge_state_status="BLOCKED")
+    with patch(f"{_MOD}.github.orphaned_check_names", return_value=["check-0"]):
+        assert pr_await.is_orphaned_block(state, "PR") is False
+
+
+def test_wait_for_settle_returns_orphaned_check_reason() -> None:
+    blocked = PrState("sha", _checks("pass", "pending"), [], merge_state_status="BLOCKED")
+    with (
+        patch(f"{_MOD}.gather_state", return_value=blocked),
+        patch(f"{_MOD}.github.orphaned_check_names", return_value=["check-1"]),
+        patch(f"{_MOD}.time.sleep") as slept,
+    ):
+        state, reason = pr_await.wait_for_settle("PR", since_sha="sha", since_reviews=0)
+    assert reason == "orphaned_check"
+    assert state is blocked
+    slept.assert_not_called()
+
+
+def test_wait_for_settle_keeps_waiting_when_pending_but_not_orphaned() -> None:
+    # First poll: blocked with a pending non-orphan → keep waiting.
+    # Second poll: checks terminal → settle normally.
+    blocked = PrState("sha", _checks("pass", "pending"), [], merge_state_status="BLOCKED")
+    terminal = PrState("sha", _checks("pass", "pass"), [], merge_state_status="CLEAN")
+    with (
+        patch(f"{_MOD}.gather_state", side_effect=[blocked, terminal]),
+        patch(f"{_MOD}.github.orphaned_check_names", return_value=[]),
+        patch(f"{_MOD}.time.sleep") as slept,
+    ):
+        state, reason = pr_await.wait_for_settle("PR", since_sha="sha", since_reviews=0)
+    assert reason == "checks_terminal"
+    assert state is terminal
+    slept.assert_called_once()
+
+
+def test_wait_for_settle_normal_reason_wins_over_orphan_check() -> None:
+    # A new commit settles before the orphan detector is even consulted.
+    blocked = PrState("new-sha", _checks("pending"), [], merge_state_status="BLOCKED")
+    with (
+        patch(f"{_MOD}.gather_state", return_value=blocked),
+        patch(f"{_MOD}.github.orphaned_check_names") as detect,
+        patch(f"{_MOD}.time.sleep"),
+    ):
+        _, reason = pr_await.wait_for_settle("PR", since_sha="old-sha", since_reviews=0)
+    assert reason == "new_commit"
+    detect.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-pr-await now settles with an "orphaned_check" reason when a PR is BLOCKED and every pending check is an orphaned check-run, so pr-watch reports the wedge instead of polling forever.

## Issue Linkage

- Closes #2750

## Notes

- wait_for_settle gains an orphaned-check settle: after the pure settle_reason verdicts return nothing, it consults the new is_orphaned_block helper, which fires only when mergeStateStatus is BLOCKED, at least one check is pending, and every pending check is in github.orphaned_check_names (the same detector vrg-finalize-pr uses). The GitHub API probe runs only once the cheap local predicates hold, and the all-pending-are-orphans guard keeps the watch waiting when a genuinely-running app-posted status is still pending. PrState carries merge_state_status (added to gather_state); to_output surfaces merge_state_status and orphaned_checks so the operator sees exactly which gates are stuck. Regression tests cover the new properties, is_orphaned_block branches, the orphaned-check settle, the keep-waiting path, precedence of a normal settle reason, and the to_output shape. Validation green: 4936 tests, 100% coverage.