### PR TITLE
fix(epics): ensure ad-hoc/archive labels exist before applying them

### DIFF
--- a/src/vergil_tooling/lib/epics.py
+++ b/src/vergil_tooling/lib/epics.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from vergil_tooling.lib import github
+from vergil_tooling.lib.labels import load_labels
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -487,6 +488,7 @@ def ensure_adhoc_epic(target_repo: str) -> IssueRef:
     found = _find_epic_by_title(home, title)
     if found is not None:
         return found
+    _ensure_labels(home, _ADHOC_EPIC_LABELS)
     url = github.create_issue(
         repo=home,
         title=title,
@@ -510,12 +512,45 @@ def find_adhoc_epic(target_repo: str) -> IssueRef | None:
     return _find_epic_by_title(home, f"{_ADHOC_EPIC_TITLE_PREFIX}{bare}")
 
 
+def _ensure_labels(repo: str, names: Sequence[str]) -> None:
+    """Create each of *names* in *repo* if absent, from the canonical registry.
+
+    The ad-hoc/archive machinery labels issues with ``archive``/``ad-hoc``/
+    ``epic``; in an org whose ``.github`` was never label-synced these labels do
+    not exist, and ``gh`` refuses to apply a missing one (``'archive' not
+    found``). Creating them on demand from ``labels.json`` — idempotent
+    ``label create --force`` with the canonical colour and description — makes
+    archive creation and normalization self-healing in every org, not only the
+    migrated one. This is the root cause of the cross-org epic-rollup failures
+    (vergil-project/.github#305): only ``vergil-project/.github`` had the
+    ``archive`` label, so every other org's ``on: issues.closed`` rollup crashed.
+    """
+    specs = {entry["name"]: entry for entry in load_labels()["labels"]}
+    for name in names:
+        spec = specs[name]
+        github.run(
+            "label",
+            "create",
+            name,
+            "--repo",
+            repo,
+            "--force",
+            "--color",
+            spec["color"],
+            "--description",
+            spec["description"],
+        )
+
+
 def _normalize_archive_in_place(ref: IssueRef, new_title: str) -> None:
     """Convert a legacy-form archive to the new form: retitle, +archive, -epic.
 
     Keeps ``ad-hoc``. Works on open or closed issues (``gh issue edit`` permits
-    editing a closed issue's title and labels).
+    editing a closed issue's title and labels). Ensures the ``archive`` label
+    exists first, so a not-yet-migrated org's ``.github`` self-heals instead of
+    failing with ``'archive' not found``.
     """
+    _ensure_labels(f"{ref.owner}/{ref.repo}", ("archive",))
     github.run(
         "issue",
         "edit",
@@ -555,6 +590,7 @@ def ensure_adhoc_archive(target_repo: str, quarter: str) -> IssueRef:
     if legacy is not None:
         _normalize_archive_in_place(legacy, title)
         return legacy
+    _ensure_labels(home, _ADHOC_ARCHIVE_LABELS)
     url = github.create_issue(
         repo=home,
         title=title,

--- a/tests/vergil_tooling/test_epics.py
+++ b/tests/vergil_tooling/test_epics.py
@@ -796,6 +796,7 @@ def test_ensure_adhoc_epic_zero_creates_in_dotgithub() -> None:
     with (
         patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
         patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.epics._ensure_labels"),
         patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
     ):
         result = epics.ensure_adhoc_epic("org/tooling")
@@ -811,6 +812,7 @@ def test_ensure_adhoc_epic_private_repo_homes_in_self() -> None:
     with (
         patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/lab"),
         patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.epics._ensure_labels"),
         patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
     ):
         result = epics.ensure_adhoc_epic("org/lab")
@@ -823,6 +825,7 @@ def test_ensure_adhoc_epic_for_dotgithub_itself() -> None:
     created = "https://github.com/org/.github/issues/5"
     with (
         patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.epics._ensure_labels"),
         patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
     ):
         assert epics.ensure_adhoc_epic("org/.github") == IssueRef("org", ".github", 5)
@@ -938,6 +941,7 @@ def test_ensure_adhoc_archive_creates_stamped_title() -> None:
     with (
         patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
         patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.epics._ensure_labels"),
         patch("vergil_tooling.lib.github.create_issue", return_value=created) as mock_create,
     ):
         ref = epics.ensure_adhoc_archive("org/tooling", "2026-Q3")
@@ -1023,13 +1027,63 @@ def test_rollup_noop_for_child_under_archive_parent() -> None:
 
 def test_normalize_archive_in_place_edits_title_and_labels() -> None:
     ref = IssueRef("org", ".github", 88)
-    with patch("vergil_tooling.lib.github.run") as mock_run:
+    with (
+        patch("vergil_tooling.lib.epics._ensure_labels") as mock_ensure,
+        patch("vergil_tooling.lib.github.run") as mock_run,
+    ):
         epics._normalize_archive_in_place(ref, "Archive (ad hoc): tooling — 2026-Q3")
     args = list(mock_run.call_args.args)
     assert args[:2] == ["issue", "edit"] and "88" in args
     assert "--title" in args and "Archive (ad hoc): tooling — 2026-Q3" in args
     assert args[args.index("--add-label") + 1] == "archive"
     assert args[args.index("--remove-label") + 1] == "epic"
+    # The 'archive' label is self-healed in the target repo before it is applied,
+    # so a not-yet-migrated org's .github does not fail with 'archive' not found.
+    mock_ensure.assert_called_once_with("org/.github", ("archive",))
+
+
+def test_ensure_labels_creates_missing_labels_from_registry() -> None:
+    # Each named label is created (idempotent --force) with the canonical colour
+    # and description drawn from labels.json — the self-healing primitive that
+    # makes the ad-hoc/archive machinery work in every org (#305).
+    with patch("vergil_tooling.lib.github.run") as mock_run:
+        epics._ensure_labels("org/.github", ("archive", "ad-hoc"))
+    created = [list(c.args) for c in mock_run.call_args_list]
+    assert [c[:3] for c in created] == [
+        ["label", "create", "archive"],
+        ["label", "create", "ad-hoc"],
+    ]
+    for call_args in created:
+        assert call_args[3:5] == ["--repo", "org/.github"]
+        assert "--force" in call_args
+        assert "--color" in call_args and "--description" in call_args
+
+
+def test_ensure_adhoc_archive_create_self_heals_labels() -> None:
+    # The create branch ensures 'archive'+'ad-hoc' exist before creating the
+    # archive issue, so the org's .github self-heals rather than failing.
+    created = "https://github.com/org/.github/issues/88"
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.epics._ensure_labels") as mock_ensure,
+        patch("vergil_tooling.lib.github.create_issue", return_value=created),
+    ):
+        epics.ensure_adhoc_archive("org/tooling", "2026-Q3")
+    mock_ensure.assert_called_once_with("org/.github", ("archive", "ad-hoc"))
+
+
+def test_ensure_adhoc_epic_create_self_heals_labels() -> None:
+    # The create branch ensures 'epic'+'ad-hoc' exist before creating the epic.
+    created = "https://github.com/org/.github/issues/77"
+    with (
+        patch("vergil_tooling.lib.epics.resolve_epic_home", return_value="org/.github"),
+        patch("vergil_tooling.lib.github.read_json", return_value=[]),
+        patch("vergil_tooling.lib.epics._ensure_labels") as mock_ensure,
+        patch("vergil_tooling.lib.github.create_issue", return_value=created),
+    ):
+        epics.ensure_adhoc_epic("org/tooling")
+    mock_ensure.assert_called_once_with("org/.github", ("epic", "ad-hoc"))
 
 
 def test_ensure_adhoc_archive_heals_legacy_in_place() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Make the ad-hoc/archive epic machinery self-heal missing labels by ensuring archive/ad-hoc/epic exist (from the canonical registry) before applying them, fixing the cross-org epic-rollup crash ('archive' not found) in every org that was never label-synced.

## Issue Linkage

- Closes #2820

## Notes

- Root cause of the failing epic-rollup Actions in non-vergil-project orgs (e.g. mnemosys-project run 31625631638): only vergil-project/.github had the 'archive' label. Fix adds _ensure_labels and calls it on the create/normalize branches only (steady-state early-return paths untouched). Tactical fix; broader label-provisioning design and the operational rollout (provision labels into the 5 affected orgs, release, one-time normalize/archive sweep) are tracked under the umbrella issue vergil-project/.github#305.