### PR TITLE
fix(commit): update stale close-keyword rejection guidance in vrg-commit and vrg-reword

### DIFF
--- a/src/vergil_tooling/bin/vrg_commit.py
+++ b/src/vergil_tooling/bin/vrg_commit.py
@@ -187,8 +187,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.body and contains_autoclose(args.body):
         return _reject(
             "ERROR: commit body contains a GitHub auto-close keyword "
-            "(close/fix/resolve). Use 'Ref #N' instead.",
-            "Issues must remain open until post-merge workflows succeed.",
+            "(close/fix/resolve). Commit bodies must carry no issue-linkage "
+            "keyword.",
+            "Issue linkage is set on the PR at submit time (via "
+            "'vrg-pr-workflow report-ready' / 'vrg-submit-pr'), not in the "
+            "commit body. Issues must remain open until post-merge workflows "
+            "succeed.",
         )
 
     co_author = os.environ.get("VRG_CO_AUTHOR")

--- a/src/vergil_tooling/bin/vrg_reword.py
+++ b/src/vergil_tooling/bin/vrg_reword.py
@@ -385,8 +385,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.body and contains_autoclose(args.body):
         return _reject(
-            "commit body contains a GitHub auto-close keyword (close/fix/resolve).",
-            "Use 'Ref #N' instead. Issues stay open until post-merge workflows succeed.",
+            "commit body contains a GitHub auto-close keyword (close/fix/resolve). "
+            "Commit bodies must carry no issue-linkage keyword.",
+            "Issue linkage is set on the PR at submit time (via "
+            "'vrg-pr-workflow report-ready' / 'vrg-submit-pr'), not in the commit "
+            "body. Issues stay open until post-merge workflows succeed.",
         )
 
     rc, target_sha, branch = _validate(args)

--- a/tests/vergil_tooling/test_vrg_commit.py
+++ b/tests/vergil_tooling/test_vrg_commit.py
@@ -460,6 +460,32 @@ def test_validate_rejects_autoclose_keywords_in_body(tmp_path: Path, body: str) 
     assert result == 1
 
 
+def test_autoclose_rejection_message_directs_to_pr_submit(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The rejection guidance points at PR-submit linkage, not a stale 'Ref #N'."""
+    with _commit_environment(tmp_path):
+        result = main(
+            [
+                "--type",
+                "feat",
+                "--scope",
+                "core",
+                "--message",
+                "test",
+                "--body",
+                "Closes #42",
+            ]
+        )
+    assert result == 1
+    err = capsys.readouterr().err
+    # The stale recommendation is gone.
+    assert "Ref #N" not in err
+    # The new guidance explains linkage is set on the PR at submit time.
+    assert "report-ready" in err
+    assert "no issue-linkage keyword" in err
+
+
 @pytest.mark.parametrize(
     "body",
     [

--- a/tests/vergil_tooling/test_vrg_reword.py
+++ b/tests/vergil_tooling/test_vrg_reword.py
@@ -296,6 +296,18 @@ def test_main_rejects_autoclose_body() -> None:
     assert rc == 1
 
 
+def test_autoclose_rejection_message_directs_to_pr_submit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The rejection guidance points at PR-submit linkage, not a stale 'Ref #N'."""
+    rc = main(["abc", "--type", "feat", "--scope", "core", "--message", "x", "--body", "Closes #5"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Ref #N" not in err
+    assert "report-ready" in err
+    assert "no issue-linkage keyword" in err
+
+
 # --------------------------------------------------------------------------
 # push behavior
 # --------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Reword the auto-close keyword rejection messages in vrg-commit and vrg-reword to explain that issue linkage is set on the PR at submit time (report-ready / vrg-submit-pr) and drop the stale 'Ref #N' advice, keeping the guard logic unchanged.

## Issue Linkage

- Closes #2792

## Notes

- Guidance text only; the close/fix/resolve guard logic is untouched. Extended the vrg-commit and vrg-reword tests to assert the new message contains the PR-submit linkage guidance and no longer mentions 'Ref #N'. Validation green: 4931 passed, 100% coverage.