### PR TITLE
fix(evidence): reject empty gate payloads in completeness validation

### DIFF
--- a/src/vergil_tooling/lib/ci_evidence.py
+++ b/src/vergil_tooling/lib/ci_evidence.py
@@ -341,30 +341,71 @@ def assemble_bundle(staging_dir: Path, out_tarball: Path) -> Path:
 
 
 class IncompleteEvidenceError(Exception):
-    """A required evidence gate produced no harvested evidence.
+    """A required evidence gate is absent or carries an empty payload.
 
-    Thin, data-carrying: ``.missing`` lists every required gate name with no
-    evidence. The message format is defined here once so the CLI (T5) can reuse
-    it via ``emit_error``. Substantive failure — terminal in enforcing mode.
+    Thin, data-carrying, distinguishing the two substantive failure modes:
+
+    - ``.missing`` — required gates with no harvested evidence at all.
+    - ``.empty_payload`` — required gates that were harvested but carry no
+      report file, only the ``evidence.json`` envelope. This is the #2812 root
+      cause: for weeks the test/audit/quality gates shipped empty payloads and
+      the name-only completeness check passed them green even while enforcing.
+
+    The message format is defined here once so the CLI (T5) can reuse it via
+    ``emit_error``. Substantive failure — terminal in enforcing mode.
     """
 
-    def __init__(self, missing: list[str]) -> None:
-        self.missing = missing
-        super().__init__(f"missing evidence for required gates: {missing}")
+    def __init__(
+        self, missing: list[str] | None = None, empty_payload: list[str] | None = None
+    ) -> None:
+        self.missing = missing or []
+        self.empty_payload = empty_payload or []
+        parts: list[str] = []
+        if self.missing:
+            parts.append(f"required gates with no evidence artifact: {self.missing}")
+        if self.empty_payload:
+            parts.append(
+                "required gates with an empty payload "
+                f"(only evidence.json, no report files): {self.empty_payload}"
+            )
+        super().__init__("; ".join(parts))
+
+
+def _has_report_payload(evidence: GateEvidence) -> bool:
+    """True when a gate carries at least one report file besides ``evidence.json``.
+
+    :func:`load_gate_evidence` builds ``GateEvidence.files`` from
+    ``gate_dir.rglob("*")``, which **always** includes the ``evidence.json``
+    envelope itself — so an empty gate still has one file. Completeness must
+    therefore count report files *excluding* ``evidence.json``; a bare
+    ``len(files) > 0`` would wave the empty payload through (#2812).
+    """
+    return any(path.name != "evidence.json" for path in evidence.files)
 
 
 def validate_completeness(
     required: Sequence[EvidenceGate],
     harvested: Mapping[str, GateEvidence],
 ) -> None:
-    """Raise :class:`IncompleteEvidenceError` for required gates lacking evidence.
+    """Raise :class:`IncompleteEvidenceError` for incomplete required gates.
 
-    A pure set-difference of required gate names against harvested keys. The
-    ``missing`` list preserves ``required`` order for a stable, readable report.
+    A required gate is complete only if it is present **and** carries at least
+    one report file besides ``evidence.json``. Both failure modes are collected
+    and reported together, each preserving ``required`` order for a stable,
+    readable report:
+
+    - **missing** — no harvested :class:`GateEvidence` for the gate at all.
+    - **empty payload** — present but every staged file is ``evidence.json``
+      (no real report), the empty-envelope bug this guard exists to catch.
     """
     missing = [gate.name for gate in required if gate.name not in harvested]
-    if missing:
-        raise IncompleteEvidenceError(missing)
+    empty_payload = [
+        gate.name
+        for gate in required
+        if gate.name in harvested and not _has_report_payload(harvested[gate.name])
+    ]
+    if missing or empty_payload:
+        raise IncompleteEvidenceError(missing, empty_payload)
 
 
 # --- GitHub harvest layer ------------------------------------------------

--- a/tests/vergil_tooling/test_ci_evidence.py
+++ b/tests/vergil_tooling/test_ci_evidence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import tarfile
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
@@ -28,9 +28,6 @@ from vergil_tooling.lib.ci_evidence import (
     write_readme,
 )
 from vergil_tooling.lib.github_config import EvidenceGate
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class TestEvidenceAssetNames:
@@ -180,15 +177,18 @@ def test_copy_sbom(tmp_path: Path) -> None:
     assert out.read_text() == "{}"
 
 
-def _gate_evidence(name: str) -> GateEvidence:
-    """A minimal GateEvidence for completeness tests (files unused here)."""
-    return GateEvidence(
-        name=name,
-        conclusion="success",
-        tools=(),
-        metrics={},
-        files=(),
-    )
+def _gate_evidence(name: str, *, files: tuple[Path, ...] | None = None) -> GateEvidence:
+    """A GateEvidence for completeness tests.
+
+    Defaults to a real report payload — a report file staged alongside the
+    ``evidence.json`` envelope — so the gate reads as complete. Pass ``files``
+    to model an empty payload (only ``evidence.json``) or any custom file set.
+    ``_has_report_payload`` inspects only ``Path.name``, so these paths need not
+    exist on disk.
+    """
+    if files is None:
+        files = (Path(f"gates/{name}/{name}.report"), Path(f"gates/{name}/evidence.json"))
+    return GateEvidence(name=name, conclusion="success", tools=(), metrics={}, files=files)
 
 
 def test_validate_completeness_all_present_ok() -> None:
@@ -208,6 +208,55 @@ def test_validate_completeness_missing_required_raises() -> None:
             {"test": _gate_evidence("test")},
         )
     assert excinfo.value.missing == ["security"]
