### PR TITLE
fix(evidence): emit machine-readable quality report files from the check registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ build/
 # Machine-readable gate reports emitted at the workspace root by the check
 # registry (see src/vergil_tooling/lib/languages.py). Consumed by the T8
 # evidence-producer composite; never committed.
+quality-ruff.json
+quality-mypy.xml
 coverage.xml
 junit.xml
 pip-audit.json

--- a/src/vergil_tooling/lib/languages.py
+++ b/src/vergil_tooling/lib/languages.py
@@ -65,6 +65,14 @@ class Language:
 # evidence-producer composite (epic vergil-project/.github#140): the composite
 # globs these exact names to bundle real report data instead of empty
 # envelopes. Keep this list in sync with the T8 composite glob.
+#
+# RUFF_REPORT and MYPY_REPORT close the ``quality`` gate's evidence gap: lint
+# and typecheck previously emitted no report files, so the producer bundled an
+# empty payload for that gate. These two filenames are the shared glob contract
+# with the T8 evidence-producer composite (vergil-actions#836) — a locked
+# contract with the producer bridge PR, so keep the names exact.
+RUFF_REPORT = "quality-ruff.json"
+MYPY_REPORT = "quality-mypy.xml"
 COVERAGE_REPORT = "coverage.xml"
 JUNIT_REPORT = "junit.xml"
 PIP_AUDIT_REPORT = "pip-audit.json"
