### PR TITLE
fix(release): raise CI-check poll ceiling 180s -> 1800s to stop spurious merge failures

### DIFF
--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -376,7 +376,16 @@ class GitHubAPIError(subprocess.CalledProcessError):
 
 
 _POLL_INTERVAL_SECS = 5
-_POLL_TIMEOUT_SECS = 180
+# Ceiling for how long the check-poll waiters block on still-PENDING checks
+# before giving up. Real CI here runs 3-8 min, so 180s guaranteed a spurious
+# finalize-merge failure on normal PRs (#2809); 1800s (30 min) comfortably
+# clears real CI and matches vrg_finalize_pr._CD_WATCH_TIMEOUT_SECS (#2753). A
+# merely-pending check is recoverable and is waited out to this deadline; a
+# *failed* check (pr_merge.failed_check_names) or an *orphaned* check
+# (OrphanedCheckError) still aborts earlier, so this ceiling never lets a
+# genuinely stuck merge hang. Single source of truth: release.subprocess imports
+# this same constant so the two waiters can never drift apart again (#2809).
+_POLL_TIMEOUT_SECS = 1800
 
 
 def _run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:

--- a/src/vergil_tooling/lib/release/subprocess.py
+++ b/src/vergil_tooling/lib/release/subprocess.py
@@ -6,10 +6,13 @@ import subprocess
 import time
 
 from vergil_tooling.lib import progress, retry
-from vergil_tooling.lib.github import _gh_env, _poll_and_watch_checks
+from vergil_tooling.lib.github import _POLL_TIMEOUT_SECS, _gh_env, _poll_and_watch_checks
 
+# _POLL_TIMEOUT_SECS is the shared pending-checks ceiling (1800s), imported from
+# lib.github so the release/update-deps merge waiter and the finalize merge
+# waiter (github.wait_for_checks) can never drift apart — the 180s-vs-real-CI
+# mismatch that caused #2809. See lib.github._POLL_TIMEOUT_SECS for rationale.
 _POLL_INTERVAL_SECS = 5
-_POLL_TIMEOUT_SECS = 180
 
 
 def _stream_with_retry(cmd: tuple[str, ...]) -> None:

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -316,6 +316,32 @@ def test_wait_for_checks_polls_until_terminal(monkeypatch: pytest.MonkeyPatch) -
     assert sleeps == [7, 7]
 
 
+def test_wait_for_checks_default_ceiling_is_1800_and_polls_past_180(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression (#2809): the default pending-checks ceiling was 180s — shorter
+    # than real CI (3-8 min) — so a normal PR whose checks were merely still
+    # running spuriously hard-failed the finalize merge. With the ceiling now
+    # 1800s, the waiter must keep polling well past 180s and raise the *plain*
+    # timeout only at the 1800s deadline (checks never terminal, nothing
+    # orphaned — e.g. an app-posted status still running).
+    assert github._POLL_TIMEOUT_SECS == 1800
+    monkeypatch.setattr(github, "all_checks_terminal", lambda pr: False)
+    monkeypatch.setattr(github, "orphaned_check_names", lambda pr: [])
+    # Fake monotonic clock, no real sleeping: deadline = 0 + 1800. The poll at
+    # t=200 is *past the old 180s ceiling* yet must NOT raise (proves 180s is
+    # gone); the deadline is only reached at t=1800.
+    clock = iter([0.0, 200.0, 1800.0])
+    monkeypatch.setattr(github.time, "monotonic", lambda: next(clock))
+    sleeps: list[int] = []
+    monkeypatch.setattr(github.time, "sleep", lambda s: sleeps.append(s))
+    with pytest.raises(github.GitHubAPIError, match="still pending after 1800s"):
+        github.wait_for_checks("934")
+    # Exactly one poll happened after crossing 180s and before the 1800s
+    # deadline — the old ceiling would have raised at that first check instead.
+    assert sleeps == [github._POLL_INTERVAL_SECS]
+
+
 def test_failed_check_names_returns_failing_checks() -> None:
     payload = json.dumps(
         [

--- a/tests/vergil_tooling/test_release_subprocess.py
+++ b/tests/vergil_tooling/test_release_subprocess.py
@@ -81,6 +81,17 @@ class TestStreamWithRetry:
         assert m_progress.run.call_count == retry.MAX_RETRIES + 1
 
 
+def test_poll_timeout_is_the_shared_github_constant() -> None:
+    # Regression (#2809): the release/update-deps merge waiter and the finalize
+    # merge waiter (github.wait_for_checks) must share one pending-checks ceiling
+    # so they can never drift apart again. subprocess imports the constant from
+    # lib.github; assert it is that same 1800s value.
+    from vergil_tooling.lib import github
+
+    assert release_subprocess._POLL_TIMEOUT_SECS is github._POLL_TIMEOUT_SECS
+    assert release_subprocess._POLL_TIMEOUT_SECS == 1800
+
+
 class TestWaitForChecks:
     """The shared poll-and-watch engine lives in lib.github (#1490)."""
 
@@ -127,7 +138,9 @@ class TestWaitForChecks:
             patch(_GH + "._checks_registered", return_value=False),
             patch(_MOD + "._stream_with_retry") as m_stream,
             patch(_GH + ".time.sleep"),
-            patch(_GH + ".time.monotonic", side_effect=[0, 200]),
+            # deadline = 0 + _POLL_TIMEOUT_SECS (1800s, #2809); the second clock
+            # read must clear it to trip the registration timeout.
+            patch(_GH + ".time.monotonic", side_effect=[0, 2000]),
             pytest.raises(subprocess.CalledProcessError, match="no checks reported"),
         ):
             wait_for_checks("https://github.com/o/r/pull/1")


### PR DESCRIPTION
# Pull Request

## Summary

- Raise the still-pending CI-check poll ceiling in wait_for_checks from 180s to 1800s (matching vrg_finalize_pr._CD_WATCH_TIMEOUT_SECS) so vrg-finalize-pr no longer spuriously hard-fails the merge while normal 3-8 min CI is still running.

## Issue Linkage

- Closes #2809

## Notes

- Unifies the two former _POLL_TIMEOUT_SECS copies: lib.github is now the single source of truth and lib.release.subprocess imports it, so the finalize and release/update-deps merge waiters can never drift again. Abort-early semantics unchanged: returns immediately when all checks are terminal, still raises OrphanedCheckError early on an orphaned pending check, and only raises the plain timeout at the 1800s deadline. Regression test asserts the default ceiling is 1800 and the waiter keeps polling past 180s before raising at 1800s; existing orphan/all-terminal tests are retained, and one release-subprocess timeout test's mock clock was updated for the new deadline. Validation green: 4979 passed, 100% coverage.