### PR TITLE
feat(github): surface a clear error when no GitHub token is available

### DIFF
--- a/src/vergil_tooling/bin/vrg_roadmap.py
+++ b/src/vergil_tooling/bin/vrg_roadmap.py
@@ -29,22 +29,28 @@ def main(argv: list[str] | None = None) -> int:
     if args.org and args.repo:
         print("vrg-roadmap: --org and --repo are mutually exclusive", file=sys.stderr)
         return 1
-    if args.repo:
-        if "/" not in args.repo:
-            print(
-                f"vrg-roadmap: --repo must be 'owner/repo' (got {args.repo!r})",
-                file=sys.stderr,
-            )
-            return 1
-        owner, bare = args.repo.split("/", 1)
-        org, home = owner, epics.resolve_epic_home(owner, bare)
-    else:
-        org, home = args.org or github.current_org(), None
-    # Scope the App token to the org being read so a cross-org --org/--repo selects
-    # that org's installation, not the cwd repo's (#2070).
+    if args.repo and "/" not in args.repo:
+        print(
+            f"vrg-roadmap: --repo must be 'owner/repo' (got {args.repo!r})",
+            file=sys.stderr,
+        )
+        return 1
+    # Resolve the org/home and render inside one try: every step here shells out
+    # to gh, so a missing token or missing installation must surface as a clean
+    # message, not a traceback. Scope the App token to the org being read so a
+    # cross-org --org/--repo selects that org's installation, not the cwd repo's
+    # (#2070).
     try:
+        if args.repo:
+            owner, bare = args.repo.split("/", 1)
+            org, home = owner, epics.resolve_epic_home(owner, bare)
+        else:
+            org, home = args.org or github.current_org(), None
         with github.target_org(org):
             print(roadmap.render(roadmap.gather(org, home=home), org, home=home))
+    except github.MissingGitHubTokenError:
+        print(github.missing_token_message("vrg-roadmap"), file=sys.stderr)
+        return 1
     except github.NoInstallationError as exc:
         print(f"vrg-roadmap: {github.no_installation_message(exc)}", file=sys.stderr)
         return 1

--- a/src/vergil_tooling/lib/github.py
+++ b/src/vergil_tooling/lib/github.py
@@ -375,6 +375,39 @@ class GitHubAPIError(subprocess.CalledProcessError):
         return base
 
 
+# gh in a GitHub Actions runner exits non-zero with this guidance when no auth
+# token is present. It is a configuration error (a step that forgot to pass a
+# token), not a tooling bug, so we surface it as a distinct, catchable error
+# with an actionable message instead of a raw traceback. The value is a
+# substring of gh's stderr matched to classify the failure — not a credential,
+# so S105 (which flags the word "token") is a false positive here.
+_MISSING_TOKEN_SIGNATURE = "gh_token environment variable"  # noqa: S105
+
+
+def _is_missing_token_error(stderr: str | None) -> bool:
+    """True when *stderr* is gh's "no token available" message."""
+    return stderr is not None and _MISSING_TOKEN_SIGNATURE in stderr.lower()
+
+
+class MissingGitHubTokenError(GitHubAPIError):
+    """A ``gh`` failure caused solely by the absence of an auth token.
+
+    Distinct from a generic :class:`GitHubAPIError` so entry points can catch
+    it and print :func:`missing_token_message` — a configuration fix — rather
+    than letting a raw traceback reach the operator.
+    """
+
+
+def missing_token_message(tool: str) -> str:
+    """An actionable message for the "no GitHub token" configuration error."""
+    return (
+        f"{tool}: no GitHub token available. Set GH_TOKEN (or GITHUB_TOKEN) in "
+        "the environment. In a GitHub Actions step, add:\n"
+        "    env:\n"
+        "      GH_TOKEN: ${{ github.token }}"
+    )
+
+
 _POLL_INTERVAL_SECS = 5
 # Ceiling for how long the check-poll waiters block on still-PENDING checks
 # before giving up. Real CI here runs 3-8 min, so 180s guaranteed a spurious