+    assert excinfo.value.empty_payload == []
+    assert "no evidence artifact" in str(excinfo.value)
+
+
+def test_validate_completeness_empty_payload_raises() -> None:
+    """A required gate present but carrying only ``evidence.json`` is incomplete.
+
+    The empty-envelope root cause of #2812: an artifact NAME was present so the
+    old check passed it green, but the payload held no report file. It must now
+    surface under ``empty_payload``.
+    """
+    with pytest.raises(IncompleteEvidenceError) as excinfo:
+        validate_completeness(
+            [EvidenceGate("test", ("test / unit / 3.14",))],
+            {"test": _gate_evidence("test", files=(Path("gates/test/evidence.json"),))},
+        )
+    assert excinfo.value.empty_payload == ["test"]
+    assert excinfo.value.missing == []
+    assert "empty payload" in str(excinfo.value)
+
+
+def test_validate_completeness_report_payload_ok() -> None:
+    """A required gate with a real report file beside ``evidence.json`` passes."""
+    validate_completeness(
+        [EvidenceGate("test", ("test / unit / 3.14",))],
+        {
+            "test": _gate_evidence(
+                "test",
+                files=(Path("gates/test/coverage.xml"), Path("gates/test/evidence.json")),
+            )
+        },
+    )  # no raise
+
+
+def test_validate_completeness_mixed_missing_and_empty() -> None:
+    """One absent gate and one empty-payload gate are both surfaced at once."""
+    with pytest.raises(IncompleteEvidenceError) as excinfo:
+        validate_completeness(
+            [
+                EvidenceGate("security", ("Trivy",)),
+                EvidenceGate("test", ("test / unit / 3.14",)),
+            ],
+            {"test": _gate_evidence("test", files=(Path("gates/test/evidence.json"),))},
+        )
+    assert excinfo.value.missing == ["security"]
+    assert excinfo.value.empty_payload == ["test"]
+    message = str(excinfo.value)
+    assert "no evidence artifact" in message
+    assert "empty payload" in message
 
 
 # --- Persisted harvest state (issue #2330) ------------------------------

--- a/tests/vergil_tooling/test_vrg_ci_evidence.py
+++ b/tests/vergil_tooling/test_vrg_ci_evidence.py
@@ -175,7 +175,7 @@ def test_bundle_missing_required_gate_errors(
 
     assert rc == 1
     err = capsys.readouterr().err
-    assert "missing evidence" in err
+    assert "no evidence artifact" in err
     assert "security" in err
     assert not (out_dir / "v2.1.129-ci-evidence.tar.gz").exists()
 
@@ -303,7 +303,7 @@ def test_harvest_missing_required_gate_errors(
 
     assert rc == 1
     err = capsys.readouterr().err
-    assert "missing evidence" in err
+    assert "no evidence artifact" in err
     assert "security" in err
     # A failed gate persists no state file (the raise precedes the write).
     assert not (staging / "harvest-state.json").exists()


### PR DESCRIPTION
# Pull Request

## Summary

- Harden CI-evidence completeness so a required gate passes only when it carries a report file besides evidence.json, closing the empty-payload gap that shipped green for weeks.

## Issue Linkage

- Closes #2812

## Notes

- ROLLOUT NOTE: this tightens the already-enforcing evidence gate from artifact-presence to report-payload-presence. Once released to @v2.1 it applies to every cd-release repo; a required gate that carries no report file (only evidence.json) will now hard-fail that repo's release. Verified good for vergil-tooling (all 4 gates carry real per-version reports as of v2.1.194); the human should confirm other cd-release repos' required gates also emit report payloads before/at rollout, with evidence-enforce=false as the per-repo escape hatch. Guard excludes evidence.json when counting report files (GateEvidence.files includes it via rglob).