### PR TITLE
fix(repo-init): adopt regenerates managed files instead of resuming from init checkpoints

### DIFF
--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -1494,11 +1494,21 @@ def run_wizard(ctx: RepoInitContext) -> None:
     """Run all wizard steps, skipping completed ones."""
     # Resume state is a property of the TARGET, not of wherever the operator is
     # standing. Only trust the local checkpoint commits when CWD is the target's
-    # own clone (or an adopt run, which uses CWD by design); an unrelated repo's
-    # `chore(init): step N -` commits would otherwise be misread as this repo's
-    # progress and silently skip vergil.toml / config / CI steps (#2717).
+    # own clone; an unrelated repo's `chore(init): step N -` commits would
+    # otherwise be misread as this repo's progress and silently skip
+    # vergil.toml / config / CI steps (#2717).
+    #
+    # Adopt is the exception: it is an idempotent "overwrite managed files to
+    # canonical state" run, so every generation step must re-run regardless of
+    # prior init history. The `chore(init): step N -` markers are permanent in
+    # any previously-init'd repo and describe a PAST init, not current drift —
+    # trusting them would skip regenerating managed files (notably ci.yml),
+    # directly contradicting adopt's stated overwrite contract (#2795).
+    # Checkpoint-based resume is meaningful only for an interrupted FRESH init.
     cwd_slug = cwd_repo_slug()
-    if ctx.adopt or (cwd_slug is not None and cwd_slug.lower() == ctx.repo.lower()):
+    if ctx.adopt:
+        local_completed = set()
+    elif cwd_slug is not None and cwd_slug.lower() == ctx.repo.lower():
         try:
             log_output = git.read_output("log", "--oneline")
         except subprocess.CalledProcessError:

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -1868,6 +1868,59 @@ class TestRunWizard:
         assert 4 not in steps_run
         assert 5 in steps_run
 
+    def test_adopt_ignores_checkpoint_markers_and_regenerates(self) -> None:
+        # #2795 regression: adopt is an idempotent "overwrite managed files to
+        # canonical" run. A previously-init'd repo carries permanent
+        # `chore(init): step N -` markers for every generation step; adopt must
+        # NOT read them as completed progress, or it skips regenerating managed
+        # files (notably ci.yml at step 5), defeating adopt's own contract.
+        ctx = RepoInitContext(org="mnemosys-project", name="docs", adopt=True)
+
+        steps_run: list[int] = []
+
+        def mock_step(step_num: int) -> Any:
+            def inner(*a: Any, **kw: Any) -> None:
+                steps_run.append(step_num)
+
+            return inner
+
+        with (
+            patch("vergil_tooling.lib.repo_init.step_create_repo", side_effect=mock_step(1)),
+            patch("vergil_tooling.lib.repo_init.step_clone", side_effect=mock_step(2)),
+            patch("vergil_tooling.lib.repo_init.step_generate_config", side_effect=mock_step(3)),
+            patch(
+                "vergil_tooling.lib.repo_init.step_scaffold_config_files",
+                side_effect=mock_step(4),
+            ),
+            patch("vergil_tooling.lib.repo_init.step_ci_cd_workflows", side_effect=mock_step(5)),
+            patch("vergil_tooling.lib.repo_init.step_docs_site", side_effect=mock_step(6)),
+            patch("vergil_tooling.lib.repo_init.step_branch_structure", side_effect=mock_step(7)),
+            patch("vergil_tooling.lib.repo_init.step_github_config", side_effect=mock_step(8)),
+            patch("vergil_tooling.lib.repo_init.step_github_pages", side_effect=mock_step(9)),
+            patch("vergil_tooling.lib.repo_init._check_remote_steps", return_value=set()),
+            # Adopt runs in the target's own clone, whose log carries markers for
+            # every past init step — the exact history that must be ignored.
+            patch(
+                "vergil_tooling.lib.repo_init.cwd_repo_slug",
+                return_value="mnemosys-project/docs",
+            ),
+            patch(
+                "vergil_tooling.lib.repo_init.git.read_output",
+                return_value=(
+                    "abc chore(init): step 3 - vergil.toml\n"
+                    "def chore(init): step 4 - config files\n"
+                    "ghi chore(init): step 5 - CI/CD workflows\n"
+                    "jkl chore(init): step 6 - docs site\n"
+                ),
+            ) as mock_log,
+        ):
+            run_wizard(ctx)
+
+        # Every generation step re-runs; step 5 (ci.yml) is the load-bearing one.
+        assert {3, 4, 5, 6}.issubset(steps_run)
+        # On adopt the checkpoint log is not even consulted.
+        mock_log.assert_not_called()
+
     def test_ignores_foreign_repo_resume_state(self) -> None:
         # #2717 regression: when CWD is a DIFFERENT repo, its own bootstrap
         # commits must not be read as this repo's progress — every step runs.


### PR DESCRIPTION
# Pull Request

## Summary

- On --adopt, run_wizard no longer derives completed-steps from the permanent chore(init) checkpoint markers, so every generation step (notably ci.yml) re-runs, honoring adopt's overwrite-to-canonical contract.

## Issue Linkage

- Closes #2795

## Notes

- Root cause: run_wizard trusted local chore(init): step N - markers on adopt; those markers are permanent in any previously-init'd repo, so adopt skipped regeneration (step 5 / ci.yml), which then tripped the #2720 CI-gates guard and blocked the re-adopt remedy. Fix: when ctx.adopt is set, local_completed is empty; checkpoint-resume is retained only for an interrupted fresh init. Remote state (repo/branch existence) is still honored via _check_remote_steps, so steps 1/7 aren't needlessly re-run. No #2720 re-adopt remedy text existed in the guard or docs to update. Regression test: a repo carrying step-N markers still regenerates ci.yml under --adopt (asserts the checkpoint log is not consulted). Validation green: 4954 passed, 100% coverage.