@@ -397,6 +430,8 @@ def _run_with_retry(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[st
         return retry.run_with_retry(*args, **kwargs)
     except subprocess.CalledProcessError as exc:
         detail = ((exc.stderr or "") + (exc.stdout or "")).strip()
+        if _is_missing_token_error(exc.stderr):
+            raise MissingGitHubTokenError(exc.returncode, exc.cmd, exc.stdout, exc.stderr) from exc
         if detail:
             raise GitHubAPIError(exc.returncode, exc.cmd, exc.stdout, exc.stderr) from exc
         raise

--- a/tests/vergil_tooling/test_github.py
+++ b/tests/vergil_tooling/test_github.py
@@ -56,6 +56,42 @@ def test_read_output_returns_stripped_stdout() -> None:
     )
 
 
+def test_missing_token_error_raised_on_gh_token_signature() -> None:
+    err = subprocess.CalledProcessError(
+        4,
+        ("gh", "repo", "view"),
+        output="",
+        stderr=(
+            "gh: To use GitHub CLI in a GitHub Actions workflow, set the "
+            "GH_TOKEN environment variable.\n"
+        ),
+    )
+    with (
+        patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+        pytest.raises(github.MissingGitHubTokenError),
+    ):
+        github.read_output("repo", "view")
+
+
+def test_generic_gh_error_is_not_a_missing_token_error() -> None:
+    err = subprocess.CalledProcessError(
+        1, ("gh", "repo", "view"), output="", stderr="HTTP 404: Not Found\n"
+    )
+    with (
+        patch("vergil_tooling.lib.retry.subprocess.run", side_effect=err),
+        pytest.raises(github.GitHubAPIError) as excinfo,
+    ):
+        github.read_output("repo", "view")
+    assert not isinstance(excinfo.value, github.MissingGitHubTokenError)
+
+
+def test_missing_token_message_is_actionable() -> None:
+    msg = github.missing_token_message("vrg-roadmap")
+    assert "vrg-roadmap" in msg
+    assert "GH_TOKEN" in msg
+    assert "github.token" in msg
+
+
 def test_current_org_returns_remote_owner() -> None:
     with patch("vergil_tooling.lib.github.current_repo", return_value="logical-minds-foundry/docs"):
         assert github.current_org() == "logical-minds-foundry"

--- a/tests/vergil_tooling/test_vrg_roadmap.py
+++ b/tests/vergil_tooling/test_vrg_roadmap.py
@@ -52,6 +52,16 @@ def test_main_reports_missing_installation() -> None:
     assert rc == 1
 
 
+def test_main_reports_missing_token(capsys: pytest.CaptureFixture[str]) -> None:
+    err = github.MissingGitHubTokenError(4, ("gh", "repo", "view"), None, "no token")
+    with patch(f"{_MOD}.github.current_org", side_effect=err):
+        rc = main([])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "no GitHub token" in captured.err
+    assert "GH_TOKEN" in captured.err
+
+
 def test_main_repo_uses_resolved_home() -> None:
     with (
         patch(f"{_MOD}.epics.resolve_epic_home", return_value="org/lab") as mock_home,


### PR DESCRIPTION
# Pull Request

## Summary

- Detect gh's no-token stderr and raise a distinct MissingGitHubTokenError, so vrg-roadmap prints an actionable 'set GH_TOKEN' message instead of a raw GitHubAPIError traceback when a GitHub Actions step forgot to pass a token.

## Issue Linkage

- Closes #2831

## Notes

- $Centralized in github.py (MissingGitHubTokenError + missing_token_message) so other gh-backed tools can adopt the same handling; vrg-roadmap now catches it at the entry point. Retry is unaffected (the no-token signature is not a retryable pattern, so it already fails fast). Validated green: vrg-container-run -- vrg-validate (4993 passed, 100% coverage, lint/typecheck/audit clean). This is the deferred direction (b) from the CD docs-refresh outage; the workflow fix is vergil-project/vergil-actions#844. Triage: vergil-project/.github#310.