### PR TITLE
fix(pr-workflow): make GitHubTransport.write quiet-by-design on stdout

### DIFF
--- a/src/vergil_tooling/bin/vrg_pr_workflow.py
+++ b/src/vergil_tooling/bin/vrg_pr_workflow.py
@@ -8,7 +8,6 @@ and ``vrg-submit-pr`` (human-run) reads it. ``status`` prints the current state.
 from __future__ import annotations
 
 import argparse
-import contextlib
 import json
 import subprocess
 import sys
@@ -125,14 +124,14 @@ def _push_relay_ref(state: WorkflowState, base: str) -> None:
     local file has already been written and stays put; a push failure is
     therefore surfaced loudly on stderr but never rolls the local state back.
 
-    ``report-ready`` speaks a JSON-on-stdout contract, so the relay push's git
-    chatter is redirected to stderr — where "loud" belongs — keeping stdout a
-    pure JSON document whether the push succeeds or fails.
+    ``report-ready`` speaks a JSON-on-stdout contract; ``GitHubTransport.write``
+    is quiet-by-design (#2793), routing the relay push's git chatter to stderr
+    itself, so no caller-side ``redirect_stdout`` workaround is needed here to
+    keep stdout a pure JSON document.
     """
     relay = GitHubTransport(git.current_branch(), base=base)
     try:
-        with contextlib.redirect_stdout(sys.stderr):
-            relay.write(state)
+        relay.write(state)
     except (subprocess.CalledProcessError, OSError) as exc:
         print(
             f"warning: could not push pr-workflow relay ref {relay.ref}: {exc}",

--- a/src/vergil_tooling/lib/pr_workflow/github_transport.py
+++ b/src/vergil_tooling/lib/pr_workflow/github_transport.py
@@ -19,6 +19,9 @@ would advance the feature branch out from under it (design
 
 from __future__ import annotations
 
+import contextlib
+import sys
+
 from vergil_tooling.lib import git
 from vergil_tooling.lib.pr_workflow.state import WorkflowState
 from vergil_tooling.lib.pr_workflow.transport import Transport
@@ -82,11 +85,21 @@ class GitHubTransport(Transport):
         INVARIANT: never runs ``git commit``; never mutates HEAD, the index, or
         the working tree. The blob/tree/commit are built with plumbing and the
         push targets only the reserved ref, keeping the write freeze-neutral.
+
+        Quiet-by-design (#2793): ``git.run`` streams the push's plumbing chatter
+        through ``progress.emit``, which prints to **stdout** outside a progress
+        pipeline. That would corrupt the stdout contract of any caller that emits
+        structured output (``report-ready`` speaks JSON-on-stdout). The push
+        chatter belongs on stderr regardless of caller, so it is redirected here
+        at the transport boundary — no caller needs the workaround. The redirect
+        is torn down only after ``git.run`` joins its output-pump threads, so
+        every emitted line lands on stderr before ``write`` returns.
         """
         blob = git.read_output_stdin(state.to_json(), "hash-object", "-w", "--stdin")
         tree = git.read_output_stdin(f"{_BLOB_MODE} blob {blob}\t{_FILE}\n", "mktree")
         commit = git.read_output("commit-tree", tree, "-m", _COMMIT_MESSAGE)
-        git.run("push", "--force", self.remote, f"{commit}:{self.ref}")
+        with contextlib.redirect_stdout(sys.stderr):
+            git.run("push", "--force", self.remote, f"{commit}:{self.ref}")
 
     def delete(self) -> None:
         """Remove the relay ref from the remote; a no-op when it is absent."""

--- a/tests/vergil_tooling/pr_workflow/test_github_transport.py
+++ b/tests/vergil_tooling/pr_workflow/test_github_transport.py
@@ -98,6 +98,19 @@ def test_write_is_a_pure_ref_write_leaving_head_index_worktree_untouched(
     assert _git("ls-remote", "origin", GitHubTransport(_BRANCH).ref, cwd=clone)
 
 
+def test_write_keeps_stdout_clean_routing_push_chatter_to_stderr(
+    clone: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Quiet-by-design (#2793): ``write`` must not leak git push chatter to
+    stdout — outside a progress pipeline ``git.run`` prints its streamed output,
+    and a caller with a JSON-on-stdout contract (``report-ready``) would be
+    corrupted. The transport redirects the chatter to stderr itself, so no
+    caller-side ``redirect_stdout`` workaround is needed."""
+    GitHubTransport(_BRANCH).write(_state())
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
 def test_write_force_overwrites_existing_ref(clone: Path) -> None:
     transport = GitHubTransport(_BRANCH)
     transport.write(_state(head="first"))


### PR DESCRIPTION
# Pull Request

## Summary

- Route GitHubTransport.write's relay-ref git push chatter to stderr inside the transport so it never corrupts a caller's stdout contract, and drop the now-redundant caller-side redirect_stdout workaround in report-ready.

## Issue Linkage

- Closes #2793

## Notes

- Root cause: write() streamed git push output via git.run -> progress.emit, which prints to stdout when no progress pipeline is active. Fix redirects the push to stderr at the transport boundary; the redirect is torn down only after git.run joins its output-pump threads, so all chatter lands on stderr before write() returns. Removed the caller-side contextlib.redirect_stdout in _push_relay_ref (and its now-unused import). Added test_write_keeps_stdout_clean_routing_push_chatter_to_stderr asserting stdout stays empty. Full validation green: 4954 tests, 100% coverage.