### PR TITLE
docs: gitignore baseline + self-policing ops audit (#2833)

### DIFF
--- a/docs/site/docs/guides/consuming-repo-setup.md
+++ b/docs/site/docs/guides/consuming-repo-setup.md
@@ -248,20 +248,21 @@ Every managed repo adopts the worktree convention so multiple
 Claude Code agents can work in parallel without colliding. Two
 tiny changes:
 
-Add `.worktrees/` to your `.gitignore`:
+Make sure `.worktrees/` is in your `.gitignore`. It is already one of
+the entries in the central baseline (see
+[Step 8: Baseline `.gitignore` and config audit](#step-8-baseline-gitignore-and-config-audit)),
+so a repo that carries the baseline superset already has it; the
+plugin's commit-block hook activates against its presence.
 
-```bash
-echo '.worktrees/' >> .gitignore
-```
-
-!!! tip "Gitignore your validation/build output too"
-    Also keep validation and build artifacts (coverage reports, compiled
-    output, cache dirs, temporary venvs) out of the tree via `.gitignore`.
-    Un-gitignored output dirties a worktree, and a *merged* worktree left
+!!! tip "The baseline already ignores your validation/build output"
+    Validation and build artifacts (coverage reports, compiled output,
+    cache dirs, temporary venvs) are part of the central baseline your
+    `.gitignore` must be a superset of. Keeping them ignored matters:
+    un-gitignored output dirties a worktree, and a *merged* worktree left
     dirty is one `vrg-finalize-pr` cannot auto-remove — it surfaces as
     **needs-attention** in `vrg-worktree-status` and requires the opt-in
-    `--clean-dirty` (or a manual clean) to clear. Gitignoring the output
-    up front means merged worktrees sweep automatically.
+    `--clean-dirty` (or a manual clean) to clear. Carrying the full
+    baseline means merged worktrees sweep automatically.
 
 Add a `## Parallel AI agent development` section to your
 `CLAUDE.md`. Every managed repo has one you can copy — they differ
@@ -313,7 +314,46 @@ no further setup is needed in the workflow.
 See the [CI Architecture](ci-architecture.md) guide if you also want
 per-language test/lint/audit tiers.
 
-## Step 8: Verify end-to-end
+## Step 8: Baseline `.gitignore` and config audit
+
+Every managed repo owes two things to the fleet's self-policing config
+audit, and both are checked nightly:
+
+1. **Your `.gitignore` must be a superset of the central baseline.** The
+   baseline is a single source of truth owned by vergil-tooling
+   (`src/vergil_tooling/data/gitignore.baseline`) — the integral of the
+   fleet's ignores (editors, OS, secrets, Vergil internals, all
+   build/validation output, and every managed language's artifacts). Each
+   baseline pattern line must appear **verbatim** in your `.gitignore`;
+   matching is order-independent and you may add any number of local
+   entries below it. Matching is verbatim by design — `.venv/` and
+   `.venv` are not equivalent, so use the canonical baseline spelling.
+
+2. **Your repo must carry a scheduled `ops.yml` wired to the config
+   audit.** `.github/workflows/ops.yml` must call the reusable
+   `ops-github-config.yml` workflow **on a `cron` schedule**. That
+   scheduled job is what runs the audit each night.
+
+Both are **fatal in the nightly audit**: any drift returns exit 1 and
+turns the scheduled `ops.yml` run red. A repo bootstrapped with
+`vrg-github-repo-init` is born conforming — it scaffolds the baseline
+`.gitignore` and a staggered-cron `ops.yml` for you. For an existing
+repo, reconcile `.gitignore` to the baseline superset and add `ops.yml`.
+
+You never bump a pin to receive baseline changes: every repo tracks the
+rolling `vergil-tooling@vX.Y` tag, so a new baseline released under that
+line is picked up automatically on the next nightly run.
+
+Check your repo locally before relying on the nightly run:
+
+```bash
+vrg-github-repo-config audit   # exit 0 compliant, 1 drift, 2 could-not-complete
+```
+
+See the [GitHub Config Audit reference](../reference/config-audit.md)
+for the full check list and the baseline propagation model.
+
+## Step 9: Verify end-to-end
 
 Once the above is in place, sanity-check each layer:
 

--- a/docs/site/docs/reference/cli-tools-overview.md
+++ b/docs/site/docs/reference/cli-tools-overview.md
@@ -190,6 +190,45 @@ and project (discover repos via a GitHub Project and sync each).
 | Exit codes | 0 success |
 | Status | Active |
 
+### vrg-github-repo-config
+
+Audit a managed repo against the canonical Vergil configuration, and
+in `apply` mode reconcile the GitHub half. Combines local filesystem
+checks (`vergil.toml`, `CLAUDE.md`, `.claude/settings.json`, hook-guard
+shim, workflow pins, `.gitignore` baseline superset, `ops.yml` wiring)
+with GitHub-API checks (repo settings, rulesets, required-check set).
+Runs nightly from each repo's `ops.yml` via the reusable
+`ops-github-config.yml` workflow, where drift is fatal. See the
+[GitHub Config Audit reference](config-audit.md).
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_github_repo_config` |
+| Args | `audit` \| `diff` \| `apply`; `--repo OWNER/REPO`, `--config PATH` |
+| Preconditions | Local checks require the repo's own checkout as CWD; GitHub checks require `gh` credentials |
+| Failure mode | `DiffItem` list on drift; clean diagnostic on unreachable GitHub state |
+| Exit codes | 0 compliant, 1 non-compliant (drift), 2 audit could not complete |
+| Status | Active |
+
+### vrg-github-repo-init
+
+Interactive (or `--non-interactive`) wizard that bootstraps a new
+managed repository: creates and clones the repo, generates
+`vergil.toml`, scaffolds config files (`CLAUDE.md`, hook-guard shim,
+the baseline `.gitignore`), CI/CD/epic-rollup/`ops.yml` workflows, the
+docs site, branch structure, GitHub config, and Pages. The scaffolded
+`.gitignore` and staggered-cron `ops.yml` make a new repo pass the
+config audit's two baseline checks from day one.
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_github_repo_init` |
+| Args | `org/name` positional; `--adopt`, `--non-interactive`, `--target-dir`, and per-field overrides (`--primary-language`, `--repository-type`, …) |
+| Preconditions | `gh` and `git` on PATH; run from the org-layout parent (or pass `--target-dir`) |
+| Failure mode | Loud refusal on a foreign-repo CWD, an occupied clone path, or missing required non-interactive values |
+| Exit codes | 0 success, 1 error |
+| Status | Active |
+
 ### vrg-container-run
 
 Run arbitrary commands inside a dev container. Auto-detects the

--- a/docs/site/docs/reference/config-audit.md
+++ b/docs/site/docs/reference/config-audit.md
@@ -1,0 +1,164 @@
+# GitHub Config Audit
+
+`vrg-github-repo-config` audits a managed repo against the canonical
+Vergil configuration and, in `apply` mode, reconciles it. It combines
+two independent halves:
+
+- **Local filesystem checks** (`audit_local_config`) — pure local file
+  I/O, no network. They verify the files every managed repo checks in:
+  `vergil.toml`, `CLAUDE.md`, `.claude/settings.json`,
+  `.claude/hooks/guard.sh`, reusable-workflow pins, `.gitignore`, and
+  `.github/workflows/ops.yml`.
+- **GitHub API checks** — repo settings, branch rulesets, and the
+  required-status-check set, fetched from the GitHub API.
+
+## The `audit` command
+
+```bash
+vrg-github-repo-config audit [--repo OWNER/REPO] [--config PATH]
+```
+
+| Attribute | Value |
+|---|---|
+| Source | `vergil_tooling.bin.vrg_github_repo_config` |
+| Subcommands | `audit` (report), `diff` (report GitHub half only), `apply` (reconcile GitHub half) |
+| Args | `--repo OWNER/REPO` (defaults to the current git remote), `--config PATH` (local `vergil.toml`) |
+| Preconditions | Local checks require running from inside the repo's own checkout; GitHub checks require `gh` credentials |
+| Exit codes | 0 compliant, 1 non-compliant (drift), 2 audit could not complete |
+| Status | Active |
+
+Local checks only run when the current directory *is* the audited
+repo's checkout — auditing a foreign `--repo` from elsewhere skips the
+local half with a warning rather than reading the wrong files.
+
+### Where it runs — the nightly self-policing loop
+
+The audit is not part of `vrg-validate` (that would add per-commit
+overhead for a check that only needs to catch slow drift). Its home is
+the **nightly `ops.yml` config-audit job**: every managed repo ships
+`.github/workflows/ops.yml`, which calls the reusable
+`vergil-project/vergil-actions/.github/workflows/ops-github-config.yml`
+workflow on a daily schedule. That job runs
+`vrg-github-repo-config audit` from inside the repo checkout, so any
+`DiffItem` returns exit 1 and **turns the scheduled run red**. Drift is
+fatal where it fires: a non-conforming repo cannot silently persist.
+
+`vrg-release` also gates on the GitHub half of this audit, so a repo
+whose required-check set has drifted cannot release until reconciled.
+
+## Local checks
+
+`audit_local_config` runs the following, appending a `DiffItem` for each
+divergence:
+
+| Check | Asserts |
+|---|---|
+| `_check_vergil_toml` | `vergil.toml` present and parseable |
+| `_check_hook_guard_shim` | `.claude/hooks/guard.sh` present |
+| `_check_claude_md` | `CLAUDE.md` carries the canonical consumer template verbatim |
+| `_check_claude_settings` | `.claude/settings.json` marketplace + `enabledPlugins` match the template |
+| `_check_workflow_refs` | every `vergil-*` reusable-workflow pin matches the `vergil.toml` version |
+| `_check_gitignore` | `.gitignore` is a superset of the central baseline **(new, #311)** |
+| `_check_required_workflows` | `ops.yml` is present, wires the audit, and is scheduled **(new, #311)** |
+
+### `_check_gitignore` — baseline superset
+
+Every non-comment, non-blank line of the central baseline (see
+[The baseline](#the-baseline)) must appear **verbatim** as a line in the
+repo's `.gitignore`. Matching is order-independent, and the repo may add
+any number of extra local lines. A missing baseline pattern is reported
+as `DiffItem(field="local.gitignore", expected=<pattern>,
+actual="missing")`; a repo with no `.gitignore` fails with every
+baseline pattern reported missing.
+
+Matching is deliberately verbatim — no pattern-equivalence
+normalization. `.venv/` and `.venv` (or a leading-slash variant) are
+**not** treated as equivalent: the baseline defines the one canonical
+spelling per pattern and the fleet is standardized to it.
+
+### `_check_required_workflows` — ops.yml wiring
+
+A **wiring validator** for a *present* `ops.yml`. It asserts the file
+(a) exists, (b) references `ops-github-config.yml` (so a repo cannot
+carry an `ops.yml` that omits the config audit), and (c) carries a
+scheduled (`cron`) trigger — because a wired-but-unscheduled `ops.yml`
+(e.g. `workflow_dispatch` only) would pass a bare wiring check yet never
+run nightly, silently defeating the self-policing mechanism.
+
+!!! note "Structural limit — a *missing* ops.yml is not caught here"
+    Because this check runs *inside* the nightly `ops.yml` job, it
+    cannot detect a repo that lacks `ops.yml` **entirely** — such a repo
+    has no nightly run, so nothing executes the check there. The local
+    validator keeps a *present* `ops.yml` honest; guaranteeing presence
+    across the fleet needs a from-outside auditor, deferred to follow-on
+    C ([#315](https://github.com/vergil-project/.github/issues/315)). In
+    the meantime, presence is established by `repo_init` scaffolding (new
+    repos) and the one-time rollout (existing repos).
+
+## The baseline
+
+The single source of truth for the baseline `.gitignore` is a packaged
+data asset:
+
+```text
+src/vergil_tooling/data/gitignore.baseline
+```
+
+It is loaded at runtime via `importlib.resources` — the same idiom used
+for the `CLAUDE.md` and `.claude/settings.json` templates — so
+scaffolding and the audit share one definition and cannot diverge.
+
+**The integral of the fleet's ignores.** The baseline is a single
+integrated file applied to *every* repo regardless of language — the
+union of universal categories (editors, OS, secrets, logs), Vergil
+internals (`.venv/`, `.worktrees/`, `.vergil/`, `.superpowers/`), all
+build/validation/CI-evidence output (including the mkdocs build path
+`docs/site/site/`), and the managed-language artifacts across Python,
+TypeScript/Node, Go, Ruby, and C++. There is **no per-language
+branching**: one file goes everywhere.
+
+**Comments and blank lines are documentation, not requirements.** Only
+the pattern lines are matched; the baseline's comment blocks explain
+intent and never need to appear in a consuming repo.
+
+**Local additions are expected.** A repo `.gitignore` must be a
+*superset*, so a repo freely adds its own entries below the baseline
+patterns. The audit never asserts the file *equals* the baseline.
+
+### Propagation — the rolling `vX.Y` pin
+
+Every managed repo pins `vergil-tooling` to the **rolling major-minor
+tag** `vX.Y`, never a specific patch. The nightly `ops.yml` job installs
+`vergil-tooling@vX.Y`, which always resolves to the latest patch under
+that line — including its `gitignore.baseline`. So:
+
+> change the baseline → release a `vergil-tooling` patch under `vX.Y` →
+> **every repo picks it up on its next nightly run, automatically** — no
+> pin bump, no per-repo edit.
+
+The rolling pin the fleet already uses *is* the propagation mechanism;
+there is no push-based renderer or separate sync engine.
+
+## New repos are born conforming
+
+`repo_init` (`vrg-github-repo-init`) scaffolds both halves of the
+contract, so a freshly created repo passes both new checks from day one:
+
+- **`.gitignore`** — `render_gitignore()` reads the baseline asset (it
+  no longer returns a hardcoded string), so a new repo starts as an exact
+  superset of the canonical baseline.
+- **`ops.yml`** — `render_ops_workflow()` writes
+  `.github/workflows/ops.yml` calling `ops-github-config.yml@vX.Y` on a
+  daily schedule. The scheduled **minute is staggered per repo** — a
+  deterministic hash of `<org>/<repo>` maps to a minute in `[0,59]` — so
+  the fleet does not stampede a single minute as it grows. The hour stays
+  in the early-UTC window; only the minute varies.
+
+## Related
+
+- [Consuming Repo Setup](../guides/consuming-repo-setup.md) — the
+  consuming-repo baseline + `ops.yml` contract
+- [CI Architecture](../guides/ci-architecture.md#every-gate-is-required-there-are-no-optional-pr-gates)
+  — how the audit gates required-check drift and `vrg-release`
+- [CLI Tools Overview](cli-tools-overview.md#vrg-github-repo-config) —
+  runtime preconditions and failure modes

--- a/docs/site/docs/reference/index.md
+++ b/docs/site/docs/reference/index.md
@@ -18,6 +18,8 @@ the dev-tree override venv.
 | [vrg-prepare-release](dev/prepare-release.md) | Automated release preparation |
 | [vrg-finalize-pr](dev/finalize-pr.md) | Merge a PR and run post-merge cleanup |
 | [vrg-ensure-label](cli-tools-overview.md#vrg-ensure-label) | Ensure GitHub labels exist |
+| [vrg-github-repo-config](config-audit.md) | Audit/reconcile a repo against canonical config |
+| [vrg-github-repo-init](cli-tools-overview.md#vrg-github-repo-init) | Bootstrap a new managed repository |
 | [vrg-container-run](cli-tools-overview.md#vrg-container-run) | Run commands inside a dev container |
 | [vrg-container-test](cli-tools-overview.md#vrg-container-test) | Run test suite inside a dev container |
 | [vrg-container-docs](cli-tools-overview.md#vrg-container-docs) | Preview/build MkDocs in a dev container |

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
   - Script Reference:
       - Overview: reference/index.md
       - CLI Tools Overview: reference/cli-tools-overview.md
+      - GitHub Config Audit: reference/config-audit.md
       - VM Spec ([vm]): reference/vm-spec.md
       - Container Config ([container]): reference/container-config.md
       - Hook Guard:


### PR DESCRIPTION
# Pull Request

## Summary

- Documentation-review bookend for epic #311. Documents the shipped centralized baseline .gitignore and self-policing nightly ops audit across the vergil-tooling site docs, so the human-facing docs reflect the merged code.

## Issue Linkage

- Closes #2833

## Notes

- New page docs/site/docs/reference/config-audit.md (wired into mkdocs nav) covers vrg-github-repo-config audit, all audit_local_config checks including the two new #311 checks (_check_gitignore baseline-superset and _check_required_workflows ops.yml wiring), the gitignore.baseline single source of truth (the integral, verbatim superset matching, canonical spelling, local additions, rolling vX.Y propagation), the nightly ops.yml loop, repo_init scaffolding of the baseline .gitignore and staggered-cron ops.yml, and the missing-ops.yml structural limit deferred to follow-on C (#315). Updated consuming-repo-setup.md with a new Step 8 stating the consuming-repo contract (superset + scheduled wired ops.yml; drift is fatal nightly). Added concise vrg-github-repo-config / vrg-github-repo-init entries to cli-tools-overview.md and reference/index.md. vrg-validate PASSED. No other-repo doc tasks needed: the canonical human-facing home for this material is the vergil-tooling site docs; the org-wide vergil-project/docs site and vergil-project/.github carry no consuming-repo/config-audit docs that reference this contract (checked).