### PR TITLE
fix(submit-pr): resolve named-branch submit path from actual state, not the mere fact a branch was named

### DIFF
--- a/src/vergil_tooling/bin/vrg_submit_pr.py
+++ b/src/vergil_tooling/bin/vrg_submit_pr.py
@@ -6,25 +6,32 @@ Supports three modes:
   confirmation, pushes the branch, and creates the PR.
 - **CLI argument mode** (``--issue``/``--summary``/``--title``): existing
   direct invocation for human emergency use.
-- **Relay branch mode** (positional ``branches``): opens PRs for
-  branches that are already on origin, worktree-free (issue #2368). Each
+- **Named branch mode** (positional ``branches``): opens PRs for one or
+  more named branches, worktree-free by default (issue #2368). Each
   branch's ready-state is resolved from a local worktree's
   ``pr-workflow.json`` when one exists, else the relay ref
-  (``GitHubTransport``); origin's tip is verified against the recorded
-  ``head_sha`` and the PR is opened **without** pushing (``--head`` names
-  the source branch). This is the Mac-side of the cloud→Mac relay handoff:
-  the branch and its metadata already rode GitHub, so no worktree, no
-  ``git.current_branch()``, and no push are involved. With a cascade flag
-  (``--finalize``/``--release``/``--install``) it also carries the branches
-  through the cascade locally, using the same batch semantics as the local
-  worktree batch — finalize each PR, then a single validation and **one**
-  release (issue #2398).
+  (``GitHubTransport``). The local-vs-relay decision is then made from
+  **actual state**, not from the mere fact that a branch was named
+  (issue #2794): when the branch has a local worktree ready-state **and**
+  origin lacks the branch, it is pushed and opened locally
+  (``push=True``) — the branch was developed on this machine and never
+  reached origin (e.g. a workflow-file change the agent's token could not
+  push). Otherwise it takes the relay path — origin's tip is verified
+  against the recorded ``head_sha`` and the PR is opened **without**
+  pushing (``--head`` names the source branch) — the Mac-side of the
+  cloud→Mac relay handoff, where the branch and its metadata already rode
+  GitHub. With a cascade flag (``--finalize``/``--release``/``--install``)
+  it also carries the branches through the cascade locally, using the same
+  batch semantics as the local worktree batch — finalize each PR, then a
+  single validation and **one** release (issue #2398).
 
 The template and CLI modes push the branch using the human's host
 credentials before creating the PR. Because the human is the superset
 of any agent's rights, this carries workflow-touching pushes that the
-agent's own credentials would be rejected for. The relay mode never
-pushes — the branch is already on origin.
+agent's own credentials would be rejected for. The named-branch mode
+pushes only when it falls back to the local path for a branch that never
+reached origin; the relay path itself never pushes — the branch is
+already on origin.
 
 Agent identities are blocked — PR submission is a Chief Steward
 (human) operation.
@@ -77,10 +84,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "branches",
         nargs="*",
-        help="Relay path: one or more branches (already on origin) to open PRs "
-        "for, worktree-free. Each branch's ready-state is resolved from a local "
-        "worktree's pr-workflow.json when present, else the relay ref. With no "
-        "branch arguments, the local-worktree flow runs unchanged.",
+        help="One or more branches to open PRs for, worktree-free. Each branch's "
+        "ready-state is resolved from a local worktree's pr-workflow.json when "
+        "present, else the relay ref; a branch that is on origin is opened "
+        "without pushing (relay), while a branch with a local ready worktree that "
+        "never reached origin is pushed then opened. With no branch arguments, "
+        "the local-worktree flow runs unchanged.",
     )
     parser.add_argument(
         "--issue", default=None, help="Issue reference: number or owner/repo#number"
@@ -861,27 +870,70 @@ def _verify_origin_tip(branch: str, state: WorkflowState) -> None:
         )
 
 
+def _local_worktree_with_state(root: Path, branch: str) -> Path | None:
+    """Return the path of a canonical worktree checked out on *branch* whose
+    local ``pr-workflow.json`` carries a ready-state, else ``None``.
+
+    This is the signal that the named branch was developed in a local worktree
+    (as opposed to a cloud VM that pushed it and relayed only the ref): a
+    checked-out worktree on the branch *and* a local state file present. It
+    mirrors the local-preference probe in :func:`_resolve_ready_state`.
+    """
+    for wt in worktrees.list_worktrees(root):
+        if wt.branch == branch and LocalFileTransport(wt.path).read() is not None:
+            return wt.path
+    return None
+
+
+def _origin_has_branch(branch: str) -> bool:
+    """True when origin already carries *branch* (``ls-remote`` finds its ref)."""
+    listing = git.read_output("ls-remote", "origin", f"refs/heads/{branch}")
+    return bool(listing)
+
+
 def _relay_open(
     root: Path, branch: str, args: argparse.Namespace, *, assume_yes: bool
 ) -> tuple[str | None, str | None]:
-    """Resolve, verify, and open the relay PR for one already-pushed *branch*.
+    """Resolve, verify, and open the PR for one named *branch*.
 
     Returns ``(pr_url, submitted_url)``: exactly one is non-``None`` on a live
     run — the new PR URL when the branch was opened, or the already-submitted
     PR's URL when the branch already carries one. A dry run returns
     ``(None, None)`` (``_open_pr`` previewed without opening). Resolves the
-    ready-state (local file preferred, else the relay ref), verifies origin's
-    tip matches the recorded ``head_sha``, and drives the shared :func:`_open_pr`
-    core with ``push=False``. Shared by the plain relay loop and the relay
-    cascade so both classify an already-submitted branch identically.
+    ready-state (local file preferred, else the relay ref) and classifies an
+    already-submitted branch identically for the plain relay loop and the relay
+    cascade.
+
+    The local-vs-relay choice is made from **actual state**, not from the mere
+    fact that a branch was named on the command line (issue #2794). The relay
+    path never pushes — it trusts origin already carries the branch — so a
+    branch developed in a local worktree and never pushed (e.g. a workflow-file
+    change the agent's token could not push) would dead-end on
+    :func:`_verify_origin_tip`'s "not on origin". When the named branch has a
+    local worktree carrying a ready-state **and** origin lacks the branch, fall
+    back to the local submit path (``push=True``: push, then open), which is
+    exactly what selecting that worktree from the interactive list would do.
+    Otherwise keep the relay path (``push=False``, verify origin's tip matches
+    the recorded ``head_sha``). The fallback is a live-run concern only: a dry
+    run merely previews the body (push vs no-push does not change it) and never
+    touches origin, so it stays on the relay preview.
     """
     state = _resolve_ready_state(root, branch)
     if state.submitted is not None:
         return None, state.submitted.get("pr_url", "")
     metadata = _metadata_from_state(state, branch)
     base = _target_branch(args.base, state.base)
+
     if not args.dry_run:
+        wt_path = _local_worktree_with_state(root, branch)
+        if wt_path is not None and not _origin_has_branch(branch):
+            pr_url = _open_pr(branch, base, metadata, push=True, assume_yes=assume_yes)
+            if pr_url is None:  # pragma: no cover - a live push=True open always yields a URL
+                raise SystemExit("vrg-submit-pr: internal error: local submit returned no PR URL")
+            submission.record_submission(wt_path, pr_url=pr_url)
+            return pr_url, None
         _verify_origin_tip(branch, state)
+
     pr_url = _open_pr(
         branch, base, metadata, push=False, dry_run=args.dry_run, assume_yes=assume_yes
     )
@@ -889,15 +941,18 @@ def _relay_open(
 
 
 def _run_relay(branches: list[str], args: argparse.Namespace) -> int:
-    """Open PRs for each already-pushed *branch* without a local worktree.
+    """Open PRs for each named *branch*, worktree-free.
 
-    For every branch: resolve its ready-state (local file preferred, else the
-    relay ref), verify origin's tip matches the recorded ``head_sha``, and drive
-    the shared :func:`_open_pr` core with ``push=False``. Branches already
-    carrying a submitted PR are reported and skipped. Standards/provenance run
-    against the resolved GitHub-carried metadata, exactly as the local path runs
-    them against the worktree's file. The finalize/release/install cascade is
-    handled separately by :func:`_run_relay_cascade`.
+    For every branch, :func:`_relay_open` resolves its ready-state (local file
+    preferred, else the relay ref) and picks the path from actual state: the
+    relay path (verify origin's tip against the recorded ``head_sha``, open with
+    ``push=False``) for a branch already on origin, or the local push+open path
+    for a branch with a local ready worktree that never reached origin
+    (issue #2794). Branches already carrying a submitted PR are reported and
+    skipped. Standards/provenance run against the resolved metadata, exactly as
+    the local path runs them against the worktree's file. The
+    finalize/release/install cascade is handled separately by
+    :func:`_run_relay_cascade`.
     """
     root = Path(git.repo_root())
     for branch in branches:

--- a/tests/vergil_tooling/test_vrg_submit_pr.py
+++ b/tests/vergil_tooling/test_vrg_submit_pr.py
@@ -10,8 +10,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vergil_tooling.bin.vrg_submit_pr import (
+    _local_worktree_with_state,
     _metadata_from_state,
     _open_pr,
+    _origin_has_branch,
     _push_branch,
     _reject_if_cross_repo,
     _reject_if_epic_link,
@@ -1985,6 +1987,53 @@ def test_resolve_ready_state_errors_when_no_source() -> None:
         _resolve_ready_state(Path("/repo"), "feature/x")
 
 
+def test_local_worktree_with_state_returns_matching_worktree() -> None:
+    """A worktree on the branch with a readable state file yields its path;
+    a non-matching worktree earlier in the list is skipped without a state read
+    (short-circuit on the branch name)."""
+    other = Worktree(path=Path("/repo/.worktrees/issue-99-y"), branch="feature/other")
+    match = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+    local = MagicMock()
+    local.read.return_value = _ready_state()
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[other, match]),
+        patch(_MOD + ".LocalFileTransport", return_value=local) as local_cls,
+    ):
+        out = _local_worktree_with_state(Path("/repo"), "feature/x")
+    assert out == match.path
+    # Only the matching worktree's state file is read — the non-match short-circuits.
+    local_cls.assert_called_once_with(match.path)
+
+
+def test_local_worktree_with_state_none_when_no_match() -> None:
+    other = Worktree(path=Path("/repo/.worktrees/issue-99-y"), branch="feature/other")
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[other]),
+        patch(_MOD + ".LocalFileTransport") as local_cls,
+    ):
+        assert _local_worktree_with_state(Path("/repo"), "feature/x") is None
+    local_cls.assert_not_called()
+
+
+def test_local_worktree_with_state_none_when_file_absent() -> None:
+    """A worktree on the branch but with no state file is not a local candidate."""
+    match = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+    local = MagicMock()
+    local.read.return_value = None
+    with (
+        patch(_MOD + ".worktrees.list_worktrees", return_value=[match]),
+        patch(_MOD + ".LocalFileTransport", return_value=local),
+    ):
+        assert _local_worktree_with_state(Path("/repo"), "feature/x") is None
+
+
+def test_origin_has_branch_reflects_ls_remote() -> None:
+    with patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"):
+        assert _origin_has_branch("feature/x") is True
+    with patch(_MOD + ".git.read_output", return_value=""):
+        assert _origin_has_branch("feature/x") is False
+
+
 def test_verify_origin_tip_passes_on_match() -> None:
     state = _ready_state(head_sha="abc123")
     with patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"):
@@ -2054,6 +2103,55 @@ class TestRelayBranchPath:
             rc = main(["feature/x", "--yes"])
         assert rc == 0
         gh_cls.assert_not_called()
+
+    def test_named_branch_local_worktree_not_on_origin_pushes_and_opens(self) -> None:
+        """Regression (issue #2794): a named branch with a local ready worktree
+        that was never pushed to origin falls back to the local push+open path
+        instead of dead-ending on `_verify_origin_tip`'s "not on origin"."""
+        wt = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        local = MagicMock()
+        local.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[wt]),
+            patch(_MOD + ".LocalFileTransport", return_value=local),
+            # origin lacks the branch: ls-remote returns nothing.
+            patch(_MOD + ".git.read_output", return_value="") as read_output,
+            patch(_MOD + "._push_branch") as push,
+            patch(_MOD + ".submission.record_submission") as record,
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/7") as create,
+        ):
+            rc = main(["feature/x", "--yes"])
+        assert rc == 0
+        push.assert_called_once_with("feature/x")
+        assert create.call_args.kwargs["head"] == "feature/x"
+        # The submission is recorded on the local worktree so the scanner shows
+        # it in-flight, exactly like the worktree submit path.
+        record.assert_called_once_with(wt.path, pr_url="https://github.com/pr/7")
+        # Only the origin-presence probe runs — no `_verify_origin_tip` ls-remote
+        # against a branch that is not there.
+        assert read_output.call_count == 1
+
+    def test_named_branch_local_worktree_already_on_origin_uses_relay(self) -> None:
+        """A local worktree branch that *is* on origin keeps the relay path
+        (verify tip, push=False) — the fallback is gated on origin lacking it."""
+        wt = Worktree(path=Path("/repo/.worktrees/issue-42-x"), branch="feature/x")
+        state = _ready_state(branch="feature/x", head_sha="abc123")
+        local = MagicMock()
+        local.read.return_value = state
+        with (
+            patch(_MOD + ".git.repo_root", return_value="/repo"),
+            patch(_MOD + ".worktrees.list_worktrees", return_value=[wt]),
+            patch(_MOD + ".LocalFileTransport", return_value=local),
+            patch(_MOD + ".git.read_output", return_value="abc123\trefs/heads/feature/x"),
+            patch(_MOD + "._push_branch") as push,
+            patch(_MOD + ".github.create_pr", return_value="https://github.com/pr/7") as create,
+        ):
+            rc = main(["feature/x", "--yes"])
+        assert rc == 0
+        push.assert_not_called()
+        assert create.call_args.kwargs["head"] == "feature/x"
 
     def test_relay_head_sha_mismatch_errors(self) -> None:
         state = _ready_state(branch="feature/x", head_sha="abc123")


### PR DESCRIPTION
# Pull Request

## Summary

- vrg-submit-pr <branch> now falls back to the local push+open path when the named branch has a local worktree ready-state but is not yet on origin, instead of dead-ending on the relay path's 'not on origin' error.

## Issue Linkage

- Closes #2794

## Notes

- Root cause: the branches dispatch always routed to the push-free relay path, so a branch developed in a local Mac worktree and never pushed (e.g. a workflow-file change the agent's token could not push) hit _verify_origin_tip's 'not on origin' dead-end; the only workaround was dropping the branch arg and picking from the interactive list.

Fix: _relay_open resolves local-vs-relay from actual state. When the named branch has a local worktree carrying a ready-state AND origin lacks the branch, it uses the local submit path (push=True) and records the submission on the worktree's state file so the scanner shows it in-flight; otherwise it keeps the relay path (push=False, verify origin tip). Dry-run still previews via the relay path (push vs no-push does not change the body).

Reviewer notes: the pr_url-None guard follows the existing _submit_one pragma pattern (a live push=True open always yields a URL). Tests: added a main()-level regression for the named-branch/local-worktree-ready/not-on-origin case, an on-origin case that keeps the relay path, and unit coverage for the new _local_worktree_with_state / _origin_has_branch helpers. Full vrg-validate green at 100% coverage.