### PR TITLE
feat(github-config): centralize baseline .gitignore + self-policing ops audit + scaffold ops.yml (#311)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,79 @@
-.DS_Store
-Thumbs.db
-.idea/
-.vscode/
+# This repo's .gitignore is a SUPERSET of the Vergil baseline
+# (src/vergil_tooling/data/gitignore.baseline, epic vergil-project/.github#311).
+# The baseline lines below are matched verbatim by the nightly config audit
+# (repo_config._check_gitignore); change the baseline in this package and
+# release, do not diverge here. Repo-local extras live in their own section.
+
+# Editors
 *.swp
 *.swo
 *~
+*.bak
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment / secrets
 .env
 .env.*
+
+# Logs
 *.log
+
+# Vergil internals
 .venv/
-__pycache__/
-*.pyc
-*.egg-info/
-src/standard_tooling.egg-info/
-dist/
-build/
-.coverage
-# Machine-readable gate reports emitted at the workspace root by the check
-# registry (see src/vergil_tooling/lib/languages.py). Consumed by the T8
-# evidence-producer composite; never committed.
-quality-ruff.json
-quality-mypy.xml
-coverage.xml
-junit.xml
-pip-audit.json
-licenses.json
-.pytest_cache/
-.mypy_cache/
-.ruff_cache/
 .worktrees/
 .vergil/
 .superpowers/
 .claude/scheduled_tasks.lock
+.claude/settings.local.json
+
+# Build / packaging output
+build/
+dist/
+*.egg-info/
+
+# Python bytecode / caches
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage / validation / CI-gate evidence
+.coverage
+coverage.xml
+junit.xml
+pip-audit.json
+licenses.json
+quality-ruff.json
+quality-mypy.xml
+
+# Docs (mkdocs build output; mkdocs.yml lives at docs/site/)
+docs/site/site/
+
+# Node / TypeScript
+node_modules/
+*.tsbuildinfo
+
+# Go (test/coverage output; binaries usually have no extension)
+*.test
+*.out
+
+# Ruby
+.bundle/
+vendor/bundle/
+
+# C/C++ object & archive output
+*.o
+*.obj
+*.a
+*.so
+
+# --- Repo-local extras (beyond the baseline) ---
+
+# Legacy egg-info path from the standard_tooling era (kept for old checkouts)
+src/standard_tooling.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ constraint-dependencies = ["msgpack>=1.2.1"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-vergil_tooling = ["data/*.json", "data/*.md", "data/*.sh", "data/licenses/*.txt", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml", "configs/cpp/.clang-format", "configs/cpp/.clang-tidy", "configs/cpp/*.txt", "configs/cpp/*.cfg", "configs/typescript/*.json", "configs/typescript/*.mjs"]
+vergil_tooling = ["data/*.json", "data/*.md", "data/*.sh", "data/gitignore.baseline", "data/licenses/*.txt", "configs/*.yaml", "configs/*.toml", "configs/ruby/*.yml", "configs/cpp/.clang-format", "configs/cpp/.clang-tidy", "configs/cpp/*.txt", "configs/cpp/*.cfg", "configs/typescript/*.json", "configs/typescript/*.mjs"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/vergil_tooling/data/gitignore.baseline
+++ b/src/vergil_tooling/data/gitignore.baseline
@@ -1,0 +1,73 @@
+# Vergil baseline .gitignore — single source of truth (epic vergil-project/.github#311).
+# Every managed repo's .gitignore must be a SUPERSET of the non-comment lines
+# below (verbatim). Repos may add their own local entries. Do not edit a
+# consuming repo to diverge — change this file in vergil-tooling and release.
+
+# Editors
+*.swp
+*.swo
+*~
+*.bak
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment / secrets
+.env
+.env.*
+
+# Logs
+*.log
+
+# Vergil internals
+.venv/
+.worktrees/
+.vergil/
+.superpowers/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
+# Build / packaging output
+build/
+dist/
+*.egg-info/
+
+# Python bytecode / caches
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage / validation / CI-gate evidence
+.coverage
+coverage.xml
+junit.xml
+pip-audit.json
+licenses.json
+quality-ruff.json
+quality-mypy.xml
+
+# Docs (mkdocs build output; mkdocs.yml lives at docs/site/)
+docs/site/site/
+
+# Node / TypeScript
+node_modules/
+*.tsbuildinfo
+
+# Go (test/coverage output; binaries usually have no extension)
+*.test
+*.out
+
+# Ruby
+.bundle/
+vendor/bundle/
+
+# C/C++ object & archive output
+*.o
+*.obj
+*.a
+*.so

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -46,6 +46,29 @@ def _load_settings_template() -> dict[str, Any]:
     return template
 
 
+def _load_gitignore_baseline() -> str:
+    return (
+        importlib.resources.files("vergil_tooling.data")
+        .joinpath("gitignore.baseline")
+        .read_text(encoding="utf-8")
+    )
+
+
+def _gitignore_patterns(text: str) -> list[str]:
+    """Baseline pattern lines: non-comment, non-blank, trailing-ws trimmed.
+
+    Comments and blanks in the baseline are documentation, not requirements
+    (spec §2, resolved O2).
+    """
+    patterns: list[str] = []
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        patterns.append(line)
+    return patterns
+
+
 def audit_local_config(repo_root: Path) -> ConfigDiff:
     """Run all local config checks against a repo root directory."""
     items: list[DiffItem] = []

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -83,14 +83,10 @@ def _check_gitignore(repo_root: Path, items: list[DiffItem]) -> None:
     if not gitignore.is_file():
         present: set[str] = set()
     else:
-        present = {
-            line.rstrip() for line in gitignore.read_text(encoding="utf-8").splitlines()
-        }
+        present = {line.rstrip() for line in gitignore.read_text(encoding="utf-8").splitlines()}
     for pattern in required:
         if pattern not in present:
-            items.append(
-                DiffItem(field="local.gitignore", expected=pattern, actual="missing")
-            )
+            items.append(DiffItem(field="local.gitignore", expected=pattern, actual="missing"))
 
 
 def _check_required_workflows(repo_root: Path, items: list[DiffItem]) -> None:
@@ -105,9 +101,7 @@ def _check_required_workflows(repo_root: Path, items: list[DiffItem]) -> None:
     """
     ops = repo_root / ".github" / "workflows" / "ops.yml"
     if not ops.is_file():
-        items.append(
-            DiffItem(field="local.ops_workflow", expected="present", actual="missing")
-        )
+        items.append(DiffItem(field="local.ops_workflow", expected="present", actual="missing"))
         return
     content = ops.read_text(encoding="utf-8")
     if "ops-github-config.yml" not in content:

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -93,6 +93,41 @@ def _check_gitignore(repo_root: Path, items: list[DiffItem]) -> None:
             )
 
 
+def _check_required_workflows(repo_root: Path, items: list[DiffItem]) -> None:
+    """Assert .github/workflows/ops.yml exists, wires the audit, and is scheduled.
+
+    A WIRING validator: it verifies a *present* ops.yml (a) calls the reusable
+    ops-github-config workflow and (b) carries a scheduled (cron) trigger, so a
+    wired-but-unscheduled ops.yml can't silently never run nightly. It cannot
+    detect a repo missing ops.yml entirely (no workflow -> no nightly run ->
+    this check never fires there); that from-outside guarantee is deferred to
+    follow-on C (#315). (#311)
+    """
+    ops = repo_root / ".github" / "workflows" / "ops.yml"
+    if not ops.is_file():
+        items.append(
+            DiffItem(field="local.ops_workflow", expected="present", actual="missing")
+        )
+        return
+    content = ops.read_text(encoding="utf-8")
+    if "ops-github-config.yml" not in content:
+        items.append(
+            DiffItem(
+                field="local.ops_workflow",
+                expected="calls ops-github-config.yml",
+                actual="ops.yml present but does not wire the config audit",
+            )
+        )
+    if "cron:" not in content:
+        items.append(
+            DiffItem(
+                field="local.ops_workflow",
+                expected="scheduled (cron) trigger",
+                actual="ops.yml present but has no schedule",
+            )
+        )
+
+
 def audit_local_config(repo_root: Path) -> ConfigDiff:
     """Run all local config checks against a repo root directory."""
     items: list[DiffItem] = []
@@ -103,6 +138,7 @@ def audit_local_config(repo_root: Path) -> ConfigDiff:
     _check_claude_settings(repo_root, items, warnings)
     _check_workflow_refs(repo_root, items)
     _check_gitignore(repo_root, items)
+    _check_required_workflows(repo_root, items)
     return ConfigDiff(items=items, warnings=warnings)
 
 

--- a/src/vergil_tooling/lib/repo_config.py
+++ b/src/vergil_tooling/lib/repo_config.py
@@ -69,6 +69,30 @@ def _gitignore_patterns(text: str) -> list[str]:
     return patterns
 
 
+def _check_gitignore(repo_root: Path, items: list[DiffItem]) -> None:
+    """Require the repo .gitignore to be a superset of the baseline.
+
+    Every baseline pattern line (`_gitignore_patterns`) must appear verbatim as a
+    line in the repo's .gitignore (trailing whitespace trimmed on both sides).
+    Repos may add any extra lines. Matching is verbatim by design — the baseline
+    defines the one canonical spelling per pattern and the fleet is standardized
+    to it (spec §2). (#311)
+    """
+    required = _gitignore_patterns(_load_gitignore_baseline())
+    gitignore = repo_root / ".gitignore"
+    if not gitignore.is_file():
+        present: set[str] = set()
+    else:
+        present = {
+            line.rstrip() for line in gitignore.read_text(encoding="utf-8").splitlines()
+        }
+    for pattern in required:
+        if pattern not in present:
+            items.append(
+                DiffItem(field="local.gitignore", expected=pattern, actual="missing")
+            )
+
+
 def audit_local_config(repo_root: Path) -> ConfigDiff:
     """Run all local config checks against a repo root directory."""
     items: list[DiffItem] = []
@@ -78,6 +102,7 @@ def audit_local_config(repo_root: Path) -> ConfigDiff:
     _check_claude_md(repo_root, items)
     _check_claude_settings(repo_root, items, warnings)
     _check_workflow_refs(repo_root, items)
+    _check_gitignore(repo_root, items)
     return ConfigDiff(items=items, warnings=warnings)
 
 

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -432,26 +432,13 @@ def render_readme(ctx: RepoInitContext) -> str:
 
 
 def render_gitignore() -> str:
-    """Render baseline .gitignore."""
-    return (
-        "# Editors\n"
-        "*.swp\n"
-        "*.swo\n"
-        "*~\n"
-        ".idea/\n"
-        ".vscode/\n"
-        "\n"
-        "# OS\n"
-        ".DS_Store\n"
-        "Thumbs.db\n"
-        "\n"
-        "# Vergil\n"
-        ".venv/\n"
-        ".worktrees/\n"
-        ".vergil/\n"
-        ".superpowers/\n"
-        "build/\n"
-    )
+    """Render the baseline .gitignore from the packaged single source of truth.
+
+    The baseline lives at ``vergil_tooling.data/gitignore.baseline`` so
+    scaffolding and the audit check (`repo_config._check_gitignore`) share one
+    definition and cannot diverge (epic vergil-project/.github#311).
+    """
+    return _load_data_file("gitignore.baseline")
 
 
 def _cpp_family_and_version(versions: list[str] | None) -> tuple[str, str] | None:

--- a/src/vergil_tooling/lib/repo_init.py
+++ b/src/vergil_tooling/lib/repo_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -822,6 +823,48 @@ def render_epic_rollup_workflow() -> str:
     )
 
 
+def _ops_cron_minute(org: str, name: str) -> int:
+    """Deterministic per-repo minute in [0,59] for the ops schedule.
+
+    A stable hash of ``<org>/<name>`` spreads scheduled runs across the hour so
+    the fleet does not stampede a single minute as it grows (spec §4, O3). Cron
+    is static YAML, so "randomize" means "derive deterministically per repo."
+    """
+    digest = hashlib.sha256(f"{org}/{name}".encode()).digest()
+    return digest[0] % 60
+
+
+def render_ops_workflow(ctx: RepoInitContext) -> str:
+    """Render .github/workflows/ops.yml — the daily config-audit caller.
+
+    Scheduled minute is staggered per repo (`_ops_cron_minute`); the reusable
+    workflow is pinned to the rolling @v2.1 tag (epic vergil-project/.github#311).
+    """
+    minute = _ops_cron_minute(ctx.org, ctx.name)
+    return (
+        "name: Ops\n"
+        "\n"
+        "on:\n"
+        "  schedule:\n"
+        f"    - cron: '{minute} 6 * * *'\n"
+        "  workflow_dispatch:\n"
+        "\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "  issues: write\n"
+        "\n"
+        "jobs:\n"
+        "  github-config:\n"
+        "    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.1\n"
+        "    permissions:\n"
+        "      contents: read\n"
+        "      issues: write\n"
+        "    secrets:\n"
+        "      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}\n"
+        "      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}\n"
+    )
+
+
 def render_mkdocs_yml(ctx: RepoInitContext) -> str:
     """Render docs/site/mkdocs.yml."""
     return (
@@ -1256,6 +1299,11 @@ def step_ci_cd_workflows(ctx: RepoInitContext) -> None:
     # vergil-project/.github#75) so a merged task closes and its epic rolls up
     # with no per-command step.
     (workflows_dir / "epic-rollup.yml").write_text(render_epic_rollup_workflow())
+
+    # Daily config-audit caller so every managed repo is born self-policing
+    # (epic vergil-project/.github#311). Staggered per-repo cron avoids a
+    # fleet-wide thundering herd at a single minute.
+    (workflows_dir / "ops.yml").write_text(render_ops_workflow(ctx))
 
     if ctx.publish_docs or ctx.publish_release:
         cd_content = render_cd_workflow(ctx)

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -599,3 +599,38 @@ class TestGitignorePatterns:
         patterns = repo_config._gitignore_patterns(repo_config._load_gitignore_baseline())
         for required in (".venv/", ".worktrees/", "quality-ruff.json", "docs/site/site/"):
             assert required in patterns
+
+
+class TestCheckGitignore:
+    def test_superset_passes(self, tmp_path: Path) -> None:
+        baseline = repo_config._load_gitignore_baseline()
+        _write_gitignore(tmp_path / ".gitignore", baseline + "\n# local\nmy-local-thing/\n")
+        items: list = []
+        repo_config._check_gitignore(tmp_path, items)
+        assert items == []
+
+    def test_missing_pattern_fails(self, tmp_path: Path) -> None:
+        _write_gitignore(tmp_path / ".gitignore", ".venv/\n")  # missing almost everything
+        items: list = []
+        repo_config._check_gitignore(tmp_path, items)
+        fields = {i.field for i in items}
+        expecteds = {i.expected for i in items}
+        assert fields == {"local.gitignore"}
+        assert ".worktrees/" in expecteds
+        assert all(i.actual == "missing" for i in items)
+
+    def test_absent_file_reports_all(self, tmp_path: Path) -> None:
+        items: list = []
+        repo_config._check_gitignore(tmp_path, items)
+        required = repo_config._gitignore_patterns(repo_config._load_gitignore_baseline())
+        assert len(items) == len(required)
+
+    def test_trailing_whitespace_tolerated(self, tmp_path: Path) -> None:
+        baseline = repo_config._load_gitignore_baseline()
+        _write_gitignore(
+            tmp_path / ".gitignore",
+            "\n".join(line + "   " for line in baseline.splitlines()),
+        )
+        items: list = []
+        repo_config._check_gitignore(tmp_path, items)
+        assert items == []

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vergil_tooling.lib import repo_config
 from vergil_tooling.lib.repo_config import audit_local_config
 
 if TYPE_CHECKING:
@@ -583,3 +584,18 @@ class TestWorkflowRefs:
         (tmp_path / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML_VER.format(version="v2.0"))
         diff = audit_local_config(tmp_path)
         assert not [i for i in diff.items if i.field == "local.workflow_ref"]
+
+
+def _write_gitignore(p: Path, text: str) -> None:
+    p.write_text(text, encoding="utf-8")
+
+
+class TestGitignorePatterns:
+    def test_strips_comments_blanks_and_trailing_ws(self) -> None:
+        text = "# comment\n\n.venv/  \n  # indented comment\nbuild/\n"
+        assert repo_config._gitignore_patterns(text) == [".venv/", "build/"]
+
+    def test_baseline_has_required_patterns(self) -> None:
+        patterns = repo_config._gitignore_patterns(repo_config._load_gitignore_baseline())
+        for required in (".venv/", ".worktrees/", "quality-ruff.json", "docs/site/site/"):
+            assert required in patterns

--- a/tests/vergil_tooling/test_repo_config.py
+++ b/tests/vergil_tooling/test_repo_config.py
@@ -434,7 +434,7 @@ class TestClaudeSettings:
 
 def _write_compliant_repo(root: Path) -> None:
     """Scaffold a fully compliant repo structure."""
-    (root / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML)
+    (root / "vergil.toml").write_text(_MINIMAL_VERGIL_TOML_VER.format(version="v2.1"))
     hooks_dir = root / ".claude" / "hooks"
     hooks_dir.mkdir(parents=True)
     (hooks_dir / "guard.sh").write_text("#!/usr/bin/env bash\nexec vrg-hook-guard\n")
@@ -453,6 +453,14 @@ def _write_compliant_repo(root: Path) -> None:
         "enabledPlugins": {"vergil@vergil-marketplace": True},
     }
     (root / ".claude" / "settings.json").write_text(json.dumps(compliant_settings))
+    # A fully compliant repo carries the baseline .gitignore and a wired,
+    # scheduled ops.yml (epic vergil-project/.github#311). The ops.yml ref is
+    # pinned to the repo's declared vergil version (v2.1) so _check_workflow_refs
+    # stays clean.
+    (root / ".gitignore").write_text(repo_config._load_gitignore_baseline(), encoding="utf-8")
+    wf = root / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "ops.yml").write_text(_SCHED + "\njobs:\n" + _WIRED, encoding="utf-8")
 
 
 class TestIntegration:
@@ -634,3 +642,49 @@ class TestCheckGitignore:
         items: list = []
         repo_config._check_gitignore(tmp_path, items)
         assert items == []
+
+
+_WIRED = (
+    "  github-config:\n"
+    "    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.1\n"
+)
+_SCHED = "on:\n  schedule:\n    - cron: '7 6 * * *'\n  workflow_dispatch:\n"
+
+
+def _write_ops(dir_: Path, body: str) -> None:
+    wf = dir_ / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "ops.yml").write_text(body, encoding="utf-8")
+
+
+class TestCheckRequiredWorkflows:
+    def test_present_wired_scheduled_passes(self, tmp_path: Path) -> None:
+        _write_ops(tmp_path, _SCHED + "\njobs:\n" + _WIRED)
+        items: list = []
+        repo_config._check_required_workflows(tmp_path, items)
+        assert items == []
+
+    def test_absent_fails(self, tmp_path: Path) -> None:
+        items: list = []
+        repo_config._check_required_workflows(tmp_path, items)
+        assert [i.field for i in items] == ["local.ops_workflow"]
+        assert items[0].actual == "missing"
+
+    def test_present_but_not_wired_fails(self, tmp_path: Path) -> None:
+        _write_ops(
+            tmp_path,
+            _SCHED
+            + "\njobs:\n  x:\n"
+            + "    uses: vergil-project/vergil-actions/.github/workflows/ci.yml@v2.1\n",
+        )
+        items: list = []
+        repo_config._check_required_workflows(tmp_path, items)
+        assert all(i.field == "local.ops_workflow" for i in items)
+        assert any("does not wire" in i.actual for i in items)
+
+    def test_wired_but_unscheduled_fails(self, tmp_path: Path) -> None:
+        _write_ops(tmp_path, "on:\n  workflow_dispatch:\n\njobs:\n" + _WIRED)
+        items: list = []
+        repo_config._check_required_workflows(tmp_path, items)
+        assert all(i.field == "local.ops_workflow" for i in items)
+        assert any("no schedule" in i.actual for i in items)

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+from vergil_tooling.lib import repo_init
 from vergil_tooling.lib.config import CiConfig, ProjectConfig, _parse_raw_config
 from vergil_tooling.lib.repo_init import (
     RepoInitContext,
@@ -484,6 +485,29 @@ class TestRenderGitignore:
             .read_text(encoding="utf-8")
         )
         assert rendered == packaged
+
+
+class TestRenderOpsWorkflow:
+    def test_ops_cron_minute_deterministic_and_in_range(self) -> None:
+        a = repo_init._ops_cron_minute("vergil-project", "vergil-tooling")
+        b = repo_init._ops_cron_minute("vergil-project", "vergil-tooling")
+        assert a == b
+        assert 0 <= a <= 59
+
+    def test_ops_cron_minute_varies_by_repo(self) -> None:
+        minutes = {
+            repo_init._ops_cron_minute("vergil-project", n)
+            for n in ("vergil-tooling", "vergil-actions", "vergil-vm", "vergil-containers")
+        }
+        assert len(minutes) >= 2  # spread, not all identical
+
+    def test_render_ops_workflow_wires_audit_with_staggered_cron(self) -> None:
+        ctx = RepoInitContext(org="vergil-project", name="vergil-actions")
+        yaml = repo_init.render_ops_workflow(ctx)
+        minute = repo_init._ops_cron_minute("vergil-project", "vergil-actions")
+        assert f"- cron: '{minute} 6 * * *'" in yaml
+        assert "ops-github-config.yml@v2.1" in yaml
+        assert "workflow_dispatch:" in yaml
 
 
 class TestRenderCiWorkflow:
@@ -1572,6 +1596,8 @@ class TestStepCiCdWorkflows:
         assert not (tmp_path / ".github" / "workflows" / "cd.yml").exists()
         # Event-driven rollup ships in every repo, even without docs/release.
         assert (tmp_path / ".github" / "workflows" / "epic-rollup.yml").exists()
+        # Daily config-audit caller ships in every repo (epic #311).
+        assert (tmp_path / ".github" / "workflows" / "ops.yml").exists()
 
 
 class TestRenderEpicRollupWorkflow:

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -509,6 +509,20 @@ class TestRenderOpsWorkflow:
         assert "ops-github-config.yml@v2.1" in yaml
         assert "workflow_dispatch:" in yaml
 
+    def test_scaffolded_repo_passes_new_audit_checks(self, tmp_path: Path) -> None:
+        """A freshly scaffolded repo passes both new audit checks (round-trip)."""
+        from vergil_tooling.lib import repo_config
+
+        (tmp_path / ".gitignore").write_text(repo_init.render_gitignore(), encoding="utf-8")
+        ctx = RepoInitContext(org="vergil-project", name="demo")
+        wf = tmp_path / ".github" / "workflows"
+        wf.mkdir(parents=True, exist_ok=True)
+        (wf / "ops.yml").write_text(repo_init.render_ops_workflow(ctx), encoding="utf-8")
+        items: list = []
+        repo_config._check_gitignore(tmp_path, items)
+        repo_config._check_required_workflows(tmp_path, items)
+        assert items == []
+
 
 class TestRenderCiWorkflow:
     def test_python_workflow(self) -> None:

--- a/tests/vergil_tooling/test_repo_init.py
+++ b/tests/vergil_tooling/test_repo_init.py
@@ -469,6 +469,22 @@ class TestRenderGitignore:
         missing = [entry for entry in baseline_entries if entry not in flagship_entries]
         assert not missing, f"baseline entries missing from flagship .gitignore: {missing}"
 
+    def test_render_gitignore_returns_packaged_baseline(self) -> None:
+        import importlib.resources
+
+        rendered = render_gitignore()
+        # Reads the single source of truth, not a hardcoded string.
+        assert ".venv/" in rendered
+        assert "quality-ruff.json" in rendered
+        assert "docs/site/site/" in rendered
+        # It IS the packaged asset, byte-for-byte.
+        packaged = (
+            importlib.resources.files("vergil_tooling.data")
+            .joinpath("gitignore.baseline")
+            .read_text(encoding="utf-8")
+        )
+        assert rendered == packaged
+
 
 class TestRenderCiWorkflow:
     def test_python_workflow(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Makes the baseline .gitignore a centrally-owned single source of truth (new packaged data asset src/vergil_tooling/data/gitignore.baseline) consumed by both repo_init scaffolding and a new nightly config-audit check. render_gitignore() now reads the asset instead of a hardcoded string. Adds two pure-local checks to audit_local_config: _check_gitignore (repo .gitignore must be a verbatim superset of the baseline pattern lines) and _check_required_workflows (a present ops.yml must wire ops-github-config.yml AND carry a cron schedule). repo_init gains render_ops_workflow + _ops_cron_minute (deterministic per-repo staggered cron) and now scaffolds .github/workflows/ops.yml so new repos are born self-policing. Implements epic vergil-project/.github#311, issue #2834.

## Issue Linkage

- Closes #2834

## Notes

- Checks added: repo_config._check_gitignore and _check_required_workflows, both registered in audit_local_config (nightly ops job). Baseline was built by integrating the fleet's existing .gitignore files; two genuinely-universal lines beyond the plan's starter set were folded in with canonical spelling: '*.bak' (generic editor/tool backup noise) and '.claude/settings.local.json' (Claude Code personal local-settings file, fleet-wide). Reconciled this repo's own .gitignore to a superset of the baseline. Updated the test_repo_config compliant-repo fixture to scaffold a baseline .gitignore and a wired+scheduled ops.yml pinned at v2.1 (matching its vergil.toml) so _check_workflow_refs stays clean. Full vrg-validate passes including --cov-fail-under=100 with no new pragmas. All docs (config-audit reference, baseline reference, repo_init docs, consuming-repo contract) are deferred to the documentation bookend #2833 per the epic architecture; this PR is code + tests only. A vergil-tooling release under v2.1 is the human-gated precondition that puts the baseline on the rolling tag before any fleet rollout task runs.