### PR TITLE
feat(validate): exempt epics/ from MD013 in the markdownlint step

### DIFF
--- a/src/vergil_tooling/bin/validate_common.py
+++ b/src/vergil_tooling/bin/validate_common.py
@@ -2,8 +2,9 @@
 
 Runs inside the dev container via ``vrg-container-run``:
   1. Repository profile validation (includes README structural checks)
-  2. markdownlint on published markdown (docs/site/, epics/, README.md)
-     using the bundled canonical config
+  2. markdownlint on published markdown, in two passes: docs/site/ +
+     README.md against the strict bundled config, and epics/ against a
+     prose-relaxed config that disables MD013 line-length (issue #2803)
   3. shellcheck on all shell scripts under ``scripts/``
   4. yamllint on YAML files under ``.github/`` and ``docs/`` using
      the bundled canonical config (issue #302, #590)
@@ -46,9 +47,15 @@ def _find_shell_files(repo_root: Path) -> list[str]:
     return sorted(found)
 
 
-def _find_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> list[str]:
-    """Discover published markdown files: docs/site/**/*.md, epics/**/*.md,
-    and README.md."""
+def _find_strict_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> list[str]:
+    """Discover human-edited markdown that gets the strict ruleset:
+    ``docs/site/**/*.md`` and ``README.md``.
+
+    These are hand-authored and rendered *and* read raw, so line-length
+    (MD013) still earns its keep here. Long-form epic prose is discovered
+    separately by :func:`_find_prose_markdown_files` and linted against a
+    relaxed config (issue #2803).
+    """
     found: list[str] = []
     ignore_paths = [repo_root / p for p in (ignore or [])]
 
@@ -59,16 +66,30 @@ def _find_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> li
                 continue
             found.append(str(path))
 
+    readme = repo_root / "README.md"
+    if readme.is_file():
+        found.append(str(readme))
+
+    return sorted(found)
+
+
+def _find_prose_markdown_files(repo_root: Path, ignore: list[str] | None = None) -> list[str]:
+    """Discover long-form epic prose: ``epics/**/*.md``.
+
+    Epic specs/plans/retrospectives are consumed rendered, not raw, so they
+    are linted against the prose-relaxed config that disables MD013
+    (line-length) while keeping every other rule (issue #2803). Honors the
+    same ``[markdownlint].ignore`` paths as the strict scope.
+    """
+    found: list[str] = []
+    ignore_paths = [repo_root / p for p in (ignore or [])]
+
     epics_dir = repo_root / "epics"
     if epics_dir.is_dir():
         for path in epics_dir.rglob("*.md"):
             if any(path.is_relative_to(ip) for ip in ignore_paths):
                 continue
             found.append(str(path))
-
-    readme = repo_root / "README.md"
-    if readme.is_file():
-        found.append(str(readme))
 
     return sorted(found)
 
@@ -214,19 +235,37 @@ def main(argv: list[str] | None = None) -> int:  # noqa: ARG001
         return rc
 
     cfg = read_config(repo_root)
-    md_files = _find_markdown_files(repo_root, ignore=cfg.markdownlint.ignore)
+    strict_md = _find_strict_markdown_files(repo_root, ignore=cfg.markdownlint.ignore)
+    prose_md = _find_prose_markdown_files(repo_root, ignore=cfg.markdownlint.ignore)
     # The "(N files ...)" counts below name their fixed discovery scope on
     # purpose: each check lints a scoped slice of the working tree (published
     # docs, scripts/, etc.), NOT the branch diff. Agents kept reading a bare
     # "(N files)" as "N markdown files I changed" and reporting a phantom
     # off-by-one when a changed file fell outside the scope (issue #2601).
-    if md_files:
-        print(f"Running: markdownlint ({len(md_files)} files in docs/site/, epics/, README.md)")
-        config = files("vergil_tooling.configs") / "markdownlint.yaml"
-        cmd: list[str] = ["markdownlint", "--config", str(config), *md_files]
-        result = subprocess.run(cmd, check=False)  # noqa: S603, S607
-        if result.returncode != 0:
-            return result.returncode
+    #
+    # markdownlint runs as two passes so long-form epic prose can be exempted
+    # from MD013 (line-length) while docs/site and README stay strict (issue
+    # #2803). Both passes always run and the step fails if EITHER reports a
+    # violation, so a failure in the first scope never masks the second.
+    markdownlint_rc = 0
+    if strict_md:
+        print(f"Running: markdownlint ({len(strict_md)} files in docs/site/, README.md)")
+        strict_config = files("vergil_tooling.configs") / "markdownlint.yaml"
+        result = subprocess.run(  # noqa: S603
+            ["markdownlint", "--config", str(strict_config), *strict_md],  # noqa: S607
+            check=False,
+        )
+        markdownlint_rc = markdownlint_rc or result.returncode
+    if prose_md:
+        print(f"Running: markdownlint ({len(prose_md)} files in epics/, MD013 relaxed)")
+        prose_config = files("vergil_tooling.configs") / "markdownlint-prose.yaml"
+        result = subprocess.run(  # noqa: S603
+            ["markdownlint", "--config", str(prose_config), *prose_md],  # noqa: S607
+            check=False,
+        )
+        markdownlint_rc = markdownlint_rc or result.returncode
+    if markdownlint_rc != 0:
+        return markdownlint_rc
 
     shell_files = _find_shell_files(repo_root)
     if shell_files:

--- a/src/vergil_tooling/configs/markdownlint-prose.yaml
+++ b/src/vergil_tooling/configs/markdownlint-prose.yaml
@@ -1,0 +1,15 @@
+# Prose-relaxed markdownlint config for long-form epic docs (epics/**).
+#
+# Mirrors the canonical markdownlint.yaml ruleset but disables MD013
+# (line-length). Epic specs/plans/retrospectives are long-form prose
+# (often authored voice->text->spec) consumed rendered, not raw, so
+# hard-wrapping at 100 columns fights the author for near-zero value
+# (issue #2803). Every other rule still applies to epics/.
+#
+# Keep this in sync with markdownlint.yaml; the only intended
+# divergence is MD013.
+default: true
+no-duplicate-heading:
+  siblings_only: true
+MD013: false
+MD060: false

--- a/tests/vergil_tooling/test_validate_common.py
+++ b/tests/vergil_tooling/test_validate_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -13,8 +14,9 @@ from vergil_tooling.bin.validate_common import (
     _ansible_lint_overrides,
     _find_ansible_lint_config,
     _find_dockerfiles,
-    _find_markdown_files,
+    _find_prose_markdown_files,
     _find_shell_files,
+    _find_strict_markdown_files,
     _find_yaml_files,
     _has_ansible_content,
     main,
@@ -90,70 +92,77 @@ def test_find_shell_files_sorted(tmp_path: Path) -> None:
     assert result[0] < result[1]
 
 
-# -- _find_markdown_files ----------------------------------------------------
+# -- _find_strict_markdown_files ---------------------------------------------
 
 
-def test_find_markdown_files_none(tmp_path: Path) -> None:
-    assert _find_markdown_files(tmp_path) == []
+def test_find_strict_markdown_files_none(tmp_path: Path) -> None:
+    assert _find_strict_markdown_files(tmp_path) == []
 
 
-def test_find_markdown_files_site(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_site(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
-    result = _find_markdown_files(tmp_path)
+    result = _find_strict_markdown_files(tmp_path)
     assert len(result) == 1
     assert result[0].endswith("index.md")
 
 
-def test_find_markdown_files_readme(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_readme(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# Hello\n")
-    result = _find_markdown_files(tmp_path)
+    result = _find_strict_markdown_files(tmp_path)
     assert len(result) == 1
     assert result[0].endswith("README.md")
 
 
-def test_find_markdown_files_both(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_both(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
     (tmp_path / "README.md").write_text("# Project\n")
-    result = _find_markdown_files(tmp_path)
+    result = _find_strict_markdown_files(tmp_path)
     assert len(result) == 2
 
 
-def test_find_markdown_files_sorted(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_excludes_epics(tmp_path: Path) -> None:
+    epic = tmp_path / "epics" / "epic-1"
+    epic.mkdir(parents=True)
+    (epic / "spec.md").write_text("# Spec\n")
+    assert _find_strict_markdown_files(tmp_path) == []
+
+
+def test_find_strict_markdown_files_sorted(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "b.md").write_text("# B\n")
     (site / "a.md").write_text("# A\n")
-    result = _find_markdown_files(tmp_path)
+    result = _find_strict_markdown_files(tmp_path)
     assert result == sorted(result)
 
 
-def test_find_markdown_files_ignore_directory(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_ignore_directory(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     research = site / "docs" / "research"
     research.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
     (research / "report.md").write_text("# Report\n")
-    result = _find_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
+    result = _find_strict_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
     assert len(result) == 1
     assert result[0].endswith("index.md")
 
 
-def test_find_markdown_files_ignore_nested(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_ignore_nested(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     deep = site / "docs" / "research" / "2026" / "output"
     deep.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
     (deep / "report.md").write_text("# Report\n")
-    result = _find_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
+    result = _find_strict_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
     assert len(result) == 1
     assert result[0].endswith("index.md")
 
 
-def test_find_markdown_files_ignore_multiple(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_ignore_multiple(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     research = site / "docs" / "research"
     archive = site / "docs" / "archive"
@@ -162,7 +171,7 @@ def test_find_markdown_files_ignore_multiple(tmp_path: Path) -> None:
     (site / "index.md").write_text("# Hello\n")
     (research / "report.md").write_text("# Report\n")
     (archive / "old.md").write_text("# Old\n")
-    result = _find_markdown_files(
+    result = _find_strict_markdown_files(
         tmp_path,
         ignore=["docs/site/docs/research", "docs/site/docs/archive"],
     )
@@ -170,60 +179,72 @@ def test_find_markdown_files_ignore_multiple(tmp_path: Path) -> None:
     assert result[0].endswith("index.md")
 
 
-def test_find_markdown_files_ignore_does_not_affect_readme(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_ignore_does_not_affect_readme(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# Hello\n")
-    result = _find_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
+    result = _find_strict_markdown_files(tmp_path, ignore=["docs/site/docs/research"])
     assert len(result) == 1
     assert result[0].endswith("README.md")
 
 
-def test_find_markdown_files_ignore_empty_list(tmp_path: Path) -> None:
+def test_find_strict_markdown_files_ignore_empty_list(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
-    result = _find_markdown_files(tmp_path, ignore=[])
+    result = _find_strict_markdown_files(tmp_path, ignore=[])
     assert len(result) == 1
 
 
-def test_find_markdown_files_epics(tmp_path: Path) -> None:
+# -- _find_prose_markdown_files ----------------------------------------------
+
+
+def test_find_prose_markdown_files_none(tmp_path: Path) -> None:
+    assert _find_prose_markdown_files(tmp_path) == []
+
+
+def test_find_prose_markdown_files_epics(tmp_path: Path) -> None:
     epic = tmp_path / "epics" / "epic-1"
     epic.mkdir(parents=True)
     (epic / "spec.md").write_text("# Spec\n")
-    result = _find_markdown_files(tmp_path)
+    result = _find_prose_markdown_files(tmp_path)
     assert len(result) == 1
     assert result[0].endswith("spec.md")
 
 
-def test_find_markdown_files_epics_nested(tmp_path: Path) -> None:
+def test_find_prose_markdown_files_epics_nested(tmp_path: Path) -> None:
     epics = tmp_path / "epics"
     (epics / "epic-1").mkdir(parents=True)
     (epics / "epic-2").mkdir(parents=True)
     (epics / "epic-1" / "spec.md").write_text("# Spec\n")
     (epics / "epic-1" / "plan.md").write_text("# Plan\n")
     (epics / "epic-2" / "retrospective.md").write_text("# Retro\n")
-    result = _find_markdown_files(tmp_path)
+    result = _find_prose_markdown_files(tmp_path)
     assert len(result) == 3
 
 
-def test_find_markdown_files_all_scopes(tmp_path: Path) -> None:
+def test_find_prose_markdown_files_excludes_site_and_readme(tmp_path: Path) -> None:
     site = tmp_path / "docs" / "site"
     site.mkdir(parents=True)
     (site / "index.md").write_text("# Hello\n")
-    epic = tmp_path / "epics" / "epic-1"
-    epic.mkdir(parents=True)
-    (epic / "spec.md").write_text("# Spec\n")
     (tmp_path / "README.md").write_text("# Project\n")
-    result = _find_markdown_files(tmp_path)
-    assert len(result) == 3
+    assert _find_prose_markdown_files(tmp_path) == []
 
 
-def test_find_markdown_files_epics_honors_ignore(tmp_path: Path) -> None:
+def test_find_prose_markdown_files_sorted(tmp_path: Path) -> None:
+    epics = tmp_path / "epics"
+    epics.mkdir()
+    (epics / "b.md").write_text("# B\n")
+    (epics / "a.md").write_text("# A\n")
+    result = _find_prose_markdown_files(tmp_path)
+    assert result == sorted(result)
+
+
+def test_find_prose_markdown_files_honors_ignore(tmp_path: Path) -> None:
     epics = tmp_path / "epics"
     (epics / "epic-1").mkdir(parents=True)
     (epics / "archived").mkdir(parents=True)
     (epics / "epic-1" / "spec.md").write_text("# Spec\n")
     (epics / "archived" / "old.md").write_text("# Old\n")
-    result = _find_markdown_files(tmp_path, ignore=["epics/archived"])
+    result = _find_prose_markdown_files(tmp_path, ignore=["epics/archived"])
     assert len(result) == 1
     assert result[0].endswith("spec.md")
 
@@ -369,6 +390,136 @@ def test_main_markdownlint_honors_ignore(tmp_path: Path) -> None:
     assert len(md_args) == 1
     assert md_args[0].endswith("index.md")
     assert not any("research" in a for a in md_args)
+
+
+def test_main_markdownlint_two_passes_use_scoped_configs(tmp_path: Path) -> None:
+    """docs/site + README lint against the strict config; epics/ lints against
+    the prose-relaxed config, in two distinct markdownlint invocations."""
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    site = tmp_path / "docs" / "site"
+    site.mkdir(parents=True)
+    (site / "index.md").write_text("# Hello\n")
+    epic = tmp_path / "epics" / "epic-1"
+    epic.mkdir(parents=True)
+    (epic / "spec.md").write_text("# Spec\n")
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        ) as mock_run,
+    ):
+        assert main() == 0
+
+    md_calls = [c[0][0] for c in mock_run.call_args_list if c[0][0][0] == "markdownlint"]
+    assert len(md_calls) == 2
+
+    strict_call = md_calls[0]
+    assert strict_call[1] == "--config"
+    assert strict_call[2].endswith("markdownlint.yaml")
+    assert any(a.endswith("index.md") for a in strict_call[3:])
+    assert not any("spec.md" in a for a in strict_call[3:])
+
+    prose_call = md_calls[1]
+    assert prose_call[1] == "--config"
+    assert prose_call[2].endswith("markdownlint-prose.yaml")
+    assert any(a.endswith("spec.md") for a in prose_call[3:])
+    assert not any("index.md" in a for a in prose_call[3:])
+
+
+def test_main_markdownlint_prose_pass_fails_step(tmp_path: Path) -> None:
+    """A violation in the epics/ (prose) pass fails the step even when the
+    strict pass has no files to lint."""
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    epic = tmp_path / "epics" / "epic-1"
+    epic.mkdir(parents=True)
+    (epic / "spec.md").write_text("# Spec\n")
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        ),
+    ):
+        assert main() == 1
+
+
+# A prose line comfortably longer than MD013's 100-column limit. Kept
+# otherwise clean (leading heading, blank line, trailing newline) so MD013
+# is the ONLY rule it can trip.
+_LONG_LINE = (
+    "This is a long line of epic prose that intentionally exceeds the one "
+    "hundred column line-length limit that MD013 enforces, for testing."
+)
+_LONG_DOC = f"# Title\n\n{_LONG_LINE}\n"
+
+
+@pytest.mark.skipif(
+    shutil.which("markdownlint") is None,
+    reason="markdownlint binary not on PATH (only present in the dev container)",
+)
+def test_main_epics_long_line_passes_md013_relaxed(tmp_path: Path) -> None:
+    """A >100-char line in epics/ PASSES because the prose config disables
+    MD013 — proving the exemption end-to-end against the real binary."""
+    assert len(_LONG_LINE) > 100
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    epic = tmp_path / "epics" / "epic-1"
+    epic.mkdir(parents=True)
+    (epic / "spec.md").write_text(_LONG_DOC)
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+    ):
+        assert main() == 0
+
+
+@pytest.mark.skipif(
+    shutil.which("markdownlint") is None,
+    reason="markdownlint binary not on PATH (only present in the dev container)",
+)
+def test_main_docs_site_long_line_fails_md013(tmp_path: Path) -> None:
+    """The SAME >100-char line in docs/site/ FAILS MD013 — proving the strict
+    scope still enforces line-length."""
+    assert len(_LONG_LINE) > 100
+    (tmp_path / "vergil.toml").write_text(_MINIMAL_TOML)
+    site = tmp_path / "docs" / "site"
+    site.mkdir(parents=True)
+    (site / "long.md").write_text(_LONG_DOC)
+
+    with (
+        patch(
+            "vergil_tooling.bin.validate_common.git.repo_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "vergil_tooling.bin.validate_common.vrg_repo_profile.main",
+            return_value=0,
+        ),
+    ):
+        assert main() != 0
 
 
 def test_main_shellcheck_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Split the vrg-validate markdownlint step into two passes so long-form epic prose is exempt from MD013 (line-length) while docs/site and README keep the strict ruleset.

## Issue Linkage

- Closes #2803

## Notes

- Two markdownlint passes: docs/site/ + README.md against the strict configs/markdownlint.yaml, and epics/ against a new prose-relaxed configs/markdownlint-prose.yaml that mirrors the base but sets MD013: false. Both passes always run and the step fails if either reports a violation; both honor the existing [markdownlint].ignore paths. _find_markdown_files is split into _find_strict_markdown_files and _find_prose_markdown_files. Tests include two real-binary integration tests proving a >100-char line in epics/ passes while the same line in docs/site fails MD013 (skipped when markdownlint is absent). Validation green: 4960 tests, 100% coverage.