@@ -74,6 +82,8 @@ LICENSES_REPORT = "licenses.json"
 # single source of truth so consumers (and tests) can assert the contract
 # without re-deriving the individual filenames.
 PYTHON_REPORT_FILES = (
+    RUFF_REPORT,
+    MYPY_REPORT,
     COVERAGE_REPORT,
     JUNIT_REPORT,
     PIP_AUDIT_REPORT,
@@ -262,8 +272,19 @@ _REGISTRY: dict[str, Language] = {
             CheckKind.LINT: [
                 ["ruff", "check", "src/", "tests/"],
                 ["ruff", "format", "--check", "src/", "tests/"],
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    f"--output-file={RUFF_REPORT}",
+                    "src/",
+                    "tests/",
+                ],
             ],
-            CheckKind.TYPECHECK: [["mypy", "src/"], ["ty", "check", "src", "tests"]],
+            CheckKind.TYPECHECK: [
+                ["mypy", "src/", "--junit-xml", MYPY_REPORT],
+                ["ty", "check", "src", "tests"],
+            ],
             CheckKind.TEST: [
                 [
                     "pytest",

--- a/tests/vergil_tooling/test_languages.py
+++ b/tests/vergil_tooling/test_languages.py
@@ -10,8 +10,10 @@ from vergil_tooling.lib.languages import (
     COVERAGE_REPORT,
     JUNIT_REPORT,
     LICENSES_REPORT,
+    MYPY_REPORT,
     PIP_AUDIT_REPORT,
     PYTHON_REPORT_FILES,
+    RUFF_REPORT,
     Cardinality,
     CheckKind,
     EcosystemInfo,
@@ -42,10 +44,34 @@ def test_python_lint_commands() -> None:
     assert "ruff format --check src/ tests/" in joined
 
 
+def test_python_lint_emits_ruff_json_report() -> None:
+    """A ``ruff check`` invocation writes the machine-readable findings file."""
+    cmds = language_commands("python", CheckKind.LINT)
+    report_cmd = [c for c in cmds if c[:2] == ["ruff", "check"] and "--output-format=json" in c]
+    assert len(report_cmd) == 1
+    assert "--output-format=json" in report_cmd[0]
+    assert f"--output-file={RUFF_REPORT}" in report_cmd[0]
+    # The developer-facing console invocations are preserved alongside it.
+    assert ["ruff", "check", "src/", "tests/"] in cmds
+    assert ["ruff", "format", "--check", "src/", "tests/"] in cmds
+
+
 def test_python_typecheck_commands() -> None:
     joined = _joined(language_commands("python", CheckKind.TYPECHECK))
-    assert "mypy src/" in joined
+    assert "mypy src/ --junit-xml quality-mypy.xml" in joined
     assert "ty check src tests" in joined
+
+
+def test_python_typecheck_mypy_emits_junit_xml() -> None:
+    """The mypy gate writes a JUnit-XML diagnostic report file."""
+    cmds = language_commands("python", CheckKind.TYPECHECK)
+    mypy_cmd = [c for c in cmds if c[0] == "mypy"]
+    assert len(mypy_cmd) == 1
+    assert "--junit-xml" in mypy_cmd[0]
+    junit_idx = mypy_cmd[0].index("--junit-xml")
+    assert mypy_cmd[0][junit_idx + 1] == MYPY_REPORT
+    # ty stays stdout-only (unchanged).
+    assert ["ty", "check", "src", "tests"] in cmds
 
 
 def test_python_test_commands() -> None:
@@ -107,11 +133,15 @@ def test_python_audit_pip_licenses_emits_json_report() -> None:
 def test_python_report_files_contract() -> None:
     """The shared report-path constants match the T8 path contract."""
     assert PYTHON_REPORT_FILES == (
+        "quality-ruff.json",
+        "quality-mypy.xml",
         "coverage.xml",
         "junit.xml",
         "pip-audit.json",
         "licenses.json",
     )
+    assert RUFF_REPORT == "quality-ruff.json"
+    assert MYPY_REPORT == "quality-mypy.xml"
     assert COVERAGE_REPORT == "coverage.xml"
     assert JUNIT_REPORT == "junit.xml"
     assert PIP_AUDIT_REPORT == "pip-audit.json"

--- a/tests/vergil_tooling/test_report_emission.py
+++ b/tests/vergil_tooling/test_report_emission.py
@@ -17,6 +17,8 @@ from vergil_tooling.lib.languages import (
     COVERAGE_REPORT,
     JUNIT_REPORT,
     LICENSES_REPORT,
+    MYPY_REPORT,
+    RUFF_REPORT,
     CheckKind,
     language_commands,
 )
@@ -70,6 +72,64 @@ def test_test_command_report_flags_write_files(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
     assert (tmp_path / COVERAGE_REPORT).is_file()
     assert (tmp_path / JUNIT_REPORT).is_file()
+
+
+def test_lint_ruff_writes_json_report(tmp_path: Path) -> None:
+    """ruff check, run with the registry's report flags, writes quality-ruff.json."""
+    if shutil.which("ruff") is None:
+        import pytest
+
+        pytest.skip("ruff not installed in this environment")
+
+    (tmp_path / "clean.py").write_text("x: int = 1\n")
+
+    cmds = language_commands("python", CheckKind.LINT)
+    report_cmd = [c for c in cmds if c[:2] == ["ruff", "check"] and "--output-format=json" in c]
+    assert len(report_cmd) == 1, f"expected one report ruff command, got {report_cmd}"
+    # Point the report flags at the fixture file instead of src/ tests/.
+    output_flags = [
+        arg
+        for arg in report_cmd[0]
+        if arg.startswith("--output-format=") or arg.startswith("--output-file=")
+    ]
+    assert len(output_flags) == 2
+
+    result = subprocess.run(
+        ["ruff", "check", *output_flags, "clean.py"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / RUFF_REPORT).is_file()
+
+
+def test_typecheck_mypy_writes_junit_report(tmp_path: Path) -> None:
+    """mypy, run with the registry's report flag, writes quality-mypy.xml."""
+    if shutil.which("mypy") is None:
+        import pytest
+
+        pytest.skip("mypy not installed in this environment")
+
+    (tmp_path / "clean.py").write_text("def f() -> int:\n    return 1\n")
+
+    mypy_cmd = _registry_cmd(CheckKind.TYPECHECK, "mypy")
+    junit_idx = mypy_cmd.index("--junit-xml")
+    report_flag = mypy_cmd[junit_idx : junit_idx + 2]
+    assert report_flag == ["--junit-xml", MYPY_REPORT]
+
+    result = subprocess.run(
+        ["mypy", "clean.py", *report_flag],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / MYPY_REPORT).is_file()
 
 
 def test_audit_pip_licenses_writes_report(tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Wires ruff and mypy in the Python check registry to write quality-ruff.json and quality-mypy.xml via their own file-output flags, so the CI evidence producer bundles real quality-gate data instead of an empty payload.

## Issue Linkage

- Closes #2811

## Notes

- The quality-ruff.json / quality-mypy.xml filenames are a locked contract with vergil-actions#836's producer bridge — keep them exact. ty stays stdout-only (unchanged); mypy provides the typecheck report file via --junit-xml. Console-facing ruff check/format commands are preserved so developer output is unchanged. New RUFF_REPORT/MYPY_REPORT constants join PYTHON_REPORT_FILES (the T8 glob single-source-of-truth) and both artifacts are gitignored alongside the existing four.