### PR TITLE
fix(retry): retry transient GitHub failures on raw git network ops

### DIFF
--- a/src/vergil_tooling/bin/vrg_git.py
+++ b/src/vergil_tooling/bin/vrg_git.py
@@ -9,9 +9,10 @@ import os
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
-from vergil_tooling.lib import branch_names, github
+from vergil_tooling.lib import branch_names, github, retry
 from vergil_tooling.lib.git import _git_auth_env, main_worktree_root
 from vergil_tooling.lib.pr_workflow import freeze
 
@@ -491,6 +492,42 @@ def _print_workflow_push_guidance() -> None:
     )
 
 
+def _run_network_with_retry(
+    argv: list[str], env: dict[str, str] | None
+) -> subprocess.CompletedProcess[str]:
+    """Run ``git *argv`` capturing output, retrying transient GitHub failures.
+
+    Returns the final attempt's ``CompletedProcess``. Network ops are captured
+    (not streamed) so their stderr can be inspected for retryable transients —
+    GitHub 502s, SSH-backend blips rejecting a valid key. Every retry is
+    announced on stderr so a genuinely non-transient failure (a real auth error,
+    a missing repo) still surfaces before the final result — no silent masking
+    (#2835).
+    """
+    for attempt in range(retry.MAX_RETRIES + 1):
+        result = subprocess.run(  # noqa: S603
+            ["git", *argv],  # noqa: S607
+            check=False,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 or attempt == retry.MAX_RETRIES:
+            return result
+        exc = subprocess.CalledProcessError(
+            result.returncode, ("git", *argv), output=result.stdout, stderr=result.stderr
+        )
+        if not retry.is_retryable(exc):
+            return result
+        delay = retry.compute_delay(attempt)
+        sys.stderr.write(
+            f"vrg-git {argv[0]}: transient GitHub failure, retrying in "
+            f"{delay:.1f}s (attempt {attempt + 1}/{retry.MAX_RETRIES + 1})\n"
+        )
+        time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
 def _print_help() -> None:
     """Print vrg-git's own help — what the wrapper enforces before forwarding."""
     denied = ", ".join(sorted(_DENIED))
@@ -619,19 +656,20 @@ def main(argv: list[str] | None = None) -> int:
     if subcmd == "rebase":
         env = _noninteractive_rebase_env(env)
 
-    if subcmd == "push":
-        push_result = subprocess.run(  # noqa: S603
-            ["git", *argv],  # noqa: S607
-            check=False,
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        if push_result.stdout:
-            sys.stdout.write(push_result.stdout)
-        if push_result.stderr:
-            sys.stderr.write(push_result.stderr)
-        if push_result.returncode != 0 and _WORKFLOW_PERMISSION_RE.search(push_result.stderr or ""):
+    if subcmd in _REMOTE_SUBCOMMANDS:
+        # Network op: capture output so its stderr can be inspected for
+        # retryable transients (GitHub 502s, SSH-backend blips), and ride
+        # those out instead of failing the first attempt (#2835).
+        net_result = _run_network_with_retry(argv, env)
+        if net_result.stdout:
+            sys.stdout.write(net_result.stdout)
+        if net_result.stderr:
+            sys.stderr.write(net_result.stderr)
+        if (
+            subcmd == "push"
+            and net_result.returncode != 0
+            and _WORKFLOW_PERMISSION_RE.search(net_result.stderr or "")
+        ):
             # A workflow-file push refusal is expected and routine: the agent
             # never pushes a workflow branch — the human's vrg-submit-pr does,
             # at submit time. Warn and report success so the agent proceeds to
@@ -639,7 +677,7 @@ def main(argv: list[str] | None = None) -> int:
             # (#2540). Any other push failure keeps its original returncode.
             _print_workflow_push_guidance()
             return 0
-        return push_result.returncode
+        return net_result.returncode
 
     result = subprocess.run(["git", *argv], check=False, env=env)  # noqa: S603, S607
     return result.returncode

--- a/src/vergil_tooling/lib/git.py
+++ b/src/vergil_tooling/lib/git.py
@@ -6,15 +6,51 @@ import base64
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from vergil_tooling.lib import github, progress
+from vergil_tooling.lib import github, progress, retry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # Subcommands that may contact the remote and therefore need the installation
 # token. "remote" is included because `git remote prune`/`update` ls-remote the
 # origin to compute stale refs — a network op — even though most `git remote`
 # subcommands are local (#1830).
 _REMOTE_SUBCOMMANDS: set[str] = {"push", "pull", "fetch", "ls-remote", "remote"}
+
+# Subcommands whose transient GitHub failures we retry (#2835). A subset of
+# _REMOTE_SUBCOMMANDS: "remote" is excluded because `git remote prune` is
+# finalize-time cleanup, out of the approved retry scope. Each transfers to or
+# from GitHub, so a 502/SSH-backend blip should be ridden out rather than
+# becoming a manual-recovery showstopper.
+_RETRYABLE_SUBCOMMANDS: frozenset[str] = frozenset({"push", "pull", "fetch", "ls-remote", "clone"})
+
+
+def _retry_network[T](subcommand: str, run_once: Callable[[], T]) -> T:
+    """Invoke *run_once* for a network *subcommand*, retrying transient failures.
+
+    *run_once* runs the command once and raises ``CalledProcessError`` on
+    failure. Every retry is announced on stderr so a genuinely non-transient
+    failure (e.g. a real SSH auth error, not a GitHub backend blip) still
+    surfaces before the final raise — no silent masking (#2835).
+    """
+    for attempt in range(retry.MAX_RETRIES + 1):
+        try:
+            return run_once()
+        except subprocess.CalledProcessError as exc:
+            if attempt == retry.MAX_RETRIES or not retry.is_retryable(exc):
+                raise
+            delay = retry.compute_delay(attempt)
+            print(
+                f"git {subcommand}: transient GitHub failure, retrying in "
+                f"{delay:.1f}s (attempt {attempt + 1}/{retry.MAX_RETRIES + 1})",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 def _git_auth_env(token: str) -> dict[str, str]:
@@ -49,21 +85,44 @@ def _git_env(args: tuple[str, ...]) -> dict[str, str]:
 
 
 def run(*args: str) -> None:
-    """Run a git command, streaming output, and raise on failure."""
-    progress.run(("git", *args), env=_git_env(args))
+    """Run a git command, streaming output, and raise on failure.
+
+    Network subcommands (push/pull/fetch/ls-remote/clone) are retried on
+    transient GitHub failures; every other subcommand runs exactly once (#2835).
+    """
+    env = _git_env(args)
+
+    def _once() -> int:
+        return progress.run(("git", *args), env=env)
+
+    if args and args[0] in _RETRYABLE_SUBCOMMANDS:
+        _retry_network(args[0], _once)
+    else:
+        _once()
 
 
 def read_output(*args: str) -> str:
-    """Run a git command and return stripped stdout."""
+    """Run a git command and return stripped stdout.
+
+    Network subcommands (e.g. ``ls-remote``) are retried on transient GitHub
+    failures; every other subcommand runs exactly once (#2835).
+    """
     env = _git_env(args)
-    try:
-        result = subprocess.run(  # noqa: S603
+
+    def _once() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603
             ("git", *args),  # noqa: S607
             check=True,
             text=True,
             capture_output=True,
             env=env,
         )
+
+    try:
+        if args and args[0] in _RETRYABLE_SUBCOMMANDS:
+            result = _retry_network(args[0], _once)
+        else:
+            result = _once()
     except subprocess.CalledProcessError as exc:
         if exc.stderr:
             print(exc.stderr, end="", file=sys.stderr)

--- a/src/vergil_tooling/lib/retry.py
+++ b/src/vergil_tooling/lib/retry.py
@@ -1,9 +1,11 @@
-"""Retry logic for transient GitHub API errors.
+"""Retry logic for transient GitHub API and git transport errors.
 
-Shared by ``github.py`` (library wrappers) and ``vrg_gh.py`` (CLI wrapper)
-so both paths handle HTTP 401/502/503/504/429 and ``net/http`` transport
-failures (TLS handshake, i/o timeout, connection refused, DNS lookup,
-EOF) identically.
+Shared by ``github.py`` (library wrappers), ``vrg_gh.py`` (CLI wrapper),
+``git.py`` and ``vrg_git.py`` (raw git network ops) so every path that
+talks to GitHub handles HTTP 401/502/503/504/429, proxy/gateway bodies
+("502 Bad Gateway"), ``net/http`` transport failures (TLS handshake, i/o
+timeout, connection refused, DNS lookup, EOF) and raw git/SSH transport
+drops identically (#2835).
 
 HTTP 401 "Bad credentials" is treated as transient: GitHub's API
 (notably the GraphQL endpoint behind ``gh pr checks --watch``)
@@ -39,6 +41,15 @@ _RETRYABLE_PATTERNS = (
     "http 503",
     "http 504",
     "http 429",
+    # Proxy/gateway phrasings that carry no "HTTP <code>" token: gh emits
+    # "non-200 OK status code: 502 Bad Gateway ..." (and nginx bodies say
+    # "502 Bad Gateway"), which the code-only patterns above miss. This gap
+    # let a 502 fail `gh pr merge` on the first attempt during the 2026-08-13
+    # GitHub incident (#2835).
+    "bad gateway",
+    "service unavailable",
+    "gateway timeout",
+    "gateway time-out",  # nginx's hyphenated 504 wording
     # net/http transport-layer transients (request never reached the app
     # layer, so retrying is safe for writes too)
     "timed out",
@@ -46,9 +57,20 @@ _RETRYABLE_PATTERNS = (
     "tls handshake",
     "connection reset",
     "connection refused",
+    "connection closed",  # SSH transport drop mid-op during an incident
+    "kex_exchange_identification",  # SSH handshake aborted by GitHub's frontend
     "no such host",  # DNS resolution failure
     "server misbehaving",  # Go DNS resolver transient
     "eof",  # "unexpected EOF" / "EOF" mid-request
+    # raw git transport transients — now reachable because git network ops
+    # are wrapped in retry too (#2835), not only the gh/API path.
+    "could not read from remote",
+    "the remote end hung up",
+    # A valid, static SSH key rejected because GitHub's key-lookup backend is
+    # degraded presents identically to a real misconfigured key. Per #2835 we
+    # retry it, but every attempt is announced (see git.py / vrg_git.py), so a
+    # genuine misconfig still surfaces loudly and hard-fails after the last try.
+    "permission denied (publickey)",
 )
 
 

--- a/tests/vergil_tooling/test_git.py
+++ b/tests/vergil_tooling/test_git.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from vergil_tooling.lib import git
+from vergil_tooling.lib import git, retry
 
 
 def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedProcess[str]:
@@ -400,3 +400,96 @@ def test_committer_timestamp_invokes_log_with_dash_c() -> None:
     with patch("vergil_tooling.lib.git.read_output", return_value="1700000000") as mock_ro:
         git.committer_timestamp("/wt")
     mock_ro.assert_called_once_with("-C", "/wt", "log", "-1", "--format=%ct", "HEAD")
+
+
+class TestNetworkRetry:
+    """Retry of transient GitHub failures on raw git network ops (#2835)."""
+
+    _PUBLICKEY = "git@github.com: Permission denied (publickey)."
+    _TRANSPORT = "fatal: Could not read from remote repository."
+
+    def test_run_retries_transient_push_then_succeeds(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        err = subprocess.CalledProcessError(255, ("git", "push"), stderr=self._PUBLICKEY)
+        with (
+            patch("vergil_tooling.lib.git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.lib.git.progress") as m_progress,
+            patch("vergil_tooling.lib.git.time.sleep") as m_sleep,
+        ):
+            m_progress.run.side_effect = [err, err, 0]
+            git.run("push", "--force-with-lease", "-u", "origin", "feature/x")
+        assert m_progress.run.call_count == 3
+        assert m_sleep.call_count == 2
+        # "loudly": every retry is announced so a real auth failure surfaces.
+        assert "retrying" in capsys.readouterr().err
+
+    def test_run_does_not_retry_non_network_subcommand(self) -> None:
+        # A retryable-looking stderr must NOT trigger retry for a local op.
+        err = subprocess.CalledProcessError(1, ("git", "status"), stderr=self._PUBLICKEY)
+        with (
+            patch("vergil_tooling.lib.git.progress") as m_progress,
+            patch("vergil_tooling.lib.git.time.sleep") as m_sleep,
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            m_progress.run.side_effect = err
+            git.run("status")
+        assert m_progress.run.call_count == 1
+        m_sleep.assert_not_called()
+
+    def test_run_raises_after_max_retries_on_persistent_transient(self) -> None:
+        err = subprocess.CalledProcessError(128, ("git", "fetch"), stderr=self._TRANSPORT)
+        with (
+            patch("vergil_tooling.lib.git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.lib.git.progress") as m_progress,
+            patch("vergil_tooling.lib.git.time.sleep") as m_sleep,
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            m_progress.run.side_effect = err
+            git.run("fetch", "origin", "develop")
+        assert m_progress.run.call_count == retry.MAX_RETRIES + 1
+        assert m_sleep.call_count == retry.MAX_RETRIES
+
+    def test_run_raises_immediately_on_non_transient_network_error(self) -> None:
+        err = subprocess.CalledProcessError(
+            1, ("git", "push"), stderr="! [rejected] main -> main (non-fast-forward)"
+        )
+        with (
+            patch("vergil_tooling.lib.git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.lib.git.progress") as m_progress,
+            patch("vergil_tooling.lib.git.time.sleep") as m_sleep,
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            m_progress.run.side_effect = err
+            git.run("push", "origin", "main")
+        assert m_progress.run.call_count == 1
+        m_sleep.assert_not_called()
+
+    def test_read_output_retries_ls_remote_transient_then_succeeds(self) -> None:
+        err = subprocess.CalledProcessError(128, ("git", "ls-remote"), stderr=self._TRANSPORT)
+        err.stdout = ""
+        ok = _completed(stdout="deadbeef\trefs/heads/main\n")
+        with (
+            patch("vergil_tooling.lib.git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.lib.git.subprocess.run", side_effect=[err, ok]) as m_run,
+            patch("vergil_tooling.lib.git.time.sleep") as m_sleep,
+        ):
+            out = git.read_output("ls-remote", "--heads", "origin")
+        assert m_run.call_count == 2
+        assert m_sleep.call_count == 1
+        assert "refs/heads/main" in out
+
+    def test_read_output_ls_remote_raises_after_max_and_prints_stderr(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        err = subprocess.CalledProcessError(128, ("git", "ls-remote"), stderr=self._TRANSPORT)
+        err.stdout = ""
+        with (
+            patch("vergil_tooling.lib.git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.lib.git.subprocess.run", side_effect=err) as m_run,
+            patch("vergil_tooling.lib.git.time.sleep"),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            git.read_output("ls-remote", "--heads", "origin")
+        assert m_run.call_count == retry.MAX_RETRIES + 1
+        assert "Could not read from remote" in capsys.readouterr().err

--- a/tests/vergil_tooling/test_retry.py
+++ b/tests/vergil_tooling/test_retry.py
@@ -56,6 +56,30 @@ class TestIsRetryable:
     @pytest.mark.parametrize(
         "stderr",
         [
+            # gh's 502/503/504 phrasing during the 2026-08-13 incident, which
+            # carries no "HTTP <code>" token so the code-only patterns miss it.
+            'non-200 OK status code: 502 Bad Gateway body: "<html>..."',
+            "502 Bad Gateway",
+            "error: 503 Service Unavailable",
+            "504 Gateway Timeout",
+            "504 Gateway Time-out",
+            # raw git transport transients (git never reached retry before #2835)
+            "fatal: Could not read from remote repository.",
+            "fatal: the remote end hung up unexpectedly",
+            "Connection closed by 140.82.112.3 port 22",
+            "kex_exchange_identification: Connection closed by remote host",
+            # SSH auth backend hiccup rejecting a valid, static key: retried
+            # loudly per the issue #2835 decision (a real misconfig still
+            # surfaces after the loud retries and the final raise).
+            "git@github.com: Permission denied (publickey).",
+        ],
+    )
+    def test_retryable_transport_and_incident_errors(self, stderr: str) -> None:
+        assert retry.is_retryable(_api_error(stderr=stderr)) is True
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
             "HTTP 404 Not Found",
             "HTTP 422 Unprocessable Entity",
             "GraphQL: Pull request is not mergeable (mergePullRequest)",

--- a/tests/vergil_tooling/test_vrg_git.py
+++ b/tests/vergil_tooling/test_vrg_git.py
@@ -18,6 +18,7 @@ from vergil_tooling.bin.vrg_git import (
     _worktree_convention_active,
     main,
 )
+from vergil_tooling.lib import retry
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -850,6 +851,103 @@ class TestPushWorkflowErrorDetection:
             )
             rc = main(["push", "origin", "feature/x"])
         assert rc == 0
+
+
+# -- transient network retry (#2835) ------------------------------------------
+
+
+class TestNetworkRetry:
+    """vrg-git retries transient GitHub failures on network ops (#2835)."""
+
+    _PUBLICKEY = "git@github.com: Permission denied (publickey).\n"
+    _TRANSPORT = "fatal: Could not read from remote repository.\n"
+
+    @staticmethod
+    def _fail(stderr: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["git"], returncode=128, stdout="", stderr=stderr)
+
+    @staticmethod
+    def _ok() -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["git"], returncode=0, stdout="", stderr="")
+
+    def test_fetch_retries_transient_then_succeeds(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("vergil_tooling.bin.vrg_git.github.get_installation_token", return_value=None),
+            patch(
+                "vergil_tooling.bin.vrg_git.subprocess.run",
+                side_effect=[self._fail(self._TRANSPORT), self._ok()],
+            ) as mock_run,
+            patch("vergil_tooling.bin.vrg_git.time.sleep") as mock_sleep,
+        ):
+            rc = main(["fetch", "origin", "develop"])
+        assert rc == 0
+        assert mock_run.call_count == 2
+        assert mock_sleep.call_count == 1
+        assert "retrying" in capsys.readouterr().err
+
+    def test_push_retries_transient_then_succeeds(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("vergil_tooling.bin.vrg_git.github.get_installation_token", return_value=None),
+            # Skip the pre-push freeze lookup so it does not consume a side_effect.
+            patch("vergil_tooling.bin.vrg_git._current_worktree_root", return_value=None),
+            patch(
+                "vergil_tooling.bin.vrg_git.subprocess.run",
+                side_effect=[self._fail(self._PUBLICKEY), self._fail(self._PUBLICKEY), self._ok()],
+            ) as mock_run,
+            patch("vergil_tooling.bin.vrg_git.time.sleep") as mock_sleep,
+        ):
+            rc = main(["push", "origin", "feature/x"])
+        assert rc == 0
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_persistent_transient_fails_after_max_and_surfaces_stderr(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("vergil_tooling.bin.vrg_git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+            patch("vergil_tooling.bin.vrg_git.time.sleep") as mock_sleep,
+        ):
+            mock_run.return_value = self._fail(self._TRANSPORT)
+            rc = main(["fetch", "origin", "develop"])
+        assert rc == 128
+        assert mock_run.call_count == retry.MAX_RETRIES + 1
+        assert mock_sleep.call_count == retry.MAX_RETRIES
+        # The real error still surfaces after the loud retries — no masking.
+        assert "Could not read from remote" in capsys.readouterr().err
+
+    def test_publickey_retried_loudly_then_hard_fails(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("vergil_tooling.bin.vrg_git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+            patch("vergil_tooling.bin.vrg_git.time.sleep"),
+        ):
+            mock_run.return_value = self._fail(self._PUBLICKEY)
+            rc = main(["push", "origin", "feature/x"])
+        assert rc == 128
+        err = capsys.readouterr().err
+        # Announced on every retry (loud), and the real error is never hidden.
+        assert err.lower().count("retrying") == retry.MAX_RETRIES
+        assert "Permission denied (publickey)" in err
+
+    def test_non_transient_network_error_not_retried(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("vergil_tooling.bin.vrg_git.github.get_installation_token", return_value=None),
+            patch("vergil_tooling.bin.vrg_git.subprocess.run") as mock_run,
+            patch("vergil_tooling.bin.vrg_git.time.sleep") as mock_sleep,
+        ):
+            mock_run.return_value = self._fail("fatal: repository not found\n")
+            rc = main(["fetch", "origin", "develop"])
+        assert rc == 128
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 # -- worktree convention -------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Wrap raw git network operations (push/pull/fetch/ls-remote/clone) in the shared retry-with-backoff, and widen the retryable-pattern set to catch gateway/transport transients (Bad Gateway, could not read from remote, publickey) — so transient GitHub instability is ridden out instead of becoming a manual-recovery showstopper.

## Issue Linkage

- Closes #2835

## Notes

- Motivated by a real GitHub instability window: SSH auth-backend blips rejecting a valid, static key with 'Permission denied (publickey)', plus a 502 Bad Gateway on 'gh pr merge', both of which failed submit/finalize and required manual recovery.

Retry logic previously wrapped only the gh/API path; raw git network ops had none, and the pattern set matched the literal 'HTTP 502' token but not the '502 Bad Gateway' string gh actually emits.

Changes:
- lib/retry.py: add gateway/transport phrases (bad gateway, service unavailable, gateway timeout, could not read from remote, the remote end hung up, connection closed, kex_exchange_identification, permission denied (publickey)). Closes the gh merge-502 gap on its own.
- lib/git.py + bin/vrg_git.py: retry network subcommands via the shared 5-attempt jittered backoff; non-network subcommands never retry. Every retry is announced on stderr, so a genuinely non-transient failure still surfaces and hard-fails after the last attempt (no silent masking).

Write-retry safety: a push that secretly landed is refused on retry by --force-with-lease; a landed merge returns a clear already-merged error. Worst case is a clean terminal error, never a double-apply.

Validation: vrg-validate green (lint, typecheck, 5014 tests, 100% coverage, audit). New/changed modules at 100% coverage.